### PR TITLE
gestaltd: serve deployment platform brand via /brand.json

### DIFF
--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -557,7 +557,10 @@ type ProviderEntry struct {
 	// ui config.theme, not from YAML).
 	ResolvedThemeStylesheet string `yaml:"-"`
 	ResolvedThemeAssetsDir  string `yaml:"-"`
-	MCPToolPrefix           string `yaml:"-"`
+	// Runtime-resolved platform brand (populated during sync from static.brand).
+	ResolvedBrandName    string `yaml:"-"`
+	ResolvedBrandMarkSrc string `yaml:"-"` // mount-relative, e.g. "theme/mark.svg"
+	MCPToolPrefix        string `yaml:"-"`
 }
 
 // AppStaticConfig configures a packaged app's static bundle mount.
@@ -565,8 +568,16 @@ type ProviderEntry struct {
 type AppStaticConfig struct {
 	Mount         string         `yaml:"mount,omitempty"`
 	Theme         *UIThemeConfig `yaml:"theme,omitempty"`
+	Brand         *UIBrandConfig `yaml:"brand,omitempty"`
 	Public        bool           `yaml:"public,omitempty"`
 	CatalogHidden bool           `yaml:"catalogHidden,omitempty"`
+}
+
+// UIBrandConfig is the typed `brand` block for a mounted UI's platform identity
+// (product name + optional logo mark). Distinct from UIThemeConfig (colors/fonts).
+type UIBrandConfig struct {
+	Name string `yaml:"name,omitempty"`
+	Mark string `yaml:"mark,omitempty"`
 }
 
 type providerEntryFields ProviderEntry

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -2296,6 +2296,46 @@ server:
 		}
 	})
 
