### PR TITLE
Document Gestalt app preview environments

### DIFF
--- a/plans/preview_environments/plan.md
+++ b/plans/preview_environments/plan.md
@@ -2,56 +2,38 @@
 
 ## Status
 
-Proposed. This plan defines a reusable preview-environment foundation and a
-`valon-tools/apps/ci-cd` pilot. It does not authorize implementation or production
-rollout by itself.
+Proposed. This plan defines a reusable preview-environment foundation and a `valon-tools/apps/ci-cd` pilot. It does not authorize implementation or production rollout by itself.
 
 ## Overview
 
-Gestalt app authors can run a frontend locally with hot module replacement, but
-backend changes that need production integrations, authorization, or workflows are
-still difficult to verify without deploying the app to production. CI/CD is the
-first pilot because its pages depend on correlated GitHub, Linear, workqueue, and
-deployment data, and because its merge-readiness feature needs real caller
-authorization.
+Gestalt app authors can run a frontend locally with hot module replacement, but backend changes that need production integrations, authorization, or workflows are still difficult to verify without deploying the app to production. CI/CD is the first pilot because its pages depend on correlated GitHub, Linear, workqueue, and deployment data, and because its merge-readiness feature needs real caller authorization.
 
 The proposed development loop is:
 
 1. An internal pull request publishes an immutable app snapshot for its exact commit.
 2. Trusted automation creates or updates a dedicated preview `gestaltd` service.
-3. The branch app provider runs in that preview with isolated application and workflow
-   storage.
+3. The branch app provider runs in that preview with isolated application and workflow storage.
 4. A loopback-only Vite proxy sends local browser API requests to the preview.
-5. The preview validates the developer's real Gestalt bearer and delegates only an
-   explicit set of integration reads through a least-privilege preview identity.
+5. The preview validates the developer's real Gestalt bearer and delegates only an explicit set of integration reads through a least-privilege preview identity.
 6. App workflows are installed paused and may be run manually.
 7. Closing or expiring the pull request deletes all preview resources.
 
-This is deliberately a separate control plane. A preview must not be a no-traffic
-revision of the production `toolshed-test` Cloud Run service, a production app-registry
-candidate, or a reverse-published provider that shadows a production app.
+This is deliberately a separate control plane. A preview must not be a no-traffic revision of the production `toolshed-test` Cloud Run service, a production app-registry candidate, or a reverse-published provider that shadows a production app.
 
 ## Goals
 
-- Run a branch version of a Gestalt app backend remotely without changing production
-  traffic or provider selection.
+- Run a branch version of a Gestalt app backend remotely without changing production traffic or provider selection.
 - Keep frontend source and HMR local.
-- Exercise real caller authentication and authorization, including CI/CD's admin-only
-  `pullRequests.mergeReadiness`.
-- Let developers materialize one or two representative records and inspect workflow
-  inputs, intermediate values, outputs, and logs.
-- Install app-declared workflows without allowing schedules or event activations to
-  run automatically.
-- Reuse the same preview deployment contract for other Gestalt apps after the CI/CD
-  pilot.
-- Make preview creation, update, attachment, reset, and teardown deterministic enough
-  for agents to execute and verify.
+- Exercise real caller authentication and authorization, including CI/CD's admin-only `pullRequests.mergeReadiness`.
+- Let developers materialize one or two representative records and inspect workflow inputs, intermediate values, outputs, and logs.
+- Install app-declared workflows without allowing schedules or event activations to run automatically.
+- Reuse the same preview deployment contract for other Gestalt apps after the CI/CD pilot.
+- Make preview creation, update, attachment, reset, and teardown deterministic enough for agents to execute and verify.
 
 ## Non-goals
 
 - Sending production traffic to preview code.
-- Testing production migrations, production writes, merge-queue mutations,
-  notifications, or fast-track actions.
+- Testing production migrations, production writes, merge-queue mutations, notifications, or fast-track actions.
 - Cloning the production Gestalt control-plane database.
 - Sharing production Temporal state or task queues.
 - Making reverse provider publication subject-aware as part of this pilot.
@@ -64,31 +46,17 @@ candidate, or a reverse-published provider that shadows a production app.
 
 ### Local UI to remote API already works
 
-The CI/CD app's
-`valon-tools/apps/ci-cd/scripts/dev-ui-remote.sh` starts Vite on loopback, obtains a
-Gestalt API token, and sets `GESTALT_API_PROXY_TARGET`. The Gestalt Vite plugin in
-`sdk/typescript-web/src/vite.js` proxies `/api/v1` and `/api/v2`, adding the bearer
-server-side so it is not exposed to frontend JavaScript.
+The CI/CD app's `valon-tools/apps/ci-cd/scripts/dev-ui-remote.sh` starts Vite on loopback, obtains a Gestalt API token, and sets `GESTALT_API_PROXY_TARGET`. The Gestalt Vite plugin in `sdk/typescript-web/src/vite.js` proxies `/api/v1` and `/api/v2`, adding the bearer server-side so it is not exposed to frontend JavaScript.
 
-The missing piece is a safe branch backend URL. Today the script points at
-`https://valon.tools`, so it can validate local UI changes only against the already
-deployed provider.
+The missing piece is a safe branch backend URL. Today the script points at `https://valon.tools`, so it can validate local UI changes only against the already deployed provider.
 
 ### Branch snapshots can already be built
 
-Toolshed's `.github/workflows/publish-app-snapshot.yml` accepts an app and arbitrary
-branch, tag, or SHA. It packages immutable
-`0.0.0-snapshot.g<full-commit-sha>` artifacts. The workflow currently packages branch
-code and later authenticates to GCP in the same job, which is acceptable for trusted
-main-branch publishing but is not an adequate boundary for automated pull-request
-previews. Branch-controlled code can leave a process running until credentials are
-minted later in the job.
+Toolshed's `.github/workflows/publish-app-snapshot.yml` accepts an app and arbitrary branch, tag, or SHA. It packages immutable `0.0.0-snapshot.g<full-commit-sha>` artifacts. The workflow currently packages branch code and later authenticates to GCP in the same job, which is acceptable for trusted main-branch publishing but is not an adequate boundary for automated pull-request previews. Branch-controlled code can leave a process running until credentials are minted later in the job.
 
 ### Gestalt config has most placement primitives
 
-Gestalt supports left-to-right config overlays, named remotes, local and remote
-provider placement, source overrides, distinct public and management listeners, and
-app-specific IndexedDB bindings. Useful implementation points include:
+Gestalt supports left-to-right config overlays, named remotes, local and remote provider placement, source overrides, distinct public and management listeners, and app-specific IndexedDB bindings. Useful implementation points include:
 
 - `gestaltd/internal/config/config.go`
 - `gestaltd/internal/config/remotes.go`
@@ -96,67 +64,41 @@ app-specific IndexedDB bindings. Useful implementation points include:
 - `gestaltd/internal/daemon/provider_local.go`
 - `gestaltd/internal/bootstrap/provider_build.go`
 
-These are building blocks, not a preview-isolation mode. Safe composition remains the
-deployment's responsibility.
+These are building blocks, not a preview-isolation mode. Safe composition remains the deployment's responsibility.
 
 ### Remote authentication is currently static
 
-`gestaltd/internal/remote/remote.go` attaches one configured bearer token to every RPC
-on a named remote. Consequently, merely marking production identity and authorization
-providers `remote: prod` does **not** preserve the interactive caller: it authenticates
-the preview's configured relay token instead.
+`gestaltd/internal/remote/remote.go` attaches one configured bearer token to every RPC on a named remote. Consequently, merely marking production identity and authorization providers `remote: prod` does **not** preserve the interactive caller: it authenticates the preview's configured relay token instead.
 
 The preview requires two distinct upstream authentication modes:
 
-- **Caller forwarding** for production identity and authorization, using the bearer
-  from the incoming local-UI request.
+- **Caller forwarding** for production identity and authorization, using the bearer from the incoming local-UI request.
 - **Static preview relay identity** for explicitly allowlisted integration operations.
 
-This must be implemented as an explicit Gestalt remote-auth contract. The preview must
-not infer or copy browser cookies, forward arbitrary caller headers, or give branch
-code direct access to either token.
+This must be implemented as an explicit Gestalt remote-auth contract. The preview must not infer or copy browser cookies, forward arbitrary caller headers, or give branch code direct access to either token.
 
 ### Shared storage is unsafe
 
-Gestalt's config exposes `apps.<name>.indexeddb.db` and `objectStores`, but the current
-host-service bootstrap does not provide enough evidence that these fields form a hard
-runtime isolation boundary for every provider. Relevant paths are:
+Gestalt's config exposes `apps.<name>.indexeddb.db` and `objectStores`, but the current host-service bootstrap does not provide enough evidence that these fields form a hard runtime isolation boundary for every provider. Relevant paths are:
 
 - `gestaltd/internal/config/provider_selection.go`
 - `gestaltd/internal/bootstrap/host_service_bootstrap.go`
 - `gestaltd/services/indexeddb/server.go`
 - `gestaltd/internal/bootstrap/executable_app_test.go`
 
-Until provider-backed isolation is enforced and tested end to end, every preview must
-receive a separate physical database or a separate provider credential constrained to
-one preview schema. A different logical `db` string on a shared privileged provider is
-not sufficient.
+Until provider-backed isolation is enforced and tested end to end, every preview must receive a separate physical database or a separate provider credential constrained to one preview schema. A different logical `db` string on a shared privileged provider is not sufficient.
 
-The same requirement applies to Gestalt core state: users, app installations,
-rollouts, authorization fragments, and remote registrations must not share the
-production control-plane database.
+The same requirement applies to Gestalt core state: users, app installations, rollouts, authorization fragments, and remote registrations must not share the production control-plane database.
 
 ### Workflow startup mutates provider state
 
-App-declared workflows are read from provider metadata and reconciled at startup by
-`gestaltd/internal/bootstrap/workflow_app_definitions.go`. Config-managed definitions
-are similarly reconciled by `workflow_config_definitions.go`. Reconciliation applies
-definitions and removes absent managed definitions. A preview connected to production
-Temporal could update, pause, activate, or delete production workflow state before any
-HTTP request reaches it.
+App-declared workflows are read from provider metadata and reconciled at startup by `gestaltd/internal/bootstrap/workflow_app_definitions.go`. Config-managed definitions are similarly reconciled by `workflow_config_definitions.go`. Reconciliation applies definitions and removes absent managed definitions. A preview connected to production Temporal could update, pause, activate, or delete production workflow state before any HTTP request reaches it.
 
-Definitions and activations already have paused flags, but deployment config cannot
-currently force app-declared workflows paused before their first reconciliation.
-Pausing after startup leaves a race with the first scheduled tick.
+Definitions and activations already have paused flags, but deployment config cannot currently force app-declared workflows paused before their first reconciliation. Pausing after startup leaves a race with the first scheduled tick.
 
 ### Reverse publication is not a preview boundary
 
-Reverse-published providers are resolved globally by kind and app name. A registered
-`app/ci-cd` takes precedence over the production provider for all callers; provider
-ownership is also global. Making this subject-aware would touch registration storage,
-provider resolution, app catalogs, mounted UI routing, workflows, auditing, fallback,
-and authorization. It is larger and riskier than a dedicated preview service and does
-not naturally solve storage isolation.
+Reverse-published providers are resolved globally by kind and app name. A registered `app/ci-cd` takes precedence over the production provider for all callers; provider ownership is also global. Making this subject-aware would touch registration storage, provider resolution, app catalogs, mounted UI routing, workflows, auditing, fallback, and authorization. It is larger and riskier than a dedicated preview service and does not naturally solve storage isolation.
 
 ## Desired End State
 
@@ -178,14 +120,10 @@ The command:
 2. Obtains the developer's Gestalt token without exposing it to the browser.
 3. Obtains and refreshes Cloud Run invocation identity.
 4. Starts Vite on `127.0.0.1`.
-5. Proxies API calls to the preview with independent Cloud Run and Gestalt
-   authorization headers.
-6. Prints commands for materializing a PR, starting a workflow manually, viewing its
-   JSON output, and opening logs.
+5. Proxies API calls to the preview with independent Cloud Run and Gestalt authorization headers.
+6. Prints commands for materializing a PR, starting a workflow manually, viewing its JSON output, and opening logs.
 
-The preview persists its isolated database across branch-provider updates. A reset
-action destroys and recreates only that preview's data. It is removed on PR close and
-also by a hard-lifetime sweeper.
+The preview persists its isolated database across branch-provider updates. A reset action destroys and recreates only that preview's data. It is removed on PR close and also by a hard-lifetime sweeper.
 
 ## Architecture
 
@@ -213,33 +151,17 @@ flowchart LR
 
 There are three identities and they must remain separate:
 
-1. **Cloud Run invoker** proves that the local proxy may reach the preview service. It
-   is carried in `X-Serverless-Authorization`.
-2. **Interactive Gestalt caller** is the developer's existing Gestalt bearer in
-   `Authorization`. Production identity validates it, and production authorization
-   evaluates that caller's relationships. This is what makes admin and non-admin
-   merge-readiness behavior realistic.
-3. **Preview integration relay** is a dedicated non-human Gestalt principal used only
-   for the named remote apps and operations allowed by the preview manifest. It is not
-   `service_account:ci-cd-sync` and has no mutation authority.
+1. **Cloud Run invoker** proves that the local proxy may reach the preview service. It is carried in `X-Serverless-Authorization`.
+2. **Interactive Gestalt caller** is the developer's existing Gestalt bearer in `Authorization`. Production identity validates it, and production authorization evaluates that caller's relationships. This is what makes admin and non-admin merge-readiness behavior realistic.
+3. **Preview integration relay** is a dedicated non-human Gestalt principal used only for the named remote apps and operations allowed by the preview manifest. It is not `service_account:ci-cd-sync` and has no mutation authority.
 
-Gestalt never passes the interactive caller bearer to branch provider code. Gestalt
-mediates host-service and remote app calls.
+Gestalt never passes the interactive caller bearer to branch provider code. Gestalt mediates host-service and remote app calls.
 
 ### Branch-code trust boundary
 
-An internal PR provider is still arbitrary code running beside `gestaltd`. The current
-local-provider process model is not a hardened sandbox, so the pilot must assume that a
-compromised provider can exercise the preview runtime identity and any static relay
-authority available to the process. Secret non-exposure alone is not the security
-boundary.
+An internal PR provider is still arbitrary code running beside `gestaltd`. The current local-provider process model is not a hardened sandbox, so the pilot must assume that a compromised provider can exercise the preview runtime identity and any static relay authority available to the process. Secret non-exposure alone is not the security boundary.
 
-Therefore the runtime identity grants only preview resource access, and the relay
-grants only operations whose production read results are acceptable for the approved
-internal PR author to see. The relay has no write, impersonation, token-minting,
-secret-reading, or broader discovery authority. Forks remain ineligible. Stronger
-subprocess/container isolation can reduce this trust later, but it is not a prerequisite
-for a read-only internal pilot and must not be implied by this plan.
+Therefore the runtime identity grants only preview resource access, and the relay grants only operations whose production read results are acceptable for the approved internal PR author to see. The relay has no write, impersonation, token-minting, secret-reading, or broader discovery authority. Forks remain ineligible. Stronger subprocess/container isolation can reduce this trust later, but it is not a prerequisite for a read-only internal pilot and must not be implied by this plan.
 
 ### Provider placement
 
@@ -249,15 +171,11 @@ The generated final overlay for a CI/CD preview uses:
 - Local preview IndexedDB provider backed by preview-constrained credentials.
 - Local preview workflow provider and workflow storage.
 - Caller-forwarding remote for identity and authorization.
-- Static-relay remote for an exact set of GitHub, Linear, Valon Profile, Datadog, and
-  Valkey operations.
+- Static-relay remote for an exact set of GitHub, Linear, Valon Profile, Datadog, and Valkey operations.
 - No remote IndexedDB or workflow provider.
 - No production registry reconciliation.
 
-Dependencies that cannot operate with the preview relay's least-privilege grants are
-excluded from the pilot. Automatic schedules remain blocked; lack of an integration
-may produce an explicit partial result but must not silently fall back to a production
-service account.
+Dependencies that cannot operate with the preview relay's least-privilege grants are excluded from the pilot. Automatic schedules remain blocked; lack of an integration may produce an explicit partial result but must not silently fall back to a production service account.
 
 ### Network surface
 
@@ -265,50 +183,33 @@ service account.
 - The public listener exposes app and normal public API routes only.
 - The management listener binds to loopback and is not mapped by Cloud Run.
 - `/activate`, `/admin`, and management metrics are not externally reachable.
-- Vite binds to `127.0.0.1`, validates the browser origin, and keeps both credentials
-  server-side.
+- Vite binds to `127.0.0.1`, validates the browser origin, and keeps both credentials server-side.
 - No preview adds permissive CORS headers to production or Gestalt.
 
 ## Safety Invariants
 
-The implementation is incomplete until all invariants are mechanically enforced or
-tested:
+The implementation is incomplete until all invariants are mechanically enforced or tested:
 
-1. Preview automation never updates the production `toolshed-test` Cloud Run service,
-   revision tags, traffic, or config.
-2. Every preview has a unique service, datastore credential, encryption key, runtime
-   identity, resource labels, and expiry.
+1. Preview automation never updates the production `toolshed-test` Cloud Run service, revision tags, traffic, or config.
+2. Every preview has a unique service, datastore credential, encryption key, runtime identity, resource labels, and expiry.
 3. Preview control-plane, app, and workflow state cannot address production storage.
-4. Branch-controlled code never executes in a job after GCP publication or deployment
-   credentials are minted.
-5. Preview artifacts are selected by full commit SHA and verified digest, never a
-   mutable branch name.
+4. Branch-controlled code never executes in a job after GCP publication or deployment credentials are minted.
+5. Preview artifacts are selected by full commit SHA and verified digest, never a mutable branch name.
 6. Only internal pull requests or explicitly approved commits can receive previews.
 7. `server.authorizationStateApply` is false and the environment override is unset.
