### PR TITLE
Print mounted app URL after local serve

### DIFF
--- a/gestaltd/internal/daemon/provider_local.go
+++ b/gestaltd/internal/daemon/provider_local.go
@@ -577,13 +577,14 @@ func logProviderLocalSummary(message string, session *providerLocalSession) {
 }
 
 func providerLocalReadyURL(session *providerLocalSession) string {
-	if session == nil || strings.TrimSpace(session.AutoMountedUIPath) == "" {
-		if session == nil {
-			return ""
-		}
+	if session == nil {
+		return ""
+	}
+	mountPath := strings.Trim(strings.TrimSpace(session.AutoMountedUIPath), "/")
+	if mountPath == "" {
 		return session.PublicURL
 	}
-	return strings.TrimRight(session.PublicURL, "/") + "/" + strings.Trim(session.AutoMountedUIPath, "/") + "/"
+	return strings.TrimRight(session.PublicURL, "/") + "/" + mountPath + "/"
 }
 
 func reserveLocalPort() (int, error) {

--- a/gestaltd/internal/daemon/provider_local.go
+++ b/gestaltd/internal/daemon/provider_local.go
@@ -540,6 +540,7 @@ func logProviderLocalSummary(message string, session *providerLocalSession) {
 	if session == nil {
 		return
 	}
+	readyURL := providerLocalReadyURL(session)
 	publicUIPaths := session.PublicUIPaths
 	if len(publicUIPaths) == 0 {
 		publicUIPaths = nil
@@ -547,6 +548,7 @@ func logProviderLocalSummary(message string, session *providerLocalSession) {
 	detailArgs := []any{
 		"config_files", session.ConfigPaths,
 		"public_url", session.PublicURL,
+		"ready_url", readyURL,
 		"admin_url", session.AdminURL,
 		"mounted_ui_paths", publicUIPaths,
 	}
@@ -567,11 +569,21 @@ func logProviderLocalSummary(message string, session *providerLocalSession) {
 		)
 	}
 	if strings.Contains(message, "ready") {
-		currentCLIReporter().Status(message + ": " + session.PublicURL)
+		currentCLIReporter().Status(message + ": " + readyURL)
 	} else {
 		currentCLIReporter().Status(message)
 	}
 	currentCLIReporter().Verbose(formatCLIFields(message+" details", detailArgs...))
+}
+
+func providerLocalReadyURL(session *providerLocalSession) string {
+	if session == nil || strings.TrimSpace(session.AutoMountedUIPath) == "" {
+		if session == nil {
+			return ""
+		}
+		return session.PublicURL
+	}
+	return strings.TrimRight(session.PublicURL, "/") + "/" + strings.Trim(session.AutoMountedUIPath, "/") + "/"
 }
 
 func reserveLocalPort() (int, error) {

--- a/gestaltd/internal/daemon/provider_local_serve_test.go
+++ b/gestaltd/internal/daemon/provider_local_serve_test.go
@@ -28,6 +28,14 @@ func TestProviderLocalReadyURL(t *testing.T) {
 			want: "http://localhost:8080/",
 		},
 		{
+			name: "provider with root-mounted UI",
+			session: &providerLocalSession{
+				PublicURL:         "http://localhost:8080/",
+				AutoMountedUIPath: "/",
+			},
+			want: "http://localhost:8080/",
+		},
+		{
 			name: "provider with mounted UI",
 			session: &providerLocalSession{
 				PublicURL:         "http://localhost:8080/",

--- a/gestaltd/internal/daemon/provider_local_serve_test.go
+++ b/gestaltd/internal/daemon/provider_local_serve_test.go
@@ -7,6 +7,44 @@ import (
 	"testing"
 )
 
+func TestProviderLocalReadyURL(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name    string
+		session *providerLocalSession
+		want    string
+	}{
+		{
+			name:    "nil session",
+			session: nil,
+			want:    "",
+		},
+		{
+			name: "provider without mounted UI",
+			session: &providerLocalSession{
+				PublicURL: "http://localhost:8080/",
+			},
+			want: "http://localhost:8080/",
+		},
+		{
+			name: "provider with mounted UI",
+			session: &providerLocalSession{
+				PublicURL:         "http://localhost:8080/",
+				AutoMountedUIPath: "/data-platform-dashboard",
+			},
+			want: "http://localhost:8080/data-platform-dashboard/",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			if got := providerLocalReadyURL(test.session); got != test.want {
+				t.Fatalf("providerLocalReadyURL() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
 func TestMaybeRunServeProviderLocalRejectsLockedWithoutConfig(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Problem Statement

`gestaltd serve` reports only the daemon root after starting an app with a mounted development UI, leaving developers to discover the actual app path themselves.

## Solution

Report the selected app's user-facing mounted URL when one is available, while preserving the daemon root output for providers without a mounted UI.

### App Operations

- Change local serve readiness output from `http://localhost:8080/` to `http://localhost:8080/<mounted-app>/` for mounted UIs.
- Include the resolved ready URL in verbose startup details.
- Add coverage for mounted UI, provider-only, and nil sessions.

### Workflows

None.

## Test plan

- [x] `go test ./internal/daemon -run 'TestProviderLocalReadyURL|TestMaybeRunServeProviderLocal'`

Made with [Cursor](https://cursor.com)