### PR TITLE
Support email subjects in authorization config

### DIFF
--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -263,6 +263,28 @@ authorization:
         id: authorization.relationships[0]
 ```
 
+Static user relationships can use an existing Gestalt user's email instead of
+copying the persisted UUID:
+
+```yaml
+authorization:
+  relationships:
+    - subject:
+        type: subject
+        email: alice@example.com
+      relation: admin
+      resource:
+        type: app
+        id: workspace-review
+```
+
+`subject.id` and `subject.email` are mutually exclusive. Email references are
+case-insensitive and resolve at startup to the canonical `user:<uuid>` subject
+stored in the system users database. An email that is not in that database is
+skipped with a warning so other relationships can still load. Ambiguous users
+and database failures abort authorization state application rather than
+silently removing grants. The same rules apply to `target.subject`.
+
 Dynamic grants are app-scoped. The `email` write field is a user-only convenience alias; `subjectId` accepts any canonical non-system subject ID, such as `user:<id>`, `service_account:<id>`, or another deployment-defined subject kind.
 
 Non-human callers are modeled as [service account subjects](/service-accounts), typically `service_account:<id>`. Grant access with static authorization relationships or provider-backed dynamic memberships using the canonical subject ID, and store third-party credentials through the configured external credentials provider under the same subject ID.

--- a/gestaltd/internal/bootstrap/authorization_bootstrap.go
+++ b/gestaltd/internal/bootstrap/authorization_bootstrap.go
@@ -310,10 +310,13 @@ func resolveStaticAuthorizationRelationshipSubject(
 	users authorizationUserResolver,
 ) (config.AuthorizationRelationshipDef, bool, error) {
 	subject := &def.Subject
-	if def.Target.Subject != nil {
+	switch {
+	case def.Target.Subject != nil:
 		targetSubject := *def.Target.Subject
 		def.Target.Subject = &targetSubject
 		subject = def.Target.Subject
+	case def.Target.Resource != nil || def.Target.SubjectSet != nil:
+		return def, true, nil
 	}
 	email := strings.TrimSpace(subject.Email)
 	if email == "" {

--- a/gestaltd/internal/bootstrap/authorization_bootstrap.go
+++ b/gestaltd/internal/bootstrap/authorization_bootstrap.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"log/slog"
 	"maps"
@@ -17,6 +18,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/protoutil"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	gproto "google.golang.org/protobuf/proto"
@@ -49,7 +51,16 @@ func resolveAuthorizationStateApply(cfg *config.Config) bool {
 	return parsed
 }
 
-func bootstrapAuthorizationProviderState(ctx context.Context, cfg *config.Config, providers map[string]core.AuthorizationProvider) error {
+type authorizationUserResolver interface {
+	FindUserByEmail(context.Context, string) (*core.User, error)
+}
+
+func bootstrapAuthorizationProviderState(
+	ctx context.Context,
+	cfg *config.Config,
+	providers map[string]core.AuthorizationProvider,
+	users authorizationUserResolver,
+) error {
 	if len(providers) == 0 {
 		return nil
 	}
@@ -79,7 +90,7 @@ func bootstrapAuthorizationProviderState(ctx context.Context, cfg *config.Config
 	if err := stampAuthorizationModel(model, time.Now()); err != nil {
 		return fmt.Errorf("bootstrap: authorization provider %q: %w", name, err)
 	}
-	staticRelationships, err := staticAuthorizationRelationships(cfg.Authorization)
+	staticRelationships, err := staticAuthorizationRelationships(ctx, cfg.Authorization, users)
 	if err != nil {
 		return fmt.Errorf("bootstrap: authorization provider %q: %w", name, err)
 	}
@@ -247,22 +258,39 @@ func staticAuthorizationAllowedTargets(subjectTypes []string, targets []config.A
 	return out, nil
 }
 
-func staticAuthorizationRelationships(cfg config.AuthorizationConfig) ([]*proto.Relationship, error) {
+func staticAuthorizationRelationships(
+	ctx context.Context,
+	cfg config.AuthorizationConfig,
+	users authorizationUserResolver,
+) ([]*proto.Relationship, error) {
 	out := make([]*proto.Relationship, 0, len(cfg.Relationships))
 	for i := range cfg.Relationships {
-		relationship, err := staticAuthorizationRelationship(cfg.Relationships[i])
+		relationship, include, err := staticAuthorizationRelationship(ctx, i, cfg.Relationships[i], users)
 		if err != nil {
 			return nil, fmt.Errorf("relationships[%d]: %w", i, err)
+		}
+		if !include {
+			continue
 		}
 		out = append(out, relationship)
 	}
 	return out, nil
 }
 
-func staticAuthorizationRelationship(def config.AuthorizationRelationshipDef) (*proto.Relationship, error) {
+func staticAuthorizationRelationship(
+	ctx context.Context,
+	index int,
+	def config.AuthorizationRelationshipDef,
+	users authorizationUserResolver,
+) (*proto.Relationship, bool, error) {
+	resolved, include, err := resolveStaticAuthorizationRelationshipSubject(ctx, index, def, users)
+	if err != nil || !include {
+		return nil, include, err
+	}
+	def = resolved
 	properties, err := stringPropertiesStruct(def.Properties)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	return &proto.Relationship{
 		Tuple: &proto.RelationshipTuple{
@@ -272,7 +300,52 @@ func staticAuthorizationRelationship(def config.AuthorizationRelationshipDef) (*
 		},
 		Properties:  properties,
 		SourceLayer: proto.SourceLayer_SOURCE_LAYER_STATIC_CONFIG,
-	}, nil
+	}, true, nil
+}
+
+func resolveStaticAuthorizationRelationshipSubject(
+	ctx context.Context,
+	index int,
+	def config.AuthorizationRelationshipDef,
+	users authorizationUserResolver,
+) (config.AuthorizationRelationshipDef, bool, error) {
+	subject := &def.Subject
+	if def.Target.Subject != nil {
+		targetSubject := *def.Target.Subject
+		def.Target.Subject = &targetSubject
+		subject = def.Target.Subject
+	}
+	email := strings.TrimSpace(subject.Email)
+	if email == "" {
+		return def, true, nil
+	}
+	if users == nil {
+		return def, false, fmt.Errorf("resolve subject email %q: user resolver is unavailable", email)
+	}
+	user, err := users.FindUserByEmail(ctx, email)
+	if errors.Is(err, core.ErrNotFound) {
+		slog.WarnContext(ctx, "skipping static authorization relationship for unknown user email",
+			"relationship_index", index,
+			"email", email,
+			"relation", strings.TrimSpace(def.Relation),
+			"resource_type", strings.TrimSpace(def.Resource.Type),
+			"resource_id", strings.TrimSpace(def.Resource.ID),
+		)
+		return def, false, nil
+	}
+	if err != nil {
+		return def, false, fmt.Errorf("resolve subject email %q: %w", email, err)
+	}
+	if user == nil || strings.TrimSpace(user.ID) == "" {
+		return def, false, fmt.Errorf("resolve subject email %q: user has no canonical id", email)
+	}
+	userID := strings.TrimSpace(user.ID)
+	if principal.ClassifyUserSubjectValue(userID) != principal.UserSubjectFormCanonical {
+		return def, false, fmt.Errorf("resolve subject email %q: user id %q is not canonical", email, userID)
+	}
+	subject.ID = principal.UserSubjectID(userID)
+	subject.Email = ""
+	return def, true, nil
 }
 
 func staticAuthorizationRelationshipTarget(def config.AuthorizationRelationshipDef) *proto.RelationshipTarget {

--- a/gestaltd/internal/bootstrap/authorization_bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/authorization_bootstrap_test.go
@@ -748,6 +748,14 @@ func TestStaticAuthorizationRelationshipsResolveSubjectEmails(t *testing.T) {
 				Relation: "viewer",
 				Resource: config.AuthorizationResourceDef{Type: "app", ID: "three"},
 			},
+			{
+				Subject: config.AuthorizationSubjectDef{Type: "subject", Email: "ignored@example.com"},
+				Target: config.AuthorizationRelationshipTargetDef{
+					Resource: &config.AuthorizationResourceDef{Type: "app", ID: "parent"},
+				},
+				Relation: "viewer",
+				Resource: config.AuthorizationResourceDef{Type: "app", ID: "child"},
+			},
 		},
 	}
 	users := &stubAuthorizationUserResolver{users: map[string]*core.User{
@@ -759,7 +767,7 @@ func TestStaticAuthorizationRelationshipsResolveSubjectEmails(t *testing.T) {
 	if err != nil {
 		t.Fatalf("staticAuthorizationRelationships: %v", err)
 	}
-	if got, want := len(relationships), 3; got != want {
+	if got, want := len(relationships), 4; got != want {
 		t.Fatalf("relationships count = %d, want %d", got, want)
 	}
 	gotSubjects := []string{
@@ -774,6 +782,9 @@ func TestStaticAuthorizationRelationshipsResolveSubjectEmails(t *testing.T) {
 	}
 	if !reflect.DeepEqual(gotSubjects, wantSubjects) {
 		t.Fatalf("relationship subjects = %#v, want %#v", gotSubjects, wantSubjects)
+	}
+	if got, want := relationships[3].GetTuple().GetTarget().GetResource().GetId(), "parent"; got != want {
+		t.Fatalf("resource target id = %q, want %q", got, want)
 	}
 	if wantCalls := []string{"alice@example.com", "bob@example.com", "missing@example.com"}; !reflect.DeepEqual(users.calls, wantCalls) {
 		t.Fatalf("user lookup calls = %#v, want %#v", users.calls, wantCalls)

--- a/gestaltd/internal/bootstrap/authorization_bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/authorization_bootstrap_test.go
@@ -2,10 +2,12 @@ package bootstrap
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"net/http"
 	"reflect"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -90,7 +92,7 @@ func TestBootstrapAuthorizationProviderStatePreservesRuntimeRelationships(t *tes
 		},
 	}
 
-	err := bootstrapAuthorizationProviderState(context.Background(), cfg, map[string]core.AuthorizationProvider{"authz": provider})
+	err := bootstrapAuthorizationProviderState(context.Background(), cfg, map[string]core.AuthorizationProvider{"authz": provider}, nil)
 	if err != nil {
 		t.Fatalf("bootstrapAuthorizationProviderState: %v", err)
 	}
@@ -233,7 +235,7 @@ func TestBootstrapAuthorizationProviderStateSkipsRemoteProvider(t *testing.T) {
 		},
 	}
 
-	if err := bootstrapAuthorizationProviderState(context.Background(), cfg, map[string]core.AuthorizationProvider{"authz": provider}); err != nil {
+	if err := bootstrapAuthorizationProviderState(context.Background(), cfg, map[string]core.AuthorizationProvider{"authz": provider}, nil); err != nil {
 		t.Fatalf("bootstrapAuthorizationProviderState: %v", err)
 	}
 	if provider.setAuthorizationState != nil {
@@ -330,7 +332,7 @@ func TestBootstrapAuthorizationProviderStateAuthorizesProviderGatewayRequests(t 
 		},
 	}
 	provider := &statefulAuthorizationProvider{}
-	if err := bootstrapAuthorizationProviderState(context.Background(), cfg, map[string]core.AuthorizationProvider{"authz": provider}); err != nil {
+	if err := bootstrapAuthorizationProviderState(context.Background(), cfg, map[string]core.AuthorizationProvider{"authz": provider}, nil); err != nil {
 		t.Fatalf("bootstrapAuthorizationProviderState: %v", err)
 	}
 
@@ -701,13 +703,167 @@ func authorizationBootstrapTestConfig(applyEnabled *bool) *config.Config {
 	}
 }
 
+type stubAuthorizationUserResolver struct {
+	users map[string]*core.User
+	err   error
+	calls []string
+}
+
+func (s *stubAuthorizationUserResolver) FindUserByEmail(_ context.Context, email string) (*core.User, error) {
+	s.calls = append(s.calls, email)
+	if s.err != nil {
+		return nil, s.err
+	}
+	user, ok := s.users[email]
+	if !ok {
+		return nil, core.ErrNotFound
+	}
+	return user, nil
+}
+
+func TestStaticAuthorizationRelationshipsResolveSubjectEmails(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.AuthorizationConfig{
+		Relationships: []config.AuthorizationRelationshipDef{
+			{
+				Subject:  config.AuthorizationSubjectDef{Type: "subject", Email: "alice@example.com"},
+				Relation: "viewer",
+				Resource: config.AuthorizationResourceDef{Type: "app", ID: "one"},
+			},
+			{
+				Target: config.AuthorizationRelationshipTargetDef{
+					Subject: &config.AuthorizationSubjectDef{Type: "subject", Email: "bob@example.com"},
+				},
+				Relation: "admin",
+				Resource: config.AuthorizationResourceDef{Type: "app", ID: "two"},
+			},
+			{
+				Subject:  config.AuthorizationSubjectDef{Type: "subject", Email: "missing@example.com"},
+				Relation: "viewer",
+				Resource: config.AuthorizationResourceDef{Type: "app", ID: "skipped"},
+			},
+			{
+				Subject:  config.AuthorizationSubjectDef{Type: "subject", ID: "service_account:unchanged"},
+				Relation: "viewer",
+				Resource: config.AuthorizationResourceDef{Type: "app", ID: "three"},
+			},
+		},
+	}
+	users := &stubAuthorizationUserResolver{users: map[string]*core.User{
+		"alice@example.com": {ID: "11111111-1111-4111-8111-111111111111"},
+		"bob@example.com":   {ID: "22222222-2222-4222-8222-222222222222"},
+	}}
+
+	relationships, err := staticAuthorizationRelationships(context.Background(), cfg, users)
+	if err != nil {
+		t.Fatalf("staticAuthorizationRelationships: %v", err)
+	}
+	if got, want := len(relationships), 3; got != want {
+		t.Fatalf("relationships count = %d, want %d", got, want)
+	}
+	gotSubjects := []string{
+		relationships[0].GetTuple().GetTarget().GetSubject().GetId(),
+		relationships[1].GetTuple().GetTarget().GetSubject().GetId(),
+		relationships[2].GetTuple().GetTarget().GetSubject().GetId(),
+	}
+	wantSubjects := []string{
+		"user:11111111-1111-4111-8111-111111111111",
+		"user:22222222-2222-4222-8222-222222222222",
+		"service_account:unchanged",
+	}
+	if !reflect.DeepEqual(gotSubjects, wantSubjects) {
+		t.Fatalf("relationship subjects = %#v, want %#v", gotSubjects, wantSubjects)
+	}
+	if wantCalls := []string{"alice@example.com", "bob@example.com", "missing@example.com"}; !reflect.DeepEqual(users.calls, wantCalls) {
+		t.Fatalf("user lookup calls = %#v, want %#v", users.calls, wantCalls)
+	}
+}
+
+func TestStaticAuthorizationRelationshipsAbortOnUserLookupFailure(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.AuthorizationConfig{
+		Relationships: []config.AuthorizationRelationshipDef{{
+			Subject:  config.AuthorizationSubjectDef{Type: "subject", Email: "alice@example.com"},
+			Relation: "viewer",
+			Resource: config.AuthorizationResourceDef{Type: "app", ID: "one"},
+		}},
+	}
+	users := &stubAuthorizationUserResolver{err: errors.New("database unavailable")}
+
+	_, err := staticAuthorizationRelationships(context.Background(), cfg, users)
+	if err == nil || !strings.Contains(err.Error(), `resolve subject email "alice@example.com": database unavailable`) {
+		t.Fatalf("staticAuthorizationRelationships error = %v, want lookup failure", err)
+	}
+}
+
+func TestBootstrapAuthorizationProviderStateResolvesEmailsInPlanOnlyMode(t *testing.T) {
+	t.Parallel()
+
+	provider := &recordingAuthorizationProvider{}
+	cfg := authorizationBootstrapTestConfig(boolPtr(false))
+	cfg.Authorization.Relationships[0].Subject = config.AuthorizationSubjectDef{
+		Type:  "subject",
+		Email: "alice@example.com",
+	}
+	users := &stubAuthorizationUserResolver{users: map[string]*core.User{
+		"alice@example.com": {ID: "11111111-1111-4111-8111-111111111111"},
+	}}
+
+	if err := bootstrapAuthorizationProviderState(
+		context.Background(),
+		cfg,
+		map[string]core.AuthorizationProvider{"authz": provider},
+		users,
+	); err != nil {
+		t.Fatalf("bootstrapAuthorizationProviderState: %v", err)
+	}
+	if provider.setAuthorizationState != nil {
+		t.Fatal("SetAuthorizationState should not be called in plan-only mode")
+	}
+	if want := []string{"alice@example.com"}; !reflect.DeepEqual(users.calls, want) {
+		t.Fatalf("user lookup calls = %#v, want %#v", users.calls, want)
+	}
+}
+
+func TestBootstrapAuthorizationProviderStateAppliesCanonicalEmailSubject(t *testing.T) {
+	t.Parallel()
+
+	provider := &recordingAuthorizationProvider{}
+	cfg := authorizationBootstrapTestConfig(boolPtr(true))
+	cfg.Authorization.Relationships[0].Subject = config.AuthorizationSubjectDef{
+		Type:  "subject",
+		Email: "alice@example.com",
+	}
+	users := &stubAuthorizationUserResolver{users: map[string]*core.User{
+		"alice@example.com": {ID: "11111111-1111-4111-8111-111111111111"},
+	}}
+
+	if err := bootstrapAuthorizationProviderState(
+		context.Background(),
+		cfg,
+		map[string]core.AuthorizationProvider{"authz": provider},
+		users,
+	); err != nil {
+		t.Fatalf("bootstrapAuthorizationProviderState: %v", err)
+	}
+	relationships := provider.setAuthorizationState.GetRelationships()
+	if got, want := len(relationships), 1; got != want {
+		t.Fatalf("applied relationships count = %d, want %d", got, want)
+	}
+	if got, want := relationships[0].GetTuple().GetTarget().GetSubject().GetId(), "user:11111111-1111-4111-8111-111111111111"; got != want {
+		t.Fatalf("applied subject id = %q, want %q", got, want)
+	}
+}
+
 func TestBootstrapAuthorizationProviderStateDefaultsToPlanOnly(t *testing.T) {
 	t.Parallel()
 
 	provider := &recordingAuthorizationProvider{}
 	cfg := authorizationBootstrapTestConfig(nil)
 
-	if err := bootstrapAuthorizationProviderState(context.Background(), cfg, map[string]core.AuthorizationProvider{"authz": provider}); err != nil {
+	if err := bootstrapAuthorizationProviderState(context.Background(), cfg, map[string]core.AuthorizationProvider{"authz": provider}, nil); err != nil {
 		t.Fatalf("bootstrapAuthorizationProviderState: %v", err)
 	}
 	if provider.setAuthorizationState != nil {
@@ -721,7 +877,7 @@ func TestBootstrapAuthorizationProviderStateExplicitFalseSkipsApply(t *testing.T
 	provider := &recordingAuthorizationProvider{}
 	cfg := authorizationBootstrapTestConfig(boolPtr(false))
 
-	if err := bootstrapAuthorizationProviderState(context.Background(), cfg, map[string]core.AuthorizationProvider{"authz": provider}); err != nil {
+	if err := bootstrapAuthorizationProviderState(context.Background(), cfg, map[string]core.AuthorizationProvider{"authz": provider}, nil); err != nil {
 		t.Fatalf("bootstrapAuthorizationProviderState: %v", err)
 	}
 	if provider.setAuthorizationState != nil {
@@ -735,7 +891,7 @@ func TestBootstrapAuthorizationProviderStateEnvEnablesApply(t *testing.T) {
 	provider := &recordingAuthorizationProvider{}
 	cfg := authorizationBootstrapTestConfig(nil)
 
-	if err := bootstrapAuthorizationProviderState(context.Background(), cfg, map[string]core.AuthorizationProvider{"authz": provider}); err != nil {
+	if err := bootstrapAuthorizationProviderState(context.Background(), cfg, map[string]core.AuthorizationProvider{"authz": provider}, nil); err != nil {
 		t.Fatalf("bootstrapAuthorizationProviderState: %v", err)
 	}
 	if provider.setAuthorizationState == nil {
@@ -749,7 +905,7 @@ func TestBootstrapAuthorizationProviderStateConfigOverridesEnv(t *testing.T) {
 	provider := &recordingAuthorizationProvider{}
 	cfg := authorizationBootstrapTestConfig(boolPtr(false))
 
-	if err := bootstrapAuthorizationProviderState(context.Background(), cfg, map[string]core.AuthorizationProvider{"authz": provider}); err != nil {
+	if err := bootstrapAuthorizationProviderState(context.Background(), cfg, map[string]core.AuthorizationProvider{"authz": provider}, nil); err != nil {
 		t.Fatalf("bootstrapAuthorizationProviderState: %v", err)
 	}
 	if provider.setAuthorizationState != nil {
@@ -762,7 +918,7 @@ func TestBootstrapAuthorizationProviderStatePlanAndApplyProduceSameDigest(t *tes
 
 	planProvider := &recordingAuthorizationProvider{}
 	planCfg := authorizationBootstrapTestConfig(boolPtr(false))
-	if err := bootstrapAuthorizationProviderState(context.Background(), planCfg, map[string]core.AuthorizationProvider{"authz": planProvider}); err != nil {
+	if err := bootstrapAuthorizationProviderState(context.Background(), planCfg, map[string]core.AuthorizationProvider{"authz": planProvider}, nil); err != nil {
 		t.Fatalf("bootstrapAuthorizationProviderState (plan): %v", err)
 	}
 	planModel, err := staticAuthorizationModel(planCfg)
@@ -776,7 +932,7 @@ func TestBootstrapAuthorizationProviderStatePlanAndApplyProduceSameDigest(t *tes
 
 	applyProvider := &recordingAuthorizationProvider{}
 	applyCfg := authorizationBootstrapTestConfig(boolPtr(true))
-	if err := bootstrapAuthorizationProviderState(context.Background(), applyCfg, map[string]core.AuthorizationProvider{"authz": applyProvider}); err != nil {
+	if err := bootstrapAuthorizationProviderState(context.Background(), applyCfg, map[string]core.AuthorizationProvider{"authz": applyProvider}, nil); err != nil {
 		t.Fatalf("bootstrapAuthorizationProviderState (apply): %v", err)
 	}
 	if applyProvider.setAuthorizationState == nil {

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -1131,7 +1131,7 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 			_ = closeAuthorizationProviders(authorizationProviders)
 		}
 	}()
-	if err := bootstrapAuthorizationProviderState(ctx, cfg, authorizationProviders); err != nil {
+	if err := bootstrapAuthorizationProviderState(ctx, cfg, authorizationProviders, svc.Users); err != nil {
 		_ = closeAuthProviders(authProviders)
 		return nil, err
 	}

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -29,6 +29,7 @@ import (
 	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
 	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/coredata"
 	"github.com/valon-technologies/gestalt/server/internal/indexeddbcodec"
 	"github.com/valon-technologies/gestalt/server/internal/testutil/metrictest"
 	"github.com/valon-technologies/gestalt/server/internal/workflowwire"
@@ -1894,9 +1895,39 @@ func TestBootstrapAuthorizationProviderStateUsesProviderGatewayTransport(t *test
 	cfg.Providers.Authorization = map[string]*config.ProviderEntry{
 		"authz": {Config: yaml.Node{Kind: yaml.MappingNode}},
 	}
+	cfg.Authorization = config.AuthorizationConfig{
+		Models: map[string]config.AuthorizationModelDef{
+			"default": {
+				ResourceTypes: map[string]config.AuthorizationResourceTypeDef{
+					"app": {
+						Relations: map[string]config.AuthorizationRelationDef{
+							"admin": {SubjectTypes: []string{"subject"}},
+						},
+					},
+				},
+			},
+		},
+		Relationships: []config.AuthorizationRelationshipDef{{
+			Subject:  config.AuthorizationSubjectDef{Type: "subject", Email: "alice@example.com"},
+			Relation: "admin",
+			Resource: config.AuthorizationResourceDef{Type: "app", ID: "example"},
+		}},
+	}
 
 	var built []*bootstrapTransportRecordingAuthorizationProvider
+	db := &coretesting.StubIndexedDB{}
+	seedServices, err := coredata.New(db)
+	if err != nil {
+		t.Fatalf("create seed services: %v", err)
+	}
+	alice, err := seedServices.Users.FindOrCreateUser(context.Background(), "alice@example.com")
+	if err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
 	factories := validFactories()
+	factories.IndexedDB = func(yaml.Node) (indexeddb.IndexedDB, error) {
+		return db, nil
+	}
 	factories.Secrets["test-secrets"] = func(yaml.Node) (core.SecretManager, error) {
 		return &coretesting.StubSecretManager{Secrets: map[string]string{}}, nil
 	}
@@ -1921,6 +1952,13 @@ func TestBootstrapAuthorizationProviderStateUsesProviderGatewayTransport(t *test
 	}
 	if result.Authorization["authz"] != provider {
 		t.Fatal("bootstrapped authorization provider is not the runtime authorization provider")
+	}
+	relationships := provider.setAuthorizationState.GetRelationships()
+	if got, want := len(relationships), 1; got != want {
+		t.Fatalf("authorization relationships = %d, want %d", got, want)
+	}
+	if got, want := relationships[0].GetTuple().GetTarget().GetSubject().GetId(), principal.UserSubjectID(alice.ID); got != want {
+		t.Fatalf("authorization subject = %q, want %q", got, want)
 	}
 }
 

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -1889,6 +1889,7 @@ type AuthorizationRelationshipDef struct {
 type AuthorizationSubjectDef struct {
 	Type       string            `yaml:"type,omitempty"`
 	ID         string            `yaml:"id,omitempty"`
+	Email      string            `yaml:"email,omitempty"`
 	Properties map[string]string `yaml:"properties,omitempty"`
 }
 
@@ -3682,6 +3683,7 @@ func normalizedAuthorizationRelationshipDef(def AuthorizationRelationshipDef) Au
 func normalizedAuthorizationSubjectDef(def AuthorizationSubjectDef) AuthorizationSubjectDef {
 	def.Type = strings.TrimSpace(def.Type)
 	def.ID = strings.TrimSpace(def.ID)
+	def.Email = strings.ToLower(strings.TrimSpace(def.Email))
 	if len(def.Properties) == 0 {
 		def.Properties = nil
 	} else {

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -1087,6 +1087,111 @@ func TestValidateAuthorizationRelationshipAllowsExplicitSubjectSetTarget(t *test
 	}
 }
 
+func TestLoadAuthorizationRelationshipSubjectEmails(t *testing.T) {
+	t.Parallel()
+
+	path := mustWriteConfigFile(t, `
+authorization:
+  models:
+    default:
+      resourceTypes:
+        app:
+          relations:
+            admin:
+              subjectTypes: [subject]
+  relationships:
+    - subject:
+        type: subject
+        email: " Alice@Example.COM "
+      relation: admin
+      resource:
+        type: app
+        id: one
+    - target:
+        subject:
+          type: subject
+          email: " BOB@example.com "
+      relation: admin
+      resource:
+        type: app
+        id: two
+`)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := cfg.Authorization.Relationships[0].Subject.Email; got != "alice@example.com" {
+		t.Fatalf("subject email = %q, want alice@example.com", got)
+	}
+	if got := cfg.Authorization.Relationships[1].Target.Subject.Email; got != "bob@example.com" {
+		t.Fatalf("target subject email = %q, want bob@example.com", got)
+	}
+}
+
+func TestValidateAuthorizationRelationshipSubjectEmail(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		subject AuthorizationSubjectDef
+		wantErr string
+	}{
+		{
+			name:    "id and email",
+			subject: AuthorizationSubjectDef{Type: "subject", ID: "user:alice", Email: "alice@example.com"},
+			wantErr: "must set exactly one of id or email",
+		},
+		{
+			name:    "neither id nor email",
+			subject: AuthorizationSubjectDef{Type: "subject"},
+			wantErr: "must set exactly one of id or email",
+		},
+		{
+			name:    "email on non-user subject type",
+			subject: AuthorizationSubjectDef{Type: "service_account", Email: "alice@example.com"},
+			wantErr: `email requires type "subject"`,
+		},
+		{
+			name:    "malformed email",
+			subject: AuthorizationSubjectDef{Type: "subject", Email: "Alice <alice@example.com>"},
+			wantErr: "email must be a valid bare email address",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := &Config{
+				APIVersion: ConfigAPIVersion,
+				Authorization: AuthorizationConfig{
+					Models: map[string]AuthorizationModelDef{
+						"default": {
+							ResourceTypes: map[string]AuthorizationResourceTypeDef{
+								"app": {
+									Relations: map[string]AuthorizationRelationDef{
+										"admin": {SubjectTypes: []string{"subject"}},
+									},
+								},
+							},
+						},
+					},
+					Relationships: []AuthorizationRelationshipDef{{
+						Subject:  tc.subject,
+						Relation: "admin",
+						Resource: AuthorizationResourceDef{Type: "app", ID: "example"},
+					}},
+				},
+			}
+			err := ValidateStructure(cfg)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("ValidateStructure error = %v, want substring %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
 func TestNormalizedAuthorizationRelationshipTargetDefCopiesSubjectSet(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"maps"
 	"net"
+	"net/mail"
 	"net/url"
 	"os"
 	"path"
@@ -1887,8 +1888,20 @@ func validateAuthorizationSubjectDef(path string, subject AuthorizationSubjectDe
 	if strings.TrimSpace(subject.Type) == "" {
 		return fmt.Errorf("config validation: %s.type is required", path)
 	}
-	if strings.TrimSpace(subject.ID) == "" {
-		return fmt.Errorf("config validation: %s.id is required", path)
+	id := strings.TrimSpace(subject.ID)
+	email := strings.TrimSpace(subject.Email)
+	if (id == "") == (email == "") {
+		return fmt.Errorf("config validation: %s must set exactly one of id or email", path)
+	}
+	if email == "" {
+		return nil
+	}
+	if strings.TrimSpace(subject.Type) != "subject" {
+		return fmt.Errorf("config validation: %s.email requires type %q", path, "subject")
+	}
+	address, err := mail.ParseAddress(email)
+	if err != nil || address.Address != email {
+		return fmt.Errorf("config validation: %s.email must be a valid bare email address", path)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- add mutually exclusive `subject.email` support for static authorization relationships and normalize email references case-insensitively
- resolve existing emails through the system users store to canonical `user:<uuid>` subjects during plan and apply bootstrap
- skip unknown emails with a structured warning while failing safely on ambiguous users or database errors
- document the syntax and cover top-level subjects, target subjects, plan-only startup, and full bootstrap wiring

## Test plan
- [x] `go test ./internal/config ./internal/bootstrap ./internal/coredata ./services/identity/principal`
- [x] `go test ./... -run '^$'`
- [x] `go vet ./...`

Made with [Cursor](https://cursor.com)