-8. The developer's bearer is forwarded only to the configured identity/authorization
-   remote over HTTPS.
-9. Integration calls use a separate least-privilege relay and exact app-operation
-   allowlists.
-10. The production `ci-cd-sync` token, production database DSN, and production Temporal
-    credentials are never available to branch code.
-11. App-declared workflow definitions and activations are forced paused before their
-    first reconciliation.
+8. The developer's bearer is forwarded only to the configured identity/authorization remote over HTTPS.
+9. Integration calls use a separate least-privilege relay and exact app-operation allowlists.
+10. The production `ci-cd-sync` token, production database DSN, and production Temporal credentials are never available to branch code.
+11. App-declared workflow definitions and activations are forced paused before their first reconciliation.
 12. Management routes are private to the container.
-13. Production app-registry activation, rollout evaluation, and authorization-state
-    writes are disabled.
-14. Preview config, IAM, secret bindings, placement, and egress are trusted inputs;
-    a pull request cannot replace them.
-15. Preview services, databases, credentials, keys, and secrets are deleted on close
-    and by a maximum-age sweeper.
-16. Resources and logs carry repository, app, PR, owner, source SHA, workflow run, and
-    expiry labels.
+13. Production app-registry activation, rollout evaluation, and authorization-state writes are disabled.
+14. Preview config, IAM, secret bindings, placement, and egress are trusted inputs; a pull request cannot replace them.
+15. Preview services, databases, credentials, keys, and secrets are deleted on close and by a maximum-age sweeper.
+16. Resources and logs carry repository, app, PR, owner, source SHA, workflow run, and expiry labels.
 
 ## Implementation Approach
 
-Deliver the capability in six phases. Phases 1 and 2 establish reusable Gestalt and
-publication safety. Phase 3 creates one manually triggered CI/CD preview. Phases 4 and
-5 provide the useful developer loop and lifecycle automation. Phase 6 generalizes only
-the parts proven by the pilot.
+Deliver the capability in six phases. Phases 1 and 2 establish reusable Gestalt and publication safety. Phase 3 creates one manually triggered CI/CD preview. Phases 4 and 5 provide the useful developer loop and lifecycle automation. Phase 6 generalizes only the parts proven by the pilot.
 
 ## Phase 1: Gestalt Preview Safety Primitives
 
@@ -326,9 +227,7 @@ the parts proven by the pilot.
 
 **Changes**
 
-Replace the implicit token-only remote contract with a backward-compatible explicit
-auth shape. Existing `token` continues to mean a static bearer. Add a mode that forwards
-the incoming bearer from trusted request context:
+Replace the implicit token-only remote contract with a backward-compatible explicit auth shape. Existing `token` continues to mean a static bearer. Add a mode that forwards the incoming bearer from trusted request context:
 
 ```yaml
 server:
@@ -343,18 +242,14 @@ Validation must:
 
 - Reject `forwardBearer` with a static token.
 - Require HTTPS except for loopback tests.
-- Allow the mode only when the remote is referenced by explicitly supported provider
-  kinds.
+- Allow the mode only when the remote is referenced by explicitly supported provider kinds.
 - Never forward cookies or arbitrary authorization-like headers.
 - Fail unauthenticated background calls instead of falling back to another identity.
 - Redact bearer values from logs and errors.
 
-The HTTP/gRPC request boundary must capture the raw bearer into a private context value
-before remote identity resolution. Public gRPC must continue stripping caller-supplied
-trusted-principal metadata. Remote interceptors read only the private context value.
+The HTTP/gRPC request boundary must capture the raw bearer into a private context value before remote identity resolution. Public gRPC must continue stripping caller-supplied trusted-principal metadata. Remote interceptors read only the private context value.
 
-Use one caller-forwarding remote for identity and authorization and a second
-static-token remote for dependency apps. Do not make all remotes inherit one auth mode.
+Use one caller-forwarding remote for identity and authorization and a second static-token remote for dependency apps. Do not make all remotes inherit one auth mode.
 
 ### 2. Force-pause app-declared workflows
 
@@ -379,14 +274,9 @@ apps:
       forcePaused: true
 ```
 
-Before app definitions are passed to the workflow provider, force both the definition
-and every activation paused. Preserve the app's original schedule and event metadata so
-an authorized developer can inspect and deliberately enable a selected activation.
-Manual `StartRun` remains available while automatic schedule and event starts remain
-blocked.
+Before app definitions are passed to the workflow provider, force both the definition and every activation paused. Preserve the app's original schedule and event metadata so an authorized developer can inspect and deliberately enable a selected activation. Manual `StartRun` remains available while automatic schedule and event starts remain blocked.
 
-The policy is deployer-owned and not part of branch package metadata. Apply it during
-desired-definition construction, not in a post-start script.
+The policy is deployer-owned and not part of branch package metadata. Apply it during desired-definition construction, not in a post-start script.
 
 ### 3. Dual-auth Vite proxy
 
@@ -400,14 +290,9 @@ desired-definition construction, not in a post-start script.
 
 **Changes**
 
-Keep the existing Gestalt bearer behavior. Add an optional serverless identity source
-that maintains a cached token and sets `X-Serverless-Authorization`. The source should
-support an external command or callback, parse JWT expiry, refresh before expiration,
-and fail the proxied request closed when refresh fails.
+Keep the existing Gestalt bearer behavior. Add an optional serverless identity source that maintains a cached token and sets `X-Serverless-Authorization`. The source should support an external command or callback, parse JWT expiry, refresh before expiration, and fail the proxied request closed when refresh fails.
 
-The browser must never receive either token. Preserve any explicit browser
-`Authorization` header only under the existing rules; the serverless token always uses
-its separate header.
+The browser must never receive either token. Preserve any explicit browser `Authorization` header only under the existing rules; the serverless token always uses its separate header.
 
 ### Phase 1 success criteria
 
@@ -415,22 +300,18 @@ its separate header.
 
 - [ ] Remote config rejects conflicting, insecure, or unknown auth modes.
 - [ ] Static-token remotes retain existing behavior.
-- [ ] Caller-forwarding sends the current request's bearer to remote identity and
-      authorization and sends no bearer for a request without one.
+- [ ] Caller-forwarding sends the current request's bearer to remote identity and authorization and sends no bearer for a request without one.
 - [ ] A concurrent request test proves bearers cannot cross between callers.
 - [ ] Logs and returned errors contain no bearer values.
 - [ ] App workflow definitions and all activations are paused on their first apply.
 - [ ] A manual workflow run can still start under `forcePaused`.
 - [ ] No scheduled run starts during a multi-tick integration test.
-- [ ] Vite sends independent `Authorization` and `X-Serverless-Authorization` headers
-      and refreshes the latter before expiry.
+- [ ] Vite sends independent `Authorization` and `X-Serverless-Authorization` headers and refreshes the latter before expiry.
 
 #### Manual verification
 
-- [ ] Two users with different production roles receive different authorization
-      decisions through a local preview server.
-- [ ] An expired Cloud Run identity produces an actionable proxy error without exposing
-      token text.
+- [ ] Two users with different production roles receive different authorization decisions through a local preview server.
+- [ ] An expired Cloud Run identity produces an actionable proxy error without exposing token text.
 
 ## Phase 2: Secure Branch Artifact Publication
 
@@ -446,26 +327,19 @@ its separate header.
 
 Split the pipeline into trust domains:
 
-1. Ordinary PR CI checks out the exact source SHA, installs frozen dependencies,
-   packages the app, and uploads an unprivileged GitHub Actions artifact containing the
-   provider archives, catalog/workflow metadata, source SHA, and checksums.
-2. A trusted default-branch workflow is triggered only after required CI succeeds. It
-   downloads bytes rather than checking out and executing the PR.
-3. Trusted code validates app name, commit SHA, archive paths, manifest identity,
-   checksums, and package metadata.
+1. Ordinary PR CI checks out the exact source SHA, installs frozen dependencies, packages the app, and uploads an unprivileged GitHub Actions artifact containing the provider archives, catalog/workflow metadata, source SHA, and checksums.
+2. A trusted default-branch workflow is triggered only after required CI succeeds. It downloads bytes rather than checking out and executing the PR.
+3. Trusted code validates app name, commit SHA, archive paths, manifest identity, checksums, and package metadata.
 4. Only then does it authenticate to GCP and publish the immutable snapshot.
 
-The trusted job must use its own checked-in scripts and Dockerfile from the default
-branch. It must not run hooks, shell scripts, package managers, or binaries from the PR
-artifact.
+The trusted job must use its own checked-in scripts and Dockerfile from the default branch. It must not run hooks, shell scripts, package managers, or binaries from the PR artifact.
 
 ### Phase 2 success criteria
 
 #### Automated verification
 
 - [ ] A valid internal PR artifact publishes under its full source SHA.
-- [ ] Mismatched app name, SHA, checksum, manifest source, or unexpected archive member
-      fails before GCP authentication.
+- [ ] Mismatched app name, SHA, checksum, manifest source, or unexpected archive member fails before GCP authentication.
 - [ ] Fork PRs cannot enter the trusted publication workflow without explicit approval.
 - [ ] The publication is create-only and cannot overwrite an existing version.
 
@@ -488,14 +362,11 @@ artifact.
 - `/Users/michael/valon/toolshed/.github/scripts/tests/app-preview-deploy_test.sh` (new)
 - `/Users/michael/valon/toolshed/valon-tools/terraform/preview/` (new)
 
-The preview Terraform root is separate from the existing production root and uses its
-own state and deploy identity. Production deployment workflows do not plan or apply it.
+The preview Terraform root is separate from the existing production root and uses its own state and deploy identity. Production deployment workflows do not plan or apply it.
 
 ### Runtime configuration
 
-Create a curated preview base rather than copying production config wholesale.
-Generated values include preview ID, source SHA, public URL, datastore credentials,
-encryption key secret, relay identity, resource labels, and expiry.
+Create a curated preview base rather than copying production config wholesale. Generated values include preview ID, source SHA, public URL, datastore credentials, encryption key secret, relay identity, resource labels, and expiry.
 
 The CI/CD overlay includes:
 
@@ -514,21 +385,13 @@ Deploy one Cloud Run service per PR:
 gestalt-preview-ci-cd-pr-<number>
 ```
 
-Use min instances `0`, max instances `1`, bounded CPU/memory, IAM-only invocation, and
-preview-specific runtime identity. A per-PR service makes URL, IAM, logs, and teardown
-obvious; consolidation into tagged revisions is deferred until usage proves service
-count is a problem.
+Use min instances `0`, max instances `1`, bounded CPU/memory, IAM-only invocation, and preview-specific runtime identity. A per-PR service makes URL, IAM, logs, and teardown obvious; consolidation into tagged revisions is deferred until usage proves service count is a problem.
 
-The deployment workflow never calls production `/activate`, changes production
-traffic, or reuses `.github/workflows/deploy-valon-tools.yml`.
+The deployment workflow never calls production `/activate`, changes production traffic, or reuses `.github/workflows/deploy-valon-tools.yml`.
 
 ### Datastore isolation
 
-Provision a distinct database and credential constrained to that database for each
-preview. The runtime identity can read its database credential but has no permission to
-enumerate or access production database secrets. Preserve the database when updating a
-preview to a newer commit. Reset replaces the preview database and credential as one
-fenced operation.
+Provision a distinct database and credential constrained to that database for each preview. The runtime identity can read its database credential but has no permission to enumerate or access production database secrets. Preserve the database when updating a preview to a newer commit. Reset replaces the preview database and credential as one fenced operation.
 
 ### Integration relay
 
@@ -538,18 +401,15 @@ Create a preview relay subject with only the operations needed for:
 - Deployment workflow/job reads.
 - Linear attachment/issue reads.
 - Valon Profile reads needed by author display and filtering.
-- Optional Datadog and Valkey reads only if their providers can enforce the same
-  least-privilege boundary.
+- Optional Datadog and Valkey reads only if their providers can enforce the same least-privilege boundary.
 
-Exclude unsupported dependencies from the first pilot. Do not grant the branch
-provider the production CI/CD sync subject.
+Exclude unsupported dependencies from the first pilot. Do not grant the branch provider the production CI/CD sync subject.
 
 ### Phase 3 success criteria
 
 #### Automated verification
 
-- [ ] Preview config validation proves IndexedDB and workflow providers are local and
-      production DSNs/Temporal values are absent.
+- [ ] Preview config validation proves IndexedDB and workflow providers are local and production DSNs/Temporal values are absent.
 - [ ] Management listener is unreachable from the Cloud Run URL.
 - [ ] `/health` and authenticated `/ready` pass before the preview is announced.
 - [ ] A known viewer can call normal CI/CD reads.
@@ -560,8 +420,7 @@ provider the production CI/CD sync subject.
 #### Manual verification
 
 - [ ] Updating the PR changes provider behavior while retaining preview data.
-- [ ] Production CI/CD routing, database rows, workflows, and app revision remain
-      unchanged.
+- [ ] Production CI/CD routing, database rows, workflows, and app revision remain unchanged.
 - [ ] Preview audit and application logs identify PR, app, owner, and source SHA.
 
 ## Phase 4: High-signal CI/CD Data and Workflow Loop
@@ -571,8 +430,7 @@ provider the production CI/CD sync subject.
 **Files**
 
 - `/Users/michael/valon/toolshed/valon-tools/apps/ci-cd/provider.ts`
-- `/Users/michael/valon/toolshed/valon-tools/apps/ci-cd/sync/` orchestration and source
-  modules
+- `/Users/michael/valon/toolshed/valon-tools/apps/ci-cd/sync/` orchestration and source modules
 - New preview-specific module and tests under the CI/CD app
 - `/Users/michael/valon/toolshed/valon-tools/deploy/preview/ci-cd.yaml`
 - `/Users/michael/valon/toolshed/valon-tools/deploy/config.yaml`
@@ -583,29 +441,22 @@ Add an operation such as:
 preview.materializePullRequest({ prNumber })
 ```
 
-It is registered by the provider but fails closed unless `previewMode` is true.
-Production omits it from `allowedOperations`; the preview overlay grants it only to
-admins.
+It is registered by the provider but fails closed unless `previewMode` is true. Production omits it from `allowedOperations`; the preview overlay grants it only to admins.
 
 The operation:
 
 1. Validates one Front Porch pull request number.
-2. Reads the PR, head checks/actions, merge commit deployments, Linear association, and
-   other available read-only sources through the preview relay.
+2. Reads the PR, head checks/actions, merge commit deployments, Linear association, and other available read-only sources through the preview relay.
 3. Runs the same normalization and correlation functions used by scheduled syncs.
 4. Writes only to the preview database.
-5. Returns structured stage results with timing, source freshness, partial failures,
-   persisted keys, and the final pull-request/revision views.
+5. Returns structured stage results with timing, source freshness, partial failures, persisted keys, and the final pull-request/revision views.
 6. Is idempotent for the same PR and source versions.
 
-Do not repurpose `deployments.clearCache` or make fixture JSON part of a production
-handler. Keep existing local fixtures useful for offline tests, but make the preview
-path explicit and auditable.
+Do not repurpose `deployments.clearCache` or make fixture JSON part of a production handler. Keep existing local fixtures useful for offline tests, but make the preview path explicit and auditable.
 
 ### Manual workflow controls
 
-Install normal CI/CD workflow definitions into the preview provider with every
-activation paused. Document and script:
+Install normal CI/CD workflow definitions into the preview provider with every activation paused. Document and script:
 
 - Listing definitions and paused state.
 - Starting a selected run manually with input.
@@ -614,8 +465,7 @@ activation paused. Document and script:
 - Opening the run inspector and logs.
 - Resetting preview data.
 
-Automatic activation remains out of scope for the initial pilot even after manual runs
-work.
+Automatic activation remains out of scope for the initial pilot even after manual runs work.
 
 ### Phase 4 success criteria
 
@@ -623,18 +473,15 @@ work.
 
 - [ ] The preview operation is denied when `previewMode` is false.
 - [ ] Production config does not allowlist the preview operation.
-- [ ] One-PR materialization uses bounded API calls and writes only expected preview
-      records.
+- [ ] One-PR materialization uses bounded API calls and writes only expected preview records.
 - [ ] Repeating materialization is idempotent.
 - [ ] Partial integration failures are explicit and preserve successful stage output.
 - [ ] Correlated JSON matches the data returned by list and detail operations.
 
 #### Manual verification
 
-- [ ] A developer can materialize one PR, open its local UI page, and inspect checks,
-      deploys, mergeability, and merge requirements without shipping backend code.
-- [ ] A developer can start a workflow manually and retrieve useful JSON for an agent
-      feedback loop.
+- [ ] A developer can materialize one PR, open its local UI page, and inspect checks, deploys, mergeability, and merge requirements without shipping backend code.
+- [ ] A developer can start a workflow manually and retrieve useful JSON for an agent feedback loop.
 
 ## Phase 5: Developer Attachment and Lifecycle Automation
 
@@ -642,17 +489,14 @@ work.
 
 **Files**
 
-- `/Users/michael/valon/toolshed/valon-tools/apps/ci-cd/scripts/dev-ui-preview.sh`
-  (new)
+- `/Users/michael/valon/toolshed/valon-tools/apps/ci-cd/scripts/dev-ui-preview.sh` (new)
 - `/Users/michael/valon/toolshed/valon-tools/apps/ci-cd/scripts/dev-common.sh`
 - `/Users/michael/valon/toolshed/valon-tools/apps/ci-cd/ui/vite.config.ts`
 - Vite proxy contract tests
 - `/Users/michael/valon/toolshed/valon-tools/apps/ci-cd/knowledge/gestalt/local-development.md`
 - `/Users/michael/valon/toolshed/valon-tools/apps/ci-cd/spec.md`
 
