### PR TITLE
gestaltd: let the product Admin pages own /admin

### DIFF
--- a/gestaltd/go.mod
+++ b/gestaltd/go.mod
@@ -18,6 +18,8 @@ require (
 	github.com/mark3labs/mcp-go v0.54.0
 	github.com/pb33f/libopenapi v0.36.4
 	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
+	github.com/prometheus/common v0.67.5
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/wundergraph/graphql-go-tools/v2 v2.4.1
@@ -150,8 +152,6 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pb33f/jsonpath v0.8.2 // indirect
 	github.com/pb33f/ordered-map/v2 v2.3.1 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
-	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/otlptranslator v1.0.0 // indirect
 	github.com/prometheus/procfs v0.20.1 // indirect
 	github.com/spf13/cast v1.7.1 // indirect

--- a/gestaltd/internal/daemon/e2e/e2e_test.go
+++ b/gestaltd/internal/daemon/e2e/e2e_test.go
@@ -1804,11 +1804,18 @@ func TestE2EServeSplitManagementRoutes(t *testing.T) {
 	})
 
 	client := &http.Client{Timeout: 2 * time.Second}
+	noFollow := &http.Client{
+		Timeout: 2 * time.Second,
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
 	for _, tc := range []struct {
 		name         string
 		url          string
 		wantStatus   int
 		wantContains string
+		noFollow     bool
 	}{
 		{
 			name:       "public serves apps API",
@@ -1821,9 +1828,14 @@ func TestE2EServeSplitManagementRoutes(t *testing.T) {
 			wantStatus: http.StatusNotFound,
 		},
 		{
-			name:       "public hides admin ui",
+			name:       "public has no builtin admin html",
 			url:        publicURL + "/admin/",
 			wantStatus: http.StatusNotFound,
+		},
+		{
+			name:       "public serves admin API",
+			url:        publicURL + "/admin/api/v1/app-registries",
+			wantStatus: http.StatusOK,
 		},
 		{
 			name:       "management becomes ready",
@@ -1842,17 +1854,21 @@ func TestE2EServeSplitManagementRoutes(t *testing.T) {
 			wantContains: "# TYPE",
 		},
 		{
-			name:         "management serves admin ui",
-			url:          managementURL + "/admin/",
-			wantStatus:   http.StatusOK,
-			wantContains: `id="root"`,
+			name:       "management redirects admin pages to public",
+			url:        managementURL + "/admin",
+			wantStatus: http.StatusMovedPermanently,
+			noFollow:   true,
 		},
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			resp, err := client.Get(tc.url)
+			httpClient := client
+			if tc.noFollow {
+				httpClient = noFollow
+			}
+			resp, err := httpClient.Get(tc.url)
 			if err != nil {
 				t.Fatalf("GET %s: %v", tc.url, err)
 			}

--- a/gestaltd/internal/daemon/e2e/e2e_test.go
+++ b/gestaltd/internal/daemon/e2e/e2e_test.go
@@ -1815,6 +1815,7 @@ func TestE2EServeSplitManagementRoutes(t *testing.T) {
 		url          string
 		wantStatus   int
 		wantContains string
+		wantLocation string
 		noFollow     bool
 	}{
 		{
@@ -1854,10 +1855,11 @@ func TestE2EServeSplitManagementRoutes(t *testing.T) {
 			wantContains: "# TYPE",
 		},
 		{
-			name:       "management redirects admin pages to public",
-			url:        managementURL + "/admin",
-			wantStatus: http.StatusMovedPermanently,
-			noFollow:   true,
+			name:         "management redirects admin pages to public",
+			url:          managementURL + "/admin",
+			wantStatus:   http.StatusMovedPermanently,
+			wantLocation: publicURL + "/admin",
+			noFollow:     true,
 		},
 	} {
 		tc := tc
@@ -1879,6 +1881,11 @@ func TestE2EServeSplitManagementRoutes(t *testing.T) {
 			}
 			if tc.wantContains != "" && !strings.Contains(string(body), tc.wantContains) {
 				t.Fatalf("expected %s body to contain %q, got: %s", tc.url, tc.wantContains, body)
+			}
+			if tc.wantLocation != "" {
+				if got := resp.Header.Get("Location"); got != tc.wantLocation {
+					t.Fatalf("expected %s Location %q, got %q", tc.url, tc.wantLocation, got)
+				}
 			}
 		})
 	}

--- a/gestaltd/internal/server/handlers_admin_auth_test.go
+++ b/gestaltd/internal/server/handlers_admin_auth_test.go
@@ -128,8 +128,5 @@ func newAuthorizedAdminTestServer(t *testing.T, grantAdmin bool) *httptest.Serve
 		})
 		cfg.Services = svc
 		cfg.Authorization = authz
-		cfg.AdminUI = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			_, _ = w.Write([]byte("admin-shell"))
-		})
 	})
 }

--- a/gestaltd/internal/server/handlers_admin_metrics.go
+++ b/gestaltd/internal/server/handlers_admin_metrics.go
@@ -1,0 +1,89 @@
+package server
+
+import (
+	"bytes"
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+)
+
+type captureResponseWriter struct {
+	header http.Header
+	code   int
+	body   bytes.Buffer
+}
+
+func (w *captureResponseWriter) Header() http.Header {
+	if w.header == nil {
+		w.header = make(http.Header)
+	}
+	return w.header
+}
+
+func (w *captureResponseWriter) Write(p []byte) (int, error) {
+	if w.code == 0 {
+		w.code = http.StatusOK
+	}
+	return w.body.Write(p)
+}
+
+func (w *captureResponseWriter) WriteHeader(statusCode int) {
+	w.code = statusCode
+}
+
+func (s *Server) scrapePrometheus(r *http.Request) (body []byte, status int, contentType string, ok bool) {
+	if s.prometheusMetrics == nil {
+		return nil, http.StatusServiceUnavailable, "", false
+	}
+	capture := &captureResponseWriter{}
+	s.prometheusMetrics.ServeHTTP(capture, r.Clone(r.Context()))
+	status = capture.code
+	if status == 0 {
+		status = http.StatusOK
+	}
+	contentType = capture.Header().Get("Content-Type")
+	if contentType == "" {
+		contentType = "text/plain; version=0.0.4; charset=utf-8"
+	}
+	return capture.body.Bytes(), status, contentType, true
+}
+
+func (s *Server) mountAdminMetricsRoutes(r chi.Router) {
+	r.Get("/metrics", s.serveAdminPrometheusMetrics)
+}
+
+func (s *Server) serveAdminPrometheusMetrics(w http.ResponseWriter, r *http.Request) {
+	body, status, contentType, ok := s.scrapePrometheus(r)
+	if !ok {
+		writeError(w, http.StatusServiceUnavailable, "Prometheus metrics are unavailable because telemetry metrics are disabled.")
+		return
+	}
+	w.Header().Set("Content-Type", contentType)
+	w.WriteHeader(status)
+	_, _ = w.Write(body)
+}
+
+func (s *Server) mountAppAdminMetricsRoutes(r chi.Router) {
+	r.With(s.pluginRouteAuthMiddleware("app"), s.appAdminAuthorizationMiddleware).
+		Get("/apps/{app}/admin/metrics", s.getAppAdminMetrics)
+}
+
+func (s *Server) getAppAdminMetrics(w http.ResponseWriter, r *http.Request) {
+	appName := strings.TrimSpace(chi.URLParam(r, "app"))
+	if appName == "" {
+		writeError(w, http.StatusBadRequest, "app is required")
+		return
+	}
+	body, status, _, ok := s.scrapePrometheus(r)
+	if !ok {
+		writeError(w, http.StatusServiceUnavailable, "Prometheus metrics are unavailable because telemetry metrics are disabled.")
+		return
+	}
+	if status != http.StatusOK {
+		writeError(w, http.StatusServiceUnavailable, "Prometheus metrics are unavailable.")
+		return
+	}
+	samples := samplesForProvider(parsePrometheus(string(body)), appName)
+	writeJSON(w, http.StatusOK, summarizeAppMetrics(appName, samples))
+}

