### PR TITLE
Fix local serve frontend URL and tunneled header overrides

### DIFF
--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -2274,6 +2274,7 @@ func buildAppStaticSpec(name string, entry *config.ProviderEntry, manifest *prov
 		ConnectionParams: appservice.ConnectionParamDefsFromManifest(conn.ConnectionParams),
 		CredentialFields: appservice.CredentialFieldsFromManifest(conn.Auth.Credentials),
 		DiscoveryConfig:  appservice.DiscoveryConfigFromManifest(conn.Discovery),
+		StaticHeaders:    maps.Clone(manifest.Spec.Headers),
 	}, plan, nil
 }
 

--- a/gestaltd/internal/bootstrap/startup_app_proxy.go
+++ b/gestaltd/internal/bootstrap/startup_app_proxy.go
@@ -105,6 +105,15 @@ func (p *startupProviderProxy) Catalog() *catalog.Catalog {
 	return p.spec.Catalog.Clone()
 }
 
+func (p *startupProviderProxy) StaticHeaders() map[string]string {
+	if provider := p.resolved(); provider != nil {
+		if headers, ok := provider.(interface{ StaticHeaders() map[string]string }); ok {
+			return maps.Clone(headers.StaticHeaders())
+		}
+	}
+	return maps.Clone(p.spec.StaticHeaders)
+}
+
 func (p *startupProviderProxy) Execute(ctx context.Context, operation string, params map[string]any, token string) (*core.OperationResult, error) {
 	done, err := p.beginCallerWait(ctx)
 	if err != nil {

--- a/gestaltd/internal/bootstrap/startup_proxy_test.go
+++ b/gestaltd/internal/bootstrap/startup_proxy_test.go
@@ -50,6 +50,24 @@ func TestStartupProviderProxyLazilyActivatesAndFailsFast(t *testing.T) {
 	}
 }
 
+func TestStartupProviderProxyExposesStaticHeadersBeforeActivation(t *testing.T) {
+	t.Parallel()
+
+	proxy := newStartupProviderProxy(appservice.StaticProviderSpec{
+		Name:          "deferred",
+		StaticHeaders: map[string]string{"X-Tenant-Sid": "TENDefault"},
+	}, startupOperationRouting{}, nil)
+
+	headers := proxy.StaticHeaders()
+	if headers["X-Tenant-Sid"] != "TENDefault" {
+		t.Fatalf("StaticHeaders() = %#v, want X-Tenant-Sid", headers)
+	}
+	headers["X-Tenant-Sid"] = "mutated"
+	if got := proxy.StaticHeaders()["X-Tenant-Sid"]; got != "TENDefault" {
+		t.Fatalf("StaticHeaders() returned mutable proxy state: %q", got)
+	}
+}
+
 func TestStartupProviderProxySurfacesActivationFailure(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/daemon/provider_local.go
+++ b/gestaltd/internal/daemon/provider_local.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/server/internal/config"
@@ -555,6 +556,7 @@ func logProviderLocalReady(env *bootstrapEnv, session *providerLocalSession) {
 		if !ok {
 			if env.Ctx.Err() == nil {
 				currentCLIReporter().Warning("local frontend did not become ready")
+				logProviderLocalSummary("local provider ready", session)
 			}
 			return
 		}
@@ -570,12 +572,22 @@ type providerLocalFrontend interface {
 
 type providerLocalFrontendLookup func(string) (providerLocalFrontend, bool)
 
+const providerLocalFrontendReadyTimeout = 30 * time.Second
+
 func waitProviderLocalFrontend(ctx context.Context, providersInitialized <-chan struct{}, lookup providerLocalFrontendLookup, app string) (string, bool) {
+	return waitProviderLocalFrontendWithin(ctx, providersInitialized, lookup, app, providerLocalFrontendReadyTimeout)
+}
+
+func waitProviderLocalFrontendWithin(ctx context.Context, providersInitialized <-chan struct{}, lookup providerLocalFrontendLookup, app string, timeout time.Duration) (string, bool) {
 	if lookup == nil || providersInitialized == nil {
 		return "", false
 	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
 	select {
 	case <-providersInitialized:
+	case <-timer.C:
+		return "", false
 	case <-ctx.Done():
 		return "", false
 	}
@@ -587,6 +599,8 @@ func waitProviderLocalFrontend(ctx context.Context, providersInitialized <-chan 
 	case <-handle.FrontendReady():
 		return handle.FrontendURL(), true
 	case <-handle.AllExited():
+		return "", false
+	case <-timer.C:
 		return "", false
 	case <-ctx.Done():
 		return "", false

--- a/gestaltd/internal/daemon/provider_local.go
+++ b/gestaltd/internal/daemon/provider_local.go
@@ -582,12 +582,8 @@ func waitProviderLocalFrontendWithin(ctx context.Context, providersInitialized <
 	if lookup == nil || providersInitialized == nil {
 		return "", false
 	}
-	timer := time.NewTimer(timeout)
-	defer timer.Stop()
 	select {
 	case <-providersInitialized:
-	case <-timer.C:
-		return "", false
 	case <-ctx.Done():
 		return "", false
 	}
@@ -595,6 +591,8 @@ func waitProviderLocalFrontendWithin(ctx context.Context, providersInitialized <
 	if !ok {
 		return "", false
 	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
 	select {
 	case <-handle.FrontendReady():
 		return handle.FrontendURL(), true

--- a/gestaltd/internal/daemon/provider_local.go
+++ b/gestaltd/internal/daemon/provider_local.go
@@ -141,7 +141,7 @@ func runServeProviderLocal(opts providerLocalCommandOptions) error {
 	session.PublicURL = providerLocalPublicURL(env.Config)
 	session.AdminURL = strings.TrimRight(session.PublicURL, "/") + "/admin/"
 	return runServerWithReady(env, opts.GestaltdVersion, func() {
-		logProviderLocalSummary("local provider ready", session)
+		logProviderLocalReady(env, session)
 	})
 }
 
@@ -536,11 +536,71 @@ func mountedPublicUIPaths(cfg *config.Config) []string {
 	return slices.Compact(paths)
 }
 
-func logProviderLocalSummary(message string, session *providerLocalSession) {
+func logProviderLocalReady(env *bootstrapEnv, session *providerLocalSession) {
 	if session == nil {
 		return
 	}
-	readyURL := providerLocalReadyURL(session)
+	if strings.TrimSpace(session.AutoMountedUIPath) == "" {
+		logProviderLocalSummary("local provider ready", session)
+		return
+	}
+	go func() {
+		var lookup providerLocalFrontendLookup
+		if env.Result.DevSupervisor != nil {
+			lookup = func(app string) (providerLocalFrontend, bool) {
+				return env.Result.DevSupervisor.AppHandle(app)
+			}
+		}
+		readyURL, ok := waitProviderLocalFrontend(env.Ctx, env.Result.AppProvidersInitialized, lookup, session.TargetKey)
+		if !ok {
+			if env.Ctx.Err() == nil {
+				currentCLIReporter().Warning("local frontend did not become ready")
+			}
+			return
+		}
+		logProviderLocalSummaryAt("local frontend ready", session, readyURL)
+	}()
+}
+
+type providerLocalFrontend interface {
+	FrontendReady() <-chan struct{}
+	AllExited() <-chan struct{}
+	FrontendURL() string
+}
+
+type providerLocalFrontendLookup func(string) (providerLocalFrontend, bool)
+
+func waitProviderLocalFrontend(ctx context.Context, providersInitialized <-chan struct{}, lookup providerLocalFrontendLookup, app string) (string, bool) {
+	if lookup == nil || providersInitialized == nil {
+		return "", false
+	}
+	select {
+	case <-providersInitialized:
+	case <-ctx.Done():
+		return "", false
+	}
+	handle, ok := lookup(app)
+	if !ok {
+		return "", false
+	}
+	select {
+	case <-handle.FrontendReady():
+		return handle.FrontendURL(), true
+	case <-handle.AllExited():
+		return "", false
+	case <-ctx.Done():
+		return "", false
+	}
+}
+
+func logProviderLocalSummary(message string, session *providerLocalSession) {
+	logProviderLocalSummaryAt(message, session, providerLocalReadyURL(session))
+}
+
+func logProviderLocalSummaryAt(message string, session *providerLocalSession, readyURL string) {
+	if session == nil {
+		return
+	}
 	publicUIPaths := session.PublicUIPaths
 	if len(publicUIPaths) == 0 {
 		publicUIPaths = nil

--- a/gestaltd/internal/daemon/provider_local_serve_test.go
+++ b/gestaltd/internal/daemon/provider_local_serve_test.go
@@ -1,11 +1,72 @@
 package daemon
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+type fakeProviderLocalFrontend struct {
+	ready  chan struct{}
+	exited chan struct{}
+	url    string
+}
+
+func (f fakeProviderLocalFrontend) FrontendReady() <-chan struct{} { return f.ready }
+func (f fakeProviderLocalFrontend) AllExited() <-chan struct{}     { return f.exited }
+func (f fakeProviderLocalFrontend) FrontendURL() string            { return f.url }
+
+func TestWaitProviderLocalFrontend(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns direct URL after provider and frontend readiness", func(t *testing.T) {
+		t.Parallel()
+		initialized := make(chan struct{})
+		frontend := fakeProviderLocalFrontend{
+			ready:  make(chan struct{}),
+			exited: make(chan struct{}),
+			url:    "http://127.0.0.1:5173/data-platform-dashboard/",
+		}
+		close(initialized)
+		close(frontend.ready)
+		got, ok := waitProviderLocalFrontend(context.Background(), initialized, func(app string) (providerLocalFrontend, bool) {
+			if app != "data-platform-dashboard" {
+				t.Fatalf("lookup app = %q", app)
+			}
+			return frontend, true
+		}, "data-platform-dashboard")
+		if !ok || got != frontend.url {
+			t.Fatalf("waitProviderLocalFrontend() = %q, %v; want %q, true", got, ok, frontend.url)
+		}
+	})
+
+	t.Run("stops when frontend exits", func(t *testing.T) {
+		t.Parallel()
+		initialized := make(chan struct{})
+		frontend := fakeProviderLocalFrontend{ready: make(chan struct{}), exited: make(chan struct{})}
+		close(initialized)
+		close(frontend.exited)
+		if got, ok := waitProviderLocalFrontend(context.Background(), initialized, func(string) (providerLocalFrontend, bool) {
+			return frontend, true
+		}, "dashboard"); ok || got != "" {
+			t.Fatalf("waitProviderLocalFrontend() = %q, %v; want empty, false", got, ok)
+		}
+	})
+
+	t.Run("stops when startup is canceled", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		if got, ok := waitProviderLocalFrontend(ctx, make(chan struct{}), func(string) (providerLocalFrontend, bool) {
+			t.Fatal("lookup should not run")
+			return nil, false
+		}, "dashboard"); ok || got != "" {
+			t.Fatalf("waitProviderLocalFrontend() = %q, %v; want empty, false", got, ok)
+		}
+	})
+}
 
 func TestProviderLocalReadyURL(t *testing.T) {
 	t.Parallel()

--- a/gestaltd/internal/daemon/provider_local_serve_test.go
+++ b/gestaltd/internal/daemon/provider_local_serve_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 type fakeProviderLocalFrontend struct {
@@ -64,6 +65,18 @@ func TestWaitProviderLocalFrontend(t *testing.T) {
 			return nil, false
 		}, "dashboard"); ok || got != "" {
 			t.Fatalf("waitProviderLocalFrontend() = %q, %v; want empty, false", got, ok)
+		}
+	})
+
+	t.Run("stops when frontend readiness times out", func(t *testing.T) {
+		t.Parallel()
+		initialized := make(chan struct{})
+		close(initialized)
+		frontend := fakeProviderLocalFrontend{ready: make(chan struct{}), exited: make(chan struct{})}
+		if got, ok := waitProviderLocalFrontendWithin(context.Background(), initialized, func(string) (providerLocalFrontend, bool) {
+			return frontend, true
+		}, "dashboard", time.Millisecond); ok || got != "" {
+			t.Fatalf("waitProviderLocalFrontendWithin() = %q, %v; want empty, false", got, ok)
 		}
 	})
 }

--- a/gestaltd/internal/daemon/provider_local_serve_test.go
+++ b/gestaltd/internal/daemon/provider_local_serve_test.go
@@ -79,6 +79,23 @@ func TestWaitProviderLocalFrontend(t *testing.T) {
 			t.Fatalf("waitProviderLocalFrontendWithin() = %q, %v; want empty, false", got, ok)
 		}
 	})
+
+	t.Run("starts timeout after providers initialize", func(t *testing.T) {
+		t.Parallel()
+		initialized := make(chan struct{})
+		frontend := fakeProviderLocalFrontend{ready: make(chan struct{}), exited: make(chan struct{}), url: "http://127.0.0.1:5173/"}
+		close(frontend.ready)
+		go func() {
+			time.Sleep(10 * time.Millisecond)
+			close(initialized)
+		}()
+		got, ok := waitProviderLocalFrontendWithin(context.Background(), initialized, func(string) (providerLocalFrontend, bool) {
+			return frontend, true
+		}, "dashboard", time.Millisecond)
+		if !ok || got != frontend.url {
+			t.Fatalf("waitProviderLocalFrontendWithin() = %q, %v; want %q, true", got, ok, frontend.url)
+		}
+	})
 }
 
 func TestProviderLocalReadyURL(t *testing.T) {

--- a/gestaltd/internal/server/tunnel_resolver.go
+++ b/gestaltd/internal/server/tunnel_resolver.go
@@ -51,6 +51,7 @@ func (r *tunnelProviderResolver) ResolveProvider(ctx context.Context, name strin
 
 	provider, err := remotepublish.NewTunnelProxyProvider(buildCtx, remotepublish.TunnelProxyConfig{
 		AppName:        name,
+		StaticHeaders:  remotepublish.StaticHeadersFromDefinition(remoteProvider.Definition),
 		TunnelHost:     reg.TunnelHost,
 		PinnedSPKI:     reg.ServerSPKISHA256,
 		ConnectAddr:    r.cfg.ConnectAddr,

--- a/gestaltd/services/apps/provider_client.go
+++ b/gestaltd/services/apps/provider_client.go
@@ -556,6 +556,10 @@ func (p staticSpecProvider) Catalog() *catalog.Catalog {
 	return p.spec.Catalog
 }
 
+func (p staticSpecProvider) StaticHeaders() map[string]string {
+	return maps.Clone(p.spec.StaticHeaders)
+}
+
 type gestaltRemoteProvider struct {
 	staticSpecProvider
 	client proto.AppClient

--- a/gestaltd/services/apps/provider_client.go
+++ b/gestaltd/services/apps/provider_client.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"strings"
 	"time"
@@ -35,6 +36,7 @@ type StaticProviderSpec struct {
 	ConnectionParams map[string]core.ConnectionParamDef
 	CredentialFields []core.CredentialFieldDef
 	DiscoveryConfig  *core.DiscoveryConfig
+	StaticHeaders    map[string]string
 }
 
 type remoteProviderBase struct {
@@ -50,6 +52,7 @@ type remoteProviderBase struct {
 	connParams          map[string]core.ConnectionParamDef
 	credFields          []core.CredentialFieldDef
 	discovery           *core.DiscoveryConfig
+	staticHeaders       map[string]string
 	closer              io.Closer
 	publicBaseURL       string
 	callerKind          invocation.ProviderKind
@@ -126,6 +129,7 @@ func NewRemote(ctx context.Context, client proto.AppProviderClient, spec StaticP
 		connParams:          spec.ConnectionParams,
 		credFields:          spec.CredentialFields,
 		discovery:           spec.DiscoveryConfig,
+		staticHeaders:       maps.Clone(spec.StaticHeaders),
 		workflowDefinitions: append([]*proto.WorkflowDefinitionSpec(nil), support.workflowDefinitions...),
 	}
 	if base.catalog == nil && support.staticCatalog != nil {
@@ -179,6 +183,13 @@ func (p *remoteProviderBase) DeclaredWorkflowDefinitions() []*proto.WorkflowDefi
 		return nil
 	}
 	return append([]*proto.WorkflowDefinitionSpec(nil), p.workflowDefinitions...)
+}
+
+func (p *remoteProviderBase) StaticHeaders() map[string]string {
+	if p == nil || len(p.staticHeaders) == 0 {
+		return nil
+	}
+	return maps.Clone(p.staticHeaders)
 }
 
 // DeclaredWorkflowDefinitions returns workflow specs declared by a remote app

--- a/gestaltd/services/apps/provider_test.go
+++ b/gestaltd/services/apps/provider_test.go
@@ -150,6 +150,31 @@ func roundTripStaticSpec() StaticProviderSpec {
 	}
 }
 
+func TestRemoteProviderForwardsStaticHeaders(t *testing.T) {
+	t.Parallel()
+
+	client := newAppProviderClient(t, NewProviderServer(&roundTripProvider{}))
+	prov, err := NewRemote(context.Background(), client, StaticProviderSpec{
+		Name:          "roundtrip",
+		StaticHeaders: map[string]string{"X-Tenant-Sid": ""},
+	}, nil)
+	if err != nil {
+		t.Fatalf("NewRemote: %v", err)
+	}
+	headers, ok := prov.(interface{ StaticHeaders() map[string]string })
+	if !ok {
+		t.Fatal("expected remote provider to expose static headers")
+	}
+	got := headers.StaticHeaders()
+	if _, ok := got["X-Tenant-Sid"]; !ok {
+		t.Fatalf("StaticHeaders() = %#v, want X-Tenant-Sid", got)
+	}
+	got["X-Tenant-Sid"] = "mutated"
+	if next := headers.StaticHeaders()["X-Tenant-Sid"]; next != "" {
+		t.Fatalf("StaticHeaders() returned mutable provider state: %q", next)
+	}
+}
+
 func manualOnlyStaticSpec() StaticProviderSpec {
 	return StaticProviderSpec{
 		Name:           "manual-only",

--- a/gestaltd/services/apps/provider_test.go
+++ b/gestaltd/services/apps/provider_test.go
@@ -175,6 +175,23 @@ func TestRemoteProviderForwardsStaticHeaders(t *testing.T) {
 	}
 }
 
+func TestStaticSpecProviderForwardsStaticHeaders(t *testing.T) {
+	t.Parallel()
+
+	prov := newStaticSpecProvider(StaticProviderSpec{
+		Name:          "remote",
+		StaticHeaders: map[string]string{"X-Tenant-Sid": ""},
+	})
+	headers := prov.StaticHeaders()
+	if _, ok := headers["X-Tenant-Sid"]; !ok {
+		t.Fatalf("StaticHeaders() = %#v, want X-Tenant-Sid", headers)
+	}
+	headers["X-Tenant-Sid"] = "mutated"
+	if next := prov.StaticHeaders()["X-Tenant-Sid"]; next != "" {
+		t.Fatalf("StaticHeaders() returned mutable provider state: %q", next)
+	}
+}
+
 func manualOnlyStaticSpec() StaticProviderSpec {
 	return StaticProviderSpec{
 		Name:           "manual-only",

--- a/gestaltd/services/providerdev/app_supervisor.go
+++ b/gestaltd/services/providerdev/app_supervisor.go
@@ -63,6 +63,21 @@ func (h *AppHandle) SocketPath() string {
 	return h.app.target.SocketPath
 }
 
+func (h *AppHandle) FrontendURL() string {
+	if h == nil || h.app == nil {
+		return ""
+	}
+	basePath := "/" + strings.Trim(h.app.target.BasePath, "/")
+	if basePath != "/" {
+		basePath += "/"
+	}
+	return (&url.URL{
+		Scheme: "http",
+		Host:   net.JoinHostPort("127.0.0.1", strconv.Itoa(h.app.port)),
+		Path:   basePath,
+	}).String()
+}
+
 type appManaged struct {
 	target AppTarget
 	port   int
@@ -185,6 +200,19 @@ func (s *Supervisor) StartApp(ctx context.Context, target AppTarget) (*AppHandle
 	}()
 	go app.probeFrontendReadiness(appCtx, s.logger)
 	return &AppHandle{name: target.Name, app: app}, nil
+}
+
+func (s *Supervisor) AppHandle(name string) (*AppHandle, bool) {
+	if s == nil {
+		return nil, false
+	}
+	s.appsMu.RLock()
+	app, ok := s.apps[name]
+	s.appsMu.RUnlock()
+	if !ok {
+		return nil, false
+	}
+	return &AppHandle{name: name, app: app}, true
 }
 
 func (s *Supervisor) StopApp(name string) {

--- a/gestaltd/services/providerdev/app_supervisor_test.go
+++ b/gestaltd/services/providerdev/app_supervisor_test.go
@@ -12,6 +12,49 @@ import (
 	"time"
 )
 
+func TestAppHandleFrontendURL(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name     string
+		basePath string
+		want     string
+	}{
+		{name: "mounted app", basePath: "/data-platform-dashboard", want: "http://127.0.0.1:5173/data-platform-dashboard/"},
+		{name: "root mount", basePath: "/", want: "http://127.0.0.1:5173/"},
+		{name: "empty mount", want: "http://127.0.0.1:5173/"},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			handle := &AppHandle{app: &appManaged{
+				target: AppTarget{BasePath: tc.basePath},
+				port:   5173,
+			}}
+			if got := handle.FrontendURL(); got != tc.want {
+				t.Fatalf("FrontendURL() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSupervisorAppHandle(t *testing.T) {
+	t.Parallel()
+
+	app := &appManaged{target: AppTarget{Name: "dashboard"}, port: 5173}
+	supervisor := &Supervisor{apps: map[string]*appManaged{"dashboard": app}}
+	handle, ok := supervisor.AppHandle("dashboard")
+	if !ok {
+		t.Fatal("AppHandle(dashboard) not found")
+	}
+	if handle.app != app {
+		t.Fatal("AppHandle(dashboard) returned a different managed app")
+	}
+	if _, ok := supervisor.AppHandle("missing"); ok {
+		t.Fatal("AppHandle(missing) unexpectedly found")
+	}
+}
+
 func TestProbeFrontendReadinessTimeoutBehavior(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/services/remotepublish/groups.go
+++ b/gestaltd/services/remotepublish/groups.go
@@ -70,6 +70,14 @@ func appProviderDefinition(name string, entry *config.ProviderEntry) map[string]
 			if entry.ResolvedManifest.Source != "" {
 				def["source"] = entry.ResolvedManifest.Source
 			}
+			if spec := entry.ResolvedManifest.Spec; spec != nil && len(spec.Headers) > 0 {
+				headerNames := make([]string, 0, len(spec.Headers))
+				for name := range spec.Headers {
+					headerNames = append(headerNames, name)
+				}
+				slices.Sort(headerNames)
+				def["staticHeaders"] = headerNames
+			}
 		}
 	}
 	return def

--- a/gestaltd/services/remotepublish/publisher_test.go
+++ b/gestaltd/services/remotepublish/publisher_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/publicrpc"
 	"github.com/valon-technologies/gestalt/server/internal/tunnel"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"github.com/valon-technologies/gestalt/server/services/apps/registry"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 	"github.com/valon-technologies/gestalt/server/services/remotemanagement"
@@ -292,8 +293,16 @@ func TestBuildPublicationGroupsPlacementMatrix(t *testing.T) {
 			},
 		},
 		Apps: map[string]*config.ProviderEntry{
-			"local-app":     {Remote: ""},
-			"published-app": {Remote: "upstream", DevActive: true},
+			"local-app": {Remote: ""},
+			"published-app": {
+				Remote:    "upstream",
+				DevActive: true,
+				ResolvedManifest: &providermanifestv1.Manifest{
+					Spec: &providermanifestv1.Spec{
+						Headers: map[string]string{"X-Tenant-Sid": "TENDefault"},
+					},
+				},
+			},
 			"delegated-app": {Remote: "upstream"},
 		},
 	}
@@ -313,6 +322,10 @@ func TestBuildPublicationGroupsPlacementMatrix(t *testing.T) {
 	}
 	if groups[0].Providers[0].Name != "published-app" {
 		t.Fatalf("expected published-app, got %s", groups[0].Providers[0].Name)
+	}
+	headers := remotepublish.StaticHeadersFromDefinition(groups[0].Providers[0].Definition)
+	if _, ok := headers["X-Tenant-Sid"]; !ok {
+		t.Fatalf("published static headers = %#v, want X-Tenant-Sid", headers)
 	}
 }
 

--- a/gestaltd/services/remotepublish/tunnel_app_provider.go
+++ b/gestaltd/services/remotepublish/tunnel_app_provider.go
@@ -2,6 +2,8 @@ package remotepublish
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
 	"strings"
 	"sync"
 
@@ -14,6 +16,7 @@ import (
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	appservice "github.com/valon-technologies/gestalt/server/services/apps"
 	"github.com/valon-technologies/gestalt/server/services/apps/registry"
+	"github.com/valon-technologies/gestalt/server/services/egress"
 )
 
 // TunnelAppProviderServer implements proto.AppProviderServer over the reverse
@@ -44,6 +47,7 @@ func NewTunnelAppProviderServer(providers *registry.ProviderMap[core.Provider]) 
 
 // tunnelAppMetadataKey is the gRPC metadata key carrying the target app name.
 const tunnelAppMetadataKey = "x-gestalt-app"
+const tunnelHeaderOverridesMetadataKey = "x-gestalt-header-overrides-bin"
 
 func appFromContext(ctx context.Context) (string, error) {
 	md, ok := metadata.FromIncomingContext(ctx)
@@ -110,6 +114,10 @@ func (s *TunnelAppProviderServer) Execute(ctx context.Context, req *proto.Execut
 	if err != nil {
 		return nil, err
 	}
+	ctx, err = s.applyHeaderOverrides(ctx)
+	if err != nil {
+		return nil, err
+	}
 	return srv.Execute(ctx, req)
 }
 
@@ -118,7 +126,71 @@ func (s *TunnelAppProviderServer) ExecuteStream(req *proto.ExecuteRequest, strea
 	if err != nil {
 		return err
 	}
-	return srv.ExecuteStream(req, stream)
+	ctx, err := s.applyHeaderOverrides(stream.Context())
+	if err != nil {
+		return err
+	}
+	return srv.ExecuteStream(req, &tunnelExecuteStreamServer{
+		AppProvider_ExecuteStreamServer: stream,
+		ctx:                             ctx,
+	})
+}
+
+type tunnelExecuteStreamServer struct {
+	proto.AppProvider_ExecuteStreamServer
+	ctx context.Context
+}
+
+func (s *tunnelExecuteStreamServer) Context() context.Context { return s.ctx }
+
+func (s *TunnelAppProviderServer) applyHeaderOverrides(ctx context.Context) (context.Context, error) {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return ctx, nil
+	}
+	values := md.Get(tunnelHeaderOverridesMetadataKey)
+	if len(values) == 0 {
+		return ctx, nil
+	}
+	if len(values) != 1 {
+		return nil, status.Error(codes.InvalidArgument, "header override metadata must have one value")
+	}
+	requested := map[string]string{}
+	if err := json.Unmarshal([]byte(values[0]), &requested); err != nil {
+		return nil, status.Error(codes.InvalidArgument, "header override metadata is invalid")
+	}
+	appName, err := appFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	provider, err := s.providers.GetWithContext(ctx, appName)
+	if err != nil {
+		return nil, status.Errorf(codes.NotFound, "app %q not found", appName)
+	}
+	allowedProvider, ok := provider.(interface{ StaticHeaders() map[string]string })
+	if !ok {
+		return nil, status.Error(codes.InvalidArgument, "provider does not allow header overrides")
+	}
+	allowed := allowedProvider.StaticHeaders()
+	validated := make(map[string]string, len(requested))
+	for name, value := range requested {
+		canonical := http.CanonicalHeaderKey(strings.TrimSpace(name))
+		if canonical == "" || strings.TrimSpace(value) == "" {
+			return nil, status.Error(codes.InvalidArgument, "header override metadata contains an empty name or value")
+		}
+		matched := false
+		for allowedName := range allowed {
+			if http.CanonicalHeaderKey(allowedName) == canonical {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return nil, status.Errorf(codes.InvalidArgument, "header %q is not overridable for provider", canonical)
+		}
+		validated[canonical] = value
+	}
+	return egress.WithOutboundHeaderOverrides(ctx, validated), nil
 }
 
 func (s *TunnelAppProviderServer) ResolveHTTPSubject(ctx context.Context, req *proto.ResolveHTTPSubjectRequest) (*proto.ResolveHTTPSubjectResponse, error) {

--- a/gestaltd/services/remotepublish/tunnel_app_provider_test.go
+++ b/gestaltd/services/remotepublish/tunnel_app_provider_test.go
@@ -4,18 +4,23 @@ import (
 	"context"
 	"testing"
 
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	"github.com/valon-technologies/gestalt/server/services/apps/registry"
+	"github.com/valon-technologies/gestalt/server/services/egress"
 )
 
 // stubProvider is a minimal core.Provider for testing.
 type stubProvider struct {
-	name string
+	name            string
+	staticHeaders   map[string]string
+	capturedHeaders map[string]string
 }
 
 func (s *stubProvider) Name() string                                            { return s.name }
@@ -28,7 +33,9 @@ func (s *stubProvider) CredentialFields() []core.CredentialFieldDef             
 func (s *stubProvider) DiscoveryConfig() *core.DiscoveryConfig                  { return nil }
 func (s *stubProvider) ConnectionForOperation(string) string                    { return "" }
 func (s *stubProvider) Catalog() *catalog.Catalog                               { return nil }
-func (s *stubProvider) Execute(_ context.Context, _ string, _ map[string]any, _ string) (*core.OperationResult, error) {
+func (s *stubProvider) StaticHeaders() map[string]string                        { return s.staticHeaders }
+func (s *stubProvider) Execute(ctx context.Context, _ string, _ map[string]any, _ string) (*core.OperationResult, error) {
+	s.capturedHeaders = egress.OutboundHeaderOverridesFromContext(ctx)
 	return &core.OperationResult{Status: 200, Body: []byte(`{"app":"` + s.name + `"}`)}, nil
 }
 
@@ -62,6 +69,68 @@ func TestTunnelAppProviderServerDispatchByMetadata(t *testing.T) {
 	}
 	if string(resp.Body) != `{"app":"ci-cd"}` {
 		t.Fatalf("Execute returned wrong body: %s", resp.Body)
+	}
+}
+
+func TestTunnelAppProviderServerAppliesValidatedHeaderOverrides(t *testing.T) {
+	t.Parallel()
+	reg := registry.New()
+	providers := &reg.Providers
+	provider := &stubProvider{
+		name:          "front-porch",
+		staticHeaders: map[string]string{"X-Tenant-Sid": "TENDefault"},
+	}
+	if err := providers.Register("front-porch", provider); err != nil {
+		t.Fatal(err)
+	}
+	server := NewTunnelAppProviderServer(providers)
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(
+		tunnelAppMetadataKey, "front-porch",
+		tunnelHeaderOverridesMetadataKey, `{"X-Tenant-Sid":"TENSelected"}`,
+	))
+	if _, err := server.Execute(ctx, &proto.ExecuteRequest{}); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+	if got := provider.capturedHeaders["X-Tenant-Sid"]; got != "TENSelected" {
+		t.Fatalf("captured X-Tenant-Sid = %q, want TENSelected", got)
+	}
+}
+
+func TestTunnelAppProviderServerRejectsUndeclaredHeaderOverride(t *testing.T) {
+	t.Parallel()
+	reg := registry.New()
+	providers := &reg.Providers
+	if err := providers.Register("front-porch", &stubProvider{
+		name:          "front-porch",
+		staticHeaders: map[string]string{"X-Tenant-Sid": "TENDefault"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	server := NewTunnelAppProviderServer(providers)
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(
+		tunnelAppMetadataKey, "front-porch",
+		tunnelHeaderOverridesMetadataKey, `{"X-Unsafe":"value"}`,
+	))
+	if _, err := server.Execute(ctx, &proto.ExecuteRequest{}); status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("Execute error = %v, want InvalidArgument", err)
+	}
+}
+
+func TestMetadataAppProviderClientCarriesHeaderOverrides(t *testing.T) {
+	t.Parallel()
+	client := &metadataAppProviderClient{appName: "front-porch"}
+	ctx := egress.WithOutboundHeaderOverrides(context.Background(), map[string]string{
+		"X-Tenant-Sid": "TENSelected",
+	})
+	md, ok := metadata.FromOutgoingContext(client.withApp(ctx))
+	if !ok {
+		t.Fatal("outgoing metadata is missing")
+	}
+	if got := md.Get(tunnelAppMetadataKey); len(got) != 1 || got[0] != "front-porch" {
+		t.Fatalf("app metadata = %#v", got)
+	}
+	if got := md.Get(tunnelHeaderOverridesMetadataKey); len(got) != 1 || got[0] != `{"X-Tenant-Sid":"TENSelected"}` {
+		t.Fatalf("header override metadata = %#v", got)
 	}
 }
 

--- a/gestaltd/services/remotepublish/tunnel_proxy_provider.go
+++ b/gestaltd/services/remotepublish/tunnel_proxy_provider.go
@@ -3,6 +3,7 @@ package remotepublish
 import (
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
 	"net"
 	"strings"
@@ -16,6 +17,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/tunnel"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	appservice "github.com/valon-technologies/gestalt/server/services/apps"
+	"github.com/valon-technologies/gestalt/server/services/egress"
 )
 
 // TunnelProxyConfig holds the parameters needed to build a tunnel proxy
@@ -122,7 +124,13 @@ type metadataAppProviderClient struct {
 }
 
 func (c *metadataAppProviderClient) withApp(ctx context.Context) context.Context {
-	return metadata.AppendToOutgoingContext(ctx, tunnelAppMetadataKey, c.appName)
+	pairs := []string{tunnelAppMetadataKey, c.appName}
+	if overrides := egress.OutboundHeaderOverridesFromContext(ctx); len(overrides) > 0 {
+		if encoded, err := json.Marshal(overrides); err == nil {
+			pairs = append(pairs, tunnelHeaderOverridesMetadataKey, string(encoded))
+		}
+	}
+	return metadata.AppendToOutgoingContext(ctx, pairs...)
 }
 
 func (c *metadataAppProviderClient) GetMetadata(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*proto.ProviderMetadata, error) {

--- a/gestaltd/services/remotepublish/tunnel_proxy_provider.go
+++ b/gestaltd/services/remotepublish/tunnel_proxy_provider.go
@@ -22,6 +22,7 @@ import (
 // provider that forwards app invocations through a reverse tunnel.
 type TunnelProxyConfig struct {
 	AppName        string
+	StaticHeaders  map[string]string
 	TunnelHost     string
 	PinnedSPKI     string
 	ConnectAddr    string
@@ -67,7 +68,8 @@ func NewTunnelProxyProvider(ctx context.Context, cfg TunnelProxyConfig) (core.Pr
 	}
 
 	provider, err := appservice.NewRemote(ctx, client, appservice.StaticProviderSpec{
-		Name: name,
+		Name:          name,
+		StaticHeaders: cfg.StaticHeaders,
 	}, nil, appservice.WithCloser(conn))
 	if err != nil {
 		_ = conn.Close()
@@ -75,6 +77,38 @@ func NewTunnelProxyProvider(ctx context.Context, cfg TunnelProxyConfig) (core.Pr
 	}
 
 	return provider, nil
+}
+
+// StaticHeadersFromDefinition returns the header names a published provider
+// declared as overridable. Values are intentionally omitted from publication
+// metadata because only the names are needed for invocation validation.
+func StaticHeadersFromDefinition(definition map[string]any) map[string]string {
+	raw, ok := definition["staticHeaders"]
+	if !ok {
+		return nil
+	}
+	var names []string
+	switch values := raw.(type) {
+	case []string:
+		names = values
+	case []any:
+		names = make([]string, 0, len(values))
+		for _, value := range values {
+			if name, ok := value.(string); ok {
+				names = append(names, name)
+			}
+		}
+	}
+	headers := make(map[string]string, len(names))
+	for _, name := range names {
+		if name = strings.TrimSpace(name); name != "" {
+			headers[name] = ""
+		}
+	}
+	if len(headers) == 0 {
+		return nil
+	}
+	return headers
 }
 
 // metadataAppProviderClient wraps an AppProviderClient to inject the


### PR DESCRIPTION
## Problem Statement

`gestaltd serve` reports the protected daemon mount for local apps instead of the dynamically assigned hot-reload frontend URL. In addition, remote app tunnel proxies discard the static-header allowlist, causing valid tenant-scoped nested invocations to fail with `provider does not allow header overrides`.

## Solution

Expose the supervised frontend's assigned URL and report it only after the frontend has bound successfully. Preserve declared overridable header names through remote publication and tunnel resolution without publishing their static values.

### App Operations

- Report `http://127.0.0.1:<port>/<mount>/` for mounted development UIs.
- Wait asynchronously for app-provider initialization and frontend readiness.
- Preserve static-header validation metadata on remote tunnel proxies.

### Workflows

None.

## Test plan

- [x] `go test ./services/apps ./services/invocation ./services/remotepublish ./internal/server ./services/providerdev ./internal/daemon`
- [x] `git diff --check`

Made with [Cursor](https://cursor.com)