-`dev-ui-preview.sh <pr-number>` resolves the preview from a GitHub deployment or Cloud
-Run labels, verifies the source SHA is on the PR, resolves stored Gestalt credentials,
-starts the refreshable Cloud Run identity source, and launches loopback Vite.
+`dev-ui-preview.sh <pr-number>` resolves the preview from a GitHub deployment or Cloud Run labels, verifies the source SHA is on the PR, resolves stored Gestalt credentials, starts the refreshable Cloud Run identity source, and launches loopback Vite.
 
 It prints:
 
@@ -663,8 +507,7 @@ It prints:
 - Cloud Logging link.
 - Preview expiry.
 
-The script refuses previews whose app, repository, owner, or SHA labels do not match the
-requested PR.
+The script refuses previews whose app, repository, owner, or SHA labels do not match the requested PR.
 
 ### Lifecycle workflows
 
@@ -675,17 +518,11 @@ requested PR.
 - `/Users/michael/valon/toolshed/.github/scripts/app-preview-cleanup.sh` (new)
 - Co-located cleanup tests
 
-Update previews on approved PR commits using concurrency keyed by repository, app, and
-PR. Announce readiness through a GitHub deployment and one updated PR comment rather
-than a new comment per commit.
+Update previews on approved PR commits using concurrency keyed by repository, app, and PR. Announce readiness through a GitHub deployment and one updated PR comment rather than a new comment per commit.
 
-Delete on PR close. A scheduled sweeper independently removes previews past hard
-lifetime or attached to closed/missing PRs. Cleanup is idempotent and removes service,
-database, database user, credentials, encryption secret, and deployment metadata.
-Artifact Registry and snapshot retention independently remove old immutable artifacts.
+Delete on PR close. A scheduled sweeper independently removes previews past hard lifetime or attached to closed/missing PRs. Cleanup is idempotent and removes service, database, database user, credentials, encryption secret, and deployment metadata. Artifact Registry and snapshot retention independently remove old immutable artifacts.
 
-Use a default hard lifetime of 72 hours. An open PR can recreate an expired preview on
-its next approved deployment; there is no indefinite keepalive.
+Use a default hard lifetime of 72 hours. An open PR can recreate an expired preview on its next approved deployment; there is no indefinite keepalive.
 
 ### Phase 5 success criteria
 
@@ -696,8 +533,7 @@ its next approved deployment; there is no indefinite keepalive.
 - [ ] Close cleanup and the sweeper select the same resource closure.
 - [ ] Repeated cleanup succeeds when resources are already absent.
 - [ ] Attachment rejects a mismatched or expired preview.
-- [ ] Tokens never appear in shell tracing, process arguments, Vite responses, GitHub
-      comments, or logs.
+- [ ] Tokens never appear in shell tracing, process arguments, Vite responses, GitHub comments, or logs.
 
 #### Manual verification
 
@@ -711,33 +547,25 @@ Generalize only after CI/CD completes the manual pilot.
 
 ### Changes
 
-- Define a trusted preview manifest describing app name, local provider source,
-  dependencies and exact operations, datastore needs, workflow policy, health smoke
-  operation, and mutation exclusions.
+- Define a trusted preview manifest describing app name, local provider source, dependencies and exact operations, datastore needs, workflow policy, health smoke operation, and mutation exclusions.
 - Extract app-independent publication, deployment, attachment, and cleanup workflows.
 - Keep app-specific materialization/reset operations in each app.
-- Add documentation under `docs/content/applications.mdx` describing preview topology,
-  credentials, storage, workflows, and the local proxy.
-- Provide a validation command that renders the effective config and rejects production
-  state references, unpaused workflows, public management listeners, mutable sources,
-  or unbounded relay catalogs.
+- Add documentation under `docs/content/applications.mdx` describing preview topology, credentials, storage, workflows, and the local proxy.
+- Provide a validation command that renders the effective config and rejects production state references, unpaused workflows, public management listeners, mutable sources, or unbounded relay catalogs.
 
-Do not automatically onboard apps that require production writes. They need a
-preview-owned downstream resource or explicit dry-run interface first.
+Do not automatically onboard apps that require production writes. They need a preview-owned downstream resource or explicit dry-run interface first.
 
 ### Phase 6 success criteria
 
 #### Automated verification
 
-- [ ] A second non-CI/CD app can deploy using only the reusable workflow plus its
-      preview manifest.
+- [ ] A second non-CI/CD app can deploy using only the reusable workflow plus its preview manifest.
 - [ ] Effective-config validation catches every safety invariant expressible in config.
 - [ ] App-specific scripts cannot override trusted IAM, secrets, placement, or cleanup.
 
 #### Manual verification
 
-- [ ] A developer can discover, deploy, attach, inspect, and delete the second app using
-      the same command vocabulary.
+- [ ] A developer can discover, deploy, attach, inspect, and delete the second app using the same command vocabulary.
 
 ## Testing Strategy
 
@@ -757,12 +585,9 @@ Run two in-process Gestalt origins:
 1. Upstream with identity, authorization, and a test dependency app.
 2. Preview with caller-forwarding auth, local app/storage/workflow, and static relay.
 
-Verify distinct callers, role decisions, nested dependency calls, isolated records,
-paused activations, manual workflow runs, and bearer non-leakage.
+Verify distinct callers, role decisions, nested dependency calls, isolated records, paused activations, manual workflow runs, and bearer non-leakage.
 
-Add a provider-backed IndexedDB test that proves one preview credential cannot read a
-second preview or production schema. This is an infrastructure acceptance test, not
-only a mock host-service test.
+Add a provider-backed IndexedDB test that proves one preview credential cannot read a second preview or production schema. This is an infrastructure acceptance test, not only a mock host-service test.
 
 ### Toolshed end-to-end test
 
@@ -779,9 +604,7 @@ For a controlled CI/CD test branch:
 9. Reset the preview and confirm only preview data changes.
 10. Close the PR and verify complete cleanup.
 
-Before and after the test, capture production Cloud Run traffic/revision, CI/CD app
-revision, workflow definitions, and representative database checksums or update
-timestamps. They must not change because of the preview.
+Before and after the test, capture production Cloud Run traffic/revision, CI/CD app revision, workflow definitions, and representative database checksums or update timestamps. They must not change because of the preview.
 
 ## Rollout
 
@@ -792,8 +615,7 @@ timestamps. They must not change because of the preview.
 5. Validate caller authorization and one-PR materialization.
 6. Validate manual workflows while all activations remain paused.
 7. Enable opt-in deployment by PR label for internal contributors.
-8. Observe cost, startup time, cleanup reliability, integration rate limits, and audit
-   volume for at least two weeks.
+8. Observe cost, startup time, cleanup reliability, integration rate limits, and audit volume for at least two weeks.
 9. Onboard a second read-oriented app through the reusable manifest.
 10. Consider broader self-service only after both pilots satisfy the same invariants.
 
@@ -803,22 +625,18 @@ timestamps. They must not change because of the preview.
 - Revoke the preview integration relay.
 - Delete all resources selected by preview labels.
 - Leave branch snapshots to normal retention.
-- Gestalt's new config fields remain dormant when unused; static named remotes and
-  existing Vite bearer proxying remain backward compatible.
+- Gestalt's new config fields remain dormant when unused; static named remotes and existing Vite bearer proxying remain backward compatible.
 
-No rollback step touches production application versions because previews never become
-production candidates.
+No rollback step touches production application versions because previews never become production candidates.
 
 ## Success Metrics
 
 - An approved CI/CD preview is ready within 10 minutes of a commit.
 - Attaching the local UI is one command and less than one minute excluding scale-up.
 - UI-only iterations remain immediate through HMR.
-- One-PR materialization returns useful JSON and a working page without a production
-  deploy.
+- One-PR materialization returns useful JSON and a working page without a production deploy.
 - At least one backend/auth feature is completed without test-only production PRs.
-- Preview cleanup succeeds automatically for every pilot PR, with the sweeper catching
-  any missed close event.
+- Preview cleanup succeeds automatically for every pilot PR, with the sweeper catching any missed close event.
 - There are zero preview writes to production Gestalt, CI/CD, or workflow state.
 - No preview credential appears in branch jobs, browser JavaScript, logs, or comments.
 
@@ -836,22 +654,17 @@ production candidates.
 | Cleanup/TTL automation | `toolshed` | Preview infrastructure |
 | Reusable app manifest | both | Successful CI/CD pilot |
 
-The first three Gestalt changes and the artifact-pipeline split can proceed in parallel.
-The preview runtime must not launch until caller authentication, force-pause, and
-artifact trust boundaries are deployed.
+The first three Gestalt changes and the artifact-pipeline split can proceed in parallel. The preview runtime must not launch until caller authentication, force-pause, and artifact trust boundaries are deployed.
 
 ## Definition of Done
 
-- All safety invariants are enforced by config validation, IAM, provider credentials,
-  or automated tests.
+- All safety invariants are enforced by config validation, IAM, provider credentials, or automated tests.
 - CI/CD's local UI works against a remote branch backend with real caller role checks.
 - One-PR data and a manual workflow produce inspectable JSON.
 - Production routing and state remain unchanged through the end-to-end test.
 - Close and TTL cleanup remove the full preview resource closure.
-- Documentation clearly distinguishes preview-local state, delegated production reads,
-  and prohibited production writes.
-- A second Gestalt app can adopt the reusable foundation without copying CI/CD-specific
-  deployment logic.
+- Documentation clearly distinguishes preview-local state, delegated production reads, and prohibited production writes.
+- A second Gestalt app can adopt the reusable foundation without copying CI/CD-specific deployment logic.
 
 ## References
 

--- a/plans/preview_environments/plan.md
+++ b/plans/preview_environments/plan.md
@@ -1,271 +1,61 @@
 # Gestalt App Preview Environments
 
-## Status
+## Decision
 
-Proposed. This plan defines a reusable preview-environment foundation and a `valon-tools/apps/ci-cd` pilot. It does not authorize implementation or production rollout by itself.
+Create one IAM-protected Cloud Run `gestaltd` service per approved internal PR. Run the branch app provider there with isolated database and workflow state, while the frontend stays local and uses Vite HMR.
 
-## Overview
+CI/CD is the first pilot. Do not use production Cloud Run revisions or reverse-provider shadowing because both can affect production routing or shared state.
 
-Gestalt app authors can run a frontend locally with hot module replacement, but backend changes that need production integrations, authorization, or workflows are still difficult to verify without deploying the app to production. CI/CD is the first pilot because its pages depend on correlated GitHub, Linear, workqueue, and deployment data, and because its merge-readiness feature needs real caller authorization.
-
-The proposed development loop is:
-
-1. An internal pull request publishes an immutable app snapshot for its exact commit.
-2. Trusted automation creates or updates a dedicated preview `gestaltd` service.
-3. The branch app provider runs in that preview with isolated application and workflow storage.
-4. A loopback-only Vite proxy sends local browser API requests to the preview.
-5. The preview validates the developer's real Gestalt bearer and delegates only an explicit set of integration reads through a least-privilege preview identity.
-6. App workflows are installed paused and may be run manually.
-7. Closing or expiring the pull request deletes all preview resources.
-
-This is deliberately a separate control plane. A preview must not be a no-traffic revision of the production `toolshed-test` Cloud Run service, a production app-registry candidate, or a reverse-published provider that shadows a production app.
-
-## Goals
-
-- Run a branch version of a Gestalt app backend remotely without changing production traffic or provider selection.
-- Keep frontend source and HMR local.
-- Exercise real caller authentication and authorization, including CI/CD's admin-only `pullRequests.mergeReadiness`.
-- Let developers materialize one or two representative records and inspect workflow inputs, intermediate values, outputs, and logs.
-- Install app-declared workflows without allowing schedules or event activations to run automatically.
-- Reuse the same preview deployment contract for other Gestalt apps after the CI/CD pilot.
-- Make preview creation, update, attachment, reset, and teardown deterministic enough for agents to execute and verify.
-
-## Non-goals
-
-- Sending production traffic to preview code.
-- Testing production migrations, production writes, merge-queue mutations, notifications, or fast-track actions.
-- Cloning the production Gestalt control-plane database.
-- Sharing production Temporal state or task queues.
-- Making reverse provider publication subject-aware as part of this pilot.
-- Supporting untrusted fork pull requests automatically.
-- Adding broad localhost CORS support to Gestalt.
-- Providing indefinite preview persistence.
-- Replacing normal unit, contract, and integration tests.
-
-## Current State
-
-### Local UI to remote API already works
-
-The CI/CD app's `valon-tools/apps/ci-cd/scripts/dev-ui-remote.sh` starts Vite on loopback, obtains a Gestalt API token, and sets `GESTALT_API_PROXY_TARGET`. The Gestalt Vite plugin in `sdk/typescript-web/src/vite.js` proxies `/api/v1` and `/api/v2`, adding the bearer server-side so it is not exposed to frontend JavaScript.
-
-The missing piece is a safe branch backend URL. Today the script points at `https://valon.tools`, so it can validate local UI changes only against the already deployed provider.
-
-### Branch snapshots can already be built
-
-Toolshed's `.github/workflows/publish-app-snapshot.yml` accepts an app and arbitrary branch, tag, or SHA. It packages immutable `0.0.0-snapshot.g<full-commit-sha>` artifacts. The workflow currently packages branch code and later authenticates to GCP in the same job, which is acceptable for trusted main-branch publishing but is not an adequate boundary for automated pull-request previews. Branch-controlled code can leave a process running until credentials are minted later in the job.
-
-### Gestalt config has most placement primitives
-
-Gestalt supports left-to-right config overlays, named remotes, local and remote provider placement, source overrides, distinct public and management listeners, and app-specific IndexedDB bindings. Useful implementation points include:
-
-- `gestaltd/internal/config/config.go`
-- `gestaltd/internal/config/remotes.go`
-- `gestaltd/internal/config/config_validate.go`
-- `gestaltd/internal/daemon/provider_local.go`
-- `gestaltd/internal/bootstrap/provider_build.go`
-
-These are building blocks, not a preview-isolation mode. Safe composition remains the deployment's responsibility.
-
-### Remote authentication is currently static
-
-`gestaltd/internal/remote/remote.go` attaches one configured bearer token to every RPC on a named remote. Consequently, merely marking production identity and authorization providers `remote: prod` does **not** preserve the interactive caller: it authenticates the preview's configured relay token instead.
-
-The preview requires two distinct upstream authentication modes:
-
-- **Caller forwarding** for production identity and authorization, using the bearer from the incoming local-UI request.
-- **Static preview relay identity** for explicitly allowlisted integration operations.
-
-This must be implemented as an explicit Gestalt remote-auth contract. The preview must not infer or copy browser cookies, forward arbitrary caller headers, or give branch code direct access to either token.
-
-### Shared storage is unsafe
-
-Gestalt's config exposes `apps.<name>.indexeddb.db` and `objectStores`, but the current host-service bootstrap does not provide enough evidence that these fields form a hard runtime isolation boundary for every provider. Relevant paths are:
-
-- `gestaltd/internal/config/provider_selection.go`
-- `gestaltd/internal/bootstrap/host_service_bootstrap.go`
-- `gestaltd/services/indexeddb/server.go`
-- `gestaltd/internal/bootstrap/executable_app_test.go`
-
-Until provider-backed isolation is enforced and tested end to end, every preview must receive a separate physical database or a separate provider credential constrained to one preview schema. A different logical `db` string on a shared privileged provider is not sufficient.
-
-The same requirement applies to Gestalt core state: users, app installations, rollouts, authorization fragments, and remote registrations must not share the production control-plane database.
-
-### Workflow startup mutates provider state
-
-App-declared workflows are read from provider metadata and reconciled at startup by `gestaltd/internal/bootstrap/workflow_app_definitions.go`. Config-managed definitions are similarly reconciled by `workflow_config_definitions.go`. Reconciliation applies definitions and removes absent managed definitions. A preview connected to production Temporal could update, pause, activate, or delete production workflow state before any HTTP request reaches it.
-
-Definitions and activations already have paused flags, but deployment config cannot currently force app-declared workflows paused before their first reconciliation. Pausing after startup leaves a race with the first scheduled tick.
-
-### Reverse publication is not a preview boundary
-
-Reverse-published providers are resolved globally by kind and app name. A registered `app/ci-cd` takes precedence over the production provider for all callers; provider ownership is also global. Making this subject-aware would touch registration storage, provider resolution, app catalogs, mounted UI routing, workflows, auditing, fallback, and authorization. It is larger and riskier than a dedicated preview service and does not naturally solve storage isolation.
-
-## Desired End State
-
-An approved internal CI/CD pull request receives a URL such as:
+## Developer experience
 
 ```text
-https://gestalt-preview-ci-cd-pr-123-<hash>.run.app
+Browser → loopback Vite proxy → PR Cloud Run preview → branch app provider
+                                                  ├─ preview-only database/workflows
+                                                  └─ allowlisted production reads
 ```
 
-From a Toolshed checkout, a developer runs:
+The developer runs:
 
 ```bash
-./valon-tools/apps/ci-cd/scripts/dev-ui-preview.sh 123
+./valon-tools/apps/ci-cd/scripts/dev-ui-preview.sh <pr-number>
 ```
 
-The command:
+The script verifies the preview commit, obtains the developer's Gestalt bearer and a refreshable Cloud Run identity token, then starts Vite on `127.0.0.1`. UI changes remain immediate; backend changes publish a new immutable preview snapshot.
 
-1. Resolves the preview for PR 123 and verifies its commit.
-2. Obtains the developer's Gestalt token without exposing it to the browser.
-3. Obtains and refreshes Cloud Run invocation identity.
-4. Starts Vite on `127.0.0.1`.
-5. Proxies API calls to the preview with independent Cloud Run and Gestalt authorization headers.
-6. Prints commands for materializing a PR, starting a workflow manually, viewing its JSON output, and opening logs.
+## Scope
 
-The preview persists its isolated database across branch-provider updates. A reset action destroys and recreates only that preview's data. It is removed on PR close and also by a hard-lifetime sweeper.
+The pilot must:
 
