### PR TITLE
Split the apps listing into a cheap catalog and per-user connection status

### DIFF
--- a/gestaltd/internal/server/advertised_connection_test.go
+++ b/gestaltd/internal/server/advertised_connection_test.go
@@ -1,0 +1,102 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+)
+
+func TestAdvertisedConnectionsZipSchemaAndStatus(t *testing.T) {
+	t.Parallel()
+
+	s := &Server{}
+	app := &config.ProviderEntry{
+		Connections: map[string]*config.ConnectionDef{
+			"workspace": {
+				ConnectionID: "demo:workspace",
+				DisplayName:  "Workspace",
+				Mode:         providermanifestv1.ConnectionModeSubject,
+				Auth: config.ConnectionAuthDef{
+					Type: providermanifestv1.AuthTypeManual,
+				},
+			},
+			"webhook": {
+				ConnectionID: "demo:webhook",
+				DisplayName:  "Webhook",
+				Mode:         providermanifestv1.ConnectionModeNone,
+			},
+		},
+	}
+	advertised := s.advertisedConnectionsForPlugin("demo", app)
+	schemas := s.connectionSchemasFromAdvertised("demo", advertised)
+	infos := s.connectionInfosFromAdvertised(context.Background(), "demo", advertised, nil, nil)
+	if len(schemas) == 0 {
+		t.Fatal("expected advertised connection schema")
+	}
+	if len(schemas) != len(infos) {
+		t.Fatalf("schema count %d != status count %d", len(schemas), len(infos))
+	}
+	for i := range schemas {
+		if schemas[i].Name != infos[i].Name {
+			t.Fatalf("name[%d] schema %q status %q", i, schemas[i].Name, infos[i].Name)
+		}
+		if schemas[i].Mode != infos[i].Mode {
+			t.Fatalf("mode[%d] schema %q status %q", i, schemas[i].Mode, infos[i].Mode)
+		}
+	}
+}
+
+func TestProjectComposedListingUsesDirectoryAdvertisedConnections(t *testing.T) {
+	t.Parallel()
+
+	s := &Server{}
+	dir := &appDirectory{entries: []appDirectoryEntry{{
+		Name: "demo",
+		Advertised: []advertisedConnection{{
+			Name:               "workspace",
+			InstanceConnection: "workspace",
+			Def: config.ConnectionDef{
+				ConnectionID: "demo:workspace",
+				Mode:         providermanifestv1.ConnectionModeSubject,
+				Auth: config.ConnectionAuthDef{
+					Type: providermanifestv1.AuthTypeManual,
+				},
+			},
+			IncludeWithoutAuth: true,
+		}},
+	}}}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/apps", nil)
+	out, err := s.projectComposedAppListing(req, dir)
+	if err != nil {
+		t.Fatalf("project: %v", err)
+	}
+	if len(out) != 1 || len(out[0].Connections) != 1 || out[0].Connections[0].Name != "workspace" {
+		t.Fatalf("composed connections = %+v, want workspace from directory advertised list", out)
+	}
+}
+
+func TestWriteAppDirectoryErrorUsesIconFallback(t *testing.T) {
+	t.Parallel()
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/catalog/apps/demo/icon", nil)
+	writeAppDirectoryError(rr, req, errors.New("boom"), "failed to load app icon")
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusInternalServerError)
+	}
+	var payload struct {
+		Error string `json:"error"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if payload.Error != "failed to load app icon" {
+		t.Fatalf("error = %q, want failed to load app icon", payload.Error)
+	}
+}

--- a/gestaltd/internal/server/app_directory.go
+++ b/gestaltd/internal/server/app_directory.go
@@ -29,6 +29,7 @@ type appDirectoryEntry struct {
 	ManagementPath   string
 	Prompts          []appPromptInfo
 	SourceTreeURL    string
+	Advertised       []advertisedConnection
 	ConnectionSchema []connectionSchemaInfo
 	Provider         core.Provider
 }
@@ -40,7 +41,6 @@ type connectionSchemaInfo struct {
 	AuthTypes        []string                       `json:"authTypes"`
 	ConnectionParams map[string]connectionParamInfo `json:"connectionParams,omitempty"`
 	CredentialFields []credentialFieldInfo          `json:"credentialFields,omitempty"`
-	McpPassthrough   bool                           `json:"mcpPassthrough,omitempty"`
 }
 
 type appCatalogEntry struct {
@@ -241,13 +241,13 @@ func (s *Server) assembleAppDirectory(r *http.Request) (*appDirectory, error) {
 		}
 		plugin := s.pluginDefs[app.name]
 		entry := appDirectoryEntry{
-			Name:             app.name,
-			DisplayName:      app.name,
-			ManagementPath:   managementPath,
-			Prompts:          s.appPrompts[app.name],
-			SourceTreeURL:    plugin.SourceTreeURL(),
-			ConnectionSchema: s.connectionSchemasForPlugin(app.name, plugin),
+			Name:           app.name,
+			DisplayName:    app.name,
+			ManagementPath: managementPath,
+			Prompts:        s.appPrompts[app.name],
+			SourceTreeURL:  plugin.SourceTreeURL(),
 		}
+		s.attachDirectoryConnections(&entry, plugin)
 		if plugin != nil && strings.TrimSpace(plugin.DisplayName) != "" {
 			entry.DisplayName = strings.TrimSpace(plugin.DisplayName)
 		}
@@ -273,14 +273,14 @@ func (s *Server) lookupProviderDirectory(r *http.Request, name string) (core.Pro
 func (s *Server) completeProviderDirectoryEntry(r *http.Request, p *principal.Principal, name string, prov core.Provider) (appDirectoryEntry, bool, error) {
 	plugin := s.pluginDefs[name]
 	entry := appDirectoryEntry{
-		Name:             name,
-		DisplayName:      prov.DisplayName(),
-		Description:      prov.Description(),
-		Prompts:          s.appPrompts[name],
-		SourceTreeURL:    plugin.SourceTreeURL(),
-		ConnectionSchema: s.connectionSchemasForPlugin(name, plugin),
-		Provider:         prov,
+		Name:          name,
+		DisplayName:   prov.DisplayName(),
+		Description:   prov.Description(),
+		Prompts:       s.appPrompts[name],
+		SourceTreeURL: plugin.SourceTreeURL(),
+		Provider:      prov,
 	}
+	s.attachDirectoryConnections(&entry, plugin)
 	if cat := prov.Catalog(); cat != nil {
 		entry.IconSVG = cat.IconSVG
 	}
@@ -378,7 +378,8 @@ func (s *Server) projectComposedAppListing(r *http.Request, dir *appDirectory) (
 			Actions:         []string{},
 		}
 		instances := connected[entry.Name]
-		authTypes := s.populateIntegrationSettings(r.Context(), &info, instances, p)
+		info.Connections = s.connectionInfosFromAdvertised(r.Context(), entry.Name, entry.Advertised, instances, p)
+		authTypes := resolvedAuthTypesFromConnections(info.Connections)
 		s.applyIntegrationConnectionStatus(&info, entry.Provider, instances, authTypes, p)
 		out = append(out, info)
 	}

--- a/gestaltd/internal/server/app_directory.go
+++ b/gestaltd/internal/server/app_directory.go
@@ -59,6 +59,7 @@ type appConnectionStatus struct {
 	CredentialState string                 `json:"credentialState"`
 	HealthState     string                 `json:"healthState"`
 	Actions         []string               `json:"actions"`
+	Connected       bool                   `json:"connected"`
 	Connections     []connectionStatusView `json:"connections"`
 }
 
@@ -186,6 +187,7 @@ func appConnectionStatusesFrom(infos []integrationInfo) []appConnectionStatus {
 			CredentialState: info.CredentialState,
 			HealthState:     info.HealthState,
 			Actions:         actions,
+			Connected:       info.Connected,
 			Connections:     connectionStatusViews(info.Connections),
 		})
 	}

--- a/gestaltd/internal/server/app_directory.go
+++ b/gestaltd/internal/server/app_directory.go
@@ -1,0 +1,371 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/services/identity/principal"
+)
+
+const appCatalogIconPathPrefix = "/api/v1/catalog/apps/"
+
+// appDirectory is the tenant app directory for one viewer: identity, display,
+// connection schema, and which surfaces this principal may see. It does not
+// include this subject's stored credentials or derived connection status.
+type appDirectory struct {
+	entries []appDirectoryEntry
+}
+
+type appDirectoryEntry struct {
+	Name             string
+	DisplayName      string
+	Description      string
+	IconSVG          string
+	MountedPath      string
+	ManagementPath   string
+	Prompts          []appPromptInfo
+	ConnectionSchema []connectionSchemaInfo
+	Provider         core.Provider
+}
+
+type connectionSchemaInfo struct {
+	DisplayName      string                         `json:"displayName,omitempty"`
+	Name             string                         `json:"name"`
+	Mode             string                         `json:"mode,omitempty"`
+	AuthTypes        []string                       `json:"authTypes"`
+	ConnectionParams map[string]connectionParamInfo `json:"connectionParams,omitempty"`
+	CredentialFields []credentialFieldInfo          `json:"credentialFields,omitempty"`
+	McpPassthrough   bool                           `json:"mcpPassthrough,omitempty"`
+}
+
+type appCatalogEntry struct {
+	Name           string                 `json:"name"`
+	DisplayName    string                 `json:"displayName,omitempty"`
+	Description    string                 `json:"description,omitempty"`
+	IconURL        string                 `json:"iconUrl,omitempty"`
+	MountedPath    string                 `json:"mountedPath,omitempty"`
+	ManagementPath string                 `json:"managementPath,omitempty"`
+	Prompts        []appPromptInfo        `json:"prompts,omitempty"`
+	Connections    []connectionSchemaInfo `json:"connections"`
+}
+
+type appConnectionStatus struct {
+	Name            string                 `json:"name"`
+	Status          string                 `json:"status"`
+	CredentialState string                 `json:"credentialState"`
+	HealthState     string                 `json:"healthState"`
+	Actions         []string               `json:"actions"`
+	Connections     []connectionStatusView `json:"connections"`
+}
+
+type connectionStatusView struct {
+	Name              string         `json:"name"`
+	Status            string         `json:"status"`
+	CredentialState   string         `json:"credentialState"`
+	HealthState       string         `json:"healthState"`
+	Actions           []string       `json:"actions"`
+	CredentialMode    string         `json:"credentialMode,omitempty"`
+	OwnerKind         string         `json:"ownerKind,omitempty"`
+	Instances         []instanceInfo `json:"instances"`
+	PreferredInstance string         `json:"preferredInstance,omitempty"`
+	StatusCode        string         `json:"statusCode,omitempty"`
+	StatusReason      string         `json:"statusReason,omitempty"`
+	Connected         bool           `json:"connected"`
+}
+
+type appListingError struct {
+	status int
+	public string
+	err    error
+}
+
+func (e *appListingError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.err != nil {
+		return e.err.Error()
+	}
+	return e.public
+}
+
+func (e *appListingError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.err
+}
+
+func appCatalogIconURL(name string) string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return ""
+	}
+	return appCatalogIconPathPrefix + url.PathEscape(name) + "/icon"
+}
+
+func (entry appDirectoryEntry) catalogJSON() appCatalogEntry {
+	connections := entry.ConnectionSchema
+	if connections == nil {
+		connections = []connectionSchemaInfo{}
+	}
+	out := appCatalogEntry{
+		Name:           entry.Name,
+		DisplayName:    entry.DisplayName,
+		Description:    entry.Description,
+		MountedPath:    entry.MountedPath,
+		ManagementPath: entry.ManagementPath,
+		Prompts:        entry.Prompts,
+		Connections:    connections,
+	}
+	if strings.TrimSpace(entry.IconSVG) != "" {
+		out.IconURL = appCatalogIconURL(entry.Name)
+	}
+	return out
+}
+
+func (dir *appDirectory) catalogJSON() []appCatalogEntry {
+	if dir == nil {
+		return []appCatalogEntry{}
+	}
+	out := make([]appCatalogEntry, 0, len(dir.entries))
+	for _, entry := range dir.entries {
+		out = append(out, entry.catalogJSON())
+	}
+	return out
+}
+
+func connectionStatusViews(connections []connectionDefInfo) []connectionStatusView {
+	if connections == nil {
+		return []connectionStatusView{}
+	}
+	out := make([]connectionStatusView, 0, len(connections))
+	for i := range connections {
+		conn := connections[i]
+		instances := conn.Instances
+		if instances == nil {
+			instances = []instanceInfo{}
+		}
+		actions := conn.Actions
+		if actions == nil {
+			actions = []string{}
+		}
+		out = append(out, connectionStatusView{
+			Name:              conn.Name,
+			Status:            conn.Status,
+			CredentialState:   conn.CredentialState,
+			HealthState:       conn.HealthState,
+			Actions:           actions,
+			CredentialMode:    conn.CredentialMode,
+			OwnerKind:         conn.OwnerKind,
+			Instances:         instances,
+			PreferredInstance: conn.PreferredInstance,
+			StatusCode:        conn.StatusCode,
+			StatusReason:      conn.StatusReason,
+			Connected:         conn.Connected,
+		})
+	}
+	return out
+}
+
+func appConnectionStatusesFrom(infos []integrationInfo) []appConnectionStatus {
+	out := make([]appConnectionStatus, 0, len(infos))
+	for i := range infos {
+		info := infos[i]
+		actions := info.Actions
+		if actions == nil {
+			actions = []string{}
+		}
+		out = append(out, appConnectionStatus{
+			Name:            info.Name,
+			Status:          info.Status,
+			CredentialState: info.CredentialState,
+			HealthState:     info.HealthState,
+			Actions:         actions,
+			Connections:     connectionStatusViews(info.Connections),
+		})
+	}
+	return out
+}
+
+func (s *Server) assembleAppDirectory(r *http.Request) (*appDirectory, error) {
+	p := PrincipalFromContext(r.Context())
+	names := s.providers.List()
+	registryApps := s.configuredRegistryApps()
+
+	ctx, _ := withListingDecisionCache(r.Context())
+	r = r.WithContext(ctx)
+	prefetchNames := make([]string, 0, len(names)+len(registryApps))
+	prefetchNames = append(prefetchNames, names...)
+	for _, app := range registryApps {
+		prefetchNames = append(prefetchNames, app.name)
+	}
+	s.prefetchIntegrationListingDecisions(ctx, p, prefetchNames)
+
+	seen := make(map[string]struct{}, len(names))
+	dir := &appDirectory{entries: make([]appDirectoryEntry, 0, len(names))}
+	for _, name := range names {
+		prov, ok := s.lookupProviderDirectory(r, name)
+		if !ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		entry, visible, err := s.completeProviderDirectoryEntry(r, p, name, prov)
+		if err != nil {
+			return nil, err
+		}
+		if !visible {
+			continue
+		}
+		dir.entries = append(dir.entries, entry)
+	}
+	for _, app := range registryApps {
+		if s.integrationHiddenFromCatalog(app.name) {
+			continue
+		}
+		if _, ok := seen[app.name]; ok {
+			continue
+		}
+		managementPath := s.integrationManagementPath(r.Context(), p, app.name)
+		if managementPath == "" {
+			continue
+		}
+		entry := appDirectoryEntry{
+			Name:           app.name,
+			DisplayName:    app.name,
+			ManagementPath: managementPath,
+			Prompts:        s.appPrompts[app.name],
+		}
+		if plugin, ok := s.pluginDefs[app.name]; ok && plugin != nil && plugin.Static != nil {
+			entry.MountedPath = s.integrationMountedPathForPrincipalContext(r.Context(), p, app.name, strings.TrimSpace(plugin.Static.Mount))
+		}
+		dir.entries = append(dir.entries, entry)
+	}
+	return dir, nil
+}
+
+func (s *Server) lookupProviderDirectory(r *http.Request, name string) (core.Provider, bool) {
+	if s.integrationHiddenFromCatalog(name) {
+		return nil, false
+	}
+	prov, err := s.providers.GetWithContext(r.Context(), name)
+	if err != nil {
+		return nil, false
+	}
+	return prov, true
+}
+
+func (s *Server) completeProviderDirectoryEntry(r *http.Request, p *principal.Principal, name string, prov core.Provider) (appDirectoryEntry, bool, error) {
+	entry := appDirectoryEntry{
+		Name:             name,
+		DisplayName:      prov.DisplayName(),
+		Description:      prov.Description(),
+		Prompts:          s.appPrompts[name],
+		ConnectionSchema: s.connectionSchemasForPlugin(name, s.pluginDefs[name]),
+		Provider:         prov,
+	}
+	if cat := prov.Catalog(); cat != nil {
+		entry.IconSVG = cat.IconSVG
+	}
+	mountedPath := ""
+	if plugin, ok := s.pluginDefs[name]; ok && plugin != nil && plugin.Static != nil {
+		mountedPath = strings.TrimSpace(plugin.Static.Mount)
+	}
+	entry.MountedPath = s.integrationMountedPathForPrincipalContext(r.Context(), p, name, mountedPath)
+	entry.ManagementPath = s.integrationManagementPath(r.Context(), p, name)
+	usable, err := s.directoryEntryUsable(r.Context(), p, entry)
+	if err != nil {
+		return appDirectoryEntry{}, false, &appListingError{
+			status: http.StatusServiceUnavailable,
+			public: "failed to authorize app access",
+			err:    fmt.Errorf("authorizing app %q: %w", name, err),
+		}
+	}
+	if !usable {
+		return appDirectoryEntry{}, false, nil
+	}
+	return entry, true, nil
+}
+
+func (s *Server) visibleProviderDirectoryEntry(r *http.Request, name string) (appDirectoryEntry, bool, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return appDirectoryEntry{}, false, nil
+	}
+	p := PrincipalFromContext(r.Context())
+	ctx, _ := withListingDecisionCache(r.Context())
+	r = r.WithContext(ctx)
+	s.prefetchIntegrationListingDecisions(ctx, p, []string{name})
+	prov, ok := s.lookupProviderDirectory(r, name)
+	if !ok {
+		return appDirectoryEntry{}, false, nil
+	}
+	return s.completeProviderDirectoryEntry(r, p, name, prov)
+}
+
+func (s *Server) directoryEntryUsable(ctx context.Context, p *principal.Principal, entry appDirectoryEntry) (bool, error) {
+	if entry.MountedPath != "" || entry.ManagementPath != "" {
+		return true, nil
+	}
+	if s.directoryHasSettingsSurface(p, entry) {
+		settingsAccessible, err := s.integrationSettingsAccessibleContext(ctx, p, entry.Name)
+		if err != nil {
+			return false, err
+		}
+		if settingsAccessible {
+			return true, nil
+		}
+	}
+	return s.integrationHasVisibleHTTPOperationsContext(ctx, p, entry.Name, entry.Provider)
+}
+
+func (s *Server) directoryHasSettingsSurface(p *principal.Principal, entry appDirectoryEntry) bool {
+	if principal.IsNonUserPrincipal(p) {
+		return false
+	}
+	if len(entry.ConnectionSchema) > 0 {
+		return true
+	}
+	return entry.Provider != nil && core.NormalizeConnectionMode(entry.Provider.ConnectionMode()) == core.ConnectionModeNone
+}
+
+func (s *Server) projectComposedAppListing(r *http.Request, dir *appDirectory) ([]integrationInfo, error) {
+	if dir == nil {
+		return []integrationInfo{}, nil
+	}
+	p := PrincipalFromContext(r.Context())
+	connected, err := s.subjectConnectedIntegrations(r)
+	if err != nil {
+		return nil, &appListingError{
+			status: http.StatusInternalServerError,
+			public: "failed to check integration status",
+			err:    err,
+		}
+	}
+	out := make([]integrationInfo, 0, len(dir.entries))
+	for _, entry := range dir.entries {
+		info := integrationInfo{
+			Name:            entry.Name,
+			DisplayName:     entry.DisplayName,
+			Description:     entry.Description,
+			IconSVG:         entry.IconSVG,
+			MountedPath:     entry.MountedPath,
+			ManagementPath:  entry.ManagementPath,
+			Prompts:         entry.Prompts,
+			Connections:     []connectionDefInfo{},
+			Status:          connectionStatusUnknown,
+			CredentialState: credentialStateUnknown,
+			HealthState:     healthStateUnknown,
+			Actions:         []string{},
+		}
+		instances := connected[entry.Name]
+		authTypes := s.populateIntegrationSettings(r.Context(), &info, instances, p)
+		s.applyIntegrationConnectionStatus(&info, entry.Provider, instances, authTypes, p)
+		out = append(out, info)
+	}
+	return out, nil
+}

--- a/gestaltd/internal/server/app_directory.go
+++ b/gestaltd/internal/server/app_directory.go
@@ -133,8 +133,8 @@ func (dir *appDirectory) catalogJSON() []appCatalogEntry {
 		return []appCatalogEntry{}
 	}
 	out := make([]appCatalogEntry, 0, len(dir.entries))
-	for _, entry := range dir.entries {
-		out = append(out, entry.catalogJSON())
+	for i := range dir.entries {
+		out = append(out, dir.entries[i].catalogJSON())
 	}
 	return out
 }
@@ -234,13 +234,18 @@ func (s *Server) assembleAppDirectory(r *http.Request) (*appDirectory, error) {
 		if managementPath == "" {
 			continue
 		}
+		plugin := s.pluginDefs[app.name]
 		entry := appDirectoryEntry{
-			Name:           app.name,
-			DisplayName:    app.name,
-			ManagementPath: managementPath,
-			Prompts:        s.appPrompts[app.name],
+			Name:             app.name,
+			DisplayName:      app.name,
+			ManagementPath:   managementPath,
+			Prompts:          s.appPrompts[app.name],
+			ConnectionSchema: s.connectionSchemasForPlugin(app.name, plugin),
 		}
-		if plugin, ok := s.pluginDefs[app.name]; ok && plugin != nil && plugin.Static != nil {
+		if plugin != nil && strings.TrimSpace(plugin.DisplayName) != "" {
+			entry.DisplayName = strings.TrimSpace(plugin.DisplayName)
+		}
+		if plugin != nil && plugin.Static != nil {
 			entry.MountedPath = s.integrationMountedPathForPrincipalContext(r.Context(), p, app.name, strings.TrimSpace(plugin.Static.Mount))
 		}
 		dir.entries = append(dir.entries, entry)
@@ -347,7 +352,8 @@ func (s *Server) projectComposedAppListing(r *http.Request, dir *appDirectory) (
 		}
 	}
 	out := make([]integrationInfo, 0, len(dir.entries))
-	for _, entry := range dir.entries {
+	for i := range dir.entries {
+		entry := &dir.entries[i]
 		info := integrationInfo{
 			Name:            entry.Name,
 			DisplayName:     entry.DisplayName,

--- a/gestaltd/internal/server/app_directory.go
+++ b/gestaltd/internal/server/app_directory.go
@@ -28,6 +28,7 @@ type appDirectoryEntry struct {
 	MountedPath      string
 	ManagementPath   string
 	Prompts          []appPromptInfo
+	SourceTreeURL    string
 	ConnectionSchema []connectionSchemaInfo
 	Provider         core.Provider
 }
@@ -50,6 +51,7 @@ type appCatalogEntry struct {
 	MountedPath    string                 `json:"mountedPath,omitempty"`
 	ManagementPath string                 `json:"managementPath,omitempty"`
 	Prompts        []appPromptInfo        `json:"prompts,omitempty"`
+	SourceTreeURL  string                 `json:"sourceTreeUrl,omitempty"`
 	Connections    []connectionSchemaInfo `json:"connections"`
 }
 
@@ -121,6 +123,7 @@ func (entry appDirectoryEntry) catalogJSON() appCatalogEntry {
 		MountedPath:    entry.MountedPath,
 		ManagementPath: entry.ManagementPath,
 		Prompts:        entry.Prompts,
+		SourceTreeURL:  entry.SourceTreeURL,
 		Connections:    connections,
 	}
 	if strings.TrimSpace(entry.IconSVG) != "" {
@@ -242,6 +245,7 @@ func (s *Server) assembleAppDirectory(r *http.Request) (*appDirectory, error) {
 			DisplayName:      app.name,
 			ManagementPath:   managementPath,
 			Prompts:          s.appPrompts[app.name],
+			SourceTreeURL:    plugin.SourceTreeURL(),
 			ConnectionSchema: s.connectionSchemasForPlugin(app.name, plugin),
 		}
 		if plugin != nil && strings.TrimSpace(plugin.DisplayName) != "" {
@@ -267,19 +271,21 @@ func (s *Server) lookupProviderDirectory(r *http.Request, name string) (core.Pro
 }
 
 func (s *Server) completeProviderDirectoryEntry(r *http.Request, p *principal.Principal, name string, prov core.Provider) (appDirectoryEntry, bool, error) {
+	plugin := s.pluginDefs[name]
 	entry := appDirectoryEntry{
 		Name:             name,
 		DisplayName:      prov.DisplayName(),
 		Description:      prov.Description(),
 		Prompts:          s.appPrompts[name],
-		ConnectionSchema: s.connectionSchemasForPlugin(name, s.pluginDefs[name]),
+		SourceTreeURL:    plugin.SourceTreeURL(),
+		ConnectionSchema: s.connectionSchemasForPlugin(name, plugin),
 		Provider:         prov,
 	}
 	if cat := prov.Catalog(); cat != nil {
 		entry.IconSVG = cat.IconSVG
 	}
 	mountedPath := ""
-	if plugin, ok := s.pluginDefs[name]; ok && plugin != nil && plugin.Static != nil {
+	if plugin != nil && plugin.Static != nil {
 		mountedPath = strings.TrimSpace(plugin.Static.Mount)
 	}
 	entry.MountedPath = s.integrationMountedPathForPrincipalContext(r.Context(), p, name, mountedPath)
@@ -364,6 +370,7 @@ func (s *Server) projectComposedAppListing(r *http.Request, dir *appDirectory) (
 			MountedPath:     entry.MountedPath,
 			ManagementPath:  entry.ManagementPath,
 			Prompts:         entry.Prompts,
+			SourceTreeURL:   entry.SourceTreeURL,
 			Connections:     []connectionDefInfo{},
 			Status:          connectionStatusUnknown,
 			CredentialState: credentialStateUnknown,

--- a/gestaltd/internal/server/connection_status.go
+++ b/gestaltd/internal/server/connection_status.go
@@ -50,6 +50,7 @@ func (s *Server) applyIntegrationConnectionStatus(info *integrationInfo, prov co
 	info.CredentialState = status.CredentialState
 	info.HealthState = status.HealthState
 	info.Actions = status.Actions
+	info.Connected = status.Connected
 }
 
 func (s *Server) defaultIntegrationStatus(info *integrationInfo, prov core.Provider, instances []instanceInfo, authTypes []string, p *principal.Principal) connectionStatusInfo {

--- a/gestaltd/internal/server/connection_status.go
+++ b/gestaltd/internal/server/connection_status.go
@@ -121,7 +121,7 @@ func (s *Server) implicitIntegrationStatus(integration string, prov core.Provide
 			CredentialState: credentialStateNotRequired,
 			HealthState:     healthStateNotApplicable,
 			Actions:         []string{},
-			Connected:       true,
+			Connected:       false,
 		}
 	default:
 		return subjectConnectionStatus(groupInstancesForConnection(instances, ""), len(authTypes) > 0, ownerKindForPrincipal(p), "")
@@ -187,7 +187,7 @@ func summarizeConnectionStatuses(connections []connectionDefInfo) connectionStat
 	if allReady {
 		status := statusFromConnectionInfo(&connections[0])
 		status.Actions = []string{}
-		status.Connected = true
+		status.Connected = subjectProductConnected(connections)
 		return status
 	}
 	for i := range connections {
@@ -224,7 +224,7 @@ func summarizeReconnectRequiredConnectionStatuses(connections []connectionDefInf
 			}
 			continue
 		}
-		if conn.Connected || conn.Status == connectionStatusReady || conn.CredentialState == credentialStateConfigured {
+		if connectionHasSubjectIdentity(conn) && conn.Connected {
 			hasConnected = true
 		}
 	}
@@ -266,8 +266,26 @@ func noAuthConnectionStatus() connectionStatusInfo {
 		Actions:         []string{},
 		CredentialMode:  credentialModeNone,
 		OwnerKind:       ownerKindNone,
-		Connected:       true,
+		Connected:       false,
 	}
+}
+
+// subjectProductConnected is true when this subject has a chosen identity on
+// any credential-bearing connection. No-auth / mode-none rows are never that.
+func subjectProductConnected(connections []connectionDefInfo) bool {
+	for i := range connections {
+		if connectionHasSubjectIdentity(&connections[i]) && connections[i].Connected {
+			return true
+		}
+	}
+	return false
+}
+
+func connectionHasSubjectIdentity(conn *connectionDefInfo) bool {
+	if conn == nil {
+		return false
+	}
+	return conn.CredentialMode != credentialModeNone
 }
 
 func subjectConnectionStatus(instances []instanceInfo, connectable bool, ownerKind string, preferredInstance string) connectionStatusInfo {

--- a/gestaltd/internal/server/connection_status.go
+++ b/gestaltd/internal/server/connection_status.go
@@ -57,19 +57,22 @@ func (s *Server) defaultIntegrationStatus(info *integrationInfo, prov core.Provi
 	if info == nil {
 		return unknownConnectionStatus()
 	}
-	if status, ok := summarizeReconnectRequiredConnectionStatuses(info.Connections); ok {
-		return status
+	var status connectionStatusInfo
+	if recon, ok := summarizeReconnectRequiredConnectionStatuses(info.Connections); ok {
+		status = recon
+	} else if conn, ok := info.connectionStatusForDefaultTarget(s.defaultConnectionName(info.Name)); ok {
+		status = statusFromConnectionInfo(conn)
+	} else if conn, ok := info.singleConnectionStatus(); ok {
+		status = statusFromConnectionInfo(conn)
+	} else if len(info.Connections) == 0 {
+		status = s.implicitIntegrationStatus(info.Name, prov, instances, authTypes, p)
+	} else {
+		status = summarizeConnectionStatuses(info.Connections)
 	}
-	if conn, ok := info.connectionStatusForDefaultTarget(s.defaultConnectionName(info.Name)); ok {
-		return statusFromConnectionInfo(conn)
+	if len(info.Connections) > 0 {
+		status.Connected = subjectProductConnected(info.Connections)
 	}
-	if conn, ok := info.singleConnectionStatus(); ok {
-		return statusFromConnectionInfo(conn)
-	}
-	if len(info.Connections) == 0 {
-		return s.implicitIntegrationStatus(info.Name, prov, instances, authTypes, p)
-	}
-	return summarizeConnectionStatuses(info.Connections)
+	return status
 }
 
 func (info *integrationInfo) connectionStatusForDefaultTarget(connection string) (*connectionDefInfo, bool) {

--- a/gestaltd/internal/server/connection_status.go
+++ b/gestaltd/internal/server/connection_status.go
@@ -424,7 +424,11 @@ func subjectConnectionActions(disconnectable, connectable, selectInstance bool) 
 }
 
 func ownerKindForPrincipal(p *principal.Principal) string {
-	subjectID := strings.TrimSpace(principal.Canonicalized(p).SubjectID)
+	canon := principal.Canonicalized(p)
+	if canon == nil {
+		return ownerKindUnknown
+	}
+	subjectID := strings.TrimSpace(canon.SubjectID)
 	if subjectID == "" {
 		return ownerKindUnknown
 	}

--- a/gestaltd/internal/server/connection_status.go
+++ b/gestaltd/internal/server/connection_status.go
@@ -110,10 +110,10 @@ func (s *Server) defaultConnectionName(integration string) string {
 }
 
 func (s *Server) implicitIntegrationStatus(integration string, prov core.Provider, instances []instanceInfo, authTypes []string, p *principal.Principal) connectionStatusInfo {
-	mode := core.ConnectionModeSubject
-	if prov != nil {
-		mode = core.NormalizeConnectionMode(prov.ConnectionMode())
+	if prov == nil {
+		return unknownConnectionStatus()
 	}
+	mode := core.NormalizeConnectionMode(prov.ConnectionMode())
 	switch mode {
 	case core.ConnectionModeNone:
 		return connectionStatusInfo{

--- a/gestaltd/internal/server/connection_status_test.go
+++ b/gestaltd/internal/server/connection_status_test.go
@@ -145,3 +145,52 @@ func TestSummarizeReconnectNoAuthDoesNotConnectTheApp(t *testing.T) {
 		t.Fatal("mode-none ready must not mark the app connected during reconnect rollup")
 	}
 }
+
+func TestDefaultModeNoneDoesNotHideSubjectProductConnected(t *testing.T) {
+	t.Parallel()
+
+	s := &Server{defaultConnection: map[string]string{"demo": "webhook"}}
+	info := &integrationInfo{
+		Name: "demo",
+		Connections: []connectionDefInfo{
+			{
+				Name:            "webhook",
+				Status:          connectionStatusReady,
+				CredentialState: credentialStateNotRequired,
+				CredentialMode:  credentialModeNone,
+				Connected:       false,
+			},
+			{
+				Name:            "workspace",
+				Status:          connectionStatusReady,
+				CredentialState: credentialStateConnected,
+				CredentialMode:  credentialModeSubject,
+				Connected:       true,
+			},
+		},
+	}
+	s.applyIntegrationConnectionStatus(info, nil, nil, nil, nil)
+	if !info.Connected {
+		t.Fatal("chosen subject account must keep the app product-connected when the default row is mode-none")
+	}
+}
+
+func TestDefaultModeNoneAloneIsNotProductConnected(t *testing.T) {
+	t.Parallel()
+
+	s := &Server{defaultConnection: map[string]string{"demo": "webhook"}}
+	info := &integrationInfo{
+		Name: "demo",
+		Connections: []connectionDefInfo{{
+			Name:            "webhook",
+			Status:          connectionStatusReady,
+			CredentialState: credentialStateNotRequired,
+			CredentialMode:  credentialModeNone,
+			Connected:       false,
+		}},
+	}
+	s.applyIntegrationConnectionStatus(info, nil, nil, nil, nil)
+	if info.Connected {
+		t.Fatal("a mode-none default row must not mark the app product-connected")
+	}
+}

--- a/gestaltd/internal/server/connection_status_test.go
+++ b/gestaltd/internal/server/connection_status_test.go
@@ -14,6 +14,13 @@ func TestNoAuthConnectionIsNotProductConnected(t *testing.T) {
 	}
 }
 
+func TestOwnerKindForNilPrincipalIsUnknown(t *testing.T) {
+	t.Parallel()
+	if got := ownerKindForPrincipal(nil); got != ownerKindUnknown {
+		t.Fatalf("owner kind = %q, want %s", got, ownerKindUnknown)
+	}
+}
+
 func TestSummarizeReadyNoAuthDoesNotConnectTheApp(t *testing.T) {
 	t.Parallel()
 
@@ -77,5 +84,64 @@ func TestSummarizeAllReadySubjectStaysConnected(t *testing.T) {
 	})
 	if !got.Connected {
 		t.Fatal("a chosen subject identity must keep the app connected")
+	}
+}
+
+func TestSummarizeReconnectKeepsAppConnectedWhenSiblingIsValid(t *testing.T) {
+	t.Parallel()
+
+	got, ok := summarizeReconnectRequiredConnectionStatuses([]connectionDefInfo{
+		{
+			Name:            "workspace",
+			Status:          connectionStatusReady,
+			CredentialState: credentialStateConnected,
+			CredentialMode:  credentialModeSubject,
+			Connected:       true,
+		},
+		{
+			Name:            "archive",
+			Status:          connectionStatusNeedsUserConnection,
+			CredentialState: credentialStateInvalid,
+			CredentialMode:  credentialModeSubject,
+			StatusCode:      "reconnect_required",
+			Connected:       false,
+		},
+	})
+	if !ok {
+		t.Fatal("expected reconnect rollup for mixed valid and stale connections")
+	}
+	if !got.Connected {
+		t.Fatal("a chosen account must keep the app connected when a sibling needs reconnect")
+	}
+	if got.Status != connectionStatusDegraded {
+		t.Fatalf("status = %q, want %s", got.Status, connectionStatusDegraded)
+	}
+}
+
+func TestSummarizeReconnectNoAuthDoesNotConnectTheApp(t *testing.T) {
+	t.Parallel()
+
+	got, ok := summarizeReconnectRequiredConnectionStatuses([]connectionDefInfo{
+		{
+			Name:            "webhook",
+			Status:          connectionStatusReady,
+			CredentialState: credentialStateNotRequired,
+			CredentialMode:  credentialModeNone,
+			Connected:       false,
+		},
+		{
+			Name:            "workspace",
+			Status:          connectionStatusNeedsUserConnection,
+			CredentialState: credentialStateInvalid,
+			CredentialMode:  credentialModeSubject,
+			StatusCode:      "reconnect_required",
+			Connected:       false,
+		},
+	})
+	if !ok {
+		t.Fatal("expected reconnect rollup when a subject connection is invalid")
+	}
+	if got.Connected {
+		t.Fatal("mode-none ready must not mark the app connected during reconnect rollup")
 	}
 }

--- a/gestaltd/internal/server/connection_status_test.go
+++ b/gestaltd/internal/server/connection_status_test.go
@@ -1,0 +1,81 @@
+package server
+
+import "testing"
+
+func TestNoAuthConnectionIsNotProductConnected(t *testing.T) {
+	t.Parallel()
+
+	status := noAuthConnectionStatus()
+	if status.Connected {
+		t.Fatal("no-auth status must not mark a subject identity as connected")
+	}
+	if status.CredentialState != credentialStateNotRequired {
+		t.Fatalf("credential state = %q, want %s", status.CredentialState, credentialStateNotRequired)
+	}
+}
+
+func TestSummarizeReadyNoAuthDoesNotConnectTheApp(t *testing.T) {
+	t.Parallel()
+
+	got := summarizeConnectionStatuses([]connectionDefInfo{
+		{
+			Name:            "webhook",
+			Status:          connectionStatusReady,
+			CredentialState: credentialStateNotRequired,
+			CredentialMode:  credentialModeNone,
+			Connected:       false,
+		},
+		{
+			Name:            "workspace",
+			Status:          connectionStatusNeedsUserConnection,
+			CredentialState: credentialStateMissing,
+			CredentialMode:  credentialModeSubject,
+			Connected:       false,
+		},
+	})
+	if got.Connected {
+		t.Fatal("a leftover no-auth row must not roll the app to connected")
+	}
+	if got.Status != connectionStatusNeedsUserConnection {
+		t.Fatalf("status = %q, want %s", got.Status, connectionStatusNeedsUserConnection)
+	}
+}
+
+func TestSummarizeAllReadyNoAuthIsNotProductConnected(t *testing.T) {
+	t.Parallel()
+
+	got := summarizeConnectionStatuses([]connectionDefInfo{{
+		Name:            "webhook",
+		Status:          connectionStatusReady,
+		CredentialState: credentialStateNotRequired,
+		CredentialMode:  credentialModeNone,
+		Connected:       false,
+	}})
+	if got.Connected {
+		t.Fatal("mode-none ready is not a chosen subject identity")
+	}
+}
+
+func TestSummarizeAllReadySubjectStaysConnected(t *testing.T) {
+	t.Parallel()
+
+	got := summarizeConnectionStatuses([]connectionDefInfo{
+		{
+			Name:            "webhook",
+			Status:          connectionStatusReady,
+			CredentialState: credentialStateNotRequired,
+			CredentialMode:  credentialModeNone,
+			Connected:       false,
+		},
+		{
+			Name:            "workspace",
+			Status:          connectionStatusReady,
+			CredentialState: credentialStateConnected,
+			CredentialMode:  credentialModeSubject,
+			Connected:       true,
+		},
+	})
+	if !got.Connected {
+		t.Fatal("a chosen subject identity must keep the app connected")
+	}
+}

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -105,6 +105,8 @@ type integrationInfo struct {
 	CredentialState string              `json:"credentialState"`
 	HealthState     string              `json:"healthState"`
 	Actions         []string            `json:"actions"`
+	// Connected is true only when this subject has a chosen account.
+	Connected bool `json:"connected"`
 }
 
 type appPromptInfo struct {

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -219,106 +219,15 @@ func (s *Server) readinessCheck(w http.ResponseWriter, _ *http.Request) {
 }
 
 func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
-	p := PrincipalFromContext(r.Context())
-	connected, err := s.subjectConnectedIntegrations(r)
+	dir, err := s.assembleAppDirectory(r)
 	if err != nil {
-		slog.ErrorContext(r.Context(), "listing integrations", "error", err)
-		writeError(w, http.StatusInternalServerError, "failed to check integration status")
+		writeAppListingError(w, r, err)
 		return
 	}
-
-	names := s.providers.List()
-	registryApps := s.configuredRegistryApps()
-
-	// Answer every app-visibility question this listing asks in one batched
-	// evaluator call. Each app below still reaches its decision through the
-	// same single-decision helper; the batch only pre-populates the answers.
-	ctx, _ := withListingDecisionCache(r.Context())
-	r = r.WithContext(ctx)
-	prefetchNames := make([]string, 0, len(names)+len(registryApps))
-	prefetchNames = append(prefetchNames, names...)
-	for _, app := range registryApps {
-		prefetchNames = append(prefetchNames, app.name)
-	}
-	s.prefetchIntegrationListingDecisions(ctx, p, prefetchNames)
-
-	seen := make(map[string]struct{}, len(names))
-	out := make([]integrationInfo, 0, len(names))
-	for _, name := range names {
-		if s.integrationHiddenFromCatalog(name) {
-			continue
-		}
-		prov, err := s.providers.GetWithContext(r.Context(), name)
-		if err != nil {
-			continue
-		}
-		seen[name] = struct{}{}
-		info := integrationInfo{
-			Name:            name,
-			DisplayName:     prov.DisplayName(),
-			Description:     prov.Description(),
-			Connections:     []connectionDefInfo{},
-			Status:          connectionStatusUnknown,
-			CredentialState: credentialStateUnknown,
-			HealthState:     healthStateUnknown,
-			Actions:         []string{},
-		}
-		if cat := prov.Catalog(); cat != nil {
-			info.IconSVG = cat.IconSVG
-		}
-		entry := s.pluginDefs[name]
-		if entry != nil && entry.Static != nil {
-			info.MountedPath = strings.TrimSpace(entry.Static.Mount)
-		}
-		info.SourceTreeURL = entry.SourceTreeURL()
-		info.Prompts = s.appPrompts[name]
-		instances := connected[name]
-		authTypes := s.populateIntegrationSettings(r.Context(), &info, instances, p)
-		s.applyIntegrationConnectionStatus(&info, prov, instances, authTypes, p)
-		info.MountedPath = s.integrationMountedPathForPrincipalContext(r.Context(), p, name, info.MountedPath)
-		info.ManagementPath = s.integrationManagementPath(r.Context(), p, name)
-		usable, err := s.integrationHasUsableSurfaceContext(r.Context(), p, name, prov, info)
-		if err != nil {
-			// An unreachable evaluator must not be reported as "you have no
-			// apps": fail the request instead of returning a silently empty or
-			// silently truncated list.
-			slog.ErrorContext(r.Context(), "listing integrations", "app", name, "error", err)
-			writeError(w, http.StatusServiceUnavailable, "failed to authorize app access")
-			return
-		}
-		if !usable {
-			continue
-		}
-		out = append(out, info)
-	}
-	for _, app := range registryApps {
-		if s.integrationHiddenFromCatalog(app.name) {
-			continue
-		}
-		if _, ok := seen[app.name]; ok {
-			continue
-		}
-		managementPath := s.integrationManagementPath(r.Context(), p, app.name)
-		if managementPath == "" {
-			continue
-		}
-		info := integrationInfo{
-			Name:            app.name,
-			DisplayName:     app.name,
-			Connections:     []connectionDefInfo{},
-			Status:          connectionStatusUnknown,
-			CredentialState: credentialStateUnknown,
-			HealthState:     healthStateUnknown,
-			Actions:         []string{},
-			ManagementPath:  managementPath,
-			Prompts:         s.appPrompts[app.name],
-		}
-		entry := s.pluginDefs[app.name]
-		if entry != nil && entry.Static != nil {
-			info.MountedPath = s.integrationMountedPathForPrincipalContext(r.Context(), p, app.name, strings.TrimSpace(entry.Static.Mount))
-		}
-		info.SourceTreeURL = entry.SourceTreeURL()
-		out = append(out, info)
+	out, err := s.projectComposedAppListing(r, dir)
+	if err != nil {
+		writeAppListingError(w, r, err)
+		return
 	}
 	writeJSON(w, http.StatusOK, out)
 }

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -256,8 +256,10 @@ func (s *Server) subjectConnectedIntegrations(r *http.Request) (map[string][]ins
 	p := PrincipalFromContext(r.Context())
 	// Ingress already canonicalized p; read the subject directly to avoid
 	// re-querying the user store and surfacing duplicate-email errors.
-	if subjectID := strings.TrimSpace(principal.Canonicalized(p).SubjectID); subjectID != "" {
-		return s.connectedIntegrationsForSubject(r.Context(), subjectID)
+	if canon := principal.Canonicalized(p); canon != nil {
+		if subjectID := strings.TrimSpace(canon.SubjectID); subjectID != "" {
+			return s.connectedIntegrationsForSubject(r.Context(), subjectID)
+		}
 	}
 	if principal.IsNonUserPrincipal(p) {
 		return nil, nil

--- a/gestaltd/internal/server/handlers_app_catalog.go
+++ b/gestaltd/internal/server/handlers_app_catalog.go
@@ -36,7 +36,7 @@ func (s *Server) serveAppCatalogIcon(w http.ResponseWriter, r *http.Request) {
 	name := chi.URLParam(r, "name")
 	entry, ok, err := s.visibleProviderDirectoryEntry(r, name)
 	if err != nil {
-		writeAppListingError(w, r, err)
+		writeAppDirectoryError(w, r, err, "failed to load app icon")
 		return
 	}
 	if !ok || strings.TrimSpace(entry.IconSVG) == "" {
@@ -50,6 +50,10 @@ func (s *Server) serveAppCatalogIcon(w http.ResponseWriter, r *http.Request) {
 }
 
 func writeAppListingError(w http.ResponseWriter, r *http.Request, err error) {
+	writeAppDirectoryError(w, r, err, "failed to list apps")
+}
+
+func writeAppDirectoryError(w http.ResponseWriter, r *http.Request, err error, unexpectedPublic string) {
 	var listingErr *appListingError
 	if errors.As(err, &listingErr) && listingErr != nil {
 		slog.ErrorContext(r.Context(), "listing integrations", "error", listingErr.Unwrap())
@@ -57,5 +61,8 @@ func writeAppListingError(w http.ResponseWriter, r *http.Request, err error) {
 		return
 	}
 	slog.ErrorContext(r.Context(), "listing integrations", "error", err)
-	writeError(w, http.StatusInternalServerError, "failed to list apps")
+	if strings.TrimSpace(unexpectedPublic) == "" {
+		unexpectedPublic = "failed to list apps"
+	}
+	writeError(w, http.StatusInternalServerError, unexpectedPublic)
 }

--- a/gestaltd/internal/server/handlers_app_catalog.go
+++ b/gestaltd/internal/server/handlers_app_catalog.go
@@ -1,0 +1,61 @@
+package server
+
+import (
+	"errors"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func (s *Server) listAppCatalog(w http.ResponseWriter, r *http.Request) {
+	dir, err := s.assembleAppDirectory(r)
+	if err != nil {
+		writeAppListingError(w, r, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, dir.catalogJSON())
+}
+
+func (s *Server) listAppConnections(w http.ResponseWriter, r *http.Request) {
+	dir, err := s.assembleAppDirectory(r)
+	if err != nil {
+		writeAppListingError(w, r, err)
+		return
+	}
+	infos, err := s.projectComposedAppListing(r, dir)
+	if err != nil {
+		writeAppListingError(w, r, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, appConnectionStatusesFrom(infos))
+}
+
+func (s *Server) serveAppCatalogIcon(w http.ResponseWriter, r *http.Request) {
+	name := chi.URLParam(r, "name")
+	entry, ok, err := s.visibleProviderDirectoryEntry(r, name)
+	if err != nil {
+		writeAppListingError(w, r, err)
+		return
+	}
+	if !ok || strings.TrimSpace(entry.IconSVG) == "" {
+		writeError(w, http.StatusNotFound, "app icon not found")
+		return
+	}
+	w.Header().Set("Content-Type", "image/svg+xml; charset=utf-8")
+	w.Header().Set("Cache-Control", "private, max-age=300")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(entry.IconSVG))
+}
+
+func writeAppListingError(w http.ResponseWriter, r *http.Request, err error) {
+	var listingErr *appListingError
+	if errors.As(err, &listingErr) && listingErr != nil {
+		slog.ErrorContext(r.Context(), "listing integrations", "error", listingErr.Unwrap())
+		writeError(w, listingErr.status, listingErr.public)
+		return
+	}
+	slog.ErrorContext(r.Context(), "listing integrations", "error", err)
+	writeError(w, http.StatusInternalServerError, "failed to list apps")
+}

--- a/gestaltd/internal/server/handlers_app_catalog_test.go
+++ b/gestaltd/internal/server/handlers_app_catalog_test.go
@@ -1,0 +1,392 @@
+package server_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/server"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	"github.com/valon-technologies/gestalt/server/services/apps/declarative"
+	"github.com/valon-technologies/gestalt/server/services/identity/principal"
+)
+
+type errorListCredentials struct {
+	core.ExternalCredentialProvider
+}
+
+func (e errorListCredentials) ListCredentials(ctx context.Context, subject, audience string) ([]*core.ExternalCredential, error) {
+	return nil, fmt.Errorf("credentials unavailable")
+}
+
+func TestAppCatalogOmitsSubjectConnectionState(t *testing.T) {
+	t.Parallel()
+
+	svc := testutil.NewStubServices(t)
+	recording := newRecordingExternalCredentialProvider(svc.ExternalCredentials)
+	svc.ExternalCredentials = recording
+	u := seedUser(t, svc, "anonymous@gestalt")
+	seedToken(t, svc, &core.ExternalCredential{
+		ID:        "tok1",
+		Subject:   principal.UserSubjectID(u.ID),
+		Audience:  "slack:default",
+		Qualifier: "default",
+		Grant:     &core.ExternalCredentialGrant{AccessToken: "test-token"},
+	})
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = testutil.NewProviderRegistry(t, &coretesting.StubIntegration{N: "slack", DN: "Slack", Desc: "Team messaging"})
+		cfg.AppDefs = testPluginDefsForConnections("slack", "default")
+		cfg.Services = svc
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	catalog := getJSONPath(t, ts, "/api/v1/catalog/apps", http.StatusOK, "")
+	if recording.listCredentialsCalls.Load() != 0 {
+		t.Fatalf("catalog listing consulted subject credentials %d times", recording.listCredentialsCalls.Load())
+	}
+
+	var catalogApps []map[string]any
+	if err := json.Unmarshal(catalog, &catalogApps); err != nil {
+		t.Fatalf("decode catalog: %v", err)
+	}
+	if len(catalogApps) != 1 {
+		t.Fatalf("catalog apps = %d, want 1: %s", len(catalogApps), catalog)
+	}
+	app := catalogApps[0]
+	if app["name"] != "slack" {
+		t.Fatalf("catalog name = %#v, want slack", app["name"])
+	}
+	for _, field := range []string{"status", "credentialState", "healthState", "actions", "iconSvg"} {
+		if _, ok := app[field]; ok {
+			t.Fatalf("catalog must not include subject or icon bytes field %q: %#v", field, app)
+		}
+	}
+	connections, _ := app["connections"].([]any)
+	if len(connections) == 0 {
+		t.Fatalf("catalog missing connection schema: %#v", app)
+	}
+	connection, _ := connections[0].(map[string]any)
+	for _, field := range []string{"status", "instances", "connected", "preferredInstance"} {
+		if _, ok := connection[field]; ok {
+			t.Fatalf("catalog connection schema must not include %q: %#v", field, connection)
+		}
+	}
+
+	overlay := getJSONPath(t, ts, "/api/v1/me/app-connections", http.StatusOK, "")
+	if recording.listCredentialsCalls.Load() == 0 {
+		t.Fatal("connection overlay did not list subject credentials")
+	}
+	var statuses []struct {
+		Name            string `json:"name"`
+		Status          string `json:"status"`
+		CredentialState string `json:"credentialState"`
+		Connections     []struct {
+			Name      string `json:"name"`
+			Connected bool   `json:"connected"`
+		} `json:"connections"`
+	}
+	if err := json.Unmarshal(overlay, &statuses); err != nil {
+		t.Fatalf("decode overlay: %v", err)
+	}
+	if len(statuses) != 1 || statuses[0].Name != "slack" {
+		t.Fatalf("overlay = %s", overlay)
+	}
+	if statuses[0].Status != "ready" || statuses[0].CredentialState != "connected" {
+		t.Fatalf("overlay status = {%q, %q}, want ready/connected", statuses[0].Status, statuses[0].CredentialState)
+	}
+	if len(statuses[0].Connections) != 1 || !statuses[0].Connections[0].Connected {
+		t.Fatalf("overlay connections = %+v", statuses[0].Connections)
+	}
+	catalogConn, _ := connection["name"].(string)
+	if catalogConn == "" || catalogConn != statuses[0].Connections[0].Name {
+		t.Fatalf("catalog connection %q does not zip with overlay %q", catalogConn, statuses[0].Connections[0].Name)
+	}
+
+	composed := getJSONPath(t, ts, "/api/v1/apps", http.StatusOK, "")
+	var integrations []struct {
+		Name            string `json:"name"`
+		Status          string `json:"status"`
+		CredentialState string `json:"credentialState"`
+	}
+	if err := json.Unmarshal(composed, &integrations); err != nil {
+		t.Fatalf("decode composed listing: %v", err)
+	}
+	if len(integrations) != 1 || integrations[0].Name != "slack" {
+		t.Fatalf("composed listing = %s", composed)
+	}
+	if integrations[0].Status != "ready" || integrations[0].CredentialState != "connected" {
+		t.Fatalf("composed status = {%q, %q}, want ready/connected", integrations[0].Status, integrations[0].CredentialState)
+	}
+}
+
+func TestAppCatalogSucceedsWhenSubjectCredentialsFail(t *testing.T) {
+	t.Parallel()
+
+	svc := testutil.NewStubServices(t)
+	seedUser(t, svc, "anonymous@gestalt")
+	svc.ExternalCredentials = errorListCredentials{ExternalCredentialProvider: svc.ExternalCredentials}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = testutil.NewProviderRegistry(t, &coretesting.StubIntegration{N: "slack", DN: "Slack"})
+		cfg.AppDefs = testPluginDefsForConnections("slack", "default")
+		cfg.Services = svc
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	catalog := getJSONPath(t, ts, "/api/v1/catalog/apps", http.StatusOK, "")
+	var catalogApps []struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(catalog, &catalogApps); err != nil {
+		t.Fatalf("decode catalog: %v", err)
+	}
+	if len(catalogApps) != 1 || catalogApps[0].Name != "slack" {
+		t.Fatalf("catalog = %s", catalog)
+	}
+
+	if body := getJSONPath(t, ts, "/api/v1/me/app-connections", http.StatusInternalServerError, ""); !jsonContainsError(body, "failed to check integration status") {
+		t.Fatalf("overlay error = %s", body)
+	}
+	if body := getJSONPath(t, ts, "/api/v1/apps", http.StatusInternalServerError, ""); !jsonContainsError(body, "failed to check integration status") {
+		t.Fatalf("composed error = %s", body)
+	}
+}
+
+func TestAppCatalogServesIconsByURL(t *testing.T) {
+	t.Parallel()
+
+	const testSVG = `<svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/></svg>`
+	prov, err := declarative.Build(&declarative.Definition{
+		Provider:    "iconprov",
+		DisplayName: "Icon Provider",
+		Description: "Has an icon",
+		IconSVG:     testSVG,
+		BaseURL:     "https://api.example.com",
+		Auth:        declarative.AuthDef{Type: "manual"},
+		Operations: map[string]declarative.OperationDef{
+			"op": {Description: "An op", Method: http.MethodGet, Path: "/op"},
+		},
+	}, declarative.ConnectionDef{})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	svc := testutil.NewStubServices(t)
+	recording := newRecordingExternalCredentialProvider(svc.ExternalCredentials)
+	svc.ExternalCredentials = recording
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = testutil.NewProviderRegistry(t, prov)
+		cfg.Services = svc
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	iconReq, err := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/catalog/apps/iconprov/icon", nil)
+	if err != nil {
+		t.Fatalf("new icon request: %v", err)
+	}
+	iconResp, err := http.DefaultClient.Do(iconReq)
+	if err != nil {
+		t.Fatalf("GET icon: %v", err)
+	}
+	defer func() { _ = iconResp.Body.Close() }()
+	iconBody, err := io.ReadAll(iconResp.Body)
+	if err != nil {
+		t.Fatalf("read icon: %v", err)
+	}
+	if iconResp.StatusCode != http.StatusOK {
+		t.Fatalf("icon status = %d: %s", iconResp.StatusCode, iconBody)
+	}
+	if recording.listCredentialsCalls.Load() != 0 {
+		t.Fatalf("icon lookup listed subject credentials %d times", recording.listCredentialsCalls.Load())
+	}
+	if got := iconResp.Header.Get("Content-Type"); got != "image/svg+xml; charset=utf-8" {
+		t.Fatalf("icon content type = %q", got)
+	}
+	if string(iconBody) != testSVG {
+		t.Fatalf("icon body = %q, want %q", iconBody, testSVG)
+	}
+
+	catalog := getJSONPath(t, ts, "/api/v1/catalog/apps", http.StatusOK, "")
+	var catalogApps []struct {
+		Name    string `json:"name"`
+		IconURL string `json:"iconUrl"`
+		IconSVG string `json:"iconSvg"`
+	}
+	if err := json.Unmarshal(catalog, &catalogApps); err != nil {
+		t.Fatalf("decode catalog: %v", err)
+	}
+	if len(catalogApps) != 1 {
+		t.Fatalf("catalog = %s", catalog)
+	}
+	if catalogApps[0].IconSVG != "" {
+		t.Fatalf("catalog inlined icon bytes: %q", catalogApps[0].IconSVG)
+	}
+	wantURL := "/api/v1/catalog/apps/iconprov/icon"
+	if catalogApps[0].IconURL != wantURL {
+		t.Fatalf("iconUrl = %q, want %q", catalogApps[0].IconURL, wantURL)
+	}
+
+	composed := getJSONPath(t, ts, "/api/v1/apps", http.StatusOK, "")
+	var integrations []struct {
+		IconSVG string `json:"iconSvg"`
+	}
+	if err := json.Unmarshal(composed, &integrations); err != nil {
+		t.Fatalf("decode composed listing: %v", err)
+	}
+	if len(integrations) != 1 || integrations[0].IconSVG != testSVG {
+		t.Fatalf("composed listing lost iconSvg compatibility: %s", composed)
+	}
+}
+
+func TestAppCatalogOmitsCatalogHiddenApps(t *testing.T) {
+	t.Parallel()
+
+	subjectID := principal.UserSubjectID(testCanonicalViewerUserID)
+	authz := &serverTestAuthorizationProvider{
+		relationships: append(
+			subjectSetGrant(subjectID, "viewer", "app", "sampleApp"),
+			subjectSetGrant(subjectID, "viewer", "app", "otherApp")...,
+		),
+	}
+	ts := listingTestServer(t, authz, subjectID)
+	catalog := getJSONPath(t, ts, "/api/v1/catalog/apps", http.StatusOK, "Bearer listing-token")
+	var catalogApps []listedIntegration
+	if err := json.Unmarshal(catalog, &catalogApps); err != nil {
+		t.Fatalf("decode catalog: %v", err)
+	}
+	if _, ok := mountedPathFor(catalogApps, "publicHidden"); ok {
+		t.Fatalf("catalog-hidden app leaked: %#v", catalogApps)
+	}
+	if mounted, ok := mountedPathFor(catalogApps, "sampleApp"); !ok || mounted == "" {
+		t.Fatalf("granted app missing from catalog: %#v", catalogApps)
+	}
+
+	_ = getJSONPath(t, ts, "/api/v1/catalog/apps/publicHidden/icon", http.StatusNotFound, "Bearer listing-token")
+}
+
+func TestAppOverlayNoAuthIsNotProductConnected(t *testing.T) {
+	t.Parallel()
+
+	svc := testutil.NewStubServices(t)
+	recording := newRecordingExternalCredentialProvider(svc.ExternalCredentials)
+	svc.ExternalCredentials = recording
+	seedUser(t, svc, "anonymous@gestalt")
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = testutil.NewProviderRegistry(t, &coretesting.StubIntegration{
+			N:        "no-auth",
+			DN:       "No Auth",
+			ConnMode: core.ConnectionModeNone,
+		})
+		cfg.AppDefs = map[string]*config.ProviderEntry{
+			"no-auth": {
+				Connections: map[string]*config.ConnectionDef{
+					"webhook": {
+						ConnectionID: "no-auth:webhook",
+						DisplayName:  "Webhook",
+						Mode:         providermanifestv1.ConnectionModeNone,
+					},
+				},
+			},
+		}
+		cfg.Services = svc
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	overlay := getJSONPath(t, ts, "/api/v1/me/app-connections", http.StatusOK, "")
+	if recording.listCredentialsCalls.Load() == 0 {
+		t.Fatal("connection overlay did not list subject credentials")
+	}
+	var statuses []struct {
+		Name            string `json:"name"`
+		Status          string `json:"status"`
+		CredentialState string `json:"credentialState"`
+		Connected       bool   `json:"connected"`
+		Connections     []struct {
+			Name            string `json:"name"`
+			Connected       bool   `json:"connected"`
+			CredentialState string `json:"credentialState"`
+			CredentialMode  string `json:"credentialMode"`
+		} `json:"connections"`
+	}
+	if err := json.Unmarshal(overlay, &statuses); err != nil {
+		t.Fatalf("decode overlay: %v", err)
+	}
+	if len(statuses) != 1 || statuses[0].Name != "no-auth" {
+		t.Fatalf("overlay = %s", overlay)
+	}
+	if len(statuses[0].Connections) == 0 {
+		t.Fatalf("overlay missing no-auth connection row: %s", overlay)
+	}
+	if statuses[0].CredentialState != "not_required" {
+		t.Fatalf("overlay credential state = %q, want not_required: %s", statuses[0].CredentialState, overlay)
+	}
+	for _, connection := range statuses[0].Connections {
+		if connection.Connected {
+			t.Fatalf("no-auth overlay connection %q must not be product-connected: %s", connection.Name, overlay)
+		}
+	}
+
+	composed := getJSONPath(t, ts, "/api/v1/apps", http.StatusOK, "")
+	var integrations []struct {
+		Name        string `json:"name"`
+		Connections []struct {
+			Connected bool `json:"connected"`
+		} `json:"connections"`
+	}
+	if err := json.Unmarshal(composed, &integrations); err != nil {
+		t.Fatalf("decode composed listing: %v", err)
+	}
+	if len(integrations) != 1 || integrations[0].Name != "no-auth" {
+		t.Fatalf("composed listing = %s", composed)
+	}
+	for i, connection := range integrations[0].Connections {
+		if connection.Connected {
+			t.Fatalf("composed no-auth connection[%d] must not be product-connected: %s", i, composed)
+		}
+	}
+}
+
+func getJSONPath(t *testing.T, ts *httptest.Server, path string, wantStatus int, authorization string) []byte {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, ts.URL+path, nil)
+	if err != nil {
+		t.Fatalf("new request %s: %v", path, err)
+	}
+	if authorization != "" {
+		req.Header.Set("Authorization", authorization)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET %s: %v", path, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if resp.StatusCode != wantStatus {
+		t.Fatalf("GET %s status = %d, want %d: %s", path, resp.StatusCode, wantStatus, body)
+	}
+	return body
+}
+
+func jsonContainsError(body []byte, want string) bool {
+	var payload struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return false
+	}
+	return payload.Error == want
+}

--- a/gestaltd/internal/server/handlers_app_catalog_test.go
+++ b/gestaltd/internal/server/handlers_app_catalog_test.go
@@ -90,6 +90,7 @@ func TestAppCatalogOmitsSubjectConnectionState(t *testing.T) {
 		Name            string `json:"name"`
 		Status          string `json:"status"`
 		CredentialState string `json:"credentialState"`
+		Connected       bool   `json:"connected"`
 		Connections     []struct {
 			Name      string `json:"name"`
 			Connected bool   `json:"connected"`
@@ -104,6 +105,9 @@ func TestAppCatalogOmitsSubjectConnectionState(t *testing.T) {
 	if statuses[0].Status != "ready" || statuses[0].CredentialState != "connected" {
 		t.Fatalf("overlay status = {%q, %q}, want ready/connected", statuses[0].Status, statuses[0].CredentialState)
 	}
+	if !statuses[0].Connected {
+		t.Fatalf("overlay app connected = false, want true: %s", overlay)
+	}
 	if len(statuses[0].Connections) != 1 || !statuses[0].Connections[0].Connected {
 		t.Fatalf("overlay connections = %+v", statuses[0].Connections)
 	}
@@ -117,6 +121,7 @@ func TestAppCatalogOmitsSubjectConnectionState(t *testing.T) {
 		Name            string `json:"name"`
 		Status          string `json:"status"`
 		CredentialState string `json:"credentialState"`
+		Connected       bool   `json:"connected"`
 	}
 	if err := json.Unmarshal(composed, &integrations); err != nil {
 		t.Fatalf("decode composed listing: %v", err)
@@ -126,6 +131,9 @@ func TestAppCatalogOmitsSubjectConnectionState(t *testing.T) {
 	}
 	if integrations[0].Status != "ready" || integrations[0].CredentialState != "connected" {
 		t.Fatalf("composed status = {%q, %q}, want ready/connected", integrations[0].Status, integrations[0].CredentialState)
+	}
+	if !integrations[0].Connected {
+		t.Fatalf("composed listing app connected = false, want true: %s", composed)
 	}
 }
 
@@ -410,6 +418,9 @@ func TestAppOverlayNoAuthIsNotProductConnected(t *testing.T) {
 	if statuses[0].CredentialState != "not_required" {
 		t.Fatalf("overlay credential state = %q, want not_required: %s", statuses[0].CredentialState, overlay)
 	}
+	if statuses[0].Connected {
+		t.Fatalf("no-auth overlay app must not be product-connected: %s", overlay)
+	}
 	for _, connection := range statuses[0].Connections {
 		if connection.Connected {
 			t.Fatalf("no-auth overlay connection %q must not be product-connected: %s", connection.Name, overlay)
@@ -419,6 +430,7 @@ func TestAppOverlayNoAuthIsNotProductConnected(t *testing.T) {
 	composed := getJSONPath(t, ts, "/api/v1/apps", http.StatusOK, "")
 	var integrations []struct {
 		Name        string `json:"name"`
+		Connected   bool   `json:"connected"`
 		Connections []struct {
 			Connected bool `json:"connected"`
 		} `json:"connections"`
@@ -428,6 +440,9 @@ func TestAppOverlayNoAuthIsNotProductConnected(t *testing.T) {
 	}
 	if len(integrations) != 1 || integrations[0].Name != "no-auth" {
 		t.Fatalf("composed listing = %s", composed)
+	}
+	if integrations[0].Connected {
+		t.Fatalf("composed no-auth app must not be product-connected: %s", composed)
 	}
 	for i, connection := range integrations[0].Connections {
 		if connection.Connected {

--- a/gestaltd/internal/server/handlers_app_catalog_test.go
+++ b/gestaltd/internal/server/handlers_app_catalog_test.go
@@ -257,6 +257,90 @@ func TestAppCatalogServesIconsByURL(t *testing.T) {
 	}
 }
 
+func TestAppCatalogIncludesSourceTreeURL(t *testing.T) {
+	t.Parallel()
+
+	githubApp := &coretesting.StubIntegration{N: "roadmap", DN: "Roadmap"}
+	gitlabApp := &coretesting.StubIntegration{N: "notes", DN: "Notes"}
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = testutil.NewProviderRegistry(t, githubApp, gitlabApp)
+		defs := testPluginDefsForConnections("roadmap", "default")
+		defs["roadmap"].Source = config.ProviderSource{
+			Git: &config.GitSourceDef{
+				Repo: "https://github.com/example/apps.git",
+				Ref:  "main",
+				Path: "apps/roadmap/manifest.yaml",
+			},
+		}
+		notes := testPluginDefsForConnections("notes", "default")["notes"]
+		notes.Source = config.ProviderSource{
+			Git: &config.GitSourceDef{
+				Repo: "https://gitlab.example.com/group/app.git",
+				Ref:  "main",
+				Path: "apps/notes/manifest.yaml",
+			},
+		}
+		defs["notes"] = notes
+		cfg.AppDefs = defs
+		cfg.Services = testutil.NewStubServices(t)
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	catalog := getJSONPath(t, ts, "/api/v1/catalog/apps", http.StatusOK, "")
+	var catalogApps []map[string]any
+	if err := json.Unmarshal(catalog, &catalogApps); err != nil {
+		t.Fatalf("decode catalog: %v", err)
+	}
+	got := map[string]map[string]any{}
+	for _, app := range catalogApps {
+		name, _ := app["name"].(string)
+		got[name] = app
+	}
+	roadmap, ok := got["roadmap"]
+	if !ok {
+		t.Fatalf("expected roadmap in catalog, got %s", catalog)
+	}
+	wantGitHub := "https://github.com/example/apps/tree/main/apps/roadmap"
+	if gotTree, _ := roadmap["sourceTreeUrl"].(string); gotTree != wantGitHub {
+		t.Fatalf("catalog roadmap sourceTreeUrl = %q, want %q: %s", gotTree, wantGitHub, catalog)
+	}
+	notes, ok := got["notes"]
+	if !ok {
+		t.Fatalf("expected notes in catalog, got %s", catalog)
+	}
+	if _, exists := notes["sourceTreeUrl"]; exists {
+		t.Fatalf("catalog notes sourceTreeUrl = %+v, want omitted for non-GitHub git", notes["sourceTreeUrl"])
+	}
+
+	overlay := getJSONPath(t, ts, "/api/v1/me/app-connections", http.StatusOK, "")
+	var statuses []map[string]any
+	if err := json.Unmarshal(overlay, &statuses); err != nil {
+		t.Fatalf("decode overlay: %v", err)
+	}
+	for _, status := range statuses {
+		if _, exists := status["sourceTreeUrl"]; exists {
+			t.Fatalf("connection overlay must not include catalog identity field sourceTreeUrl: %#v", status)
+		}
+	}
+
+	composed := getJSONPath(t, ts, "/api/v1/apps", http.StatusOK, "")
+	var integrations []map[string]any
+	if err := json.Unmarshal(composed, &integrations); err != nil {
+		t.Fatalf("decode composed listing: %v", err)
+	}
+	composedByName := map[string]map[string]any{}
+	for _, integration := range integrations {
+		name, _ := integration["name"].(string)
+		composedByName[name] = integration
+	}
+	if gotTree, _ := composedByName["roadmap"]["sourceTreeUrl"].(string); gotTree != wantGitHub {
+		t.Fatalf("composed roadmap sourceTreeUrl = %q, want %q: %s", gotTree, wantGitHub, composed)
+	}
+	if _, exists := composedByName["notes"]["sourceTreeUrl"]; exists {
+		t.Fatalf("composed notes sourceTreeUrl = %+v, want omitted", composedByName["notes"]["sourceTreeUrl"])
+	}
+}
+
 func TestAppCatalogOmitsCatalogHiddenApps(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/server/handlers_app_catalog_test.go
+++ b/gestaltd/internal/server/handlers_app_catalog_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/server"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"github.com/valon-technologies/gestalt/server/services/apps/declarative"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
@@ -272,6 +273,84 @@ func TestAppCatalogOmitsCatalogHiddenApps(t *testing.T) {
 	}
 
 	_ = getJSONPath(t, ts, "/api/v1/catalog/apps/publicHidden/icon", http.StatusNotFound, "Bearer listing-token")
+}
+
+func TestAppCatalogIncludesSchemaForRegistryOnlyApps(t *testing.T) {
+	t.Parallel()
+
+	subjectID := principal.UserSubjectID(testCanonicalAdminUserID)
+	authz := &serverTestAuthorizationProvider{
+		relationships: []*proto.Relationship{
+			testAuthorizationRelationship(subjectID, "admin", "app", "registry-only"),
+		},
+	}
+	svc := testutil.NewStubServices(t)
+	recording := newRecordingExternalCredentialProvider(svc.ExternalCredentials)
+	svc.ExternalCredentials = recording
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = authStubWithSessionTokenIntrospect("alice-token", subjectID, "")
+		cfg.Authorization = authz
+		cfg.Providers = testutil.NewProviderRegistry(t)
+		cfg.AppDefs = map[string]*config.ProviderEntry{
+			"registry-only": {
+				Source:      config.ProviderSource{Registry: "toolshed"},
+				DisplayName: "Registry Only",
+				Connections: map[string]*config.ConnectionDef{
+					"workspace": {
+						ConnectionID: "registry-only:workspace",
+						DisplayName:  "Workspace",
+						Mode:         providermanifestv1.ConnectionModeSubject,
+						Auth: config.ConnectionAuthDef{
+							Type: providermanifestv1.AuthTypeManual,
+						},
+					},
+				},
+			},
+		}
+		cfg.Services = svc
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	catalog := getJSONPath(t, ts, "/api/v1/catalog/apps", http.StatusOK, "Bearer alice-token")
+	if recording.listCredentialsCalls.Load() != 0 {
+		t.Fatalf("catalog listing consulted subject credentials %d times", recording.listCredentialsCalls.Load())
+	}
+	var catalogApps []map[string]any
+	if err := json.Unmarshal(catalog, &catalogApps); err != nil {
+		t.Fatalf("decode catalog: %v", err)
+	}
+	if len(catalogApps) != 1 || catalogApps[0]["name"] != "registry-only" {
+		t.Fatalf("catalog = %s", catalog)
+	}
+	connections, _ := catalogApps[0]["connections"].([]any)
+	if len(connections) != 1 {
+		t.Fatalf("registry-only catalog missing connection schema: %s", catalog)
+	}
+	catalogConn, _ := connections[0].(map[string]any)
+	if catalogConn["name"] != "workspace" {
+		t.Fatalf("catalog connection = %#v, want workspace", catalogConn)
+	}
+
+	overlay := getJSONPath(t, ts, "/api/v1/me/app-connections", http.StatusOK, "Bearer alice-token")
+	if recording.listCredentialsCalls.Load() == 0 {
+		t.Fatal("connection overlay did not list subject credentials")
+	}
+	var statuses []struct {
+		Name        string `json:"name"`
+		Connections []struct {
+			Name string `json:"name"`
+		} `json:"connections"`
+	}
+	if err := json.Unmarshal(overlay, &statuses); err != nil {
+		t.Fatalf("decode overlay: %v", err)
+	}
+	if len(statuses) != 1 || statuses[0].Name != "registry-only" {
+		t.Fatalf("overlay = %s", overlay)
+	}
+	if len(statuses[0].Connections) != 1 || statuses[0].Connections[0].Name != "workspace" {
+		t.Fatalf("overlay connections = %+v, want workspace so catalog and overlay zip", statuses[0].Connections)
+	}
 }
 
 func TestAppOverlayNoAuthIsNotProductConnected(t *testing.T) {

--- a/gestaltd/internal/server/handlers_tokens.go
+++ b/gestaltd/internal/server/handlers_tokens.go
@@ -168,17 +168,41 @@ func (s *Server) revokeAPIToken(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"status": "revoked"})
 }
 
-func (s *Server) connectionInfosForPlugin(ctx context.Context, integration string, app *config.ProviderEntry, instances []instanceInfo, integrationAuthTypes []string, p *principal.Principal) []connectionDefInfo {
+func (s *Server) attachDirectoryConnections(entry *appDirectoryEntry, plugin *config.ProviderEntry) {
+	if entry == nil {
+		return
+	}
+	entry.Advertised = s.advertisedConnectionsForPlugin(entry.Name, plugin)
+	entry.ConnectionSchema = s.connectionSchemasFromAdvertised(entry.Name, entry.Advertised)
+}
+
+type advertisedConnection struct {
+	Name               string
+	InstanceConnection string
+	Def                config.ConnectionDef
+	IncludeWithoutAuth bool
+}
+
+func (s *Server) advertisedConnectionsForPlugin(integration string, app *config.ProviderEntry) []advertisedConnection {
+	first := s.advertisedConnectionsForPluginWithAuthTypes(integration, app, nil)
+	resolved := s.authTypesForAdvertised(integration, first)
+	if len(resolved) == 0 {
+		return first
+	}
+	return s.advertisedConnectionsForPluginWithAuthTypes(integration, app, resolved)
+}
+
+func (s *Server) advertisedConnectionsForPluginWithAuthTypes(integration string, app *config.ProviderEntry, integrationAuthTypes []string) []advertisedConnection {
 	if app == nil {
-		return []connectionDefInfo{}
+		return []advertisedConnection{}
 	}
 	manifestSpec := app.ManifestSpec()
 	plan, err := config.BuildStaticConnectionPlan(app, manifestSpec)
 	if err != nil {
-		return []connectionDefInfo{}
+		return []advertisedConnection{}
 	}
 	names := plan.AdvertisedConnectionNames()
-	infos := make([]connectionDefInfo, 0, len(names))
+	out := make([]advertisedConnection, 0, len(names))
 	for _, name := range names {
 		conn, ok := plan.LookupConnection(name)
 		if !ok || shouldHidePassiveNamedConnection(plan, name, conn, integrationAuthTypes) {
@@ -187,58 +211,61 @@ func (s *Server) connectionInfosForPlugin(ctx context.Context, integration strin
 		if name == config.AppConnectionName {
 			conn = displayAppConnectionDef(app, manifestSpec, conn)
 		}
-		if info, ok := s.connectionInfoFromAuth(ctx, integration, userFacingConnectionName(name), name, conn, instances, integrationAuthTypes, name != config.AppConnectionName, p); ok {
-			infos = append(infos, info)
-		}
+		out = append(out, advertisedConnection{
+			Name:               userFacingConnectionName(name),
+			InstanceConnection: name,
+			Def:                conn,
+			IncludeWithoutAuth: name != config.AppConnectionName,
+		})
 	}
-
-	return infos
+	return out
 }
 
-func (s *Server) connectionSchemasForPlugin(integration string, app *config.ProviderEntry) []connectionSchemaInfo {
-	authTypes := []string{}
-	schemas := s.connectionSchemasForPluginWithAuthTypes(integration, app, authTypes)
-	resolvedAuthTypes := resolvedSchemaAuthTypes(schemas)
-	if len(authTypes) == 0 && len(resolvedAuthTypes) > 0 {
-		return s.connectionSchemasForPluginWithAuthTypes(integration, app, resolvedAuthTypes)
-	}
-	return schemas
-}
-
-func (s *Server) connectionSchemasForPluginWithAuthTypes(integration string, app *config.ProviderEntry, integrationAuthTypes []string) []connectionSchemaInfo {
-	if app == nil {
-		return []connectionSchemaInfo{}
-	}
-	manifestSpec := app.ManifestSpec()
-	plan, err := config.BuildStaticConnectionPlan(app, manifestSpec)
-	if err != nil {
-		return []connectionSchemaInfo{}
-	}
-	names := plan.AdvertisedConnectionNames()
-	schemas := make([]connectionSchemaInfo, 0, len(names))
-	for _, name := range names {
-		conn, ok := plan.LookupConnection(name)
-		if !ok || shouldHidePassiveNamedConnection(plan, name, conn, integrationAuthTypes) {
-			continue
-		}
-		if name == config.AppConnectionName {
-			conn = displayAppConnectionDef(app, manifestSpec, conn)
-		}
-		if schema, ok := s.connectionSchemaFromDef(integration, userFacingConnectionName(name), conn, name != config.AppConnectionName); ok {
+func (s *Server) connectionSchemasFromAdvertised(integration string, connections []advertisedConnection) []connectionSchemaInfo {
+	schemas := make([]connectionSchemaInfo, 0, len(connections))
+	for i := range connections {
+		conn := connections[i]
+		if schema, ok := s.connectionSchemaFromDef(integration, conn.Name, conn.Def, conn.IncludeWithoutAuth); ok {
 			schemas = append(schemas, schema)
 		}
 	}
 	return schemas
 }
 
+func (s *Server) connectionInfosFromAdvertised(ctx context.Context, integration string, connections []advertisedConnection, instances []instanceInfo, p *principal.Principal) []connectionDefInfo {
+	infos := make([]connectionDefInfo, 0, len(connections))
+	for i := range connections {
+		conn := connections[i]
+		if info, ok := s.connectionInfoFromAuth(ctx, integration, conn.Name, conn.InstanceConnection, conn.Def, instances, conn.IncludeWithoutAuth, p); ok {
+			infos = append(infos, info)
+		}
+	}
+	return infos
+}
+
+func (s *Server) authTypesForAdvertised(integration string, connections []advertisedConnection) []string {
+	combined := make([]string, 0, 2)
+	for i := range connections {
+		conn := connections[i]
+		authTypes := s.connectionAuthTypesForDef(integration, conn.Name, conn.Def)
+		if len(authTypes) == 0 && !conn.IncludeWithoutAuth {
+			continue
+		}
+		combined = append(combined, authTypes...)
+	}
+	return resolvedAuthTypes(combined)
+}
+
+func (s *Server) connectionAuthTypesForDef(integration, name string, conn config.ConnectionDef) []string {
+	return s.supportedConnectionAuthTypes(integration, name, connectionAuthTypes(conn.Auth, nil))
+}
+
 func (s *Server) connectionSchemaFromDef(integration, name string, conn config.ConnectionDef, includeWithoutAuth bool) (connectionSchemaInfo, bool) {
-	mode := config.ConnectionModeForConnection(conn)
-	authTypes := connectionAuthTypes(conn.Auth, nil)
-	authTypes = s.supportedConnectionAuthTypes(integration, name, authTypes)
+	authTypes := s.connectionAuthTypesForDef(integration, name, conn)
 	if len(authTypes) == 0 && !includeWithoutAuth {
 		return connectionSchemaInfo{}, false
 	}
-	displayMode := mode
+	displayMode := config.ConnectionModeForConnection(conn)
 	if displayMode == core.ConnectionModeNone && len(authTypes) > 0 {
 		displayMode = core.ConnectionModeSubject
 	}
@@ -265,17 +292,6 @@ func (s *Server) connectionSchemaFromDef(integration, name string, conn config.C
 		schema.CredentialFields = defaultManualCredentialFieldInfos()
 	}
 	return schema, true
-}
-
-func resolvedSchemaAuthTypes(connections []connectionSchemaInfo) []string {
-	combined := make([]string, 0, 2)
-	for i := range connections {
-		combined = append(combined, connections[i].AuthTypes...)
-	}
-	if authTypes := userFacingAuthTypes(combined); len(authTypes) > 0 {
-		return authTypes
-	}
-	return []string{}
 }
 
 func displayAppConnectionDef(app *config.ProviderEntry, manifestSpec *providermanifestv1.Spec, conn config.ConnectionDef) config.ConnectionDef {
@@ -308,14 +324,47 @@ func userFacingConnectionName(name string) string {
 	return name
 }
 
-func (s *Server) populateIntegrationSettings(ctx context.Context, info *integrationInfo, instances []instanceInfo, p *principal.Principal) []string {
-	authTypes := []string{}
-	info.Connections = s.connectionInfosForPlugin(ctx, info.Name, s.pluginDefs[info.Name], instances, authTypes, p)
-	resolvedAuthTypes := resolvedIntegrationAuthTypes(info.Connections)
-	if len(authTypes) == 0 && len(resolvedAuthTypes) > 0 {
-		info.Connections = s.connectionInfosForPlugin(ctx, info.Name, s.pluginDefs[info.Name], instances, resolvedAuthTypes, p)
+func (s *Server) connectionInfoFromAuth(ctx context.Context, integration, name, instanceConnection string, conn config.ConnectionDef, instances []instanceInfo, includeWithoutAuth bool, p *principal.Principal) (connectionDefInfo, bool) {
+	schema, ok := s.connectionSchemaFromDef(integration, name, conn, includeWithoutAuth)
+	if !ok {
+		return connectionDefInfo{}, false
 	}
-	return resolvedIntegrationAuthTypes(info.Connections)
+	connectionInstances := groupInstancesForConnection(instances, instanceConnection)
+	connectionID := serverCredentialConnectionID(integration, instanceConnection, conn)
+	subjectID, _ := principal.ResolveCredentialSubjectID(ctx, s.users, p)
+	storedPreferred := s.preferredInstanceForConnection(ctx, subjectID, connectionID)
+	status := noAuthConnectionStatus()
+	preferredInstance := ""
+	if schema.Mode != string(core.ConnectionModeNone) {
+		status = subjectConnectionStatus(connectionInstances, len(schema.AuthTypes) > 0, ownerKindForPrincipal(p), storedPreferred)
+		connectionInstances = markPreferredInstances(connectionInstances, storedPreferred)
+		// preferredInstance is the chosen account — omit stale/invalid store rows.
+		if preferredInstanceValid(connectionInstances, storedPreferred) {
+			preferredInstance = strings.TrimSpace(storedPreferred)
+		}
+	}
+
+	return connectionDefInfo{
+		DisplayName:       schema.DisplayName,
+		Name:              schema.Name,
+		Mode:              schema.Mode,
+		AuthTypes:         schema.AuthTypes,
+		ConnectionParams:  schema.ConnectionParams,
+		CredentialFields:  schema.CredentialFields,
+		Status:            status.Status,
+		CredentialState:   status.CredentialState,
+		HealthState:       status.HealthState,
+		Actions:           status.Actions,
+		CredentialMode:    status.CredentialMode,
+		OwnerKind:         status.OwnerKind,
+		Instances:         connectionInstances,
+		PreferredInstance: preferredInstance,
+		StatusCode:        status.StatusCode,
+		StatusReason:      status.StatusReason,
+		Connected:         status.Connected,
+		connectable:       len(schema.AuthTypes) > 0,
+		disconnectable:    status.Disconnectable,
+	}, true
 }
 
 func connectionParamInfosFromConnection(conn config.ConnectionDef) map[string]connectionParamInfo {
@@ -345,71 +394,6 @@ func credentialFieldInfos[T any](fields []T, mapField func(T) credentialFieldInf
 		infos[i] = mapField(field)
 	}
 	return infos
-}
-
-func (s *Server) connectionInfoFromAuth(ctx context.Context, integration, name, instanceConnection string, conn config.ConnectionDef, instances []instanceInfo, integrationAuthTypes []string, includeWithoutAuth bool, p *principal.Principal) (connectionDefInfo, bool) {
-	mode := config.ConnectionModeForConnection(conn)
-	connectionInstances := groupInstancesForConnection(instances, instanceConnection)
-	connectionParams := connectionParamInfosFromConnection(conn)
-	authTypes := connectionAuthTypes(conn.Auth, nil)
-	authTypes = s.supportedConnectionAuthTypes(integration, name, authTypes)
-	if len(authTypes) == 0 && !includeWithoutAuth {
-		return connectionDefInfo{}, false
-	}
-	displayMode := mode
-	if displayMode == core.ConnectionModeNone && len(authTypes) > 0 {
-		displayMode = core.ConnectionModeSubject
-	}
-	connectionID := serverCredentialConnectionID(integration, instanceConnection, conn)
-	subjectID, _ := principal.ResolveCredentialSubjectID(ctx, s.users, p)
-	storedPreferred := s.preferredInstanceForConnection(ctx, subjectID, connectionID)
-	status := noAuthConnectionStatus()
-	preferredInstance := ""
-	if displayMode != core.ConnectionModeNone {
-		status = subjectConnectionStatus(connectionInstances, len(authTypes) > 0, ownerKindForPrincipal(p), storedPreferred)
-		connectionInstances = markPreferredInstances(connectionInstances, storedPreferred)
-		// preferredInstance is the chosen account — omit stale/invalid store rows.
-		if preferredInstanceValid(connectionInstances, storedPreferred) {
-			preferredInstance = strings.TrimSpace(storedPreferred)
-		}
-	}
-
-	info := connectionDefInfo{
-		DisplayName:       connectionDisplayName(name, conn.DisplayName),
-		Name:              name,
-		Mode:              string(displayMode),
-		AuthTypes:         []string{},
-		ConnectionParams:  connectionParams,
-		CredentialFields:  []credentialFieldInfo{},
-		Status:            status.Status,
-		CredentialState:   status.CredentialState,
-		HealthState:       status.HealthState,
-		Actions:           status.Actions,
-		CredentialMode:    status.CredentialMode,
-		OwnerKind:         status.OwnerKind,
-		Instances:         connectionInstances,
-		PreferredInstance: preferredInstance,
-		StatusCode:        status.StatusCode,
-		StatusReason:      status.StatusReason,
-		Connected:         status.Connected,
-		connectable:       len(authTypes) > 0,
-		disconnectable:    status.Disconnectable,
-	}
-	if len(authTypes) > 0 {
-		info.AuthTypes = authTypes
-	}
-	if fields := credentialFieldInfos(conn.Auth.Credentials, func(field config.CredentialFieldDef) credentialFieldInfo {
-		return credentialFieldInfo{
-			Name:        field.Name,
-			Label:       field.Label,
-			Description: field.Description,
-		}
-	}); len(fields) > 0 {
-		info.CredentialFields = fields
-	} else if authTypesContain(authTypes, "manual") {
-		info.CredentialFields = defaultManualCredentialFieldInfos()
-	}
-	return info, true
 }
 
 func (s *Server) invocationConnectionMode(prov core.Provider, integration, connection string) core.ConnectionMode {
@@ -511,12 +495,15 @@ func connectionDisplayName(name, configured string) string {
 	return userFacingConnectionName(name)
 }
 
-func resolvedIntegrationAuthTypes(connections []connectionDefInfo) []string {
+func resolvedAuthTypesFromConnections(connections []connectionDefInfo) []string {
 	combined := make([]string, 0, 2)
 	for i := range connections {
-		connection := &connections[i]
-		combined = append(combined, connection.AuthTypes...)
+		combined = append(combined, connections[i].AuthTypes...)
 	}
+	return resolvedAuthTypes(combined)
+}
+
+func resolvedAuthTypes(combined []string) []string {
 	if authTypes := userFacingAuthTypes(combined); len(authTypes) > 0 {
 		return authTypes
 	}

--- a/gestaltd/internal/server/handlers_tokens.go
+++ b/gestaltd/internal/server/handlers_tokens.go
@@ -195,6 +195,89 @@ func (s *Server) connectionInfosForPlugin(ctx context.Context, integration strin
 	return infos
 }
 
+func (s *Server) connectionSchemasForPlugin(integration string, app *config.ProviderEntry) []connectionSchemaInfo {
+	authTypes := []string{}
+	schemas := s.connectionSchemasForPluginWithAuthTypes(integration, app, authTypes)
+	resolvedAuthTypes := resolvedSchemaAuthTypes(schemas)
+	if len(authTypes) == 0 && len(resolvedAuthTypes) > 0 {
+		return s.connectionSchemasForPluginWithAuthTypes(integration, app, resolvedAuthTypes)
+	}
+	return schemas
+}
+
+func (s *Server) connectionSchemasForPluginWithAuthTypes(integration string, app *config.ProviderEntry, integrationAuthTypes []string) []connectionSchemaInfo {
+	if app == nil {
+		return []connectionSchemaInfo{}
+	}
+	manifestSpec := app.ManifestSpec()
+	plan, err := config.BuildStaticConnectionPlan(app, manifestSpec)
+	if err != nil {
+		return []connectionSchemaInfo{}
+	}
+	names := plan.AdvertisedConnectionNames()
+	schemas := make([]connectionSchemaInfo, 0, len(names))
+	for _, name := range names {
+		conn, ok := plan.LookupConnection(name)
+		if !ok || shouldHidePassiveNamedConnection(plan, name, conn, integrationAuthTypes) {
+			continue
+		}
+		if name == config.AppConnectionName {
+			conn = displayAppConnectionDef(app, manifestSpec, conn)
+		}
+		if schema, ok := s.connectionSchemaFromDef(integration, userFacingConnectionName(name), conn, name != config.AppConnectionName); ok {
+			schemas = append(schemas, schema)
+		}
+	}
+	return schemas
+}
+
+func (s *Server) connectionSchemaFromDef(integration, name string, conn config.ConnectionDef, includeWithoutAuth bool) (connectionSchemaInfo, bool) {
+	mode := config.ConnectionModeForConnection(conn)
+	authTypes := connectionAuthTypes(conn.Auth, nil)
+	authTypes = s.supportedConnectionAuthTypes(integration, name, authTypes)
+	if len(authTypes) == 0 && !includeWithoutAuth {
+		return connectionSchemaInfo{}, false
+	}
+	displayMode := mode
+	if displayMode == core.ConnectionModeNone && len(authTypes) > 0 {
+		displayMode = core.ConnectionModeSubject
+	}
+	schema := connectionSchemaInfo{
+		DisplayName:      connectionDisplayName(name, conn.DisplayName),
+		Name:             name,
+		Mode:             string(displayMode),
+		AuthTypes:        []string{},
+		ConnectionParams: connectionParamInfosFromConnection(conn),
+		CredentialFields: []credentialFieldInfo{},
+	}
+	if len(authTypes) > 0 {
+		schema.AuthTypes = authTypes
+	}
+	if fields := credentialFieldInfos(conn.Auth.Credentials, func(field config.CredentialFieldDef) credentialFieldInfo {
+		return credentialFieldInfo{
+			Name:        field.Name,
+			Label:       field.Label,
+			Description: field.Description,
+		}
+	}); len(fields) > 0 {
+		schema.CredentialFields = fields
+	} else if authTypesContain(authTypes, "manual") {
+		schema.CredentialFields = defaultManualCredentialFieldInfos()
+	}
+	return schema, true
+}
+
+func resolvedSchemaAuthTypes(connections []connectionSchemaInfo) []string {
+	combined := make([]string, 0, 2)
+	for i := range connections {
+		combined = append(combined, connections[i].AuthTypes...)
+	}
+	if authTypes := userFacingAuthTypes(combined); len(authTypes) > 0 {
+		return authTypes
+	}
+	return []string{}
+}
+
 func displayAppConnectionDef(app *config.ProviderEntry, manifestSpec *providermanifestv1.Spec, conn config.ConnectionDef) config.ConnectionDef {
 	if app == nil || manifestSpec == nil || manifestSpec.IsManifestBacked() {
 		return conn

--- a/gestaltd/internal/server/integration_visibility.go
+++ b/gestaltd/internal/server/integration_visibility.go
@@ -14,35 +14,6 @@ func (s *Server) integrationHiddenFromCatalog(provider string) bool {
 	return ok && entry != nil && entry.Static != nil && entry.Static.CatalogHidden
 }
 
-func (s *Server) integrationHasUsableSurfaceContext(ctx context.Context, p *principal.Principal, provider string, prov core.Provider, info integrationInfo) (bool, error) {
-	if info.MountedPath != "" {
-		return true, nil
-	}
-	if info.ManagementPath != "" {
-		return true, nil
-	}
-	if s.integrationHasSettingsSurface(p, info) {
-		settingsAccessible, err := s.integrationSettingsAccessibleContext(ctx, p, provider)
-		if err != nil {
-			return false, err
-		}
-		if settingsAccessible {
-			return true, nil
-		}
-	}
-	return s.integrationHasVisibleHTTPOperationsContext(ctx, p, provider, prov)
-}
-
-func (s *Server) integrationHasSettingsSurface(p *principal.Principal, info integrationInfo) bool {
-	if principal.IsNonUserPrincipal(p) {
-		return false
-	}
-	return info.CredentialState == credentialStateConnected ||
-		info.CredentialState == credentialStateConfigured ||
-		info.CredentialState == credentialStateNotRequired ||
-		len(info.Connections) > 0
-}
-
 func (s *Server) integrationSettingsAccessibleContext(ctx context.Context, p *principal.Principal, provider string) (bool, error) {
 	if s == nil || s.authorization == nil {
 		return true, nil

--- a/gestaltd/internal/server/routes_user.go
+++ b/gestaltd/internal/server/routes_user.go
@@ -12,6 +12,10 @@ func (s *Server) mountAuthenticatedRoutes(r chi.Router) {
 	r.Group(func(r chi.Router) {
 		r.Use(s.authMiddleware)
 
+		r.Get("/catalog/apps", s.listAppCatalog)
+		r.Get("/catalog/apps/{name}/icon", s.serveAppCatalogIcon)
+		r.Get("/me/app-connections", s.listAppConnections)
+
 		r.Get("/apps", s.listIntegrations)
 		r.Delete("/apps/{name}", s.disconnectIntegration)
 		r.Put("/apps/{name}/preferred-instance", s.selectPreferredInstance)


### PR DESCRIPTION
## Summary

The Apps list mixed directory data (names, icons, connection schema) with each signed-in user's stored credentials. That made the list slow and large enough to fail at the gateway. This splits the contract: a cheap catalog with no credential reads, a per-user connection overlay, and icons by URL. The old listing stays as a composed compatibility response.

## Why / context

A typical list response was about five seconds and hundreds of kilobytes, with large inline SVG icons. Auth was fine. The console then spun on Loading until the gateway returned unavailable.

Caching or stripping icons from the mixed payload would still run credential I/O on every catalog paint. The durable split is two resources with different owners: the directory does not depend on this user, and connection status does.

`connected` now means this identity has a chosen account. A no-auth or mode-none row is ready to use, not product-connected. That stops a leftover webhook row from making an app look installed while another connection still needs sign-in.

## What changed

- `GET /api/v1/catalog/apps` returns directory and connection schema. It does not list stored credentials. Icons are URLs, not inline bytes.
- `GET /api/v1/catalog/apps/{name}/icon` serves one SVG without rebuilding the full listing.
- `GET /api/v1/me/app-connections` returns this subject's status, instances, and `connected`.
- `GET /api/v1/apps` still returns the composed listing for CLI and older consoles, including `iconSvg`.
- Catalog visibility uses schema, mount, and access, not live credential state.
- Registry-only directory rows advertise connection schema from plugin config so catalog and overlay zip. Implicit Connect is not invented when no provider is loaded.

## Validation

- [x] Automated: `go test ./internal/server/ -count=1 -run 'TestListIntegrations|TestAppsListing|TestAppCatalog|TestNoAuth|TestSummarize|TestAppOverlay'`
- [ ] Not run: live production listing after deploy. Confirm catalog latency and that Apps still paints when credentials are slow.

## Reviewer focus

- Catalog must never call `ListCredentials`. Overlay and composed listing must.
- Icon lookup should complete one provider, not assemble the whole directory.
- Registry-only directory rows should still advertise connection schema from plugin config so catalog and overlay zip.
- No-auth `connected` is false. A mixed webhook plus missing user connection must not roll the app to connected.

## Rollout / compatibility

Ship this daemon before or with the console consumer. Older consoles keep using `GET /api/v1/apps`. The new console falls back to that listing only when the catalog route is missing (404), not when it fails (503). Rollback is revert.

## Links

Companion console: https://github.com/valon-technologies/gestalt-providers/pull/1277