+	t.Run("static brand config is preserved", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+providers:
+  indexeddb:
+    sqlite:
+      source:
+        path: ./providers/indexeddb/sqlite
+apps:
+  roadmap:
+    source:
+      path: ./app/manifest.yaml
+    static:
+      mount: /roadmap
+      brand:
+        name: Valon Tools
+        mark: ./ui/mark.svg
+server:
+  providers:
+    indexeddb: sqlite
+  encryptionKey: server-key
+`)
+
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		brand := cfg.Apps["roadmap"].Static.Brand
+		if brand == nil {
+			t.Fatal(`Apps["roadmap"].Static.Brand = nil`)
+		}
+		if got := brand.Name; got != "Valon Tools" {
+			t.Fatalf(`brand.name = %q, want %q`, got, "Valon Tools")
+		}
+		if got := brand.Mark; got != "./ui/mark.svg" {
+			t.Fatalf(`brand.mark = %q, want %q`, got, "./ui/mark.svg")
+		}
+	})
+
 	t.Run("reserved static mount path is rejected", func(t *testing.T) {
 		t.Parallel()
 

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -4627,32 +4627,73 @@ func resolveAppStaticTheme(paths lifecyclePaths, name string, entry *config.Prov
 	}
 	entry.ResolvedThemeStylesheet = ""
 	entry.ResolvedThemeAssetsDir = ""
-	if entry.Static == nil || entry.Static.Theme == nil {
+	entry.ResolvedBrandName = ""
+	entry.ResolvedBrandMarkSrc = ""
+	if entry.Static == nil {
 		return nil
 	}
-	theme := entry.Static.Theme
-	if stylesheet := strings.TrimSpace(theme.Stylesheet); stylesheet != "" {
-		resolved := resolveUIThemePath(paths.configDir, stylesheet)
-		info, err := os.Stat(resolved)
-		if err != nil {
-			return fmt.Errorf("app %q static theme stylesheet not found at %s: %w", name, resolved, err)
+	if theme := entry.Static.Theme; theme != nil {
+		if stylesheet := strings.TrimSpace(theme.Stylesheet); stylesheet != "" {
+			resolved := resolveUIThemePath(paths.configDir, stylesheet)
+			info, err := os.Stat(resolved)
+			if err != nil {
+				return fmt.Errorf("app %q static theme stylesheet not found at %s: %w", name, resolved, err)
+			}
+			if info.IsDir() {
+				return fmt.Errorf("app %q static theme stylesheet at %s is a directory", name, resolved)
+			}
+			entry.ResolvedThemeStylesheet = resolved
 		}
-		if info.IsDir() {
-			return fmt.Errorf("app %q static theme stylesheet at %s is a directory", name, resolved)
+		if assetsDir := strings.TrimSpace(theme.AssetsDir); assetsDir != "" {
+			resolved := resolveUIThemePath(paths.configDir, assetsDir)
+			info, err := os.Stat(resolved)
+			if err != nil {
+				return fmt.Errorf("app %q static theme assetsDir not found at %s: %w", name, resolved, err)
+			}
+			if !info.IsDir() {
+				return fmt.Errorf("app %q static theme assetsDir at %s is not a directory", name, resolved)
+			}
+			entry.ResolvedThemeAssetsDir = resolved
 		}
-		entry.ResolvedThemeStylesheet = resolved
 	}
-	if assetsDir := strings.TrimSpace(theme.AssetsDir); assetsDir != "" {
-		resolved := resolveUIThemePath(paths.configDir, assetsDir)
-		info, err := os.Stat(resolved)
-		if err != nil {
-			return fmt.Errorf("app %q static theme assetsDir not found at %s: %w", name, resolved, err)
-		}
-		if !info.IsDir() {
-			return fmt.Errorf("app %q static theme assetsDir at %s is not a directory", name, resolved)
-		}
-		entry.ResolvedThemeAssetsDir = resolved
+	if err := resolveAppStaticBrand(paths, name, entry); err != nil {
+		return err
 	}
+	return nil
+}
+
+// resolveAppStaticBrand resolves static.brand against the deployment config directory.
+// Mark files must live under theme.assetsDir so they are served at /theme/<rel>.
+func resolveAppStaticBrand(paths lifecyclePaths, name string, entry *config.ProviderEntry) error {
+	if entry == nil || entry.Static == nil || entry.Static.Brand == nil {
+		return nil
+	}
+	brand := entry.Static.Brand
+	entry.ResolvedBrandName = strings.TrimSpace(brand.Name)
+	mark := strings.TrimSpace(brand.Mark)
+	if mark == "" {
+		return nil
+	}
+	if entry.ResolvedThemeAssetsDir == "" {
+		return fmt.Errorf("app %q static.brand.mark requires static.theme.assetsDir", name)
+	}
+	resolvedMark := resolveUIThemePath(paths.configDir, mark)
+	info, err := os.Stat(resolvedMark)
+	if err != nil {
+		return fmt.Errorf("app %q static brand mark not found at %s: %w", name, resolvedMark, err)
+	}
+	if info.IsDir() {
+		return fmt.Errorf("app %q static brand mark at %s is a directory", name, resolvedMark)
+	}
+	rel, err := filepath.Rel(entry.ResolvedThemeAssetsDir, resolvedMark)
+	if err != nil {
+		return fmt.Errorf("app %q static brand mark path: %w", name, err)
+	}
+	rel = filepath.ToSlash(rel)
+	if rel == ".." || strings.HasPrefix(rel, "../") {
+		return fmt.Errorf("app %q static.brand.mark must be inside static.theme.assetsDir", name)
+	}
+	entry.ResolvedBrandMarkSrc = "theme/" + rel
 	return nil
 }
 

--- a/gestaltd/internal/server/mounted_app_static.go
+++ b/gestaltd/internal/server/mounted_app_static.go
@@ -133,6 +133,7 @@ func registryAppStaticHandler(app, mount string, entry *config.ProviderEntry, pr
 				RenderIndex: composeIndexRenderers(
 					injectBaseHref(mount),
 					injectPlatformBrand(MountedUI{
+						Path:         mount,
 						BrandName:    entry.ResolvedBrandName,
 						BrandMarkSrc: entry.ResolvedBrandMarkSrc,
 					}),

--- a/gestaltd/internal/server/mounted_app_static.go
+++ b/gestaltd/internal/server/mounted_app_static.go
@@ -47,6 +47,8 @@ func mountedAppStaticsFromEntries(apps map[string]*config.ProviderEntry, provide
 				Handler:             handler,
 				ThemeStylesheet:     entry.ResolvedThemeStylesheet,
 				ThemeAssetsDir:      entry.ResolvedThemeAssetsDir,
+				BrandName:           entry.ResolvedBrandName,
+				BrandMarkSrc:        entry.ResolvedBrandMarkSrc,
 				IsDev:               true,
 			})
 			continue
@@ -61,6 +63,8 @@ func mountedAppStaticsFromEntries(apps map[string]*config.ProviderEntry, provide
 				Handler:             registryAppStaticHandler(name, mount, entry, providers, artifactsDir, runtimeState),
 				ThemeStylesheet:     entry.ResolvedThemeStylesheet,
 				ThemeAssetsDir:      entry.ResolvedThemeAssetsDir,
+				BrandName:           entry.ResolvedBrandName,
+				BrandMarkSrc:        entry.ResolvedBrandMarkSrc,
 			})
 			continue
 		}
@@ -69,25 +73,31 @@ func mountedAppStaticsFromEntries(apps map[string]*config.ProviderEntry, provide
 			return nil, fmt.Errorf("app %q static configured but asset root not resolved", name)
 		}
 
-		handler, err := ui.StaticHandler(ui.StaticConfig{
-			FS:           os.DirFS(entry.ResolvedStaticRoot),
-			DynamicIndex: true,
-			RenderIndex:  injectBaseHref(mount),
-		})
-		if err != nil {
-			return nil, fmt.Errorf("app %q static: %w", name, err)
-		}
-
-		mounted = append(mounted, MountedUI{
+		mountedUI := MountedUI{
 			Name:                mountedName,
 			Path:                mount,
 			AppName:             name,
 			AuthorizationPolicy: entry.AuthorizationPolicy,
 			AppLevelAuth:        !entry.Static.Public,
-			Handler:             handler,
 			ThemeStylesheet:     entry.ResolvedThemeStylesheet,
 			ThemeAssetsDir:      entry.ResolvedThemeAssetsDir,
+			BrandName:           entry.ResolvedBrandName,
+			BrandMarkSrc:        entry.ResolvedBrandMarkSrc,
+		}
+		handler, err := ui.StaticHandler(ui.StaticConfig{
+			FS:           os.DirFS(entry.ResolvedStaticRoot),
+			DynamicIndex: true,
+			RenderIndex: composeIndexRenderers(
+				injectBaseHref(mount),
+				injectPlatformBrand(mountedUI),
+			),
 		})
+		if err != nil {
+			return nil, fmt.Errorf("app %q static: %w", name, err)
+		}
+		mountedUI.Handler = handler
+
+		mounted = append(mounted, mountedUI)
 	}
 
 	return mounted, nil
@@ -120,7 +130,13 @@ func registryAppStaticHandler(app, mount string, entry *config.ProviderEntry, pr
 			handler, err := ui.StaticHandler(ui.StaticConfig{
 				FS:           os.DirFS(resolved.ResolvedStaticRoot),
 				DynamicIndex: true,
-				RenderIndex:  injectBaseHref(mount),
+				RenderIndex: composeIndexRenderers(
+					injectBaseHref(mount),
+					injectPlatformBrand(MountedUI{
+						BrandName:    entry.ResolvedBrandName,
+						BrandMarkSrc: entry.ResolvedBrandMarkSrc,
+					}),
+				),
 			})
 			if err != nil {
 				return err

--- a/gestaltd/internal/server/mounted_ui.go
+++ b/gestaltd/internal/server/mounted_ui.go
@@ -126,9 +126,9 @@ func (s *Server) mountedUIHandler(mounted MountedUI) http.Handler {
 		inner = s.tunnelUIProxyHandler(mounted.AppName, mounted.Path, inner)
 	}
 	if mounted.IsDev {
-		if mounted.ThemeStylesheet != "" || mounted.ThemeAssetsDir != "" {
-			inner = mountedUIThemeHandlerFullPath(mounted, inner)
-		}
+		// Always wrap so /brand.json (and theme endpoints) are served from
+		// deployment assets instead of being forwarded to the Vite process.
+		inner = mountedUIThemeHandlerFullPath(mounted, inner)
 		inner = mountedUITelemetryHandler(mounted, inner)
 		return withDevContentSecurityPolicy(s.protectedUIHandler(mounted, inner, s.redirectMountedUILogin))
 	}

--- a/gestaltd/internal/server/mounted_ui_brand.go
+++ b/gestaltd/internal/server/mounted_ui_brand.go
@@ -18,10 +18,25 @@ type platformBrandPayload struct {
 	MarkSrc string `json:"markSrc,omitempty"`
 }
 
+func absoluteBrandMarkSrc(mountPath, markSrc string) string {
+	markSrc = strings.TrimSpace(markSrc)
+	if markSrc == "" {
+		return ""
+	}
+	if strings.HasPrefix(markSrc, "/") || strings.HasPrefix(markSrc, "http://") || strings.HasPrefix(markSrc, "https://") {
+		return markSrc
+	}
+	mountPath = strings.TrimRight(strings.TrimSpace(mountPath), "/")
+	if mountPath == "" {
+		return "/" + markSrc
+	}
+	return mountPath + "/" + markSrc
+}
+
 func mountedUIBrandJSON(mounted MountedUI) []byte {
 	payload := platformBrandPayload{
 		Name:    strings.TrimSpace(mounted.BrandName),
-		MarkSrc: strings.TrimSpace(mounted.BrandMarkSrc),
+		MarkSrc: absoluteBrandMarkSrc(mounted.Path, mounted.BrandMarkSrc),
 	}
 	body, err := json.Marshal(payload)
 	if err != nil {

--- a/gestaltd/internal/server/mounted_ui_brand.go
+++ b/gestaltd/internal/server/mounted_ui_brand.go
@@ -61,14 +61,18 @@ func serveMountedUIBrandJSON(w http.ResponseWriter, r *http.Request, mounted Mou
 }
 
 // injectPlatformBrand rewrites the frozen index.html placeholder so first paint
-// sees the deployment product name (no Gestalt→tenant flash).
+// sees the deployment product name and mark (no Gestalt→tenant flash).
 func injectPlatformBrand(mounted MountedUI) func([]byte) []byte {
 	body := mountedUIBrandJSON(mounted)
 	name := strings.TrimSpace(mounted.BrandName)
+	markSrc := absoluteBrandMarkSrc(mounted.Path, mounted.BrandMarkSrc)
 	return func(data []byte) []byte {
 		data = replacePlatformBrandScriptJSON(data, body)
 		if name != "" {
 			data = replaceHTMLTitle(data, name)
+		}
+		if markSrc != "" {
+			data = replaceBrandIconHrefs(data, markSrc)
 		}
 		return data
 	}
@@ -78,8 +82,35 @@ var (
 	platformBrandScriptPattern = regexp.MustCompile(
 		`(?is)(<script\b[^>]*\bid\s*=\s*["']` + platformBrandScriptID + `["'][^>]*>)(.*?)(</script>)`,
 	)
-	htmlTitlePattern = regexp.MustCompile(`(?is)(<title\b[^>]*>)(.*?)(</title>)`)
+	htmlTitlePattern     = regexp.MustCompile(`(?is)(<title\b[^>]*>)(.*?)(</title>)`)
+	brandIconLinkPattern = regexp.MustCompile(
+		`(?is)<link\b[^>]*\brel\s*=\s*["'](?:apple-touch-icon|shortcut icon|icon)["'][^>]*>`,
+	)
+	hrefAttrPattern  = regexp.MustCompile(`(?i)\bhref\s*=\s*["'][^"']*["']`)
+	typeAttrPattern  = regexp.MustCompile(`(?i)\btype\s*=\s*["'][^"']*["']`)
+	sizesAttrPattern = regexp.MustCompile(`(?i)\s*\bsizes\s*=\s*["'][^"']*["']`)
+	relIconPattern   = regexp.MustCompile(`(?i)\brel\s*=\s*["'](?:shortcut icon|icon)["']`)
 )
+
+func replaceBrandIconHrefs(data []byte, markSrc string) []byte {
+	markSrc = strings.TrimSpace(markSrc)
+	if markSrc == "" {
+		return data
+	}
+	href := []byte(`href="` + html.EscapeString(markSrc) + `"`)
+	return brandIconLinkPattern.ReplaceAllFunc(data, func(tag []byte) []byte {
+		if hrefAttrPattern.Match(tag) {
+			tag = hrefAttrPattern.ReplaceAll(tag, href)
+		}
+		if relIconPattern.Match(tag) {
+			if typeAttrPattern.Match(tag) {
+				tag = typeAttrPattern.ReplaceAll(tag, []byte(`type="image/svg+xml"`))
+			}
+			tag = sizesAttrPattern.ReplaceAll(tag, nil)
+		}
+		return tag
+	})
+}
 
 func replacePlatformBrandScriptJSON(data, body []byte) []byte {
 	if platformBrandScriptPattern.Match(data) {

--- a/gestaltd/internal/server/mounted_ui_brand.go
+++ b/gestaltd/internal/server/mounted_ui_brand.go
@@ -1,0 +1,129 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"html"
+	"net/http"
+	"regexp"
+	"strings"
+)
+
+const mountedUIBrandJSONPath = "/brand.json"
+
+const platformBrandScriptID = "gestalt-platform-brand"
+
+type platformBrandPayload struct {
+	Name    string `json:"name,omitempty"`
+	MarkSrc string `json:"markSrc,omitempty"`
+}
+
+func mountedUIBrandJSON(mounted MountedUI) []byte {
+	payload := platformBrandPayload{
+		Name:    strings.TrimSpace(mounted.BrandName),
+		MarkSrc: strings.TrimSpace(mounted.BrandMarkSrc),
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return []byte("{}")
+	}
+	if payload.Name == "" && payload.MarkSrc == "" {
+		return []byte("{}")
+	}
+	return body
+}
+
+func mountedUIBrandPaths(mountPath string) string {
+	mountPath = strings.TrimRight(mountPath, "/")
+	if mountPath == "" {
+		return mountedUIBrandJSONPath
+	}
+	return mountPath + mountedUIBrandJSONPath
+}
+
+func serveMountedUIBrandJSON(w http.ResponseWriter, r *http.Request, mounted MountedUI) {
+	serveMountedUIThemeContent(w, r, "application/json; charset=utf-8", mountedUIBrandJSON(mounted))
+}
+
+// injectPlatformBrand rewrites the frozen index.html placeholder so first paint
+// sees the deployment product name (no Gestalt→tenant flash).
+func injectPlatformBrand(mounted MountedUI) func([]byte) []byte {
+	body := mountedUIBrandJSON(mounted)
+	name := strings.TrimSpace(mounted.BrandName)
+	return func(data []byte) []byte {
+		data = replacePlatformBrandScriptJSON(data, body)
+		if name != "" {
+			data = replaceHTMLTitle(data, name)
+		}
+		return data
+	}
+}
+
+var (
+	platformBrandScriptPattern = regexp.MustCompile(
+		`(?is)(<script\b[^>]*\bid\s*=\s*["']` + platformBrandScriptID + `["'][^>]*>)(.*?)(</script>)`,
+	)
+	htmlTitlePattern = regexp.MustCompile(`(?is)(<title\b[^>]*>)(.*?)(</title>)`)
+)
+
+func replacePlatformBrandScriptJSON(data, body []byte) []byte {
+	if platformBrandScriptPattern.Match(data) {
+		return platformBrandScriptPattern.ReplaceAllFunc(data, func(match []byte) []byte {
+			parts := platformBrandScriptPattern.FindSubmatch(match)
+			if len(parts) != 4 {
+				return match
+			}
+			out := make([]byte, 0, len(parts[1])+len(body)+len(parts[3]))
+			out = append(out, parts[1]...)
+			out = append(out, body...)
+			out = append(out, parts[3]...)
+			return out
+		})
+	}
+	// Bundle without the placeholder: insert after <head>.
+	tag := []byte(
+		`<script type="application/json" id="` + platformBrandScriptID + `">` +
+			string(body) +
+			`</script>`,
+	)
+	lower := bytes.ToLower(data)
+	if idx := bytes.Index(lower, []byte("<head>")); idx >= 0 {
+		insertAt := idx + len("<head>")
+		out := make([]byte, 0, len(data)+len(tag))
+		out = append(out, data[:insertAt]...)
+		out = append(out, tag...)
+		out = append(out, data[insertAt:]...)
+		return out
+	}
+	return data
+}
+
+func replaceHTMLTitle(data []byte, title string) []byte {
+	escaped := []byte(html.EscapeString(title))
+	if !htmlTitlePattern.Match(data) {
+		return data
+	}
+	return htmlTitlePattern.ReplaceAllFunc(data, func(match []byte) []byte {
+		parts := htmlTitlePattern.FindSubmatch(match)
+		if len(parts) != 4 {
+			return match
+		}
+		out := make([]byte, 0, len(parts[1])+len(escaped)+len(parts[3]))
+		out = append(out, parts[1]...)
+		out = append(out, escaped...)
+		out = append(out, parts[3]...)
+		return out
+	})
+}
+
+func composeIndexRenderers(fns ...func([]byte) []byte) func([]byte) []byte {
+	return func(data []byte) []byte {
+		for _, fn := range fns {
+			if fn == nil {
+				continue
+			}
+			data = fn(data)
+		}
+		return data
+	}
+}

--- a/gestaltd/internal/server/mounted_ui_brand_test.go
+++ b/gestaltd/internal/server/mounted_ui_brand_test.go
@@ -22,7 +22,7 @@ func TestInjectPlatformBrand(t *testing.T) {
 	if !strings.Contains(html, `<title>Valon Tools</title>`) {
 		t.Fatalf("title not rewritten: %s", html)
 	}
-	want := `{"name":"Valon Tools","markSrc":"theme/mark.svg"}`
+	want := `{"name":"Valon Tools","markSrc":"/theme/mark.svg"}`
 	if !strings.Contains(html, want) {
 		t.Fatalf("brand JSON not injected: %s", html)
 	}

--- a/gestaltd/internal/server/mounted_ui_brand_test.go
+++ b/gestaltd/internal/server/mounted_ui_brand_test.go
@@ -1,0 +1,50 @@
+package server
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestInjectPlatformBrand(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(
+		`<html><head><title>Gestalt</title>` +
+			`<script type="application/json" id="gestalt-platform-brand">{}</script>` +
+			`</head><body></body></html>`,
+	)
+	out := injectPlatformBrand(MountedUI{
+		BrandName:    "Valon Tools",
+		BrandMarkSrc: "theme/mark.svg",
+	})(input)
+
+	html := string(out)
+	if !strings.Contains(html, `<title>Valon Tools</title>`) {
+		t.Fatalf("title not rewritten: %s", html)
+	}
+	want := `{"name":"Valon Tools","markSrc":"theme/mark.svg"}`
+	if !strings.Contains(html, want) {
+		t.Fatalf("brand JSON not injected: %s", html)
+	}
+}
+
+func TestInjectPlatformBrandInsertsWhenMissing(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`<html><head><title>Gestalt</title></head><body></body></html>`)
+	out := injectPlatformBrand(MountedUI{BrandName: "Acme"})(input)
+	html := string(out)
+	if !strings.Contains(html, `id="gestalt-platform-brand"`) {
+		t.Fatalf("script not inserted: %s", html)
+	}
+	if !strings.Contains(html, `{"name":"Acme"}`) {
+		t.Fatalf("brand JSON missing: %s", html)
+	}
+}
+
+func TestMountedUIBrandJSONEmpty(t *testing.T) {
+	t.Parallel()
+	if got := string(mountedUIBrandJSON(MountedUI{})); got != "{}" {
+		t.Fatalf("got %q, want {}", got)
+	}
+}

--- a/gestaltd/internal/server/mounted_ui_brand_test.go
+++ b/gestaltd/internal/server/mounted_ui_brand_test.go
@@ -10,6 +10,9 @@ func TestInjectPlatformBrand(t *testing.T) {
 
 	input := []byte(
 		`<html><head><title>Gestalt</title>` +
+			`<link rel="icon" href="/favicon.svg" type="image/svg+xml" />` +
+			`<link rel="icon" href="/favicon-32x32.png" type="image/png" sizes="32x32" />` +
+			`<link rel="apple-touch-icon" href="/apple-touch-icon.png" sizes="180x180" />` +
 			`<script type="application/json" id="gestalt-platform-brand">{}</script>` +
 			`</head><body></body></html>`,
 	)
@@ -25,6 +28,15 @@ func TestInjectPlatformBrand(t *testing.T) {
 	want := `{"name":"Valon Tools","markSrc":"/theme/mark.svg"}`
 	if !strings.Contains(html, want) {
 		t.Fatalf("brand JSON not injected: %s", html)
+	}
+	if strings.Count(html, `href="/theme/mark.svg"`) != 3 {
+		t.Fatalf("icon hrefs not rewritten to mark: %s", html)
+	}
+	if strings.Contains(html, "/favicon.svg") || strings.Contains(html, "favicon-32x32.png") {
+		t.Fatalf("bundle favicon hrefs still present: %s", html)
+	}
+	if strings.Contains(html, `type="image/png"`) {
+		t.Fatalf("raster icon type left in place: %s", html)
 	}
 }
 

--- a/gestaltd/internal/server/mounted_ui_brand_test.go
+++ b/gestaltd/internal/server/mounted_ui_brand_test.go
@@ -48,3 +48,16 @@ func TestMountedUIBrandJSONEmpty(t *testing.T) {
 		t.Fatalf("got %q, want {}", got)
 	}
 }
+
+func TestAbsoluteBrandMarkSrc(t *testing.T) {
+	t.Parallel()
+	if got := absoluteBrandMarkSrc("/portal", "theme/mark.svg"); got != "/portal/theme/mark.svg" {
+		t.Fatalf("got %q", got)
+	}
+	if got := absoluteBrandMarkSrc("/", "theme/mark.svg"); got != "/theme/mark.svg" {
+		t.Fatalf("got %q", got)
+	}
+	if got := absoluteBrandMarkSrc("/portal", "/theme/mark.svg"); got != "/theme/mark.svg" {
+		t.Fatalf("already absolute got %q", got)
+	}
+}

--- a/gestaltd/internal/server/mounted_ui_theme.go
+++ b/gestaltd/internal/server/mounted_ui_theme.go
@@ -33,7 +33,7 @@ func mountedUIThemeHandlerFullPath(mounted MountedUI, next http.Handler) http.Ha
 		case r.URL.Path == stylesheetPath:
 			serveMountedUIThemeStylesheet(w, r, mounted.ThemeStylesheet)
 		case mounted.ThemeAssetsDir != "" && strings.HasPrefix(r.URL.Path, assetsPrefix):
-			serveMountedUIThemeAsset(w, r, mounted.ThemeAssetsDir)
+			serveMountedUIThemeAsset(w, r, mounted.ThemeAssetsDir, assetsPrefix)
 		default:
 			next.ServeHTTP(w, r)
 		}
@@ -60,7 +60,7 @@ func mountedUIThemeHandler(mounted MountedUI, next http.Handler) http.Handler {
 		case r.URL.Path == mountedUIThemeStylesheetPath:
 			serveMountedUIThemeStylesheet(w, r, mounted.ThemeStylesheet)
 		case mounted.ThemeAssetsDir != "" && strings.HasPrefix(r.URL.Path, mountedUIThemeAssetsPrefix):
-			serveMountedUIThemeAsset(w, r, mounted.ThemeAssetsDir)
+			serveMountedUIThemeAsset(w, r, mounted.ThemeAssetsDir, mountedUIThemeAssetsPrefix)
 		default:
 			next.ServeHTTP(w, r)
 		}
@@ -80,8 +80,8 @@ func serveMountedUIThemeStylesheet(w http.ResponseWriter, r *http.Request, style
 	serveMountedUIThemeContent(w, r, "text/css; charset=utf-8", body)
 }
 
-func serveMountedUIThemeAsset(w http.ResponseWriter, r *http.Request, assetsDir string) {
-	assetPath, ok := cleanMountedUIThemeAssetPath(strings.TrimPrefix(r.URL.Path, mountedUIThemeAssetsPrefix))
+func serveMountedUIThemeAsset(w http.ResponseWriter, r *http.Request, assetsDir, assetsPrefix string) {
+	assetPath, ok := cleanMountedUIThemeAssetPath(strings.TrimPrefix(r.URL.Path, assetsPrefix))
 	if !ok {
 		http.NotFound(w, r)
 		return

--- a/gestaltd/internal/server/mounted_ui_theme.go
+++ b/gestaltd/internal/server/mounted_ui_theme.go
@@ -28,6 +28,8 @@ func mountedUIThemeHandlerFullPath(mounted MountedUI, next http.Handler) http.Ha
 			return
 		}
 		switch {
+		case r.URL.Path == mountedUIBrandPaths(mounted.Path):
+			serveMountedUIBrandJSON(w, r, mounted)
 		case r.URL.Path == stylesheetPath:
 			serveMountedUIThemeStylesheet(w, r, mounted.ThemeStylesheet)
 		case mounted.ThemeAssetsDir != "" && strings.HasPrefix(r.URL.Path, assetsPrefix):
@@ -53,6 +55,8 @@ func mountedUIThemeHandler(mounted MountedUI, next http.Handler) http.Handler {
 			return
 		}
 		switch {
+		case r.URL.Path == mountedUIBrandJSONPath:
+			serveMountedUIBrandJSON(w, r, mounted)
 		case r.URL.Path == mountedUIThemeStylesheetPath:
 			serveMountedUIThemeStylesheet(w, r, mounted.ThemeStylesheet)
 		case mounted.ThemeAssetsDir != "" && strings.HasPrefix(r.URL.Path, mountedUIThemeAssetsPrefix):
@@ -108,6 +112,8 @@ func serveMountedUIThemeAsset(w http.ResponseWriter, r *http.Request, assetsDir 
 // table lacks .woff2, and OS mime databases are absent in minimal containers
 // — while delivering licensed fonts is the main reason assetsDir exists.
 var mountedUIThemeContentTypes = map[string]string{
+	".svg":   "image/svg+xml",
+	".png":   "image/png",
 	".woff2": "font/woff2",
 	".woff":  "font/woff",
 }

--- a/gestaltd/internal/server/mounted_ui_theme_brand_dev_test.go
+++ b/gestaltd/internal/server/mounted_ui_theme_brand_dev_test.go
@@ -1,0 +1,71 @@
+package server_test
+
+import (
+	"io"
+	"net/http"
+	"path/filepath"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/internal/server"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
+)
+
+func TestMountedUIThemeAssetFullPathDev(t *testing.T) {
+	t.Parallel()
+
+	uiDir := t.TempDir()
+	writeTestUIAsset(t, filepath.Join(uiDir, "index.html"), "<html>portal-shell</html>")
+	themeDir := t.TempDir()
+	writeTestUIAsset(t, filepath.Join(themeDir, "assets", "mark.svg"), "<svg></svg>")
+
+	handler, err := testutilUIHandler(uiDir)
+	if err != nil {
+		t.Fatalf("ui handler: %v", err)
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.MountedUIs = []server.MountedUI{{
+			Name:           "portal",
+			Path:           "/portal",
+			Handler:        handler,
+			ThemeAssetsDir: filepath.Join(themeDir, "assets"),
+			BrandName:      "Acme",
+			BrandMarkSrc:   "theme/mark.svg",
+			IsDev:          true,
+		}}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	resp, err := http.Get(ts.URL + "/portal/theme/mark.svg")
+	if err != nil {
+		t.Fatalf("GET mark: %v", err)
+	}
+	body, err := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 body=%q", resp.StatusCode, body)
+	}
+	if got := string(body); got != "<svg></svg>" {
+		t.Fatalf("body = %q", got)
+	}
+	if got := resp.Header.Get("Content-Type"); got != "image/svg+xml" {
+		t.Fatalf("Content-Type = %q", got)
+	}
+
+	resp, err = http.Get(ts.URL + "/portal/brand.json")
+	if err != nil {
+		t.Fatalf("GET brand.json: %v", err)
+	}
+	body, err = io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if err != nil {
+		t.Fatalf("ReadAll brand: %v", err)
+	}
+	want := `{"name":"Acme","markSrc":"/portal/theme/mark.svg"}`
+	if got := string(body); got != want {
+		t.Fatalf("brand.json = %q, want %q", got, want)
+	}
+}

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -64,9 +64,14 @@ type MountedUI struct {
 	// <mount>/theme/ respectively. Both are optional.
 	ThemeStylesheet string
 	ThemeAssetsDir  string
-	IsDev           bool
-	AppLevelAuth    bool
-	builtInAdmin    bool
+	// BrandName and BrandMarkSrc are the serve-time platform identity for this
+	// mount (product name + optional mark URL). BrandMarkSrc is mount-relative
+	// (e.g. "theme/mark.svg"). Both are optional; empty means the UI default.
+	BrandName    string
+	BrandMarkSrc string
+	IsDev        bool
+	AppLevelAuth bool
+	builtInAdmin bool
 }
 
 type MountedHTTPBinding struct {

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -2408,6 +2408,88 @@ func TestMountedUIThemeRoutes(t *testing.T) {
 	}
 }
 
+func TestMountedUIBrandJSON(t *testing.T) {
+	t.Parallel()
+
+	uiDir := t.TempDir()
+	writeTestUIAsset(t, filepath.Join(uiDir, "index.html"), "<html>portal-shell</html>")
+
+	handler, err := testutilUIHandler(uiDir)
+	if err != nil {
+		t.Fatalf("ui handler: %v", err)
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.MountedUIs = []server.MountedUI{{
+			Name:         "portal",
+			Path:         "/portal",
+			Handler:      handler,
+			BrandName:    "Valon Tools",
+			BrandMarkSrc: "theme/mark.svg",
+		}}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	resp, err := http.Get(ts.URL + "/portal/brand.json")
+	if err != nil {
+		t.Fatalf("GET brand.json: %v", err)
+	}
+	body, err := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if err != nil {
+		t.Fatalf("ReadAll brand.json: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("brand.json status = %d, want 200", resp.StatusCode)
+	}
+	want := `{"name":"Valon Tools","markSrc":"theme/mark.svg"}`
+	if got := string(body); got != want {
+		t.Fatalf("brand.json body = %q, want %q", got, want)
+	}
+	if got := resp.Header.Get("Content-Type"); got != "application/json; charset=utf-8" {
+		t.Fatalf("brand.json Content-Type = %q, want application/json; charset=utf-8", got)
+	}
+}
+
+func TestMountedUIBrandJSONUnconfigured(t *testing.T) {
+	t.Parallel()
+
+	rootDir := t.TempDir()
+	writeTestUIAsset(t, filepath.Join(rootDir, "index.html"), "<html>root-shell</html>")
+	handler, err := testutilUIHandler(rootDir)
+	if err != nil {
+		t.Fatalf("ui handler: %v", err)
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.MountedUIs = []server.MountedUI{{
+			Name:    "root",
+			Path:    "/",
+			Handler: handler,
+		}}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	resp, err := http.Get(ts.URL + "/brand.json")
+	if err != nil {
+		t.Fatalf("GET brand.json: %v", err)
+	}
+	body, err := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if err != nil {
+		t.Fatalf("ReadAll brand.json: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("brand.json status = %d, want 200", resp.StatusCode)
+	}
+	if got := string(body); got != "{}" {
+		t.Fatalf("brand.json body = %q, want {}", got)
+	}
+	if got := resp.Header.Get("Content-Type"); got != "application/json; charset=utf-8" {
+		t.Fatalf("brand.json Content-Type = %q, want application/json; charset=utf-8", got)
+	}
+}
+
 func TestMountedUIThemeStylesheetUnconfigured(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -2442,7 +2442,7 @@ func TestMountedUIBrandJSON(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("brand.json status = %d, want 200", resp.StatusCode)
 	}
-	want := `{"name":"Valon Tools","markSrc":"theme/mark.svg"}`
+	want := `{"name":"Valon Tools","markSrc":"/portal/theme/mark.svg"}`
 	if got := string(body); got != want {
 		t.Fatalf("brand.json body = %q, want %q", got, want)
 	}


### PR DESCRIPTION
## Summary

Deployments can declare a product name and optional mark on a mounted app. gestaltd serves that identity as `/brand.json`, injects it into the app's `index.html`, and points the tab icon at the mark when one is configured.

## Why / context

Mounted shells had no serve-time product identity parallel to theme, so public UIs fell back to a framework name. Brand follows the same ownership model as theme: config in the deployment repo, resolved and served by gestaltd, consumed by the UI.

## What changed

- Typed `static.brand.{name,mark}` with resolve-time validation (mark must live under `theme.assetsDir`)
- `/brand.json` on mounted UIs, including the Vite/dev wrap path
- `markSrc` emitted as a site-root absolute path under the app mount
- Index HTML injection into `#gestalt-platform-brand` (insert after `<head>` when missing) and `<title>` rewrite
- Favicon and apple-touch links rewritten to the mark so the tab icon matches chrome on first paint
- SVG/PNG content types for theme-served mark assets

## Validation

- [x] Automated: `go test ./internal/server -count=1 -run 'TestInjectPlatformBrand|TestAbsoluteBrandMarkSrc|TestMountedUIBrandJSONEmpty'`
- [x] Automated: `go test ./internal/server -count=1 -run 'Brand|ThemeRoutes'` (earlier on this branch)
- [x] Manual: companion UI stack serves `/brand.json` and uses the mark as the tab icon in local-dev

## Reviewer focus

Empty brand must return `{}` without SPA fallthrough. Mark paths outside `assetsDir` must fail at resolve time. When a mark is set, raster bundle favicon hrefs must not remain (they would win over the SVG mark).

## Rollout / compatibility

Additive. Older bundles without the placeholder still get a script inserted after `<head>`. Deployments omit `brand` until the UI consumer and tenant config land. Tab-icon rewrite is a no-op when `mark` is unset.

## Links

Companion UI: https://github.com/valon-technologies/gestalt-providers/pull/1266