-## Architecture
+- Test a branch backend without changing production traffic, provider selection, or state.
+- Exercise real caller authorization, including admin-only `pullRequests.mergeReadiness`.
+- Materialize one representative PR into preview storage and return inspectable JSON.
+- Support manual workflow runs while schedules and event activations remain paused.
+- Provide deterministic deployment, attachment, reset, logs, expiry, and teardown.
 
-```mermaid
-flowchart LR
-    browser[Browser]
-    vite["Loopback Vite proxy"]
-    preview["PR Cloud Run gestaltd"]
-    branchApp["Branch CI/CD provider"]
-    previewDb["Preview control and app DB"]
-    previewWorkflow["Preview workflow provider"]
-    prodIdentity["Production identity and authorization"]
-    prodApps["Allowlisted production integration apps"]
+It does not support production writes, migrations, notifications, merge actions, production database or Temporal sharing, untrusted forks, or indefinite previews.
 
-    browser -->|Local assets and API| vite
-    vite -->|"Cloud Run identity + Gestalt bearer"| preview
-    preview --> branchApp
-    branchApp --> previewDb
-    branchApp --> previewWorkflow
-    preview -->|"Forward caller bearer"| prodIdentity
-    branchApp -->|"Preview relay identity"| prodApps
-```
+## Required safety properties
 
-### Request identities
+1. Every preview has a unique service, runtime identity, database credential, encryption key, labels, and expiry.
+2. Artifacts are selected by full commit SHA and verified digest.
+3. Branch code packages without cloud credentials; trusted default-branch automation validates the artifact before authenticating and deploying.
+4. Preview config disables authorization-state application and exposes no management or `/activate` route.
+5. The developer bearer is forwarded only to production identity and authorization over HTTPS.
+6. Integration reads use a separate preview relay with exact operation allowlists and no write, impersonation, secret-reading, or token-minting authority.
+7. Production database, Temporal, and `service_account:ci-cd-sync` credentials are unavailable to previews.
+8. Workflow definitions and activations are paused before their first reconciliation; authorized manual runs remain possible.
+9. Only approved internal PRs are eligible.
+10. PR-close cleanup and a maximum-age sweeper delete the complete resource set.
 
-There are three identities and they must remain separate:
+Branch providers are arbitrary code beside `gestaltd`, not a hardened sandbox. The preview runtime and relay permissions must therefore be safe even if branch code can exercise them.
 
-1. **Cloud Run invoker** proves that the local proxy may reach the preview service. It is carried in `X-Serverless-Authorization`.
-2. **Interactive Gestalt caller** is the developer's existing Gestalt bearer in `Authorization`. Production identity validates it, and production authorization evaluates that caller's relationships. This is what makes admin and non-admin merge-readiness behavior realistic.
-3. **Preview integration relay** is a dedicated non-human Gestalt principal used only for the named remote apps and operations allowed by the preview manifest. It is not `service_account:ci-cd-sync` and has no mutation authority.
+## Implementation
 
-Gestalt never passes the interactive caller bearer to branch provider code. Gestalt mediates host-service and remote app calls.
+### 1. Add reusable Gestalt primitives
 
-### Branch-code trust boundary
+**Caller-forwarding remotes:** Extend `gestaltd/internal/config/remotes.go`, `config_validate.go`, `gestaltd/internal/remote/remote.go`, and request authentication plumbing with an explicit `forwardBearer` mode. Capture the incoming bearer in private request context and forward it only to configured identity and authorization remotes. Preserve static-token remotes for dependencies. Test concurrency, redaction, validation, and backward compatibility.
 
-An internal PR provider is still arbitrary code running beside `gestaltd`. The current local-provider process model is not a hardened sandbox, so the pilot must assume that a compromised provider can exercise the preview runtime identity and any static relay authority available to the process. Secret non-exposure alone is not the security boundary.
-
-Therefore the runtime identity grants only preview resource access, and the relay grants only operations whose production read results are acceptable for the approved internal PR author to see. The relay has no write, impersonation, token-minting, secret-reading, or broader discovery authority. Forks remain ineligible. Stronger subprocess/container isolation can reduce this trust later, but it is not a prerequisite for a read-only internal pilot and must not be implied by this plan.
-
-### Provider placement
-
-The generated final overlay for a CI/CD preview uses:
-
-- Local branch `ci-cd` app provider.
-- Local preview IndexedDB provider backed by preview-constrained credentials.
-- Local preview workflow provider and workflow storage.
-- Caller-forwarding remote for identity and authorization.
-- Static-relay remote for an exact set of GitHub, Linear, Valon Profile, Datadog, and Valkey operations.
-- No remote IndexedDB or workflow provider.
-- No production registry reconciliation.
-
-Dependencies that cannot operate with the preview relay's least-privilege grants are excluded from the pilot. Automatic schedules remain blocked; lack of an integration may produce an explicit partial result but must not silently fall back to a production service account.
-
-### Network surface
-
-- Cloud Run requires IAM invocation.
-- The public listener exposes app and normal public API routes only.
-- The management listener binds to loopback and is not mapped by Cloud Run.
-- `/activate`, `/admin`, and management metrics are not externally reachable.
-- Vite binds to `127.0.0.1`, validates the browser origin, and keeps both credentials server-side.
-- No preview adds permissive CORS headers to production or Gestalt.
-
-## Safety Invariants
-
-The implementation is incomplete until all invariants are mechanically enforced or tested:
-
-1. Preview automation never updates the production `toolshed-test` Cloud Run service, revision tags, traffic, or config.
-2. Every preview has a unique service, datastore credential, encryption key, runtime identity, resource labels, and expiry.
-3. Preview control-plane, app, and workflow state cannot address production storage.
-4. Branch-controlled code never executes in a job after GCP publication or deployment credentials are minted.
-5. Preview artifacts are selected by full commit SHA and verified digest, never a mutable branch name.
-6. Only internal pull requests or explicitly approved commits can receive previews.
-7. `server.authorizationStateApply` is false and the environment override is unset.
-8. The developer's bearer is forwarded only to the configured identity/authorization remote over HTTPS.
-9. Integration calls use a separate least-privilege relay and exact app-operation allowlists.
-10. The production `ci-cd-sync` token, production database DSN, and production Temporal credentials are never available to branch code.
-11. App-declared workflow definitions and activations are forced paused before their first reconciliation.
-12. Management routes are private to the container.
-13. Production app-registry activation, rollout evaluation, and authorization-state writes are disabled.
-14. Preview config, IAM, secret bindings, placement, and egress are trusted inputs; a pull request cannot replace them.
-15. Preview services, databases, credentials, keys, and secrets are deleted on close and by a maximum-age sweeper.
-16. Resources and logs carry repository, app, PR, owner, source SHA, workflow run, and expiry labels.
-
-## Implementation Approach
-
-Deliver the capability in six phases. Phases 1 and 2 establish reusable Gestalt and publication safety. Phase 3 creates one manually triggered CI/CD preview. Phases 4 and 5 provide the useful developer loop and lifecycle automation. Phase 6 generalizes only the parts proven by the pilot.
-
-## Phase 1: Gestalt Preview Safety Primitives
-
-### 1. Caller-forwarding named remote authentication
-
-**Files**
-
-- `gestaltd/internal/config/remotes.go`
-- `gestaltd/internal/config/config_validate.go`
-- `gestaltd/internal/remote/remote.go`
-- `gestaltd/internal/remote/remote_test.go`
-- Request authentication/context plumbing under `gestaltd/internal/server/`
-- `gestaltd/internal/bootstrap/bootstrap.go`
-- `docs/content/reference/config-file.mdx`
-
-**Changes**
-
-Replace the implicit token-only remote contract with a backward-compatible explicit auth shape. Existing `token` continues to mean a static bearer. Add a mode that forwards the incoming bearer from trusted request context:
-
-```yaml
-server:
-  remotes:
-    caller-auth:
-      url: https://valon.tools
-      auth:
-        mode: forwardBearer
-```
-
-Validation must:
-
-- Reject `forwardBearer` with a static token.
-- Require HTTPS except for loopback tests.
-- Allow the mode only when the remote is referenced by explicitly supported provider kinds.
-- Never forward cookies or arbitrary authorization-like headers.
-- Fail unauthenticated background calls instead of falling back to another identity.
-- Redact bearer values from logs and errors.
-
-The HTTP/gRPC request boundary must capture the raw bearer into a private context value before remote identity resolution. Public gRPC must continue stripping caller-supplied trusted-principal metadata. Remote interceptors read only the private context value.
-
-Use one caller-forwarding remote for identity and authorization and a second static-token remote for dependency apps. Do not make all remotes inherit one auth mode.
-
-### 2. Force-pause app-declared workflows
-
-**Files**
-
-- `gestaltd/internal/config/config.go`
-- `gestaltd/internal/config/config_validate.go`
-- `gestaltd/internal/bootstrap/workflow_app_definitions.go`
-- `gestaltd/internal/bootstrap/workflow_app_definitions_test.go`
-- `gestaltd/internal/bootstrap/workflow_startup_test.go`
-- `docs/content/reference/config-file.mdx`
-- `docs/content/applications.mdx`
-
-**Changes**
-
-Add deployment policy on an app binding:
+**Forced-paused workflows:** Add an app deployment policy in `gestaltd/internal/config/config.go` and enforce it in `gestaltd/internal/bootstrap/workflow_app_definitions.go`:
 
 ```yaml
 apps:
@@ -274,421 +64,69 @@ apps:
       forcePaused: true
 ```
 
-Before app definitions are passed to the workflow provider, force both the definition and every activation paused. Preserve the app's original schedule and event metadata so an authorized developer can inspect and deliberately enable a selected activation. Manual `StartRun` remains available while automatic schedule and event starts remain blocked.
+Apply the policy before workflow reconciliation and prove that no first tick occurs while manual `StartRun` still works.
 
-The policy is deployer-owned and not part of branch package metadata. Apply it during desired-definition construction, not in a post-start script.
+**Dual-auth Vite proxy:** Extend `sdk/typescript-web/src/vite.js` and its types/tests to keep the Gestalt bearer in `Authorization` and add a separately refreshed Cloud Run token in `X-Serverless-Authorization`. Neither token may reach browser JavaScript.
 
-### 3. Dual-auth Vite proxy
+Document these capabilities in `docs/content/applications.mdx` and `docs/content/reference/config-file.mdx`.
 
-**Files**
+### 2. Secure branch publication
 
-- `sdk/typescript-web/src/vite.js`
-- `sdk/typescript-web/src/vite.d.ts`
-- `sdk/typescript-web/tests/vite-plugin.test.ts`
-- `sdk/typescript-web/README.md`
-- `docs/content/applications.mdx`
+Split `/Users/michael/valon/toolshed/.github/workflows/publish-app-snapshot.yml` into:
 
-**Changes**
+1. An unprivileged PR job that packages the exact SHA and uploads checksummed artifacts and provenance.
+2. A trusted default-branch workflow that downloads bytes without executing PR code, validates the archive and manifest, then authenticates to GCP and publishes create-only immutable artifacts.
 
-Keep the existing Gestalt bearer behavior. Add an optional serverless identity source that maintains a cached token and sets `X-Serverless-Authorization`. The source should support an external command or callback, parse JWT expiry, refresh before expiration, and fail the proxied request closed when refresh fails.
+### 3. Deploy the CI/CD preview
 
-The browser must never receive either token. Preserve any explicit browser `Authorization` header only under the existing rules; the serverless token always uses its separate header.
+Add trusted config and infrastructure under:
 
-### Phase 1 success criteria
+- `/Users/michael/valon/toolshed/valon-tools/deploy/preview/`
+- `/Users/michael/valon/toolshed/valon-tools/terraform/preview/`
+- `/Users/michael/valon/toolshed/.github/workflows/deploy-app-preview.yml`
 
-#### Automated verification
+Deploy `gestalt-preview-ci-cd-pr-<number>` with min instances zero, max one, IAM-only invocation, preview-specific storage, and repository/app/PR/SHA/expiry labels.
 
-- [ ] Remote config rejects conflicting, insecure, or unknown auth modes.
-- [ ] Static-token remotes retain existing behavior.
-- [ ] Caller-forwarding sends the current request's bearer to remote identity and authorization and sends no bearer for a request without one.
-- [ ] A concurrent request test proves bearers cannot cross between callers.
-- [ ] Logs and returned errors contain no bearer values.
-- [ ] App workflow definitions and all activations are paused on their first apply.
-- [ ] A manual workflow run can still start under `forcePaused`.
-- [ ] No scheduled run starts during a multi-tick integration test.
-- [ ] Vite sends independent `Authorization` and `X-Serverless-Authorization` headers and refreshes the latter before expiry.
+Use a curated config containing only the branch snapshot, preview-local IndexedDB and workflows, forced-paused activations, caller-forwarding identity/authorization, and allowlisted read dependencies. Do not modify or reuse `.github/workflows/deploy-valon-tools.yml`.
 
-#### Manual verification
+### 4. Add a useful CI/CD pilot operation
 
-- [ ] Two users with different production roles receive different authorization decisions through a local preview server.
-- [ ] An expired Cloud Run identity produces an actionable proxy error without exposing token text.
-
-## Phase 2: Secure Branch Artifact Publication
-
-### Files
-
-- `/Users/michael/valon/toolshed/.github/workflows/publish-app-snapshot.yml`
-- `/Users/michael/valon/toolshed/.github/workflows/publish-app-preview.yml` (new)
-- `/Users/michael/valon/toolshed/.github/valon-tools-provider-snapshot-publish.yaml`
-- `/Users/michael/valon/toolshed/.github/scripts/` preview artifact validation scripts
-- Co-located script tests
-
-### Changes
-
-Split the pipeline into trust domains:
-
-1. Ordinary PR CI checks out the exact source SHA, installs frozen dependencies, packages the app, and uploads an unprivileged GitHub Actions artifact containing the provider archives, catalog/workflow metadata, source SHA, and checksums.
-2. A trusted default-branch workflow is triggered only after required CI succeeds. It downloads bytes rather than checking out and executing the PR.
-3. Trusted code validates app name, commit SHA, archive paths, manifest identity, checksums, and package metadata.
-4. Only then does it authenticate to GCP and publish the immutable snapshot.
-
-The trusted job must use its own checked-in scripts and Dockerfile from the default branch. It must not run hooks, shell scripts, package managers, or binaries from the PR artifact.
-
-### Phase 2 success criteria
-
-#### Automated verification
-
-- [ ] A valid internal PR artifact publishes under its full source SHA.
-- [ ] Mismatched app name, SHA, checksum, manifest source, or unexpected archive member fails before GCP authentication.
-- [ ] Fork PRs cannot enter the trusted publication workflow without explicit approval.
-- [ ] The publication is create-only and cannot overwrite an existing version.
-
-#### Manual verification
-
-- [ ] Registry metadata points to the reviewed PR commit and expected artifact digest.
-- [ ] Cancelling or retrying a publish is idempotent.
-
-## Phase 3: CI/CD Preview Runtime Pilot
-
-### Trusted preview deployment assets
-
-**Files**
-
-- `/Users/michael/valon/toolshed/valon-tools/deploy/preview/base.yaml` (new)
-- `/Users/michael/valon/toolshed/valon-tools/deploy/preview/ci-cd.yaml` (new)
-- `/Users/michael/valon/toolshed/valon-tools/deploy/preview/Dockerfile` (new)
-- `/Users/michael/valon/toolshed/.github/workflows/deploy-app-preview.yml` (new)
-- `/Users/michael/valon/toolshed/.github/scripts/app-preview-deploy.sh` (new)
-- `/Users/michael/valon/toolshed/.github/scripts/tests/app-preview-deploy_test.sh` (new)
-- `/Users/michael/valon/toolshed/valon-tools/terraform/preview/` (new)
-
-The preview Terraform root is separate from the existing production root and uses its own state and deploy identity. Production deployment workflows do not plan or apply it.
-
-### Runtime configuration
-
-Create a curated preview base rather than copying production config wholesale. Generated values include preview ID, source SHA, public URL, datastore credentials, encryption key secret, relay identity, resource labels, and expiry.
-
-The CI/CD overlay includes:
-
-- The normal CI/CD operation authorization policy and `mergeReadiness` admin rule.
-- Branch snapshot selected by immutable version/digest.
-- Preview-only IndexedDB and workflow bindings.
-- `workflowPolicy.forcePaused: true`.
-- `authorizationStateApply: false`.
-- Only the dependency apps and operation metadata required for the pilot.
-- No mutation operations for Trunk, GitHub, notifications, or fast-track behavior.
-- No production Temporal provider or database references.
-
-Deploy one Cloud Run service per PR:
-
-```text
-gestalt-preview-ci-cd-pr-<number>
-```
-
-Use min instances `0`, max instances `1`, bounded CPU/memory, IAM-only invocation, and preview-specific runtime identity. A per-PR service makes URL, IAM, logs, and teardown obvious; consolidation into tagged revisions is deferred until usage proves service count is a problem.
-
-The deployment workflow never calls production `/activate`, changes production traffic, or reuses `.github/workflows/deploy-valon-tools.yml`.
-
-### Datastore isolation
-
-Provision a distinct database and credential constrained to that database for each preview. The runtime identity can read its database credential but has no permission to enumerate or access production database secrets. Preserve the database when updating a preview to a newer commit. Reset replaces the preview database and credential as one fenced operation.
-
-### Integration relay
-
-Create a preview relay subject with only the operations needed for:
-
-- Pull request and check reads from GitHub.
-- Deployment workflow/job reads.
-- Linear attachment/issue reads.
-- Valon Profile reads needed by author display and filtering.
-- Optional Datadog and Valkey reads only if their providers can enforce the same least-privilege boundary.
-
-Exclude unsupported dependencies from the first pilot. Do not grant the branch provider the production CI/CD sync subject.
-
-### Phase 3 success criteria
-
-#### Automated verification
-
-- [ ] Preview config validation proves IndexedDB and workflow providers are local and production DSNs/Temporal values are absent.
-- [ ] Management listener is unreachable from the Cloud Run URL.
-- [ ] `/health` and authenticated `/ready` pass before the preview is announced.
-- [ ] A known viewer can call normal CI/CD reads.
-- [ ] An admin can call `mergeReadiness`; a non-admin receives permission denied.
-- [ ] No workflow activation starts automatically.
-- [ ] Deployment scripts cannot name or update `toolshed-test`.
-
-#### Manual verification
-
-- [ ] Updating the PR changes provider behavior while retaining preview data.
-- [ ] Production CI/CD routing, database rows, workflows, and app revision remain unchanged.
-- [ ] Preview audit and application logs identify PR, app, owner, and source SHA.
-
-## Phase 4: High-signal CI/CD Data and Workflow Loop
-
-### Explicit preview operation
-
-**Files**
-
-- `/Users/michael/valon/toolshed/valon-tools/apps/ci-cd/provider.ts`
-- `/Users/michael/valon/toolshed/valon-tools/apps/ci-cd/sync/` orchestration and source modules
-- New preview-specific module and tests under the CI/CD app
-- `/Users/michael/valon/toolshed/valon-tools/deploy/preview/ci-cd.yaml`
-- `/Users/michael/valon/toolshed/valon-tools/deploy/config.yaml`
-
-Add an operation such as:
+Add an admin-only preview operation in `valon-tools/apps/ci-cd/provider.ts`:
 
 ```text
 preview.materializePullRequest({ prNumber })
 ```
 