--- a/gestaltd/internal/server/handlers_admin_metrics.go
+++ b/gestaltd/internal/server/handlers_admin_metrics.go
@@ -56,7 +56,7 @@ func (s *Server) mountAdminMetricsRoutes(r chi.Router) {
 func (s *Server) serveAdminPrometheusMetrics(w http.ResponseWriter, r *http.Request) {
 	body, status, contentType, ok := s.scrapePrometheus(r)
 	if !ok {
-		writeError(w, http.StatusServiceUnavailable, "Prometheus metrics are unavailable because telemetry metrics are disabled.")
+		writeError(w, http.StatusServiceUnavailable, "prometheus metrics are unavailable because telemetry metrics are disabled")
 		return
 	}
 	w.Header().Set("Content-Type", contentType)
@@ -77,13 +77,18 @@ func (s *Server) getAppAdminMetrics(w http.ResponseWriter, r *http.Request) {
 	}
 	body, status, _, ok := s.scrapePrometheus(r)
 	if !ok {
-		writeError(w, http.StatusServiceUnavailable, "Prometheus metrics are unavailable because telemetry metrics are disabled.")
+		writeError(w, http.StatusServiceUnavailable, "prometheus metrics are unavailable because telemetry metrics are disabled")
 		return
 	}
 	if status != http.StatusOK {
-		writeError(w, http.StatusServiceUnavailable, "Prometheus metrics are unavailable.")
+		writeError(w, http.StatusServiceUnavailable, "prometheus metrics are unavailable because the metrics scrape failed")
 		return
 	}
-	samples := samplesForProvider(parsePrometheus(string(body)), appName)
+	parsed, err := parsePrometheus(string(body))
+	if err != nil {
+		writeError(w, http.StatusServiceUnavailable, "prometheus metrics are unavailable because the metrics scrape could not be parsed")
+		return
+	}
+	samples := samplesForProvider(parsed, appName)
 	writeJSON(w, http.StatusOK, summarizeAppMetrics(appName, samples))
 }

--- a/gestaltd/internal/server/handlers_admin_metrics.go
+++ b/gestaltd/internal/server/handlers_admin_metrics.go
@@ -2,6 +2,8 @@ package server
 
 import (
 	"bytes"
+	"compress/gzip"
+	"io"
 	"net/http"
 	"strings"
 
@@ -37,7 +39,11 @@ func (s *Server) scrapePrometheus(r *http.Request) (body []byte, status int, con
 		return nil, http.StatusServiceUnavailable, "", false
 	}
 	capture := &captureResponseWriter{}
-	s.prometheusMetrics.ServeHTTP(capture, r.Clone(r.Context()))
+	req := r.Clone(r.Context())
+	// Parsing needs plaintext. Do not ask the scrape handler to gzip, and
+	// decompress if it still does.
+	req.Header.Del("Accept-Encoding")
+	s.prometheusMetrics.ServeHTTP(capture, req)
 	status = capture.code
 	if status == 0 {
 		status = http.StatusOK
@@ -46,7 +52,20 @@ func (s *Server) scrapePrometheus(r *http.Request) (body []byte, status int, con
 	if contentType == "" {
 		contentType = "text/plain; version=0.0.4; charset=utf-8"
 	}
-	return capture.body.Bytes(), status, contentType, true
+	body = capture.body.Bytes()
+	if strings.EqualFold(capture.Header().Get("Content-Encoding"), "gzip") {
+		reader, err := gzip.NewReader(bytes.NewReader(body))
+		if err != nil {
+			return nil, http.StatusServiceUnavailable, contentType, true
+		}
+		decoded, err := io.ReadAll(reader)
+		_ = reader.Close()
+		if err != nil {
+			return nil, http.StatusServiceUnavailable, contentType, true
+		}
+		body = decoded
+	}
+	return body, status, contentType, true
 }
 
 func (s *Server) mountAdminMetricsRoutes(r chi.Router) {
@@ -54,14 +73,11 @@ func (s *Server) mountAdminMetricsRoutes(r chi.Router) {
 }
 
 func (s *Server) serveAdminPrometheusMetrics(w http.ResponseWriter, r *http.Request) {
-	body, status, contentType, ok := s.scrapePrometheus(r)
-	if !ok {
+	if s.prometheusMetrics == nil {
 		writeError(w, http.StatusServiceUnavailable, "prometheus metrics are unavailable because telemetry metrics are disabled")
 		return
 	}
-	w.Header().Set("Content-Type", contentType)
-	w.WriteHeader(status)
-	_, _ = w.Write(body)
+	s.prometheusMetrics.ServeHTTP(w, r)
 }
 
 func (s *Server) mountAppAdminMetricsRoutes(r chi.Router) {

--- a/gestaltd/internal/server/handlers_admin_metrics_test.go
+++ b/gestaltd/internal/server/handlers_admin_metrics_test.go
@@ -1,0 +1,181 @@
+package server_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/internal/server"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"github.com/valon-technologies/gestalt/server/services/identity/principal"
+)
+
+func TestAppAdminMetricsFiltersByProvider(t *testing.T) {
+	t.Parallel()
+
+	adminID := principal.UserSubjectID(testCanonicalAdminUserID)
+	authz := &serverTestAuthorizationProvider{
+		relationships: []*proto.Relationship{
+			testAuthorizationRelationship(adminID, "admin", "app", "g-issues"),
+		},
+	}
+	scrape := `
+gestaltd_operation_count_total{gestalt_provider="g-issues",gestalt_operation="list"} 4
+gestaltd_operation_count_total{gestalt_provider="slack",gestalt_operation="post"} 9
+gestaltd_operation_error_count_total{gestalt_provider="g-issues",gestalt_operation="list"} 1
+`
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = authStubWithSessionTokenIntrospect("alice-token", adminID, "")
+		cfg.Authorization = authz
+		cfg.AppDefs = appAdminTestAppDefs()
+		cfg.PrometheusMetrics = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "text/plain; version=0.0.4")
+			_, _ = w.Write([]byte(scrape))
+		})
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	request, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/apps/g-issues/admin/metrics", nil)
+	request.Header.Set("Authorization", "Bearer alice-token")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("GET metrics: %v", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	body, _ := io.ReadAll(response.Body)
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d: %s", response.StatusCode, body)
+	}
+	var payload struct {
+		App        string  `json:"app"`
+		Requests   float64 `json:"requests"`
+		Errors     float64 `json:"errors"`
+		Operations []struct {
+			Operation string  `json:"operation"`
+			Requests  float64 `json:"requests"`
+		} `json:"operations"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if payload.App != "g-issues" || payload.Requests != 4 || payload.Errors != 1 {
+		t.Fatalf("payload = %#v", payload)
+	}
+	if len(payload.Operations) != 1 || payload.Operations[0].Operation != "list" {
+		t.Fatalf("operations = %#v", payload.Operations)
+	}
+}
+
+func TestAppAdminMetricsForbiddenWithoutAppAdmin(t *testing.T) {
+	t.Parallel()
+
+	viewerID := principal.UserSubjectID(testCanonicalViewerUserID)
+	authz := &serverTestAuthorizationProvider{
+		relationships: []*proto.Relationship{
+			testAuthorizationRelationship(viewerID, "viewer", "app", "g-issues"),
+		},
+	}
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = authStubWithSessionTokenIntrospect("viewer-token", viewerID, "")
+		cfg.Authorization = authz
+		cfg.AppDefs = appAdminTestAppDefs()
+		cfg.PrometheusMetrics = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte("gestaltd_operation_count_total 1\n"))
+		})
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	request, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/apps/g-issues/admin/metrics", nil)
+	request.Header.Set("Authorization", "Bearer viewer-token")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("GET metrics: %v", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusForbidden {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("status = %d, want 403: %s", response.StatusCode, body)
+	}
+}
+
+func TestAppAdminMetricsUnavailableWhenTelemetryDisabled(t *testing.T) {
+	t.Parallel()
+
+	adminID := principal.UserSubjectID(testCanonicalAdminUserID)
+	authz := &serverTestAuthorizationProvider{
+		relationships: []*proto.Relationship{
+			testAuthorizationRelationship(adminID, "admin", "app", "g-issues"),
+		},
+	}
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = authStubWithSessionTokenIntrospect("alice-token", adminID, "")
+		cfg.Authorization = authz
+		cfg.AppDefs = appAdminTestAppDefs()
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	request, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/apps/g-issues/admin/metrics", nil)
+	request.Header.Set("Authorization", "Bearer alice-token")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("GET metrics: %v", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusServiceUnavailable {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("status = %d, want 503: %s", response.StatusCode, body)
+	}
+}
+
+func TestAdminPrometheusMetricsEndpoint(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.PrometheusMetrics = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "text/plain; version=0.0.4")
+			_, _ = w.Write([]byte("gestaltd_operation_count_total 7\n"))
+		})
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	resp, err := http.Get(ts.URL + "/admin/api/v1/metrics")
+	if err != nil {
+		t.Fatalf("GET admin metrics: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d: %s", resp.StatusCode, body)
+	}
+	if !strings.Contains(string(body), "gestaltd_operation_count_total 7") {
+		t.Fatalf("body = %s", body)
+	}
+}
+
+func TestAdminRegistryBookmarkRedirect(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestServer(t)
+	testutil.CloseOnCleanup(t, ts)
+
+	client := &http.Client{
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	resp, err := client.Get(ts.URL + "/admin/registry/g-issues")
+	if err != nil {
+		t.Fatalf("GET registry bookmark: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusMovedPermanently {
+		t.Fatalf("status = %d, want 301", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Location"); got != "/admin/versions/g-issues" {
+		t.Fatalf("Location = %q", got)
+	}
+}

--- a/gestaltd/internal/server/handlers_admin_metrics_test.go
+++ b/gestaltd/internal/server/handlers_admin_metrics_test.go
@@ -156,26 +156,51 @@ func TestAdminPrometheusMetricsEndpoint(t *testing.T) {
 	}
 }
 
-func TestAdminRegistryBookmarkRedirect(t *testing.T) {
+func TestAdminPrometheusMetricsRequiresSessionWhenAdminAuthorizationEnabled(t *testing.T) {
 	t.Parallel()
 
-	ts := newTestServer(t)
+	ts := newAuthorizedAdminTestServer(t, true)
 	testutil.CloseOnCleanup(t, ts)
 
-	client := &http.Client{
-		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
-			return http.ErrUseLastResponse
-		},
-	}
-	resp, err := client.Get(ts.URL + "/admin/registry/g-issues")
+	resp, err := http.Get(ts.URL + "/admin/api/v1/metrics")
 	if err != nil {
-		t.Fatalf("GET registry bookmark: %v", err)
+		t.Fatalf("GET admin metrics: %v", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusMovedPermanently {
-		t.Fatalf("status = %d, want 301", resp.StatusCode)
+	if resp.StatusCode != http.StatusUnauthorized {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 401: %s", resp.StatusCode, body)
 	}
-	if got := resp.Header.Get("Location"); got != "/admin/versions/g-issues" {
-		t.Fatalf("Location = %q", got)
+}
+
+func TestAppAdminMetricsRejectsMalformedPrometheus(t *testing.T) {
+	t.Parallel()
+
+	adminID := principal.UserSubjectID(testCanonicalAdminUserID)
+	authz := &serverTestAuthorizationProvider{
+		relationships: []*proto.Relationship{
+			testAuthorizationRelationship(adminID, "admin", "app", "g-issues"),
+		},
+	}
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = authStubWithSessionTokenIntrospect("alice-token", adminID, "")
+		cfg.Authorization = authz
+		cfg.AppDefs = appAdminTestAppDefs()
+		cfg.PrometheusMetrics = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte("not a metric line {\n"))
+		})
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	request, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/apps/g-issues/admin/metrics", nil)
+	request.Header.Set("Authorization", "Bearer alice-token")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("GET metrics: %v", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusServiceUnavailable {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("status = %d, want 503: %s", response.StatusCode, body)
 	}
 }

--- a/gestaltd/internal/server/handlers_admin_metrics_test.go
+++ b/gestaltd/internal/server/handlers_admin_metrics_test.go
@@ -1,6 +1,7 @@
 package server_test
 
 import (
+	"compress/gzip"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -67,6 +68,106 @@ gestaltd_operation_error_count_total{gestalt_provider="g-issues",gestalt_operati
 	}
 	if len(payload.Operations) != 1 || payload.Operations[0].Operation != "list" {
 		t.Fatalf("operations = %#v", payload.Operations)
+	}
+}
+
+func TestAppAdminMetricsIgnoresCallerGzipAccept(t *testing.T) {
+	t.Parallel()
+
+	adminID := principal.UserSubjectID(testCanonicalAdminUserID)
+	authz := &serverTestAuthorizationProvider{
+		relationships: []*proto.Relationship{
+			testAuthorizationRelationship(adminID, "admin", "app", "g-issues"),
+		},
+	}
+	scrape := `gestaltd_operation_count_total{gestalt_provider="g-issues",gestalt_operation="list"} 4
+gestaltd_operation_count_total{gestalt_provider="slack",gestalt_operation="post"} 9
+`
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = authStubWithSessionTokenIntrospect("alice-token", adminID, "")
+		cfg.Authorization = authz
+		cfg.AppDefs = appAdminTestAppDefs()
+		cfg.PrometheusMetrics = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if strings.Contains(r.Header.Get("Accept-Encoding"), "gzip") {
+				w.Header().Set("Content-Encoding", "gzip")
+				gz := gzip.NewWriter(w)
+				_, _ = gz.Write([]byte(scrape))
+				_ = gz.Close()
+				return
+			}
+			_, _ = w.Write([]byte(scrape))
+		})
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	request, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/apps/g-issues/admin/metrics", nil)
+	request.Header.Set("Authorization", "Bearer alice-token")
+	request.Header.Set("Accept-Encoding", "gzip")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("GET metrics: %v", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	body, _ := io.ReadAll(response.Body)
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d: %s", response.StatusCode, body)
+	}
+	var payload struct {
+		App      string  `json:"app"`
+		Requests float64 `json:"requests"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if payload.App != "g-issues" || payload.Requests != 4 {
+		t.Fatalf("payload = %#v", payload)
+	}
+}
+
+func TestAppAdminMetricsDecodesGzipScrape(t *testing.T) {
+	t.Parallel()
+
+	adminID := principal.UserSubjectID(testCanonicalAdminUserID)
+	authz := &serverTestAuthorizationProvider{
+		relationships: []*proto.Relationship{
+			testAuthorizationRelationship(adminID, "admin", "app", "g-issues"),
+		},
+	}
+	scrape := `gestaltd_operation_count_total{gestalt_provider="g-issues",gestalt_operation="list"} 4
+`
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = authStubWithSessionTokenIntrospect("alice-token", adminID, "")
+		cfg.Authorization = authz
+		cfg.AppDefs = appAdminTestAppDefs()
+		cfg.PrometheusMetrics = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Encoding", "gzip")
+			gz := gzip.NewWriter(w)
+			_, _ = gz.Write([]byte(scrape))
+			_ = gz.Close()
+		})
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	request, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/apps/g-issues/admin/metrics", nil)
+	request.Header.Set("Authorization", "Bearer alice-token")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("GET metrics: %v", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	body, _ := io.ReadAll(response.Body)
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d: %s", response.StatusCode, body)
+	}
+	var payload struct {
+		App      string  `json:"app"`
+		Requests float64 `json:"requests"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if payload.App != "g-issues" || payload.Requests != 4 {
+		t.Fatalf("payload = %#v", payload)
 	}
 }
 

--- a/gestaltd/internal/server/handlers_admin_platform_admins.go
+++ b/gestaltd/internal/server/handlers_admin_platform_admins.go
@@ -1,0 +1,63 @@
+package server
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+)
+
+type adminPlatformAdminsResponse struct {
+	Resource adminPlatformAdminResource `json:"resource"`
+	Role     string                     `json:"role"`
+	Members  []appAdminMemberRow        `json:"members"`
+}
+
+type adminPlatformAdminResource struct {
+	Type string `json:"type"`
+	ID   string `json:"id"`
+}
+
+func (s *Server) mountAdminPlatformAdminsRoutes(r chi.Router) {
+	r.Get("/platform-admins", s.listAdminPlatformAdmins)
+}
+
+func (s *Server) platformAdminResource() *proto.Resource {
+	name := strings.TrimSpace(s.adminRoute.AuthorizationPolicy)
+	if name == "" {
+		name = defaultAdminAuthorizationResource
+	}
+	return s.authorizationResource(name)
+}
+
+func (s *Server) platformAdminRole() string {
+	for _, role := range s.adminRoute.AllowedRoles {
+		role = strings.TrimSpace(role)
+		if role != "" {
+			return role
+		}
+	}
+	return "admin"
+}
+
+func (s *Server) listAdminPlatformAdmins(w http.ResponseWriter, r *http.Request) {
+	if s.authorization == nil {
+		writeError(w, http.StatusServiceUnavailable, "authorization is unavailable")
+		return
+	}
+	resource := s.platformAdminResource()
+	rows, err := s.listAuthorizationMemberRows(r.Context(), resource)
+	if err != nil {
+		writeError(w, http.StatusServiceUnavailable, "authorization is unavailable")
+		return
+	}
+	writeJSON(w, http.StatusOK, adminPlatformAdminsResponse{
+		Resource: adminPlatformAdminResource{
+			Type: resource.GetType(),
+			ID:   resource.GetId(),
+		},
+		Role:    s.platformAdminRole(),
+		Members: s.projectAppAdminHumanMemberRows(r.Context(), rows),
+	})
+}

--- a/gestaltd/internal/server/handlers_admin_platform_admins.go
+++ b/gestaltd/internal/server/handlers_admin_platform_admins.go
@@ -31,7 +31,7 @@ func (s *Server) platformAdminResource() *proto.Resource {
 	return s.authorizationResource(name)
 }
 
-func (s *Server) platformAdminRole() string {
+func (s *Server) configuredPlatformAdminRole() string {
 	for _, role := range s.adminRoute.AllowedRoles {
 		role = strings.TrimSpace(role)
 		if role != "" {
@@ -57,7 +57,7 @@ func (s *Server) listAdminPlatformAdmins(w http.ResponseWriter, r *http.Request)
 			Type: resource.GetType(),
 			ID:   resource.GetId(),
 		},
-		Role:    s.platformAdminRole(),
+		Role:    s.configuredPlatformAdminRole(),
 		Members: s.projectAppAdminHumanMemberRows(r.Context(), rows),
 	})
 }

--- a/gestaltd/internal/server/handlers_admin_platform_admins_test.go
+++ b/gestaltd/internal/server/handlers_admin_platform_admins_test.go
@@ -1,0 +1,98 @@
+package server_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/internal/server"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"github.com/valon-technologies/gestalt/server/services/identity/principal"
+)
+
+func TestAdminPlatformAdminsList(t *testing.T) {
+	t.Parallel()
+
+	adminID := principal.UserSubjectID(testCanonicalAdminUserID)
+	authz := &serverTestAuthorizationProvider{
+		relationships: []*proto.Relationship{
+			testAuthorizationRelationship(adminID, "admin", "gestaltAdmin", "gestaltAdmin"),
+			{
+				Tuple: &proto.RelationshipTuple{
+					Target: &proto.RelationshipTarget{
+						Kind: &proto.RelationshipTarget_SubjectSet{
+							SubjectSet: &proto.SubjectSet{
+								Resource: &proto.Resource{Type: "group", Id: "eng"},
+								Relation: "member",
+							},
+						},
+					},
+					Relation: "admin",
+					Resource: &proto.Resource{Type: "gestaltAdmin", Id: "gestaltAdmin"},
+				},
+				SourceLayer: proto.SourceLayer_SOURCE_LAYER_STATIC_CONFIG,
+			},
+		},
+	}
+	authz.relationships[0].SourceLayer = proto.SourceLayer_SOURCE_LAYER_RUNTIME
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Authorization = authz
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	resp, err := http.Get(ts.URL + "/admin/api/v1/platform-admins")
+	if err != nil {
+		t.Fatalf("GET platform-admins: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d: %s", resp.StatusCode, body)
+	}
+	var payload struct {
+		Resource struct {
+			Type string `json:"type"`
+			ID   string `json:"id"`
+		} `json:"resource"`
+		Role    string `json:"role"`
+		Members []struct {
+			Role          string `json:"role"`
+			Source        string `json:"source"`
+			Mutable       bool   `json:"mutable"`
+			SelectorKind  string `json:"selectorKind"`
+			SelectorValue string `json:"selectorValue"`
+		} `json:"members"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if payload.Resource.Type != "gestaltAdmin" || payload.Resource.ID != "gestaltAdmin" {
+		t.Fatalf("resource = %#v", payload.Resource)
+	}
+	if payload.Role != "admin" {
+		t.Fatalf("role = %q", payload.Role)
+	}
+	if len(payload.Members) != 2 {
+		t.Fatalf("members = %#v", payload.Members)
+	}
+}
+
+func TestAdminPlatformAdminsUnavailableWithoutAuthorization(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestServer(t)
+	testutil.CloseOnCleanup(t, ts)
+
+	resp, err := http.Get(ts.URL + "/admin/api/v1/platform-admins")
+	if err != nil {
+		t.Fatalf("GET platform-admins: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 503: %s", resp.StatusCode, body)
+	}
+}

--- a/gestaltd/internal/server/handlers_admin_platform_admins_test.go
+++ b/gestaltd/internal/server/handlers_admin_platform_admins_test.go
@@ -78,6 +78,26 @@ func TestAdminPlatformAdminsList(t *testing.T) {
 	if len(payload.Members) != 2 {
 		t.Fatalf("members = %#v", payload.Members)
 	}
+	var staticGroup, runtimeUser int
+	for _, member := range payload.Members {
+		switch {
+		case member.SelectorKind == "subject_set" && member.SelectorValue == "group:eng#member":
+			staticGroup++
+			if member.Source != "static" || member.Mutable {
+				t.Fatalf("config-locked group = %#v", member)
+			}
+		case member.SelectorKind == "subject_id":
+			runtimeUser++
+			if member.Source != "dynamic" || !member.Mutable {
+				t.Fatalf("runtime member = %#v", member)
+			}
+		default:
+			t.Fatalf("unexpected member = %#v", member)
+		}
+	}
+	if staticGroup != 1 || runtimeUser != 1 {
+		t.Fatalf("members = %#v", payload.Members)
+	}
 }
 
 func TestAdminPlatformAdminsUnavailableWithoutAuthorization(t *testing.T) {
@@ -94,5 +114,22 @@ func TestAdminPlatformAdminsUnavailableWithoutAuthorization(t *testing.T) {
 	if resp.StatusCode != http.StatusServiceUnavailable {
 		body, _ := io.ReadAll(resp.Body)
 		t.Fatalf("status = %d, want 503: %s", resp.StatusCode, body)
+	}
+}
+
+func TestAdminPlatformAdminsRequiresSessionWhenAdminAuthorizationEnabled(t *testing.T) {
+	t.Parallel()
+
+	ts := newAuthorizedAdminTestServer(t, true)
+	testutil.CloseOnCleanup(t, ts)
+
+	resp, err := http.Get(ts.URL + "/admin/api/v1/platform-admins")
+	if err != nil {
+		t.Fatalf("GET platform-admins: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusUnauthorized {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 401: %s", resp.StatusCode, body)
 	}
 }

--- a/gestaltd/internal/server/handlers_admin_routes_test.go
+++ b/gestaltd/internal/server/handlers_admin_routes_test.go
@@ -1,0 +1,60 @@
+package server_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/internal/server"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
+)
+
+func TestAdminRegistryBookmarkRedirect(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestServer(t)
+	testutil.CloseOnCleanup(t, ts)
+
+	client := &http.Client{
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	resp, err := client.Get(ts.URL + "/admin/registry/g-issues")
+	if err != nil {
+		t.Fatalf("GET registry bookmark: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusMovedPermanently {
+		t.Fatalf("status = %d, want 301", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Location"); got != "/admin/versions/g-issues" {
+		t.Fatalf("Location = %q", got)
+	}
+}
+
+func TestAdminRegistryBookmarkRedirectOnManagementProfile(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.RouteProfile = server.RouteProfileManagement
+		cfg.PublicBaseURL = "https://gestalt.example.test"
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	client := &http.Client{
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	resp, err := client.Get(ts.URL + "/admin/registry/g-issues")
+	if err != nil {
+		t.Fatalf("GET registry bookmark: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusMovedPermanently {
+		t.Fatalf("status = %d, want 301", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Location"); got != "https://gestalt.example.test/admin/versions/g-issues" {
+		t.Fatalf("Location = %q", got)
+	}
+}

--- a/gestaltd/internal/server/handlers_admin_routes_test.go
+++ b/gestaltd/internal/server/handlers_admin_routes_test.go
@@ -58,3 +58,28 @@ func TestAdminRegistryBookmarkRedirectOnManagementProfile(t *testing.T) {
 		t.Fatalf("Location = %q", got)
 	}
 }
+
+func TestManagementAdminPagesDoNotRedirectWithoutPublicBaseURL(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.RouteProfile = server.RouteProfileManagement
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	client := &http.Client{
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	for _, path := range []string{"/", "/admin", "/admin/", "/admin/metrics", "/admin/versions"} {
+		resp, err := client.Get(ts.URL + path)
+		if err != nil {
+			t.Fatalf("GET %s: %v", path, err)
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode == http.StatusMovedPermanently || resp.StatusCode == http.StatusFound {
+			t.Fatalf("%s status = %d Location = %q, want no redirect", path, resp.StatusCode, resp.Header.Get("Location"))
+		}
+	}
+}

--- a/gestaltd/internal/server/handlers_app_admin_members.go
+++ b/gestaltd/internal/server/handlers_app_admin_members.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -89,13 +90,19 @@ func (s *Server) projectAppAdminHumanMemberRows(ctx context.Context, rows []appA
 }
 
 func (s *Server) listAppAuthorizationMemberRows(ctx context.Context, appName string) ([]appAdminMemberRow, error) {
-	appName = strings.TrimSpace(appName)
+	return s.listAuthorizationMemberRows(ctx, s.authorizationResource(strings.TrimSpace(appName)))
+}
+
+func (s *Server) listAuthorizationMemberRows(ctx context.Context, resource *proto.Resource) ([]appAdminMemberRow, error) {
+	if resource == nil || strings.TrimSpace(resource.GetId()) == "" {
+		return nil, fmt.Errorf("authorization resource is required")
+	}
 	rows := make([]appAdminMemberRow, 0)
 	pageToken := ""
 	for {
 		resp, err := s.authorization.ListRelationships(ctx, &proto.ListRelationshipsRequest{
 			Filter: &proto.RelationshipFilter{
-				Resource: s.authorizationResource(appName),
+				Resource: resource,
 			},
 			PageSize:  500,
 			PageToken: pageToken,

--- a/gestaltd/internal/server/mounted_ui.go
+++ b/gestaltd/internal/server/mounted_ui.go
@@ -15,7 +15,6 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"github.com/valon-technologies/gestalt/server/services/observability/metricutil"
-	"github.com/valon-technologies/gestalt/server/services/ui/adminui"
 )
 
 const browserLoginPath = "/api/v1/auth/login"
@@ -94,17 +93,6 @@ func parseAbsoluteBaseURL(label, raw string) (*url.URL, error) {
 	return parsed, nil
 }
 
-func resolveBuiltinAdminUI(opts BuiltinAdminUIOptions) (http.Handler, error) {
-	handler := adminui.EmbeddedHandler(adminui.Options{
-		BrandHref: opts.BrandHref,
-		LoginBase: opts.LoginBase,
-	})
-	if handler == nil {
-		return nil, fmt.Errorf("embedded admin ui assets not found")
-	}
-	return handler, nil
-}
-
 func normalizeMountedUIs(mounted []MountedUI) ([]MountedUI, error) {
 	if len(mounted) == 0 {
 		return nil, nil
@@ -138,15 +126,6 @@ func (s *Server) mountedUIHandler(mounted MountedUI) http.Handler {
 	}
 	inner = mountedUITelemetryHandler(mounted, inner)
 	return s.protectedUIHandler(mounted, inner, s.redirectMountedUILogin)
-}
-
-func (s *Server) adminUIHandler() http.Handler {
-	if s.adminUI == nil {
-		return http.NotFoundHandler()
-	}
-	mounted := s.adminMountedUI()
-	inner := http.StripPrefix(mounted.Path, mounted.Handler)
-	return mountedUITelemetryHandler(mounted, s.protectedUIHandler(mounted, inner, s.redirectAdminUILogin))
 }
 
 func (s *Server) adminMountedUI() MountedUI {
@@ -573,22 +552,6 @@ func (s *Server) legacyDirectGrantRoles(ctx context.Context, subjectID, resource
 
 func (s *Server) redirectMountedUILogin(w http.ResponseWriter, r *http.Request) error {
 	target := browserLoginPath + "?next=" + url.QueryEscape(r.URL.RequestURI())
-	http.Redirect(w, r, target, http.StatusFound)
-	return nil
-}
-
-func (s *Server) redirectAdminUILogin(w http.ResponseWriter, r *http.Request) error {
-	if s.routeProfile != RouteProfileManagement {
-		return s.redirectMountedUILogin(w, r)
-	}
-	if s.publicBaseURL == "" {
-		return fmt.Errorf("admin login redirect requires server.baseUrl")
-	}
-	if s.managementBaseURL == "" {
-		return fmt.Errorf("admin login redirect requires server.management.baseUrl")
-	}
-
-	target := s.publicBaseURL + browserLoginPath + "?next=" + url.QueryEscape(s.managementBaseURL+r.URL.RequestURI())
 	http.Redirect(w, r, target, http.StatusFound)
 	return nil
 }

--- a/gestaltd/internal/server/mounted_ui.go
+++ b/gestaltd/internal/server/mounted_ui.go
@@ -128,14 +128,13 @@ func (s *Server) mountedUIHandler(mounted MountedUI) http.Handler {
 	return s.protectedUIHandler(mounted, inner, s.redirectMountedUILogin)
 }
 
-func (s *Server) adminMountedUI() MountedUI {
+func (s *Server) adminAPIAuthTarget() MountedUI {
 	return MountedUI{
-		Name:                "builtin_admin",
-		Path:                "/admin",
+		Name:                "admin_api",
+		Path:                "/admin/api/v1",
 		AuthorizationPolicy: s.adminRoute.AuthorizationPolicy,
 		AllowedRoles:        append([]string(nil), s.adminRoute.AllowedRoles...),
 		builtInAdmin:        true,
-		Handler:             s.adminUI,
 	}
 }
 
@@ -155,7 +154,7 @@ func (s *Server) protectedUIHandler(mounted MountedUI, inner http.Handler, redir
 
 func (s *Server) adminAPIAuthMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx, ok := s.authorizeMountedResource(w, r, s.adminMountedUI(), nil)
+		ctx, ok := s.authorizeMountedResource(w, r, s.adminAPIAuthTarget(), nil)
 		if !ok {
 			return
 		}

--- a/gestaltd/internal/server/prometheus_filter.go
+++ b/gestaltd/internal/server/prometheus_filter.go
@@ -1,0 +1,198 @@
+package server
+
+import (
+	"math"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+const (
+	promLabelProvider         = "gestalt_provider"
+	promLabelProviderName     = "gestaltd_provider_name"
+	promLabelOperation        = "gestalt_operation"
+	promMetricOpCount         = "gestaltd_operation_count_total"
+	promMetricOpErrors        = "gestaltd_operation_error_count_total"
+	promMetricOpDurationSum   = "gestaltd_operation_duration_seconds_sum"
+	promMetricOpDurationCount = "gestaltd_operation_duration_seconds_count"
+)
+
+type prometheusSample struct {
+	name   string
+	labels map[string]string
+	value  float64
+}
+
+type appAdminOperationMetric struct {
+	Operation            string  `json:"operation"`
+	Requests             float64 `json:"requests"`
+	Errors               float64 `json:"errors"`
+	DurationSecondsSum   float64 `json:"durationSecondsSum"`
+	DurationSecondsCount float64 `json:"durationSecondsCount"`
+}
+
+type appAdminMetricsResponse struct {
+	App                  string                    `json:"app"`
+	Available            bool                      `json:"available"`
+	Requests             float64                   `json:"requests"`
+	Errors               float64                   `json:"errors"`
+	DurationSecondsSum   float64                   `json:"durationSecondsSum"`
+	DurationSecondsCount float64                   `json:"durationSecondsCount"`
+	Operations           []appAdminOperationMetric `json:"operations"`
+}
+
+func parsePrometheus(text string) []prometheusSample {
+	samples := make([]prometheusSample, 0)
+	for _, raw := range strings.Split(text, "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		sample, ok := parsePrometheusLine(line)
+		if ok {
+			samples = append(samples, sample)
+		}
+	}
+	return samples
+}
+
+func parsePrometheusLine(line string) (prometheusSample, bool) {
+	nameEnd := 0
+	for nameEnd < len(line) {
+		c := line[nameEnd]
+		if c == '{' || c == ' ' || c == '\t' {
+			break
+		}
+		nameEnd++
+	}
+	if nameEnd == 0 {
+		return prometheusSample{}, false
+	}
+	name := line[:nameEnd]
+	rest := strings.TrimSpace(line[nameEnd:])
+	labels := map[string]string{}
+	if strings.HasPrefix(rest, "{") {
+		end := strings.IndexByte(rest, '}')
+		if end < 0 {
+			return prometheusSample{}, false
+		}
+		labels = parsePrometheusLabels(rest[1:end])
+		rest = strings.TrimSpace(rest[end+1:])
+	}
+	fields := strings.Fields(rest)
+	if len(fields) == 0 {
+		return prometheusSample{}, false
+	}
+	value, err := strconv.ParseFloat(fields[0], 64)
+	if err != nil || math.IsNaN(value) {
+		return prometheusSample{}, false
+	}
+	return prometheusSample{name: name, labels: labels, value: value}, true
+}
+
+func parsePrometheusLabels(raw string) map[string]string {
+	labels := map[string]string{}
+	rest := strings.TrimSpace(raw)
+	for rest != "" {
+		eq := strings.IndexByte(rest, '=')
+		if eq <= 0 {
+			break
+		}
+		key := strings.TrimSpace(rest[:eq])
+		rest = strings.TrimSpace(rest[eq+1:])
+		if !strings.HasPrefix(rest, `"`) {
+			break
+		}
+		rest = rest[1:]
+		var value strings.Builder
+		escaped := false
+		closed := false
+		for i := 0; i < len(rest); i++ {
+			c := rest[i]
+			if escaped {
+				value.WriteByte(c)
+				escaped = false
+				continue
+			}
+			if c == '\\' {
+				escaped = true
+				continue
+			}
+			if c == '"' {
+				rest = strings.TrimSpace(strings.TrimPrefix(rest[i+1:], ","))
+				closed = true
+				break
+			}
+			value.WriteByte(c)
+		}
+		if !closed || key == "" {
+			break
+		}
+		labels[key] = value.String()
+	}
+	return labels
+}
+
+func sampleProvider(sample prometheusSample) string {
+	if value := strings.TrimSpace(sample.labels[promLabelProvider]); value != "" {
+		return value
+	}
+	return strings.TrimSpace(sample.labels[promLabelProviderName])
+}
+
+func samplesForProvider(samples []prometheusSample, provider string) []prometheusSample {
+	provider = strings.TrimSpace(provider)
+	if provider == "" {
+		return nil
+	}
+	out := make([]prometheusSample, 0)
+	for _, sample := range samples {
+		if sampleProvider(sample) == provider {
+			out = append(out, sample)
+		}
+	}
+	return out
+}
+
+func summarizeAppMetrics(app string, samples []prometheusSample) appAdminMetricsResponse {
+	byOp := map[string]*appAdminOperationMetric{}
+	response := appAdminMetricsResponse{
+		App:       app,
+		Available: true,
+	}
+	for _, sample := range samples {
+		operation := strings.TrimSpace(sample.labels[promLabelOperation])
+		if operation == "" {
+			operation = "unknown"
+		}
+		row := byOp[operation]
+		if row == nil {
+			row = &appAdminOperationMetric{Operation: operation}
+			byOp[operation] = row
+		}
+		switch sample.name {
+		case promMetricOpCount:
+			row.Requests += sample.value
+			response.Requests += sample.value
+		case promMetricOpErrors:
+			row.Errors += sample.value
+			response.Errors += sample.value
+		case promMetricOpDurationSum:
+			row.DurationSecondsSum += sample.value
+			response.DurationSecondsSum += sample.value
+		case promMetricOpDurationCount:
+			row.DurationSecondsCount += sample.value
+			response.DurationSecondsCount += sample.value
+		}
+	}
+	names := make([]string, 0, len(byOp))
+	for name := range byOp {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	response.Operations = make([]appAdminOperationMetric, 0, len(names))
+	for _, name := range names {
+		response.Operations = append(response.Operations, *byOp[name])
+	}
+	return response
+}

--- a/gestaltd/internal/server/prometheus_filter.go
+++ b/gestaltd/internal/server/prometheus_filter.go
@@ -1,10 +1,14 @@
 package server
 
 import (
+	"fmt"
 	"math"
 	"sort"
-	"strconv"
 	"strings"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/model"
 )
 
 const (
@@ -41,96 +45,80 @@ type appAdminMetricsResponse struct {
 	Operations           []appAdminOperationMetric `json:"operations"`
 }
 
-func parsePrometheus(text string) []prometheusSample {
+func parsePrometheus(text string) ([]prometheusSample, error) {
+	parser := expfmt.NewTextParser(model.UTF8Validation)
+	families, err := parser.TextToMetricFamilies(strings.NewReader(text))
+	if err != nil {
+		return nil, fmt.Errorf("parse prometheus text: %w", err)
+	}
 	samples := make([]prometheusSample, 0)
-	for _, raw := range strings.Split(text, "\n") {
-		line := strings.TrimSpace(raw)
-		if line == "" || strings.HasPrefix(line, "#") {
+	for _, family := range families {
+		if family == nil {
 			continue
 		}
-		sample, ok := parsePrometheusLine(line)
-		if ok {
-			samples = append(samples, sample)
+		samples = append(samples, prometheusSamplesFromFamily(family)...)
+	}
+	return samples, nil
+}
+
+func prometheusSamplesFromFamily(family *dto.MetricFamily) []prometheusSample {
+	name := family.GetName()
+	samples := make([]prometheusSample, 0, len(family.GetMetric()))
+	for _, metric := range family.GetMetric() {
+		if metric == nil {
+			continue
+		}
+		labels := prometheusLabelsFromMetric(metric)
+		switch family.GetType() {
+		case dto.MetricType_HISTOGRAM, dto.MetricType_GAUGE_HISTOGRAM:
+			hist := metric.GetHistogram()
+			samples = append(samples,
+				prometheusSample{name: name + "_sum", labels: labels, value: hist.GetSampleSum()},
+				prometheusSample{name: name + "_count", labels: labels, value: float64(hist.GetSampleCount())},
+			)
+		case dto.MetricType_SUMMARY:
+			summary := metric.GetSummary()
+			samples = append(samples,
+				prometheusSample{name: name + "_sum", labels: labels, value: summary.GetSampleSum()},
+				prometheusSample{name: name + "_count", labels: labels, value: float64(summary.GetSampleCount())},
+			)
+		default:
+			value, ok := prometheusScalarValue(metric)
+			if !ok {
+				continue
+			}
+			samples = append(samples, prometheusSample{name: name, labels: labels, value: value})
 		}
 	}
 	return samples
 }
 
-func parsePrometheusLine(line string) (prometheusSample, bool) {
-	nameEnd := 0
-	for nameEnd < len(line) {
-		c := line[nameEnd]
-		if c == '{' || c == ' ' || c == '\t' {
-			break
+func prometheusLabelsFromMetric(metric *dto.Metric) map[string]string {
+	labels := make(map[string]string, len(metric.GetLabel()))
+	for _, pair := range metric.GetLabel() {
+		if pair == nil {
+			continue
 		}
-		nameEnd++
-	}
-	if nameEnd == 0 {
-		return prometheusSample{}, false
-	}
-	name := line[:nameEnd]
-	rest := strings.TrimSpace(line[nameEnd:])
-	labels := map[string]string{}
-	if strings.HasPrefix(rest, "{") {
-		end := strings.IndexByte(rest, '}')
-		if end < 0 {
-			return prometheusSample{}, false
+		key := strings.TrimSpace(pair.GetName())
+		if key == "" {
+			continue
 		}
-		labels = parsePrometheusLabels(rest[1:end])
-		rest = strings.TrimSpace(rest[end+1:])
-	}
-	fields := strings.Fields(rest)
-	if len(fields) == 0 {
-		return prometheusSample{}, false
-	}
-	value, err := strconv.ParseFloat(fields[0], 64)
-	if err != nil || math.IsNaN(value) {
-		return prometheusSample{}, false
-	}
-	return prometheusSample{name: name, labels: labels, value: value}, true
-}
-
-func parsePrometheusLabels(raw string) map[string]string {
-	labels := map[string]string{}
-	rest := strings.TrimSpace(raw)
-	for rest != "" {
-		eq := strings.IndexByte(rest, '=')
-		if eq <= 0 {
-			break
-		}
-		key := strings.TrimSpace(rest[:eq])
-		rest = strings.TrimSpace(rest[eq+1:])
-		if !strings.HasPrefix(rest, `"`) {
-			break
-		}
-		rest = rest[1:]
-		var value strings.Builder
-		escaped := false
-		closed := false
-		for i := 0; i < len(rest); i++ {
-			c := rest[i]
-			if escaped {
-				value.WriteByte(c)
-				escaped = false
-				continue
-			}
-			if c == '\\' {
-				escaped = true
-				continue
-			}
-			if c == '"' {
-				rest = strings.TrimSpace(strings.TrimPrefix(rest[i+1:], ","))
-				closed = true
-				break
-			}
-			value.WriteByte(c)
-		}
-		if !closed || key == "" {
-			break
-		}
-		labels[key] = value.String()
+		labels[key] = pair.GetValue()
 	}
 	return labels
+}
+
+func prometheusScalarValue(metric *dto.Metric) (float64, bool) {
+	switch {
+	case metric.Counter != nil:
+		return metric.GetCounter().GetValue(), true
+	case metric.Gauge != nil:
+		return metric.GetGauge().GetValue(), true
+	case metric.Untyped != nil:
+		return metric.GetUntyped().GetValue(), true
+	default:
+		return 0, false
+	}
 }
 
 func sampleProvider(sample prometheusSample) string {
@@ -161,6 +149,9 @@ func summarizeAppMetrics(app string, samples []prometheusSample) appAdminMetrics
 		Available: true,
 	}
 	for _, sample := range samples {
+		if math.IsNaN(sample.value) {
+			continue
+		}
 		operation := strings.TrimSpace(sample.labels[promLabelOperation])
 		if operation == "" {
 			operation = "unknown"

--- a/gestaltd/internal/server/prometheus_filter.go
+++ b/gestaltd/internal/server/prometheus_filter.go
@@ -128,6 +128,15 @@ func sampleProvider(sample prometheusSample) string {
 	return strings.TrimSpace(sample.labels[promLabelProviderName])
 }
 
+func isAppOperationMetric(name string) bool {
+	switch name {
+	case promMetricOpCount, promMetricOpErrors, promMetricOpDurationSum, promMetricOpDurationCount:
+		return true
+	default:
+		return false
+	}
+}
+
 func samplesForProvider(samples []prometheusSample, provider string) []prometheusSample {
 	provider = strings.TrimSpace(provider)
 	if provider == "" {
@@ -149,7 +158,7 @@ func summarizeAppMetrics(app string, samples []prometheusSample) appAdminMetrics
 		Available: true,
 	}
 	for _, sample := range samples {
-		if math.IsNaN(sample.value) {
+		if math.IsNaN(sample.value) || !isAppOperationMetric(sample.name) {
 			continue
 		}
 		operation := strings.TrimSpace(sample.labels[promLabelOperation])

--- a/gestaltd/internal/server/prometheus_filter_test.go
+++ b/gestaltd/internal/server/prometheus_filter_test.go
@@ -17,7 +17,11 @@ gestaltd_operation_duration_seconds_sum{gestalt_provider="slack",gestalt_operati
 gestaltd_operation_duration_seconds_count{gestalt_provider="slack",gestalt_operation="post"} 3
 go_goroutines 12
 `
-	samples := samplesForProvider(parsePrometheus(text), "slack")
+	parsed, err := parsePrometheus(text)
+	if err != nil {
+		t.Fatalf("parsePrometheus: %v", err)
+	}
+	samples := samplesForProvider(parsed, "slack")
 	got := summarizeAppMetrics("slack", samples)
 	if !got.Available || got.App != "slack" {
 		t.Fatalf("summary = %#v", got)
@@ -41,7 +45,11 @@ func TestSamplesForProviderUsesGestaltdProviderName(t *testing.T) {
 
 	text := `gestaltd_operation_count_total{gestaltd_provider_name="ai-spend-tracker",gestalt_operation="list"} 2
 `
-	samples := samplesForProvider(parsePrometheus(text), "ai-spend-tracker")
+	parsed, err := parsePrometheus(text)
+	if err != nil {
+		t.Fatalf("parsePrometheus: %v", err)
+	}
+	samples := samplesForProvider(parsed, "ai-spend-tracker")
 	if len(samples) != 1 {
 		t.Fatalf("samples = %#v", samples)
 	}
@@ -53,5 +61,49 @@ func TestSummarizeAppMetricsEmpty(t *testing.T) {
 	got := summarizeAppMetrics("quiet-app", nil)
 	if !got.Available || got.App != "quiet-app" || len(got.Operations) != 0 || got.Requests != 0 {
 		t.Fatalf("empty summary = %#v", got)
+	}
+}
+
+func TestParsePrometheusHistogramSumAndCount(t *testing.T) {
+	t.Parallel()
+
+	text := `
+# TYPE gestaltd_operation_duration_seconds histogram
+gestaltd_operation_duration_seconds_bucket{gestalt_provider="slack",gestalt_operation="post",le="0.1"} 1
+gestaltd_operation_duration_seconds_bucket{gestalt_provider="slack",gestalt_operation="post",le="+Inf"} 3
+gestaltd_operation_duration_seconds_sum{gestalt_provider="slack",gestalt_operation="post"} 0.4
+gestaltd_operation_duration_seconds_count{gestalt_provider="slack",gestalt_operation="post"} 3
+`
+	parsed, err := parsePrometheus(text)
+	if err != nil {
+		t.Fatalf("parsePrometheus: %v", err)
+	}
+	got := summarizeAppMetrics("slack", samplesForProvider(parsed, "slack"))
+	if got.DurationSecondsSum != 0.4 || got.DurationSecondsCount != 3 {
+		t.Fatalf("duration = %#v", got)
+	}
+}
+
+func TestParsePrometheusEscapedProviderLabel(t *testing.T) {
+	t.Parallel()
+
+	text := `gestaltd_operation_count_total{gestalt_provider="app\"quoted",gestalt_operation="list"} 2
+`
+	parsed, err := parsePrometheus(text)
+	if err != nil {
+		t.Fatalf("parsePrometheus: %v", err)
+	}
+	samples := samplesForProvider(parsed, `app"quoted`)
+	if len(samples) != 1 || samples[0].value != 2 {
+		t.Fatalf("samples = %#v", samples)
+	}
+}
+
+func TestParsePrometheusRejectsMalformedText(t *testing.T) {
+	t.Parallel()
+
+	_, err := parsePrometheus("not a metric line {")
+	if err == nil {
+		t.Fatal("expected parse error")
 	}
 }

--- a/gestaltd/internal/server/prometheus_filter_test.go
+++ b/gestaltd/internal/server/prometheus_filter_test.go
@@ -64,6 +64,27 @@ func TestSummarizeAppMetricsEmpty(t *testing.T) {
 	}
 }
 
+func TestSummarizeAppMetricsIgnoresNonOperationSeries(t *testing.T) {
+	t.Parallel()
+
+	text := `
+gestaltd_operation_count_total{gestalt_provider="slack",gestalt_operation="post"} 3
+http_server_request_duration_seconds_count{gestalt_provider="slack",gestalt_operation="get",code="200"} 40
+go_goroutines{gestalt_provider="slack"} 12
+`
+	parsed, err := parsePrometheus(text)
+	if err != nil {
+		t.Fatalf("parsePrometheus: %v", err)
+	}
+	got := summarizeAppMetrics("slack", samplesForProvider(parsed, "slack"))
+	if got.Requests != 3 || got.Errors != 0 {
+		t.Fatalf("totals = %#v", got)
+	}
+	if len(got.Operations) != 1 || got.Operations[0].Operation != "post" || got.Operations[0].Requests != 3 {
+		t.Fatalf("operations = %#v", got.Operations)
+	}
+}
+
 func TestParsePrometheusHistogramSumAndCount(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/server/prometheus_filter_test.go
+++ b/gestaltd/internal/server/prometheus_filter_test.go
@@ -1,0 +1,57 @@
+package server
+
+import (
+	"testing"
+)
+
+func TestParsePrometheusAndSummarizeByProvider(t *testing.T) {
+	t.Parallel()
+
+	text := `
+# HELP gestaltd_operation_count_total Operation invocations
+# TYPE gestaltd_operation_count_total counter
+gestaltd_operation_count_total{gestalt_provider="slack",gestalt_operation="post"} 3
+gestaltd_operation_count_total{gestalt_provider="httpbin",gestalt_operation="get"} 9
+gestaltd_operation_error_count_total{gestalt_provider="slack",gestalt_operation="post"} 1
+gestaltd_operation_duration_seconds_sum{gestalt_provider="slack",gestalt_operation="post"} 0.4
+gestaltd_operation_duration_seconds_count{gestalt_provider="slack",gestalt_operation="post"} 3
+go_goroutines 12
+`
+	samples := samplesForProvider(parsePrometheus(text), "slack")
+	got := summarizeAppMetrics("slack", samples)
+	if !got.Available || got.App != "slack" {
+		t.Fatalf("summary = %#v", got)
+	}
+	if got.Requests != 3 || got.Errors != 1 {
+		t.Fatalf("totals = %#v", got)
+	}
+	if got.DurationSecondsSum != 0.4 || got.DurationSecondsCount != 3 {
+		t.Fatalf("duration = %#v", got)
+	}
+	if len(got.Operations) != 1 || got.Operations[0].Operation != "post" {
+		t.Fatalf("operations = %#v", got.Operations)
+	}
+	if got.Operations[0].Requests != 3 || got.Operations[0].Errors != 1 {
+		t.Fatalf("operation row = %#v", got.Operations[0])
+	}
+}
+
+func TestSamplesForProviderUsesGestaltdProviderName(t *testing.T) {
+	t.Parallel()
+
+	text := `gestaltd_operation_count_total{gestaltd_provider_name="ai-spend-tracker",gestalt_operation="list"} 2
+`
+	samples := samplesForProvider(parsePrometheus(text), "ai-spend-tracker")
+	if len(samples) != 1 {
+		t.Fatalf("samples = %#v", samples)
+	}
+}
+
+func TestSummarizeAppMetricsEmpty(t *testing.T) {
+	t.Parallel()
+
+	got := summarizeAppMetrics("quiet-app", nil)
+	if !got.Available || got.App != "quiet-app" || len(got.Operations) != 0 || got.Requests != 0 {
+		t.Fatalf("empty summary = %#v", got)
+	}
+}

--- a/gestaltd/internal/server/route_auth_runtime.go
+++ b/gestaltd/internal/server/route_auth_runtime.go
@@ -131,9 +131,6 @@ func (s *Server) mountedUIForPath(path string) (MountedUI, bool) {
 	for i := range s.mountedUIs {
 		consider(s.mountedUIs[i])
 	}
-	if s.adminUI != nil {
-		consider(s.adminMountedUI())
-	}
 	return best, bestMatched
 }
 

--- a/gestaltd/internal/server/routes.go
+++ b/gestaltd/internal/server/routes.go
@@ -3,6 +3,8 @@ package server
 import (
 	"fmt"
 	"net/http"
+	"net/url"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -38,13 +40,15 @@ func (s *Server) routes() {
 		s.mountHTTPBindingRoutes(r)
 		s.mountS3ObjectAccessRoutes(r)
 		s.mountAPIRoutes(r)
+		s.mountAdminAPIRoutes(r)
+		s.mountAdminPageRedirects(r)
 		s.mountMountedUIRoutes(r)
 		s.mountManagementHiddenRoutes(r)
 	case RouteProfileManagement:
 		s.mountCoreRoutes(r, metricsUnauthenticated)
 		s.mountManagementRootRedirect(r)
 		s.mountAdminAPIRoutes(r)
-		s.mountAdminUIRoutes(r)
+		s.mountAdminPageRedirects(r)
 		s.mountActivateRoute(r)
 	default:
 		s.mountCoreRoutes(r, metricsAuthenticated)
@@ -52,9 +56,9 @@ func (s *Server) routes() {
 		s.mountHTTPBindingRoutes(r)
 		s.mountS3ObjectAccessRoutes(r)
 		s.mountAPIRoutes(r)
-		s.mountMountedUIRoutes(r)
 		s.mountAdminAPIRoutes(r)
-		s.mountAdminUIRoutes(r)
+		s.mountAdminPageRedirects(r)
+		s.mountMountedUIRoutes(r)
 		s.mountActivateRoute(r)
 	}
 }
@@ -86,24 +90,50 @@ func (s *Server) mountCoreRoutes(r chi.Router, exposure metricsExposure) {
 }
 
 func (s *Server) mountManagementRootRedirect(r chi.Router) {
-	if s.adminUI == nil {
-		return
-	}
-
 	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
-		redirectPreservingQuery(w, r, "/admin/", http.StatusMovedPermanently)
+		redirectPreservingQuery(w, r, s.adminProductURL("/admin"), http.StatusMovedPermanently)
 	})
 }
 
-func (s *Server) mountAdminUIRoutes(r chi.Router) {
-	if s.adminUI == nil {
-		return
-	}
-
-	r.Get("/admin", func(w http.ResponseWriter, r *http.Request) {
-		redirectPreservingQuery(w, r, "/admin/", http.StatusMovedPermanently)
+func (s *Server) mountAdminPageRedirects(r chi.Router) {
+	r.Get("/admin/registry", func(w http.ResponseWriter, r *http.Request) {
+		redirectPreservingQuery(w, r, s.adminProductURL("/admin/versions"), http.StatusMovedPermanently)
 	})
-	r.Handle("/admin/*", s.adminUIHandler())
+	r.Get("/admin/registry/{app}", func(w http.ResponseWriter, r *http.Request) {
+		app := strings.TrimSpace(chi.URLParam(r, "app"))
+		redirectPreservingQuery(w, r, s.adminProductURL("/admin/versions/"+url.PathEscape(app)), http.StatusMovedPermanently)
+	})
+	if s.routeProfile == RouteProfileManagement {
+		r.Get("/admin", func(w http.ResponseWriter, r *http.Request) {
+			redirectPreservingQuery(w, r, s.adminProductURL("/admin"), http.StatusMovedPermanently)
+		})
+		r.Get("/admin/", func(w http.ResponseWriter, r *http.Request) {
+			redirectPreservingQuery(w, r, s.adminProductURL("/admin"), http.StatusMovedPermanently)
+		})
+		r.Get("/admin/metrics", func(w http.ResponseWriter, r *http.Request) {
+			redirectPreservingQuery(w, r, s.adminProductURL("/admin/metrics"), http.StatusMovedPermanently)
+		})
+		r.Get("/admin/versions", func(w http.ResponseWriter, r *http.Request) {
+			redirectPreservingQuery(w, r, s.adminProductURL("/admin/versions"), http.StatusMovedPermanently)
+		})
+		r.Get("/admin/versions/{app}", func(w http.ResponseWriter, r *http.Request) {
+			app := strings.TrimSpace(chi.URLParam(r, "app"))
+			redirectPreservingQuery(w, r, s.adminProductURL("/admin/versions/"+url.PathEscape(app)), http.StatusMovedPermanently)
+		})
+	}
+}
+
+func (s *Server) adminProductURL(path string) string {
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	if s.routeProfile == RouteProfileManagement {
+		base := strings.TrimRight(strings.TrimSpace(s.publicBaseURL), "/")
+		if base != "" {
+			return base + path
+		}
+	}
+	return path
 }
 
 func (s *Server) mountAdminAPIRoutes(r chi.Router) {
@@ -115,6 +145,8 @@ func (s *Server) mountAdminAPIRoutes(r chi.Router) {
 			s.mountAdminAppRegistryRoutes(r)
 			s.mountAdminAppInstallReadRoutes(r)
 			s.mountAdminAppRolloutRoutes(r)
+			s.mountAdminMetricsRoutes(r)
+			s.mountAdminPlatformAdminsRoutes(r)
 		})
 		r.Group(func(r chi.Router) {
 			r.Use(middleware.Timeout(10 * time.Minute))
@@ -169,10 +201,6 @@ func routePatternTelemetryMiddleware(next http.Handler) http.Handler {
 func (s *Server) mountManagementHiddenRoutes(r chi.Router) {
 	notFound := http.NotFoundHandler()
 	r.Handle("/metrics", notFound)
-	r.Handle("/admin/api/v1", notFound)
-	r.Handle("/admin/api/v1/*", notFound)
-	r.Handle("/admin", notFound)
-	r.Handle("/admin/*", notFound)
 	r.Handle("/activate", notFound)
 }
 

--- a/gestaltd/internal/server/routes.go
+++ b/gestaltd/internal/server/routes.go
@@ -90,12 +90,18 @@ func (s *Server) mountCoreRoutes(r chi.Router, exposure metricsExposure) {
 }
 
 func (s *Server) mountManagementRootRedirect(r chi.Router) {
+	if s.adminProductBase() == "" {
+		return
+	}
 	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
 		redirectPreservingQuery(w, r, s.adminProductURL("/admin"), http.StatusMovedPermanently)
 	})
 }
 
 func (s *Server) mountAdminPageRedirects(r chi.Router) {
+	if s.routeProfile == RouteProfileManagement && s.adminProductBase() == "" {
+		return
+	}
 	r.Get("/admin/registry", func(w http.ResponseWriter, r *http.Request) {
 		redirectPreservingQuery(w, r, s.adminProductURL("/admin/versions"), http.StatusMovedPermanently)
 	})
@@ -123,15 +129,19 @@ func (s *Server) mountAdminPageRedirects(r chi.Router) {
 	}
 }
 
+func (s *Server) adminProductBase() string {
+	if s.routeProfile != RouteProfileManagement {
+		return ""
+	}
+	return strings.TrimRight(strings.TrimSpace(s.publicBaseURL), "/")
+}
+
 func (s *Server) adminProductURL(path string) string {
 	if !strings.HasPrefix(path, "/") {
 		path = "/" + path
 	}
-	if s.routeProfile == RouteProfileManagement {
-		base := strings.TrimRight(strings.TrimSpace(s.publicBaseURL), "/")
-		if base != "" {
-			return base + path
-		}
+	if base := s.adminProductBase(); base != "" {
+		return base + path
 	}
 	return path
 }

--- a/gestaltd/internal/server/routes_user.go
+++ b/gestaltd/internal/server/routes_user.go
@@ -8,6 +8,7 @@ func (s *Server) mountAuthenticatedRoutes(r chi.Router) {
 	s.mountAppAdminRegistryRoutes(r)
 	s.mountAppAdminMembersRoutes(r)
 	s.mountAppAdminIdentitiesRoutes(r)
+	s.mountAppAdminMetricsRoutes(r)
 
 	r.Group(func(r chi.Router) {
 		r.Use(s.authMiddleware)

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -67,14 +67,6 @@ func run(ctx context.Context, cfg *config.Config, result *bootstrap.Result, gest
 		)
 	}
 
-	publicBrandHref := "/admin/"
-	for _, entry := range cfg.Apps {
-		if entry != nil && entry.Static != nil && strings.TrimSpace(entry.Static.Mount) == "/" {
-			publicBrandHref = "/"
-			break
-		}
-	}
-
 	managementAddr := cfg.Server.ManagementAddr()
 	mcpSlot := &switchableHandler{}
 	workflowProvidersReady := make(chan struct{})
@@ -222,11 +214,6 @@ func run(ctx context.Context, cfg *config.Config, result *bootstrap.Result, gest
 		publicConfig.DevHandlerResolver = devSupervisor.DevHandler
 	}
 
-	publicConfig.BuiltinAdminUI = &BuiltinAdminUIOptions{
-		BrandHref: publicBrandHref,
-		LoginBase: browserLoginPath,
-	}
-
 	publicHandler, err := New(publicConfig)
 	if err != nil {
 		if devSupervisor != nil {
@@ -243,11 +230,11 @@ func run(ctx context.Context, cfg *config.Config, result *bootstrap.Result, gest
 	if managementAddr != "" {
 		if cfg.Server.Admin.AuthorizationPolicy != "" {
 			slog.Warn(
-				"management listener serves /metrics without Gestalt auth; /admin requires Gestalt session auth and server.admin policy access",
+				"management listener serves /metrics without Gestalt auth; /admin/api/v1 requires Gestalt session auth and server.admin policy access",
 			)
 		} else {
 			slog.Warn(
-				"management listener serves /admin and /metrics without Gestalt auth; protect server.management with private networking or an internal reverse proxy",
+				"management listener serves /metrics and /admin/api/v1 without Gestalt auth; protect server.management with private networking or an internal reverse proxy",
 			)
 		}
 		slog.Debug("management listener address", "addr", managementAddr)
@@ -255,14 +242,6 @@ func run(ctx context.Context, cfg *config.Config, result *bootstrap.Result, gest
 		managementConfig := baseConfig
 		managementConfig.RouteProfile = RouteProfileManagement
 		managementConfig.DevHandlerResolver = publicConfig.DevHandlerResolver
-		managementLoginBase := browserLoginPath
-		if baseURL := strings.TrimRight(cfg.Server.BaseURL, "/"); baseURL != "" {
-			managementLoginBase = baseURL + browserLoginPath
-		}
-		managementConfig.BuiltinAdminUI = &BuiltinAdminUIOptions{
-			BrandHref: "/admin/",
-			LoginBase: managementLoginBase,
-		}
 
 		managementHandler, err := New(managementConfig)
 		if err != nil {

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -87,11 +87,6 @@ type AdminRouteConfig struct {
 	AllowedRoles        []string
 }
 
-type BuiltinAdminUIOptions struct {
-	BrandHref string
-	LoginBase string
-}
-
 type AppRuntimeState interface {
 	WithRunningVersion(app string, fn func(version string) error) error
 }
@@ -179,7 +174,6 @@ type Server struct {
 	mountedHTTPBindings           []MountedHTTPBinding
 	mountedUIs                    []MountedUI
 	adminRoute                    AdminRouteConfig
-	adminUI                       http.Handler
 	appRegistries                 map[string]config.AppRegistryConfig
 	appRegistryReader             *appregistry.RegistryReader
 	appRegistryInstaller          *appregistry.Installer
@@ -257,8 +251,6 @@ type Config struct {
 	MountedUIs                    []MountedUI
 	DevHandlerResolver            func(name string) http.Handler
 	Admin                         AdminRouteConfig
-	AdminUI                       http.Handler
-	BuiltinAdminUI                *BuiltinAdminUIOptions
 	AppRegistries                 map[string]config.AppRegistryConfig
 	AppRegistryReader             *appregistry.RegistryReader
 	AppRegistryPublish            *appregistry.StatelessPublishService
@@ -503,7 +495,6 @@ func New(cfg Config) (*Server, error) {
 		mountedHTTPBindings:           mountedHTTPBindings,
 		mountedUIs:                    mountedUIs,
 		adminRoute:                    adminRoute,
-		adminUI:                       cfg.AdminUI,
 		appRegistries:                 cloneAppRegistryConfig(cfg.AppRegistries),
 		appRegistryReader:             cfg.AppRegistryReader,
 		appRegistryInstaller:          newAppRegistryInstaller(cfg),

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -370,14 +370,6 @@ func New(cfg Config) (*Server, error) {
 	if err != nil {
 		return nil, err
 	}
-	adminUI := cfg.AdminUI
-	if adminUI == nil && cfg.BuiltinAdminUI != nil {
-		adminUI, err = resolveBuiltinAdminUI(*cfg.BuiltinAdminUI)
-		if err != nil {
-			return nil, fmt.Errorf("resolve admin ui: %w", err)
-		}
-	}
-
 	if cfg.Services == nil {
 		return nil, fmt.Errorf("services are required")
 	}
@@ -511,7 +503,7 @@ func New(cfg Config) (*Server, error) {
 		mountedHTTPBindings:           mountedHTTPBindings,
 		mountedUIs:                    mountedUIs,
 		adminRoute:                    adminRoute,
-		adminUI:                       adminUI,
+		adminUI:                       cfg.AdminUI,
 		appRegistries:                 cloneAppRegistryConfig(cfg.AppRegistries),
 		appRegistryReader:             cfg.AppRegistryReader,
 		appRegistryInstaller:          newAppRegistryInstaller(cfg),

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -2683,7 +2683,6 @@ func TestMountedUIAppLevelAuthorizationRelationships(t *testing.T) {
 			},
 		}
 		cfg.Admin = server.AdminRouteConfig{AuthorizationPolicy: "adminPolicy"}
-		cfg.AdminUI = shell("admin")
 	})
 	testutil.CloseOnCleanup(t, ts)
 
@@ -2741,19 +2740,16 @@ func TestMountedUIAppLevelAuthorizationRelationships(t *testing.T) {
 		t.Fatalf("explicit default-role mounted UI body = %q, want default-role-shell", body)
 	}
 
-	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/admin/", nil)
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/app-registries", nil)
 	req.AddCookie(&http.Cookie{Name: "session_token", Value: sessionToken})
 	resp, err = http.DefaultClient.Do(req)
 	if err != nil {
-		t.Fatalf("GET admin UI: %v", err)
+		t.Fatalf("GET admin API: %v", err)
 	}
 	body, _ = io.ReadAll(resp.Body)
 	_ = resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("admin UI status = %d, want 200: %s", resp.StatusCode, body)
-	}
-	if !bytes.Contains(body, []byte("admin-shell")) {
-		t.Fatalf("admin UI body = %q, want admin-shell", body)
+		t.Fatalf("admin API status = %d, want 200: %s", resp.StatusCode, body)
 	}
 	if len(authz.checkAccessRequests) < 2 {
 		t.Fatalf("authorization CheckAccess calls = %d, want at least 2", len(authz.checkAccessRequests))


### PR DESCRIPTION
## Summary

gestaltd no longer serves its own Admin website at `/admin`. That URL is left for the product Admin pages. Existing Admin JSON APIs stay in place, and this adds the roster and metrics endpoints those pages need.

## Why / context

`/admin` was a second website baked into gestaltd (adminui). Because the server claimed that path, the product Admin app could not. On valon.tools, Metrics and Registry still came from that embedded site.

App admins also should not pull the whole-process `/metrics` scrape in the browser. They need a summary that only includes their app.

## What changed

- Stop mounting the builtin Admin HTML at `/admin/*`. `/admin/api/v1/*` is unchanged as JSON.
- On the public listener, `/admin/api/v1` is served so the product Admin pages can call it on the same host. Public `/metrics` stays hidden.
- `GET /admin/api/v1/metrics` returns the full in-process scrape for Gestalt admins (needed when public `/metrics` is hidden).
- `GET /admin/api/v1/platform-admins` lists people and groups on the platform-admin resource, including config-locked rows.
- `GET /api/v1/apps/{app}/admin/metrics` is gated like other app-admin routes. It keeps series whose provider label matches that app and returns a JSON summary.
- Old `/admin/registry` bookmarks redirect to `/admin/versions`. On the management listener, `/admin` pages redirect to the public product Admin URL.

## Validation

- [x] Automated: `go test ./internal/server -count=1 -run 'Metrics|PlatformAdmins|RegistryBookmark|Prometheus|AdminUI|AdminPage'`
- [ ] Manual: run this gestaltd next to the product Admin UI. `/admin` should be that UI, not adminui. Platform admins and Metrics should stop returning HTML.

## Reviewer focus

Confirm `/admin/api/v1` still wins over the product page fallback. The per-app metrics handler must not return other apps' series. Public `/metrics` must stay hidden on the public listener.

## Rollout / compatibility

Ship this gestaltd build with or before the product Admin UI. Until it is deployed, `/admin` on valon.tools is still adminui, and the new JSON routes fall through to HTML.

Old `/admin/registry` bookmarks 301 to `/admin/versions`. The adminui package stays in the tree but is not mounted.

## Links

Companion UI work is in gestalt-providers (unified Admin for Gestalt admins).