-It is registered by the provider but fails closed unless `previewMode` is true. Production omits it from `allowedOperations`; the preview overlay grants it only to admins.
+Enable it only when `previewMode` is true and omit it from production `allowedOperations`. It reads one Front Porch PR plus available checks, deployments, and Linear data through the preview relay; reuses existing normalization/correlation logic; writes only preview storage; and returns intermediate and final JSON. Repeated calls must be idempotent.
 
-The operation:
+Install normal CI/CD workflow definitions in preview storage with automatic activations paused. Provide commands to start one run manually, inspect events/output, open logs, and reset preview data.
 
-1. Validates one Front Porch pull request number.
-2. Reads the PR, head checks/actions, merge commit deployments, Linear association, and other available read-only sources through the preview relay.
-3. Runs the same normalization and correlation functions used by scheduled syncs.
-4. Writes only to the preview database.
-5. Returns structured stage results with timing, source freshness, partial failures, persisted keys, and the final pull-request/revision views.
-6. Is idempotent for the same PR and source versions.
+### 5. Add attachment and lifecycle automation
 
-Do not repurpose `deployments.clearCache` or make fixture JSON part of a production handler. Keep existing local fixtures useful for offline tests, but make the preview path explicit and auditable.
+Add `valon-tools/apps/ci-cd/scripts/dev-ui-preview.sh` to discover and verify the preview, resolve both credentials, start loopback Vite, and print data, workflow, logging, and reset commands.
 
-### Manual workflow controls
+Update approved commits with concurrency keyed by app and PR. Delete resources on PR close and with a 72-hour sweeper. Cleanup must remove the service, database, database user, credentials, encryption secret, and deployment metadata.
 
-Install normal CI/CD workflow definitions into the preview provider with every activation paused. Document and script:
+### 6. Generalize after the pilot
 
-- Listing definitions and paused state.
-- Starting a selected run manually with input.
-- Waiting for terminal status.
-- Printing step inputs/outputs as JSON.
-- Opening the run inspector and logs.
-- Resetting preview data.
+After CI/CD succeeds, extract a reusable preview manifest and app-independent publication, deployment, attachment, validation, and cleanup tooling. Keep materialization app-specific. Onboard a second read-oriented app before broader self-service; apps requiring writes need preview-owned resources or dry-run interfaces.
 
-Automatic activation remains out of scope for the initial pilot even after manual runs work.
+## Verification
 
-### Phase 4 success criteria
+Automated tests must cover remote auth and token isolation, forced-paused workflows, dual proxy headers, artifact provenance, preview naming/cleanup, CI/CD authorization/idempotency, isolated IndexedDB, and the absence of automatic workflow ticks.
 
-#### Automated verification
+The end-to-end pilot must:
 
-- [ ] The preview operation is denied when `previewMode` is false.
-- [ ] Production config does not allowlist the preview operation.
-- [ ] One-PR materialization uses bounded API calls and writes only expected preview records.
-- [ ] Repeating materialization is idempotent.
-- [ ] Partial integration failures are explicit and preserve successful stage output.
-- [ ] Correlated JSON matches the data returned by list and detail operations.
+1. Publish and deploy a controlled CI/CD branch.
+2. Attach the local UI with one command.
+3. Materialize one PR and verify list/detail pages.
+4. Verify admin and non-admin `mergeReadiness`.
+5. Run one workflow manually and inspect JSON.
+6. Update and reset the preview without affecting production.
+7. Close the PR and verify complete cleanup.
 
-#### Manual verification
+## Rollout and success
 
-- [ ] A developer can materialize one PR, open its local UI page, and inspect checks, deploys, mergeability, and merge requirements without shipping backend code.
-- [ ] A developer can start a workflow manually and retrieve useful JSON for an agent feedback loop.
+Ship the Gestalt safety primitives and secure artifact split first. Then run manual CI/CD previews for maintainers, enable opt-in deployment by PR label, and generalize only after CI/CD and a second read-oriented app pass the same invariants.
 
-## Phase 5: Developer Attachment and Lifecycle Automation
-
-### Local command
-
-**Files**
-
-- `/Users/michael/valon/toolshed/valon-tools/apps/ci-cd/scripts/dev-ui-preview.sh` (new)
-- `/Users/michael/valon/toolshed/valon-tools/apps/ci-cd/scripts/dev-common.sh`
-- `/Users/michael/valon/toolshed/valon-tools/apps/ci-cd/ui/vite.config.ts`
-- Vite proxy contract tests
-- `/Users/michael/valon/toolshed/valon-tools/apps/ci-cd/knowledge/gestalt/local-development.md`
-- `/Users/michael/valon/toolshed/valon-tools/apps/ci-cd/spec.md`
-
-`dev-ui-preview.sh <pr-number>` resolves the preview from a GitHub deployment or Cloud Run labels, verifies the source SHA is on the PR, resolves stored Gestalt credentials, starts the refreshable Cloud Run identity source, and launches loopback Vite.
-
-It prints:
-
-- Local application URL.
-- Preview PR and source SHA.
-- Materialize/reset commands.
-- Workflow run and output commands.
-- Cloud Logging link.
-- Preview expiry.
-
-The script refuses previews whose app, repository, owner, or SHA labels do not match the requested PR.
-
-### Lifecycle workflows
-
-**Files**
-
-- `/Users/michael/valon/toolshed/.github/workflows/delete-app-preview.yml` (new)
-- `/Users/michael/valon/toolshed/.github/workflows/prune-app-previews.yml` (new)
-- `/Users/michael/valon/toolshed/.github/scripts/app-preview-cleanup.sh` (new)
-- Co-located cleanup tests
-
-Update previews on approved PR commits using concurrency keyed by repository, app, and PR. Announce readiness through a GitHub deployment and one updated PR comment rather than a new comment per commit.
-
-Delete on PR close. A scheduled sweeper independently removes previews past hard lifetime or attached to closed/missing PRs. Cleanup is idempotent and removes service, database, database user, credentials, encryption secret, and deployment metadata. Artifact Registry and snapshot retention independently remove old immutable artifacts.
-
-Use a default hard lifetime of 72 hours. An open PR can recreate an expired preview on its next approved deployment; there is no indefinite keepalive.
-
-### Phase 5 success criteria
-
-#### Automated verification
-
-- [ ] Resource naming and labels are deterministic and injection-safe.
-- [ ] New commits supersede older deployments for the same app/PR.
-- [ ] Close cleanup and the sweeper select the same resource closure.
-- [ ] Repeated cleanup succeeds when resources are already absent.
-- [ ] Attachment rejects a mismatched or expired preview.
-- [ ] Tokens never appear in shell tracing, process arguments, Vite responses, GitHub comments, or logs.
-
-#### Manual verification
-
-- [ ] One command attaches a local UI to the correct preview.
-- [ ] Scale-from-zero latency and token refresh produce actionable progress messages.
-- [ ] Closing the PR removes all preview resources within the documented window.
-
-## Phase 6: Reusable App Preview Contract
-
-Generalize only after CI/CD completes the manual pilot.
-
-### Changes
-
-- Define a trusted preview manifest describing app name, local provider source, dependencies and exact operations, datastore needs, workflow policy, health smoke operation, and mutation exclusions.
-- Extract app-independent publication, deployment, attachment, and cleanup workflows.
-- Keep app-specific materialization/reset operations in each app.
-- Add documentation under `docs/content/applications.mdx` describing preview topology, credentials, storage, workflows, and the local proxy.
-- Provide a validation command that renders the effective config and rejects production state references, unpaused workflows, public management listeners, mutable sources, or unbounded relay catalogs.
-
-Do not automatically onboard apps that require production writes. They need a preview-owned downstream resource or explicit dry-run interface first.
-
-### Phase 6 success criteria
-
-#### Automated verification
-
-- [ ] A second non-CI/CD app can deploy using only the reusable workflow plus its preview manifest.
-- [ ] Effective-config validation catches every safety invariant expressible in config.
-- [ ] App-specific scripts cannot override trusted IAM, secrets, placement, or cleanup.
-
-#### Manual verification
-
-- [ ] A developer can discover, deploy, attach, inspect, and delete the second app using the same command vocabulary.
-
-## Testing Strategy
-
-### Unit tests
-
-- Remote auth mode parsing, validation, bearer extraction, redaction, and concurrency.
-- App workflow force-pause transformation.
-- Vite dual-header injection and refresh.
-- Artifact provenance and archive validation.
-- Preview naming, labels, expiry, and cleanup selection.
-- CI/CD preview-mode gate and one-PR orchestration.
-
-### Gestalt integration tests
-
-Run two in-process Gestalt origins:
-
-1. Upstream with identity, authorization, and a test dependency app.
-2. Preview with caller-forwarding auth, local app/storage/workflow, and static relay.
-
-Verify distinct callers, role decisions, nested dependency calls, isolated records, paused activations, manual workflow runs, and bearer non-leakage.
-
-Add a provider-backed IndexedDB test that proves one preview credential cannot read a second preview or production schema. This is an infrastructure acceptance test, not only a mock host-service test.
-
-### Toolshed end-to-end test
-
-For a controlled CI/CD test branch:
-
-1. Publish an immutable branch snapshot.
-2. Deploy a preview.
-3. Attach local Vite.
-4. Materialize one PR.
-5. Verify list/detail UI data.
-6. Verify admin and non-admin merge-readiness behavior.
-7. Run one workflow manually and inspect JSON.
-8. Update the branch provider and confirm data persists.
-9. Reset the preview and confirm only preview data changes.
-10. Close the PR and verify complete cleanup.
-
-Before and after the test, capture production Cloud Run traffic/revision, CI/CD app revision, workflow definitions, and representative database checksums or update timestamps. They must not change because of the preview.
-
-## Rollout
-
-1. Ship and pin the Gestalt remote-auth, workflow-policy, and Vite changes.
-2. Provision preview infrastructure with no app deployment enabled.
-3. Run artifact publication security tests.
-4. Manually deploy one CI/CD preview for designated maintainers.
-5. Validate caller authorization and one-PR materialization.
-6. Validate manual workflows while all activations remain paused.
-7. Enable opt-in deployment by PR label for internal contributors.
-8. Observe cost, startup time, cleanup reliability, integration rate limits, and audit volume for at least two weeks.
-9. Onboard a second read-oriented app through the reusable manifest.
-10. Consider broader self-service only after both pilots satisfy the same invariants.
-
-### Rollback
-
-- Disable the preview deployment workflow and remove its WIF binding.
-- Revoke the preview integration relay.
-- Delete all resources selected by preview labels.
-- Leave branch snapshots to normal retention.
-- Gestalt's new config fields remain dormant when unused; static named remotes and existing Vite bearer proxying remain backward compatible.
-
-No rollback step touches production application versions because previews never become production candidates.
-
-## Success Metrics
-
-- An approved CI/CD preview is ready within 10 minutes of a commit.
-- Attaching the local UI is one command and less than one minute excluding scale-up.
-- UI-only iterations remain immediate through HMR.
-- One-PR materialization returns useful JSON and a working page without a production deploy.
-- At least one backend/auth feature is completed without test-only production PRs.
-- Preview cleanup succeeds automatically for every pilot PR, with the sweeper catching any missed close event.
-- There are zero preview writes to production Gestalt, CI/CD, or workflow state.
-- No preview credential appears in branch jobs, browser JavaScript, logs, or comments.
-
-## Work Breakdown and Dependencies
-
-| Work item | Repository | Depends on |
-| --- | --- | --- |
-| Caller-forwarding remote auth | `gestalt` | — |
-| Forced-paused app workflows | `gestalt` | — |
-| Dual-auth Vite proxy | `gestalt` | — |
-| Trusted branch artifact split | `toolshed` | — |
-| Preview infrastructure/config | `toolshed` | Gestalt safety primitives |
-| CI/CD materialization operation | `toolshed` | Preview relay contract |
-| Local attachment command | `toolshed` | Dual-auth proxy and preview deployment |
-| Cleanup/TTL automation | `toolshed` | Preview infrastructure |
-| Reusable app manifest | both | Successful CI/CD pilot |
-
-The first three Gestalt changes and the artifact-pipeline split can proceed in parallel. The preview runtime must not launch until caller authentication, force-pause, and artifact trust boundaries are deployed.
-
-## Definition of Done
-
-- All safety invariants are enforced by config validation, IAM, provider credentials, or automated tests.
-- CI/CD's local UI works against a remote branch backend with real caller role checks.
-- One-PR data and a manual workflow produce inspectable JSON.
-- Production routing and state remain unchanged through the end-to-end test.
-- Close and TTL cleanup remove the full preview resource closure.
-- Documentation clearly distinguishes preview-local state, delegated production reads, and prohibited production writes.
-- A second Gestalt app can adopt the reusable foundation without copying CI/CD-specific deployment logic.
-
-## References
-
-### Gestalt
-
-- `docs/content/applications.mdx`
-- `docs/content/reference/config-file.mdx`
-- `gestaltd/internal/config/config.go`
-- `gestaltd/internal/config/remotes.go`
-- `gestaltd/internal/remote/remote.go`
-- `gestaltd/internal/bootstrap/workflow_app_definitions.go`
-- `gestaltd/internal/bootstrap/workflow_config_definitions.go`
-- `gestaltd/internal/bootstrap/host_service_bootstrap.go`
-- `gestaltd/internal/server/handlers_activate.go`
-- `gestaltd/services/indexeddb/server.go`
-- `sdk/typescript-web/src/vite.js`
-- `plans/service_mesh/plan.md`, especially the Development Sandbox contract
-
-### Toolshed
-
-- `/Users/michael/valon/toolshed/.github/workflows/publish-app-snapshot.yml`
-- `/Users/michael/valon/toolshed/.github/workflows/deploy-valon-tools.yml`
-- `/Users/michael/valon/toolshed/valon-tools/deploy/config.yaml`
-- `/Users/michael/valon/toolshed/valon-tools/deploy/local/config.yaml`
-- `/Users/michael/valon/toolshed/valon-tools/apps/ci-cd/scripts/dev-ui-remote.sh`
-- `/Users/michael/valon/toolshed/valon-tools/apps/ci-cd/knowledge/gestalt/local-development.md`
-- `/Users/michael/valon/toolshed/valon-tools/apps/ci-cd/workflows.ts`
+Success means an approved preview is ready within 10 minutes, attachment is one command, frontend changes remain immediate, preview data and workflow output are useful for debugging, teardown is deterministic, and preview activity causes zero production routing or state changes.

--- a/plans/preview_environments/plan.md
+++ b/plans/preview_environments/plan.md
@@ -1,0 +1,881 @@
+# Gestalt App Preview Environments
+
+## Status
+
+Proposed. This plan defines a reusable preview-environment foundation and a
+`valon-tools/apps/ci-cd` pilot. It does not authorize implementation or production
+rollout by itself.
+
+## Overview
+
+Gestalt app authors can run a frontend locally with hot module replacement, but
+backend changes that need production integrations, authorization, or workflows are
+still difficult to verify without deploying the app to production. CI/CD is the
+first pilot because its pages depend on correlated GitHub, Linear, workqueue, and
+deployment data, and because its merge-readiness feature needs real caller
+authorization.
+
+The proposed development loop is:
+
+1. An internal pull request publishes an immutable app snapshot for its exact commit.
+2. Trusted automation creates or updates a dedicated preview `gestaltd` service.
+3. The branch app provider runs in that preview with isolated application and workflow
+   storage.
+4. A loopback-only Vite proxy sends local browser API requests to the preview.
+5. The preview validates the developer's real Gestalt bearer and delegates only an
+   explicit set of integration reads through a least-privilege preview identity.
+6. App workflows are installed paused and may be run manually.
+7. Closing or expiring the pull request deletes all preview resources.
+
+This is deliberately a separate control plane. A preview must not be a no-traffic
+revision of the production `toolshed-test` Cloud Run service, a production app-registry
+candidate, or a reverse-published provider that shadows a production app.
+
+## Goals
+
+- Run a branch version of a Gestalt app backend remotely without changing production
+  traffic or provider selection.
+- Keep frontend source and HMR local.
+- Exercise real caller authentication and authorization, including CI/CD's admin-only
+  `pullRequests.mergeReadiness`.
+- Let developers materialize one or two representative records and inspect workflow
+  inputs, intermediate values, outputs, and logs.
+- Install app-declared workflows without allowing schedules or event activations to
+  run automatically.
+- Reuse the same preview deployment contract for other Gestalt apps after the CI/CD
+  pilot.
+- Make preview creation, update, attachment, reset, and teardown deterministic enough
+  for agents to execute and verify.
+
+## Non-goals
+
+- Sending production traffic to preview code.
+- Testing production migrations, production writes, merge-queue mutations,
+  notifications, or fast-track actions.
+- Cloning the production Gestalt control-plane database.
+- Sharing production Temporal state or task queues.
+- Making reverse provider publication subject-aware as part of this pilot.
+- Supporting untrusted fork pull requests automatically.
+- Adding broad localhost CORS support to Gestalt.
+- Providing indefinite preview persistence.
+- Replacing normal unit, contract, and integration tests.
+
+## Current State
+
+### Local UI to remote API already works
+
+The CI/CD app's
+`valon-tools/apps/ci-cd/scripts/dev-ui-remote.sh` starts Vite on loopback, obtains a
+Gestalt API token, and sets `GESTALT_API_PROXY_TARGET`. The Gestalt Vite plugin in
+`sdk/typescript-web/src/vite.js` proxies `/api/v1` and `/api/v2`, adding the bearer
+server-side so it is not exposed to frontend JavaScript.
+
+The missing piece is a safe branch backend URL. Today the script points at
+`https://valon.tools`, so it can validate local UI changes only against the already
+deployed provider.
+
+### Branch snapshots can already be built
+
+Toolshed's `.github/workflows/publish-app-snapshot.yml` accepts an app and arbitrary
+branch, tag, or SHA. It packages immutable
+`0.0.0-snapshot.g<full-commit-sha>` artifacts. The workflow currently packages branch
+code and later authenticates to GCP in the same job, which is acceptable for trusted
+main-branch publishing but is not an adequate boundary for automated pull-request
+previews. Branch-controlled code can leave a process running until credentials are
+minted later in the job.
+
+### Gestalt config has most placement primitives
+
+Gestalt supports left-to-right config overlays, named remotes, local and remote
+provider placement, source overrides, distinct public and management listeners, and
+app-specific IndexedDB bindings. Useful implementation points include:
+
+- `gestaltd/internal/config/config.go`
+- `gestaltd/internal/config/remotes.go`
+- `gestaltd/internal/config/config_validate.go`
+- `gestaltd/internal/daemon/provider_local.go`
+- `gestaltd/internal/bootstrap/provider_build.go`
+
+These are building blocks, not a preview-isolation mode. Safe composition remains the
+deployment's responsibility.
+
+### Remote authentication is currently static
+
+`gestaltd/internal/remote/remote.go` attaches one configured bearer token to every RPC
+on a named remote. Consequently, merely marking production identity and authorization
+providers `remote: prod` does **not** preserve the interactive caller: it authenticates
+the preview's configured relay token instead.
+
+The preview requires two distinct upstream authentication modes:
+
+- **Caller forwarding** for production identity and authorization, using the bearer
+  from the incoming local-UI request.
+- **Static preview relay identity** for explicitly allowlisted integration operations.
+
+This must be implemented as an explicit Gestalt remote-auth contract. The preview must
+not infer or copy browser cookies, forward arbitrary caller headers, or give branch
+code direct access to either token.
+
+### Shared storage is unsafe
+
+Gestalt's config exposes `apps.<name>.indexeddb.db` and `objectStores`, but the current
+host-service bootstrap does not provide enough evidence that these fields form a hard
+runtime isolation boundary for every provider. Relevant paths are:
+
+- `gestaltd/internal/config/provider_selection.go`
+- `gestaltd/internal/bootstrap/host_service_bootstrap.go`
+- `gestaltd/services/indexeddb/server.go`
+- `gestaltd/internal/bootstrap/executable_app_test.go`
+
+Until provider-backed isolation is enforced and tested end to end, every preview must
+receive a separate physical database or a separate provider credential constrained to
+one preview schema. A different logical `db` string on a shared privileged provider is
+not sufficient.
+
+The same requirement applies to Gestalt core state: users, app installations,
+rollouts, authorization fragments, and remote registrations must not share the
+production control-plane database.
+
+### Workflow startup mutates provider state
+
+App-declared workflows are read from provider metadata and reconciled at startup by
+`gestaltd/internal/bootstrap/workflow_app_definitions.go`. Config-managed definitions
+are similarly reconciled by `workflow_config_definitions.go`. Reconciliation applies
+definitions and removes absent managed definitions. A preview connected to production
+Temporal could update, pause, activate, or delete production workflow state before any
+HTTP request reaches it.
+
+Definitions and activations already have paused flags, but deployment config cannot
+currently force app-declared workflows paused before their first reconciliation.
+Pausing after startup leaves a race with the first scheduled tick.
+
+### Reverse publication is not a preview boundary
+
+Reverse-published providers are resolved globally by kind and app name. A registered
+`app/ci-cd` takes precedence over the production provider for all callers; provider
+ownership is also global. Making this subject-aware would touch registration storage,
+provider resolution, app catalogs, mounted UI routing, workflows, auditing, fallback,
+and authorization. It is larger and riskier than a dedicated preview service and does
+not naturally solve storage isolation.
+
+## Desired End State
+
+An approved internal CI/CD pull request receives a URL such as:
+
+```text
+https://gestalt-preview-ci-cd-pr-123-<hash>.run.app
+```
+
+From a Toolshed checkout, a developer runs:
+
+```bash
+./valon-tools/apps/ci-cd/scripts/dev-ui-preview.sh 123
+```
+
+The command:
+
+1. Resolves the preview for PR 123 and verifies its commit.
+2. Obtains the developer's Gestalt token without exposing it to the browser.
+3. Obtains and refreshes Cloud Run invocation identity.
+4. Starts Vite on `127.0.0.1`.
+5. Proxies API calls to the preview with independent Cloud Run and Gestalt
+   authorization headers.
+6. Prints commands for materializing a PR, starting a workflow manually, viewing its
+   JSON output, and opening logs.
+
+The preview persists its isolated database across branch-provider updates. A reset
+action destroys and recreates only that preview's data. It is removed on PR close and
+also by a hard-lifetime sweeper.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    browser[Browser]
+    vite["Loopback Vite proxy"]
+    preview["PR Cloud Run gestaltd"]
+    branchApp["Branch CI/CD provider"]
+    previewDb["Preview control and app DB"]
+    previewWorkflow["Preview workflow provider"]
+    prodIdentity["Production identity and authorization"]
+    prodApps["Allowlisted production integration apps"]
+
+    browser -->|Local assets and API| vite
+    vite -->|"Cloud Run identity + Gestalt bearer"| preview
+    preview --> branchApp
+    branchApp --> previewDb
+    branchApp --> previewWorkflow
+    preview -->|"Forward caller bearer"| prodIdentity
+    branchApp -->|"Preview relay identity"| prodApps
+```
+
+### Request identities
+
+There are three identities and they must remain separate:
+
+1. **Cloud Run invoker** proves that the local proxy may reach the preview service. It
+   is carried in `X-Serverless-Authorization`.
+2. **Interactive Gestalt caller** is the developer's existing Gestalt bearer in
+   `Authorization`. Production identity validates it, and production authorization
+   evaluates that caller's relationships. This is what makes admin and non-admin
+   merge-readiness behavior realistic.
+3. **Preview integration relay** is a dedicated non-human Gestalt principal used only
+   for the named remote apps and operations allowed by the preview manifest. It is not
+   `service_account:ci-cd-sync` and has no mutation authority.
+
+Gestalt never passes the interactive caller bearer to branch provider code. Gestalt
+mediates host-service and remote app calls.
+
+### Branch-code trust boundary
+
+An internal PR provider is still arbitrary code running beside `gestaltd`. The current
+local-provider process model is not a hardened sandbox, so the pilot must assume that a
+compromised provider can exercise the preview runtime identity and any static relay
+authority available to the process. Secret non-exposure alone is not the security
+boundary.
+
+Therefore the runtime identity grants only preview resource access, and the relay
+grants only operations whose production read results are acceptable for the approved
+internal PR author to see. The relay has no write, impersonation, token-minting,
+secret-reading, or broader discovery authority. Forks remain ineligible. Stronger
+subprocess/container isolation can reduce this trust later, but it is not a prerequisite
+for a read-only internal pilot and must not be implied by this plan.
+
+### Provider placement
+
+The generated final overlay for a CI/CD preview uses:
+
+- Local branch `ci-cd` app provider.
+- Local preview IndexedDB provider backed by preview-constrained credentials.
+- Local preview workflow provider and workflow storage.
+- Caller-forwarding remote for identity and authorization.
+- Static-relay remote for an exact set of GitHub, Linear, Valon Profile, Datadog, and
+  Valkey operations.
+- No remote IndexedDB or workflow provider.
+- No production registry reconciliation.
+
+Dependencies that cannot operate with the preview relay's least-privilege grants are
+excluded from the pilot. Automatic schedules remain blocked; lack of an integration
+may produce an explicit partial result but must not silently fall back to a production
+service account.
+
+### Network surface
+
+- Cloud Run requires IAM invocation.
+- The public listener exposes app and normal public API routes only.
+- The management listener binds to loopback and is not mapped by Cloud Run.
+- `/activate`, `/admin`, and management metrics are not externally reachable.
+- Vite binds to `127.0.0.1`, validates the browser origin, and keeps both credentials
+  server-side.
+- No preview adds permissive CORS headers to production or Gestalt.
+
+## Safety Invariants
+
+The implementation is incomplete until all invariants are mechanically enforced or
+tested:
+
+1. Preview automation never updates the production `toolshed-test` Cloud Run service,
+   revision tags, traffic, or config.
+2. Every preview has a unique service, datastore credential, encryption key, runtime
+   identity, resource labels, and expiry.
+3. Preview control-plane, app, and workflow state cannot address production storage.
+4. Branch-controlled code never executes in a job after GCP publication or deployment
+   credentials are minted.
+5. Preview artifacts are selected by full commit SHA and verified digest, never a
+   mutable branch name.
+6. Only internal pull requests or explicitly approved commits can receive previews.
+7. `server.authorizationStateApply` is false and the environment override is unset.
+8. The developer's bearer is forwarded only to the configured identity/authorization
+   remote over HTTPS.
+9. Integration calls use a separate least-privilege relay and exact app-operation
+   allowlists.
+10. The production `ci-cd-sync` token, production database DSN, and production Temporal
+    credentials are never available to branch code.
+11. App-declared workflow definitions and activations are forced paused before their
+    first reconciliation.
+12. Management routes are private to the container.
+13. Production app-registry activation, rollout evaluation, and authorization-state
+    writes are disabled.
+14. Preview config, IAM, secret bindings, placement, and egress are trusted inputs;
+    a pull request cannot replace them.
+15. Preview services, databases, credentials, keys, and secrets are deleted on close
+    and by a maximum-age sweeper.
+16. Resources and logs carry repository, app, PR, owner, source SHA, workflow run, and
+    expiry labels.
+
+## Implementation Approach
+
+Deliver the capability in six phases. Phases 1 and 2 establish reusable Gestalt and
+publication safety. Phase 3 creates one manually triggered CI/CD preview. Phases 4 and
+5 provide the useful developer loop and lifecycle automation. Phase 6 generalizes only
+the parts proven by the pilot.
+
+## Phase 1: Gestalt Preview Safety Primitives
+
+### 1. Caller-forwarding named remote authentication
+
+**Files**
+
+- `gestaltd/internal/config/remotes.go`
+- `gestaltd/internal/config/config_validate.go`
+- `gestaltd/internal/remote/remote.go`
+- `gestaltd/internal/remote/remote_test.go`
+- Request authentication/context plumbing under `gestaltd/internal/server/`
+- `gestaltd/internal/bootstrap/bootstrap.go`
+- `docs/content/reference/config-file.mdx`
+
+**Changes**
+
+Replace the implicit token-only remote contract with a backward-compatible explicit
+auth shape. Existing `token` continues to mean a static bearer. Add a mode that forwards
+the incoming bearer from trusted request context:
+
+```yaml
+server:
+  remotes:
+    caller-auth:
+      url: https://valon.tools
+      auth:
+        mode: forwardBearer
+```
+
+Validation must:
+
+- Reject `forwardBearer` with a static token.
+- Require HTTPS except for loopback tests.
+- Allow the mode only when the remote is referenced by explicitly supported provider
+  kinds.
+- Never forward cookies or arbitrary authorization-like headers.
+- Fail unauthenticated background calls instead of falling back to another identity.
+- Redact bearer values from logs and errors.
+
+The HTTP/gRPC request boundary must capture the raw bearer into a private context value
+before remote identity resolution. Public gRPC must continue stripping caller-supplied
+trusted-principal metadata. Remote interceptors read only the private context value.
+
+Use one caller-forwarding remote for identity and authorization and a second
+static-token remote for dependency apps. Do not make all remotes inherit one auth mode.
+
+### 2. Force-pause app-declared workflows
+
+**Files**
+
+- `gestaltd/internal/config/config.go`
+- `gestaltd/internal/config/config_validate.go`
+- `gestaltd/internal/bootstrap/workflow_app_definitions.go`
+- `gestaltd/internal/bootstrap/workflow_app_definitions_test.go`
+- `gestaltd/internal/bootstrap/workflow_startup_test.go`
+- `docs/content/reference/config-file.mdx`
+- `docs/content/applications.mdx`
+
+**Changes**
+
+Add deployment policy on an app binding:
+
+```yaml
+apps:
+  ci-cd:
+    workflowPolicy:
+      forcePaused: true
+```
+
+Before app definitions are passed to the workflow provider, force both the definition
+and every activation paused. Preserve the app's original schedule and event metadata so
+an authorized developer can inspect and deliberately enable a selected activation.
+Manual `StartRun` remains available while automatic schedule and event starts remain
+blocked.
+
+The policy is deployer-owned and not part of branch package metadata. Apply it during
+desired-definition construction, not in a post-start script.
+
+### 3. Dual-auth Vite proxy
+
+**Files**
+
+- `sdk/typescript-web/src/vite.js`
+- `sdk/typescript-web/src/vite.d.ts`
+- `sdk/typescript-web/tests/vite-plugin.test.ts`
+- `sdk/typescript-web/README.md`
+- `docs/content/applications.mdx`
+
+**Changes**
+
+Keep the existing Gestalt bearer behavior. Add an optional serverless identity source
+that maintains a cached token and sets `X-Serverless-Authorization`. The source should
+support an external command or callback, parse JWT expiry, refresh before expiration,
+and fail the proxied request closed when refresh fails.
+
+The browser must never receive either token. Preserve any explicit browser
+`Authorization` header only under the existing rules; the serverless token always uses
+its separate header.
+
+### Phase 1 success criteria
+
+#### Automated verification
+
+- [ ] Remote config rejects conflicting, insecure, or unknown auth modes.
+- [ ] Static-token remotes retain existing behavior.
+- [ ] Caller-forwarding sends the current request's bearer to remote identity and
+      authorization and sends no bearer for a request without one.
+- [ ] A concurrent request test proves bearers cannot cross between callers.
+- [ ] Logs and returned errors contain no bearer values.
+- [ ] App workflow definitions and all activations are paused on their first apply.
+- [ ] A manual workflow run can still start under `forcePaused`.
+- [ ] No scheduled run starts during a multi-tick integration test.
+- [ ] Vite sends independent `Authorization` and `X-Serverless-Authorization` headers
+      and refreshes the latter before expiry.
+
+#### Manual verification
+
+- [ ] Two users with different production roles receive different authorization
+      decisions through a local preview server.
+- [ ] An expired Cloud Run identity produces an actionable proxy error without exposing
+      token text.
+
+## Phase 2: Secure Branch Artifact Publication
+
+### Files
+
+- `/Users/michael/valon/toolshed/.github/workflows/publish-app-snapshot.yml`
+- `/Users/michael/valon/toolshed/.github/workflows/publish-app-preview.yml` (new)
+- `/Users/michael/valon/toolshed/.github/valon-tools-provider-snapshot-publish.yaml`
+- `/Users/michael/valon/toolshed/.github/scripts/` preview artifact validation scripts
+- Co-located script tests
+
+### Changes
+
+Split the pipeline into trust domains:
+
+1. Ordinary PR CI checks out the exact source SHA, installs frozen dependencies,
+   packages the app, and uploads an unprivileged GitHub Actions artifact containing the
+   provider archives, catalog/workflow metadata, source SHA, and checksums.
+2. A trusted default-branch workflow is triggered only after required CI succeeds. It
+   downloads bytes rather than checking out and executing the PR.
+3. Trusted code validates app name, commit SHA, archive paths, manifest identity,
+   checksums, and package metadata.
+4. Only then does it authenticate to GCP and publish the immutable snapshot.
+
+The trusted job must use its own checked-in scripts and Dockerfile from the default
+branch. It must not run hooks, shell scripts, package managers, or binaries from the PR
+artifact.
+
+### Phase 2 success criteria
+
+#### Automated verification
+
+- [ ] A valid internal PR artifact publishes under its full source SHA.
+- [ ] Mismatched app name, SHA, checksum, manifest source, or unexpected archive member
+      fails before GCP authentication.
+- [ ] Fork PRs cannot enter the trusted publication workflow without explicit approval.
+- [ ] The publication is create-only and cannot overwrite an existing version.
+
+#### Manual verification
+
+- [ ] Registry metadata points to the reviewed PR commit and expected artifact digest.
+- [ ] Cancelling or retrying a publish is idempotent.
+
+## Phase 3: CI/CD Preview Runtime Pilot
+
+### Trusted preview deployment assets
+
+**Files**
+
+- `/Users/michael/valon/toolshed/valon-tools/deploy/preview/base.yaml` (new)
+- `/Users/michael/valon/toolshed/valon-tools/deploy/preview/ci-cd.yaml` (new)
+- `/Users/michael/valon/toolshed/valon-tools/deploy/preview/Dockerfile` (new)
+- `/Users/michael/valon/toolshed/.github/workflows/deploy-app-preview.yml` (new)
+- `/Users/michael/valon/toolshed/.github/scripts/app-preview-deploy.sh` (new)
+- `/Users/michael/valon/toolshed/.github/scripts/tests/app-preview-deploy_test.sh` (new)
+- `/Users/michael/valon/toolshed/valon-tools/terraform/preview/` (new)
+
+The preview Terraform root is separate from the existing production root and uses its
+own state and deploy identity. Production deployment workflows do not plan or apply it.
+
+### Runtime configuration
+
+Create a curated preview base rather than copying production config wholesale.
+Generated values include preview ID, source SHA, public URL, datastore credentials,
+encryption key secret, relay identity, resource labels, and expiry.
+
+The CI/CD overlay includes:
+
+- The normal CI/CD operation authorization policy and `mergeReadiness` admin rule.
+- Branch snapshot selected by immutable version/digest.
+- Preview-only IndexedDB and workflow bindings.
+- `workflowPolicy.forcePaused: true`.
+- `authorizationStateApply: false`.
+- Only the dependency apps and operation metadata required for the pilot.
+- No mutation operations for Trunk, GitHub, notifications, or fast-track behavior.
+- No production Temporal provider or database references.
+
+Deploy one Cloud Run service per PR:
+
+```text
+gestalt-preview-ci-cd-pr-<number>
+```
+
+Use min instances `0`, max instances `1`, bounded CPU/memory, IAM-only invocation, and
+preview-specific runtime identity. A per-PR service makes URL, IAM, logs, and teardown
+obvious; consolidation into tagged revisions is deferred until usage proves service
+count is a problem.
+
+The deployment workflow never calls production `/activate`, changes production
+traffic, or reuses `.github/workflows/deploy-valon-tools.yml`.
+
+### Datastore isolation
+
+Provision a distinct database and credential constrained to that database for each
+preview. The runtime identity can read its database credential but has no permission to
+enumerate or access production database secrets. Preserve the database when updating a
+preview to a newer commit. Reset replaces the preview database and credential as one
+fenced operation.
+
+### Integration relay
+
+Create a preview relay subject with only the operations needed for:
+
+- Pull request and check reads from GitHub.
+- Deployment workflow/job reads.
+- Linear attachment/issue reads.
+- Valon Profile reads needed by author display and filtering.
+- Optional Datadog and Valkey reads only if their providers can enforce the same
+  least-privilege boundary.
+
+Exclude unsupported dependencies from the first pilot. Do not grant the branch
+provider the production CI/CD sync subject.
+
+### Phase 3 success criteria
+
+#### Automated verification
+
+- [ ] Preview config validation proves IndexedDB and workflow providers are local and
+      production DSNs/Temporal values are absent.
+- [ ] Management listener is unreachable from the Cloud Run URL.
+- [ ] `/health` and authenticated `/ready` pass before the preview is announced.
+- [ ] A known viewer can call normal CI/CD reads.
+- [ ] An admin can call `mergeReadiness`; a non-admin receives permission denied.
+- [ ] No workflow activation starts automatically.
+- [ ] Deployment scripts cannot name or update `toolshed-test`.
+
+#### Manual verification
+
+- [ ] Updating the PR changes provider behavior while retaining preview data.
+- [ ] Production CI/CD routing, database rows, workflows, and app revision remain
+      unchanged.
+- [ ] Preview audit and application logs identify PR, app, owner, and source SHA.
+
+## Phase 4: High-signal CI/CD Data and Workflow Loop
+
+### Explicit preview operation
+
+**Files**
+
+- `/Users/michael/valon/toolshed/valon-tools/apps/ci-cd/provider.ts`
+- `/Users/michael/valon/toolshed/valon-tools/apps/ci-cd/sync/` orchestration and source
+  modules
+- New preview-specific module and tests under the CI/CD app
+- `/Users/michael/valon/toolshed/valon-tools/deploy/preview/ci-cd.yaml`
+- `/Users/michael/valon/toolshed/valon-tools/deploy/config.yaml`
+
+Add an operation such as:
+
+```text
+preview.materializePullRequest({ prNumber })
+```
+
+It is registered by the provider but fails closed unless `previewMode` is true.
+Production omits it from `allowedOperations`; the preview overlay grants it only to
+admins.
+
+The operation:
+
+1. Validates one Front Porch pull request number.
+2. Reads the PR, head checks/actions, merge commit deployments, Linear association, and
+   other available read-only sources through the preview relay.
+3. Runs the same normalization and correlation functions used by scheduled syncs.
+4. Writes only to the preview database.
+5. Returns structured stage results with timing, source freshness, partial failures,
+   persisted keys, and the final pull-request/revision views.
+6. Is idempotent for the same PR and source versions.
+
+Do not repurpose `deployments.clearCache` or make fixture JSON part of a production
+handler. Keep existing local fixtures useful for offline tests, but make the preview
+path explicit and auditable.
+
+### Manual workflow controls
+
+Install normal CI/CD workflow definitions into the preview provider with every
+activation paused. Document and script:
+
+- Listing definitions and paused state.
+- Starting a selected run manually with input.
+- Waiting for terminal status.
+- Printing step inputs/outputs as JSON.
+- Opening the run inspector and logs.
+- Resetting preview data.
+
+Automatic activation remains out of scope for the initial pilot even after manual runs
+work.
+
+### Phase 4 success criteria
+
+#### Automated verification
+
+- [ ] The preview operation is denied when `previewMode` is false.
+- [ ] Production config does not allowlist the preview operation.
+- [ ] One-PR materialization uses bounded API calls and writes only expected preview
+      records.
+- [ ] Repeating materialization is idempotent.
+- [ ] Partial integration failures are explicit and preserve successful stage output.
+- [ ] Correlated JSON matches the data returned by list and detail operations.
+
+#### Manual verification
+
+- [ ] A developer can materialize one PR, open its local UI page, and inspect checks,
+      deploys, mergeability, and merge requirements without shipping backend code.
+- [ ] A developer can start a workflow manually and retrieve useful JSON for an agent
+      feedback loop.
+
+## Phase 5: Developer Attachment and Lifecycle Automation
+
+### Local command
+
+**Files**
+
+- `/Users/michael/valon/toolshed/valon-tools/apps/ci-cd/scripts/dev-ui-preview.sh`
+  (new)
+- `/Users/michael/valon/toolshed/valon-tools/apps/ci-cd/scripts/dev-common.sh`
+- `/Users/michael/valon/toolshed/valon-tools/apps/ci-cd/ui/vite.config.ts`
+- Vite proxy contract tests
+- `/Users/michael/valon/toolshed/valon-tools/apps/ci-cd/knowledge/gestalt/local-development.md`
+- `/Users/michael/valon/toolshed/valon-tools/apps/ci-cd/spec.md`
+
+`dev-ui-preview.sh <pr-number>` resolves the preview from a GitHub deployment or Cloud
+Run labels, verifies the source SHA is on the PR, resolves stored Gestalt credentials,
+starts the refreshable Cloud Run identity source, and launches loopback Vite.
+
+It prints:
+
+- Local application URL.
+- Preview PR and source SHA.
+- Materialize/reset commands.
+- Workflow run and output commands.
+- Cloud Logging link.
+- Preview expiry.
+
+The script refuses previews whose app, repository, owner, or SHA labels do not match the
+requested PR.
+
+### Lifecycle workflows
+
+**Files**
+
+- `/Users/michael/valon/toolshed/.github/workflows/delete-app-preview.yml` (new)
+- `/Users/michael/valon/toolshed/.github/workflows/prune-app-previews.yml` (new)
+- `/Users/michael/valon/toolshed/.github/scripts/app-preview-cleanup.sh` (new)
+- Co-located cleanup tests
+
+Update previews on approved PR commits using concurrency keyed by repository, app, and
+PR. Announce readiness through a GitHub deployment and one updated PR comment rather
+than a new comment per commit.
+
+Delete on PR close. A scheduled sweeper independently removes previews past hard
+lifetime or attached to closed/missing PRs. Cleanup is idempotent and removes service,
+database, database user, credentials, encryption secret, and deployment metadata.
+Artifact Registry and snapshot retention independently remove old immutable artifacts.
+
+Use a default hard lifetime of 72 hours. An open PR can recreate an expired preview on
+its next approved deployment; there is no indefinite keepalive.
+
+### Phase 5 success criteria
+
+#### Automated verification
+
+- [ ] Resource naming and labels are deterministic and injection-safe.
+- [ ] New commits supersede older deployments for the same app/PR.
+- [ ] Close cleanup and the sweeper select the same resource closure.
+- [ ] Repeated cleanup succeeds when resources are already absent.
+- [ ] Attachment rejects a mismatched or expired preview.
+- [ ] Tokens never appear in shell tracing, process arguments, Vite responses, GitHub
+      comments, or logs.
+
+#### Manual verification
+
+- [ ] One command attaches a local UI to the correct preview.
+- [ ] Scale-from-zero latency and token refresh produce actionable progress messages.
+- [ ] Closing the PR removes all preview resources within the documented window.
+
+## Phase 6: Reusable App Preview Contract
+
+Generalize only after CI/CD completes the manual pilot.
+
+### Changes
+
+- Define a trusted preview manifest describing app name, local provider source,
+  dependencies and exact operations, datastore needs, workflow policy, health smoke
+  operation, and mutation exclusions.
+- Extract app-independent publication, deployment, attachment, and cleanup workflows.
+- Keep app-specific materialization/reset operations in each app.
+- Add documentation under `docs/content/applications.mdx` describing preview topology,
+  credentials, storage, workflows, and the local proxy.
+- Provide a validation command that renders the effective config and rejects production
+  state references, unpaused workflows, public management listeners, mutable sources,
+  or unbounded relay catalogs.
+
+Do not automatically onboard apps that require production writes. They need a
+preview-owned downstream resource or explicit dry-run interface first.
+
+### Phase 6 success criteria
+
+#### Automated verification
+
+- [ ] A second non-CI/CD app can deploy using only the reusable workflow plus its
+      preview manifest.
+- [ ] Effective-config validation catches every safety invariant expressible in config.
+- [ ] App-specific scripts cannot override trusted IAM, secrets, placement, or cleanup.
+
+#### Manual verification
+
+- [ ] A developer can discover, deploy, attach, inspect, and delete the second app using
+      the same command vocabulary.
+
+## Testing Strategy
+
+### Unit tests
+
+- Remote auth mode parsing, validation, bearer extraction, redaction, and concurrency.
+- App workflow force-pause transformation.
+- Vite dual-header injection and refresh.
+- Artifact provenance and archive validation.
+- Preview naming, labels, expiry, and cleanup selection.
+- CI/CD preview-mode gate and one-PR orchestration.
+
+### Gestalt integration tests
+
+Run two in-process Gestalt origins:
+
+1. Upstream with identity, authorization, and a test dependency app.
+2. Preview with caller-forwarding auth, local app/storage/workflow, and static relay.
+
+Verify distinct callers, role decisions, nested dependency calls, isolated records,
+paused activations, manual workflow runs, and bearer non-leakage.
+
+Add a provider-backed IndexedDB test that proves one preview credential cannot read a
+second preview or production schema. This is an infrastructure acceptance test, not
+only a mock host-service test.
+
+### Toolshed end-to-end test
+
+For a controlled CI/CD test branch:
+
+1. Publish an immutable branch snapshot.
+2. Deploy a preview.
+3. Attach local Vite.
+4. Materialize one PR.
+5. Verify list/detail UI data.
+6. Verify admin and non-admin merge-readiness behavior.
+7. Run one workflow manually and inspect JSON.
+8. Update the branch provider and confirm data persists.
+9. Reset the preview and confirm only preview data changes.
+10. Close the PR and verify complete cleanup.
+
+Before and after the test, capture production Cloud Run traffic/revision, CI/CD app
+revision, workflow definitions, and representative database checksums or update
+timestamps. They must not change because of the preview.
+
+## Rollout
+
+1. Ship and pin the Gestalt remote-auth, workflow-policy, and Vite changes.
+2. Provision preview infrastructure with no app deployment enabled.
+3. Run artifact publication security tests.
+4. Manually deploy one CI/CD preview for designated maintainers.
+5. Validate caller authorization and one-PR materialization.
+6. Validate manual workflows while all activations remain paused.
+7. Enable opt-in deployment by PR label for internal contributors.
+8. Observe cost, startup time, cleanup reliability, integration rate limits, and audit
+   volume for at least two weeks.
+9. Onboard a second read-oriented app through the reusable manifest.
+10. Consider broader self-service only after both pilots satisfy the same invariants.
+
+### Rollback
+
+- Disable the preview deployment workflow and remove its WIF binding.
+- Revoke the preview integration relay.
+- Delete all resources selected by preview labels.
+- Leave branch snapshots to normal retention.
+- Gestalt's new config fields remain dormant when unused; static named remotes and
+  existing Vite bearer proxying remain backward compatible.
+
+No rollback step touches production application versions because previews never become
+production candidates.
+
+## Success Metrics
+
+- An approved CI/CD preview is ready within 10 minutes of a commit.
+- Attaching the local UI is one command and less than one minute excluding scale-up.
+- UI-only iterations remain immediate through HMR.
+- One-PR materialization returns useful JSON and a working page without a production
+  deploy.
+- At least one backend/auth feature is completed without test-only production PRs.
+- Preview cleanup succeeds automatically for every pilot PR, with the sweeper catching
+  any missed close event.
+- There are zero preview writes to production Gestalt, CI/CD, or workflow state.
+- No preview credential appears in branch jobs, browser JavaScript, logs, or comments.
+
+## Work Breakdown and Dependencies
+
+| Work item | Repository | Depends on |
+| --- | --- | --- |
+| Caller-forwarding remote auth | `gestalt` | — |
+| Forced-paused app workflows | `gestalt` | — |
+| Dual-auth Vite proxy | `gestalt` | — |
+| Trusted branch artifact split | `toolshed` | — |
+| Preview infrastructure/config | `toolshed` | Gestalt safety primitives |
+| CI/CD materialization operation | `toolshed` | Preview relay contract |
+| Local attachment command | `toolshed` | Dual-auth proxy and preview deployment |
+| Cleanup/TTL automation | `toolshed` | Preview infrastructure |
+| Reusable app manifest | both | Successful CI/CD pilot |
+
+The first three Gestalt changes and the artifact-pipeline split can proceed in parallel.
+The preview runtime must not launch until caller authentication, force-pause, and
+artifact trust boundaries are deployed.
+
+## Definition of Done
+
+- All safety invariants are enforced by config validation, IAM, provider credentials,
+  or automated tests.
+- CI/CD's local UI works against a remote branch backend with real caller role checks.
+- One-PR data and a manual workflow produce inspectable JSON.
+- Production routing and state remain unchanged through the end-to-end test.
+- Close and TTL cleanup remove the full preview resource closure.
+- Documentation clearly distinguishes preview-local state, delegated production reads,
+  and prohibited production writes.
+- A second Gestalt app can adopt the reusable foundation without copying CI/CD-specific
+  deployment logic.
+
+## References
+
+### Gestalt
+
+- `docs/content/applications.mdx`
+- `docs/content/reference/config-file.mdx`
+- `gestaltd/internal/config/config.go`
+- `gestaltd/internal/config/remotes.go`
+- `gestaltd/internal/remote/remote.go`
+- `gestaltd/internal/bootstrap/workflow_app_definitions.go`
+- `gestaltd/internal/bootstrap/workflow_config_definitions.go`
+- `gestaltd/internal/bootstrap/host_service_bootstrap.go`
+- `gestaltd/internal/server/handlers_activate.go`
+- `gestaltd/services/indexeddb/server.go`
+- `sdk/typescript-web/src/vite.js`
+- `plans/service_mesh/plan.md`, especially the Development Sandbox contract
+
+### Toolshed
+
+- `/Users/michael/valon/toolshed/.github/workflows/publish-app-snapshot.yml`
+- `/Users/michael/valon/toolshed/.github/workflows/deploy-valon-tools.yml`
+- `/Users/michael/valon/toolshed/valon-tools/deploy/config.yaml`
+- `/Users/michael/valon/toolshed/valon-tools/deploy/local/config.yaml`
+- `/Users/michael/valon/toolshed/valon-tools/apps/ci-cd/scripts/dev-ui-remote.sh`
+- `/Users/michael/valon/toolshed/valon-tools/apps/ci-cd/knowledge/gestalt/local-development.md`
+- `/Users/michael/valon/toolshed/valon-tools/apps/ci-cd/workflows.ts`

--- a/plans/preview_environments/plan.md
+++ b/plans/preview_environments/plan.md
@@ -2,131 +2,82 @@
 
 ## Decision
 
-Create one IAM-protected Cloud Run `gestaltd` service per approved internal PR. Run the branch app provider there with isolated database and workflow state, while the frontend stays local and uses Vite HMR.
+Create one IAM-protected Cloud Run `gestaltd` service per approved internal PR. Run branch backend code there with isolated database and workflow state. Keep the frontend local with normal HMR.
 
-CI/CD is the first pilot. Do not use production Cloud Run revisions or reverse-provider shadowing because both can affect production routing or shared state.
+CI/CD is the first pilot, but the interface and deployment model must work for any Gestalt app. Do not use production Cloud Run revisions or reverse-provider shadowing because both risk production routing or shared state.
 
 ## Developer experience
 
-```text
-Browser → loopback Vite proxy → PR Cloud Run preview → branch app provider
-                                                  ├─ preview-only database/workflows
-                                                  └─ allowlisted production reads
-```
-
-The developer runs:
+Add a generic Gestalt CLI command:
 
 ```bash
-./valon-tools/apps/ci-cd/scripts/dev-ui-preview.sh <pr-number>
+gestalt app preview <app-path> --pr <number>
 ```
 
-The script verifies the preview commit, obtains the developer's Gestalt bearer and a refreshable Cloud Run identity token, then starts Vite on `127.0.0.1`. UI changes remain immediate; backend changes publish a new immutable preview snapshot.
+For example:
 
-## Scope
+```bash
+gestalt app preview ./valon-tools/apps/ci-cd --pr 123
+```
 
-The pilot must:
+The command reads the app manifest, verifies that the remote preview matches the repository, PR, and commit, obtains the developer's Gestalt bearer and Cloud Run identity, then starts the app's local UI command on loopback. Browser API requests are proxied to the remote branch backend; credentials remain server-side.
 
-- Test a branch backend without changing production traffic, provider selection, or state.
-- Exercise real caller authorization, including admin-only `pullRequests.mergeReadiness`.
-- Materialize one representative PR into preview storage and return inspectable JSON.
-- Support manual workflow runs while schedules and event activations remain paused.
-- Provide deterministic deployment, attachment, reset, logs, expiry, and teardown.
+```text
+Browser → local Gestalt UI proxy → PR Cloud Run gestaltd → branch provider
+                                                     ├─ isolated database/workflows
+                                                     └─ allowlisted production reads
+```
 
-It does not support production writes, migrations, notifications, merge actions, production database or Temporal sharing, untrusted forks, or indefinite previews.
+## Safety requirements
 
-## Required safety properties
+- Previews never change production traffic, provider selection, app-registry state, authorization state, databases, or Temporal.
+- Every preview has a unique service, runtime identity, database credential, encryption key, labels, and expiry.
+- Artifacts are pinned by full commit SHA and verified digest.
+- PR code packages without cloud credentials. Trusted default-branch automation validates the artifact before authenticating and deploying.
+- The management listener and `/activate` are not public, and `authorizationStateApply` is false.
+- The developer bearer is forwarded only to production identity and authorization.
+- Dependency access uses a separate preview relay with exact read-operation allowlists and no write, impersonation, secret-reading, or token-minting authority.
+- Production database, Temporal, and `service_account:ci-cd-sync` credentials are unavailable to previews.
+- Workflow definitions and activations are paused before first reconciliation; authorized manual runs remain possible.
+- Only approved internal PRs are eligible. Close cleanup and a maximum-age sweeper remove all resources.
 
-1. Every preview has a unique service, runtime identity, database credential, encryption key, labels, and expiry.
-2. Artifacts are selected by full commit SHA and verified digest.
-3. Branch code packages without cloud credentials; trusted default-branch automation validates the artifact before authenticating and deploying.
-4. Preview config disables authorization-state application and exposes no management or `/activate` route.
-5. The developer bearer is forwarded only to production identity and authorization over HTTPS.
-6. Integration reads use a separate preview relay with exact operation allowlists and no write, impersonation, secret-reading, or token-minting authority.
-7. Production database, Temporal, and `service_account:ci-cd-sync` credentials are unavailable to previews.
-8. Workflow definitions and activations are paused before their first reconciliation; authorized manual runs remain possible.
-9. Only approved internal PRs are eligible.
-10. PR-close cleanup and a maximum-age sweeper delete the complete resource set.
-
-Branch providers are arbitrary code beside `gestaltd`, not a hardened sandbox. The preview runtime and relay permissions must therefore be safe even if branch code can exercise them.
+Branch providers are arbitrary code beside `gestaltd`, not a hardened sandbox. Preview runtime and relay permissions must therefore be safe even if branch code can exercise them.
 
 ## Implementation
 
-### 1. Add reusable Gestalt primitives
+### 1. Gestalt primitives
 
-**Caller-forwarding remotes:** Extend `gestaltd/internal/config/remotes.go`, `config_validate.go`, `gestaltd/internal/remote/remote.go`, and request authentication plumbing with an explicit `forwardBearer` mode. Capture the incoming bearer in private request context and forward it only to configured identity and authorization remotes. Preserve static-token remotes for dependencies. Test concurrency, redaction, validation, and backward compatibility.
+- Add a `forwardBearer` remote-auth mode in `gestaltd/internal/config/remotes.go` and `gestaltd/internal/remote/remote.go`. Preserve static-token remotes for dependencies and test concurrent callers, validation, and redaction.
+- Add `apps.<name>.workflowPolicy.forcePaused` and enforce it in `gestaltd/internal/bootstrap/workflow_app_definitions.go` before reconciliation.
+- Extend `sdk/typescript-web/src/vite.js` to send the Gestalt bearer in `Authorization` and a refreshable Cloud Run token in `X-Serverless-Authorization`.
+- Add `gestalt app preview <app-path> --pr <number>` to the Go CLI. It must be app-agnostic and use manifest `run` commands rather than app-specific scripts.
 
-**Forced-paused workflows:** Add an app deployment policy in `gestaltd/internal/config/config.go` and enforce it in `gestaltd/internal/bootstrap/workflow_app_definitions.go`:
+### 2. Secure preview deployment
 
-```yaml
-apps:
-  ci-cd:
-    workflowPolicy:
-      forcePaused: true
-```
+Split Toolshed publication into an unprivileged PR packaging job and a trusted deployment job that validates checksums, provenance, app identity, and source SHA before obtaining GCP credentials.
 
-Apply the policy before workflow reconciliation and prove that no first tick occurs while manual `StartRun` still works.
+Add reusable preview config, Terraform, deploy, update, close-cleanup, and TTL-sweeper workflows. Deploy one service per app and PR with min instances zero, max one, IAM-only invocation, isolated storage, and structured labels. Do not reuse or modify the production deployment workflow.
 
-**Dual-auth Vite proxy:** Extend `sdk/typescript-web/src/vite.js` and its types/tests to keep the Gestalt bearer in `Authorization` and add a separately refreshed Cloud Run token in `X-Serverless-Authorization`. Neither token may reach browser JavaScript.
+### 3. CI/CD pilot
 
-Document these capabilities in `docs/content/applications.mdx` and `docs/content/reference/config-file.mdx`.
-
-### 2. Secure branch publication
-
-Split `/Users/michael/valon/toolshed/.github/workflows/publish-app-snapshot.yml` into:
-
-1. An unprivileged PR job that packages the exact SHA and uploads checksummed artifacts and provenance.
-2. A trusted default-branch workflow that downloads bytes without executing PR code, validates the archive and manifest, then authenticates to GCP and publishes create-only immutable artifacts.
-
-### 3. Deploy the CI/CD preview
-
-Add trusted config and infrastructure under:
-
-- `/Users/michael/valon/toolshed/valon-tools/deploy/preview/`
-- `/Users/michael/valon/toolshed/valon-tools/terraform/preview/`
-- `/Users/michael/valon/toolshed/.github/workflows/deploy-app-preview.yml`
-
-Deploy `gestalt-preview-ci-cd-pr-<number>` with min instances zero, max one, IAM-only invocation, preview-specific storage, and repository/app/PR/SHA/expiry labels.
-
-Use a curated config containing only the branch snapshot, preview-local IndexedDB and workflows, forced-paused activations, caller-forwarding identity/authorization, and allowlisted read dependencies. Do not modify or reuse `.github/workflows/deploy-valon-tools.yml`.
-
-### 4. Add a useful CI/CD pilot operation
-
-Add an admin-only preview operation in `valon-tools/apps/ci-cd/provider.ts`:
+Add a preview-only admin operation:
 
 ```text
 preview.materializePullRequest({ prNumber })
 ```
 
-Enable it only when `previewMode` is true and omit it from production `allowedOperations`. It reads one Front Porch PR plus available checks, deployments, and Linear data through the preview relay; reuses existing normalization/correlation logic; writes only preview storage; and returns intermediate and final JSON. Repeated calls must be idempotent.
+It reads one Front Porch PR plus available checks, deployments, and Linear data through the read-only preview relay; reuses existing normalization and correlation code; writes only preview storage; and returns intermediate and final JSON. It must be idempotent and absent from production `allowedOperations`.
 
-Install normal CI/CD workflow definitions in preview storage with automatic activations paused. Provide commands to start one run manually, inspect events/output, open logs, and reset preview data.
+Install CI/CD workflow definitions in preview-local storage with automatic activations paused. Expose generic CLI commands to start a run manually and inspect events and output.
 
-### 5. Add attachment and lifecycle automation
+### 4. Generalize
 
-Add `valon-tools/apps/ci-cd/scripts/dev-ui-preview.sh` to discover and verify the preview, resolve both credentials, start loopback Vite, and print data, workflow, logging, and reset commands.
+After CI/CD succeeds, define a reusable preview manifest for dependency allowlists, storage, workflow policy, and health checks. Keep app-specific materialization inside each app. Validate the design with a second read-oriented app before broader self-service.
 
-Update approved commits with concurrency keyed by app and PR. Delete resources on PR close and with a 72-hour sweeper. Cleanup must remove the service, database, database user, credentials, encryption secret, and deployment metadata.
+## Verification and success
 
-### 6. Generalize after the pilot
+Automated tests cover remote caller auth, token isolation, forced-paused workflows, dual proxy headers, artifact provenance, storage isolation, deterministic cleanup, and CI/CD preview authorization/idempotency.
 
-After CI/CD succeeds, extract a reusable preview manifest and app-independent publication, deployment, attachment, validation, and cleanup tooling. Keep materialization app-specific. Onboard a second read-oriented app before broader self-service; apps requiring writes need preview-owned resources or dry-run interfaces.
+The end-to-end pilot must attach the local CI/CD UI with the generic CLI, materialize one PR, verify admin and non-admin behavior, manually run a workflow, update and reset preview state, and delete all resources on PR close. Production routing and state must remain unchanged.
 
-## Verification
-
-Automated tests must cover remote auth and token isolation, forced-paused workflows, dual proxy headers, artifact provenance, preview naming/cleanup, CI/CD authorization/idempotency, isolated IndexedDB, and the absence of automatic workflow ticks.
-
-The end-to-end pilot must:
-
-1. Publish and deploy a controlled CI/CD branch.
-2. Attach the local UI with one command.
-3. Materialize one PR and verify list/detail pages.
-4. Verify admin and non-admin `mergeReadiness`.
-5. Run one workflow manually and inspect JSON.
-6. Update and reset the preview without affecting production.
-7. Close the PR and verify complete cleanup.
-
-## Rollout and success
-
-Ship the Gestalt safety primitives and secure artifact split first. Then run manual CI/CD previews for maintainers, enable opt-in deployment by PR label, and generalize only after CI/CD and a second read-oriented app pass the same invariants.
-
-Success means an approved preview is ready within 10 minutes, attachment is one command, frontend changes remain immediate, preview data and workflow output are useful for debugging, teardown is deterministic, and preview activity causes zero production routing or state changes.
+The work succeeds when an approved preview is ready within 10 minutes, any app can attach with one generic command, frontend changes remain immediate, backend and workflow output are useful for debugging, and teardown is deterministic.

--- a/plans/preview_environments/plan.md
+++ b/plans/preview_environments/plan.md
@@ -8,19 +8,19 @@ CI/CD is the first pilot, but the interface and deployment model must work for a
 
 ## Developer experience
 
-Add a generic Gestalt CLI command:
+Extend the existing source-app runtime:
 
 ```bash
-gestalt app preview <app-path> --pr <number>
+gestaltd serve <app-path> --remote-preview <url>
 ```
 
 For example:
 
 ```bash
-gestalt app preview ./valon-tools/apps/ci-cd --pr 123
+gestaltd serve ./valon-tools/apps/ci-cd --remote-preview https://gestalt-preview-ci-cd-pr-123.example
 ```
 
-The command reads the app manifest, verifies that the remote preview matches the repository, PR, and commit, obtains the developer's Gestalt bearer and Cloud Run identity, then starts the app's local UI command on loopback. Browser API requests are proxied to the remote branch backend; credentials remain server-side.
+The trusted deployment workflow publishes the exact command for its commit. `gestaltd serve` remains the single owner of manifests, local `run` commands, HMR, credentials, and proxy lifecycle. In remote-preview mode it starts only the manifest command explicitly marked as the UI target plus a trusted loopback proxy; ambiguous manifests fail validation instead of relying on command heuristics.
 
 ```text
 Browser → local Gestalt UI proxy → PR Cloud Run gestaltd → branch provider
@@ -35,10 +35,10 @@ Browser → local Gestalt UI proxy → PR Cloud Run gestaltd → branch provider
 - Artifacts are pinned by full commit SHA and verified digest.
 - PR code packages without cloud credentials. Trusted default-branch automation validates the artifact before authenticating and deploying.
 - The management listener and `/activate` are not public, and `authorizationStateApply` is false.
-- The developer bearer is forwarded only to production identity and authorization.
+- Dedicated identity and authorization connectors forward the developer bearer only to those upstream services.
 - Dependency access uses a separate preview relay with exact read-operation allowlists and no write, impersonation, secret-reading, or token-minting authority.
 - Production database, Temporal, and `service_account:ci-cd-sync` credentials are unavailable to previews.
-- Workflow definitions and activations are paused before first reconciliation; authorized manual runs remain possible.
+- The workflow manager blocks every automatic activation; authorized manual runs remain possible.
 - Only approved internal PRs are eligible. Close cleanup and a maximum-age sweeper remove all resources.
 
 Branch providers are arbitrary code beside `gestaltd`, not a hardened sandbox. Preview runtime and relay permissions must therefore be safe even if branch code can exercise them.
@@ -47,10 +47,10 @@ Branch providers are arbitrary code beside `gestaltd`, not a hardened sandbox. P
 
 ### 1. Gestalt primitives
 
-- Add a `forwardBearer` remote-auth mode in `gestaltd/internal/config/remotes.go` and `gestaltd/internal/remote/remote.go`. Preserve static-token remotes for dependencies and test concurrent callers, validation, and redaction.
-- Add `apps.<name>.workflowPolicy.forcePaused` and enforce it in `gestaltd/internal/bootstrap/workflow_app_definitions.go` before reconciliation.
-- Extend `sdk/typescript-web/src/vite.js` to send the Gestalt bearer in `Authorization` and a refreshable Cloud Run token in `X-Serverless-Authorization`.
-- Add `gestalt app preview <app-path> --pr <number>` to the Go CLI. It must be app-agnostic and use manifest `run` commands rather than app-specific scripts.
+- Add dedicated remote identity and authorization connectors that forward the incoming bearer from private request context. Do not add bearer forwarding to generic remotes. Test concurrent callers, validation, and redaction.
+- Add a workflow-manager execution policy such as `server.workflows.activationPolicy: manualOnly`. Keep declared schedules visible, block every automatic activation at the canonical execution boundary, and preserve authorized manual starts.
+- Add an explicit `role: ui` to manifest `run` entries. Remote-preview mode requires exactly one UI target; normal `gestaltd serve` remains backward compatible with existing untyped run lists.
+- Add `gestaltd serve <app-path> --remote-preview <url>`. A trusted loopback proxy owned by `gestaltd` refreshes Cloud Run identity and injects both Cloud Run and Gestalt authorization headers. Existing Vite integration targets this proxy unchanged.
 
 ### 2. Secure preview deployment
 
@@ -60,15 +60,15 @@ Add reusable preview config, Terraform, deploy, update, close-cleanup, and TTL-s
 
 ### 3. CI/CD pilot
 
-Add a preview-only admin operation:
+Extend the canonical CI/CD ingestion workflow to accept an optional bounded PR scope:
 
 ```text
-preview.materializePullRequest({ prNumber })
+sync({ pullRequestNumbers: [123] })
 ```
 
-It reads one Front Porch PR plus available checks, deployments, and Linear data through the read-only preview relay; reuses existing normalization and correlation code; writes only preview storage; and returns intermediate and final JSON. It must be idempotent and absent from production `allowedOperations`.
+Scheduled production runs omit the scope and retain current behavior. A manual preview run uses the same orchestration, normalization, correlation, and persistence path for one PR. Isolation comes from preview storage and relay policy, not a preview-only application contract. The run must be idempotent and return inspectable intermediate and final JSON.
 
-Install CI/CD workflow definitions in preview-local storage with automatic activations paused. Expose generic CLI commands to start a run manually and inspect events and output.
+Install the normal CI/CD definitions in preview-local storage under the runtime's `manualOnly` activation policy. Use existing generic workflow commands to start the scoped run and inspect events and output.
 
 ### 4. Generalize
 
@@ -76,8 +76,8 @@ After CI/CD succeeds, define a reusable preview manifest for dependency allowlis
 
 ## Verification and success
 
-Automated tests cover remote caller auth, token isolation, forced-paused workflows, dual proxy headers, artifact provenance, storage isolation, deterministic cleanup, and CI/CD preview authorization/idempotency.
+Automated tests cover remote caller auth, token isolation, manual-only workflow execution, loopback proxy auth injection, artifact provenance, storage isolation, deterministic cleanup, and CI/CD preview authorization/idempotency.
 
-The end-to-end pilot must attach the local CI/CD UI with the generic CLI, materialize one PR, verify admin and non-admin behavior, manually run a workflow, update and reset preview state, and delete all resources on PR close. Production routing and state must remain unchanged.
+The end-to-end pilot must attach the local CI/CD UI through `gestaltd serve`, run the canonical sync workflow for one PR, verify admin and non-admin behavior, update and reset preview state, and delete all resources on PR close. Production routing and state must remain unchanged.
 
-The work succeeds when an approved preview is ready within 10 minutes, any app can attach with one generic command, frontend changes remain immediate, backend and workflow output are useful for debugging, and teardown is deterministic.
+The work succeeds when an approved preview is ready within 10 minutes, any app can attach through the same `gestaltd serve` path, frontend changes remain immediate, backend and workflow output are useful for debugging, and teardown is deterministic.


### PR DESCRIPTION
## Summary
- define a production-isolated architecture for running local app frontends against branch-specific remote Gestalt backends
- scope reusable Gestalt safety primitives and a CI/CD pilot across artifact publication, preview deployment, data seeding, workflows, and lifecycle automation
- document security invariants, phased verification, rollout, rollback, and measurable success criteria

## Test plan
- [x] Verify all cited existing Gestalt and Toolshed paths
- [x] Check the plan for whitespace errors
- [x] Confirm the CI/CD pilot is separated from later reusable generalization

Made with [Cursor](https://cursor.com)