### PR TITLE
Expose app source tree URLs on the apps list

### DIFF
--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -470,41 +470,6 @@ func (g GitSourceDef) Location() string {
 	return "git+" + repo + "@" + ref + "#" + manifestPath
 }
 
-// TreeURL is the browseable GitHub tree for this git source: the app
-// directory (parent of the manifest), not the install locator from Location.
-func (g GitSourceDef) TreeURL() string {
-	repo, ref, manifestPath := g.NormalizedLocationParts()
-	if repo == "" || ref == "" {
-		return ""
-	}
-	parsed, err := url.Parse(repo)
-	if err != nil {
-		return ""
-	}
-	if parsed.Scheme != "https" && parsed.Scheme != "http" {
-		return ""
-	}
-	if !strings.EqualFold(parsed.Host, "github.com") {
-		return ""
-	}
-	clean := strings.Trim(path.Clean(parsed.Path), "/")
-	parts := strings.Split(clean, "/")
-	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-		return ""
-	}
-	owner := parts[0]
-	name := strings.TrimSuffix(parts[1], ".git")
-	if name == "" {
-		return ""
-	}
-	treePath := "/" + owner + "/" + name + "/tree/" + ref
-	dir := path.Dir(manifestPath)
-	if dir != "" && dir != "." {
-		treePath += "/" + dir
-	}
-	return (&url.URL{Scheme: "https", Host: "github.com", Path: treePath}).String()
-}
-
 // NormalizedLocationParts returns the canonical repo, ref, and manifest path used by Location.
 func (g GitSourceDef) NormalizedLocationParts() (repo, ref, manifestPath string) {
 	return normalizeGitLocationRepoURL(g.Repo),
@@ -1700,8 +1665,8 @@ func (e *ProviderEntry) HasGitSource() bool {
 	return e != nil && e.Source.IsGit()
 }
 
-// SourceTreeURL is the browseable source tree for Overview and other
-// catalog surfaces. Empty when the app has no GitHub git source.
+// SourceTreeURL is the GitHub website tree for this app's checkout identity.
+// Empty when the app has no GitHub git source.
 func (e *ProviderEntry) SourceTreeURL() string {
 	if e == nil || !e.HasGitSource() {
 		return ""

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -470,6 +470,41 @@ func (g GitSourceDef) Location() string {
 	return "git+" + repo + "@" + ref + "#" + manifestPath
 }
 
+// TreeURL is the browseable GitHub tree for this git source: the app
+// directory (parent of the manifest), not the install locator from Location.
+func (g GitSourceDef) TreeURL() string {
+	repo, ref, manifestPath := g.NormalizedLocationParts()
+	if repo == "" || ref == "" {
+		return ""
+	}
+	parsed, err := url.Parse(repo)
+	if err != nil {
+		return ""
+	}
+	if parsed.Scheme != "https" && parsed.Scheme != "http" {
+		return ""
+	}
+	if !strings.EqualFold(parsed.Host, "github.com") {
+		return ""
+	}
+	clean := strings.Trim(path.Clean(parsed.Path), "/")
+	parts := strings.Split(clean, "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return ""
+	}
+	owner := parts[0]
+	name := strings.TrimSuffix(parts[1], ".git")
+	if name == "" {
+		return ""
+	}
+	treePath := "/" + owner + "/" + name + "/tree/" + ref
+	dir := path.Dir(manifestPath)
+	if dir != "" && dir != "." {
+		treePath += "/" + dir
+	}
+	return (&url.URL{Scheme: "https", Host: "github.com", Path: treePath}).String()
+}
+
 // NormalizedLocationParts returns the canonical repo, ref, and manifest path used by Location.
 func (g GitSourceDef) NormalizedLocationParts() (repo, ref, manifestPath string) {
 	return normalizeGitLocationRepoURL(g.Repo),
@@ -1663,6 +1698,19 @@ func (e *ProviderEntry) HasLocalReleaseSource() bool {
 
 func (e *ProviderEntry) HasGitSource() bool {
 	return e != nil && e.Source.IsGit()
+}
+
+// SourceTreeURL is the browseable source tree for Overview and other
+// catalog surfaces. Empty when the app has no GitHub git source.
+func (e *ProviderEntry) SourceTreeURL() string {
+	if e == nil || !e.HasGitSource() {
+		return ""
+	}
+	git := e.Source.GitSource()
+	if git == nil {
+		return ""
+	}
+	return git.TreeURL()
 }
 
 func (e *ProviderEntry) SourceMetadataURL() string {

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -7423,6 +7423,32 @@ func TestGitSourceDefIdentity(t *testing.T) {
 	}
 }
 
+func TestAppDirFromManifestPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{name: "nested", path: "apps/foo/manifest.yaml", want: "apps/foo"},
+		{name: "root", path: "manifest.yaml", want: ""},
+		{name: "messy", path: "apps//foo/../foo/manifest.yaml", want: "apps/foo"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := AppDirFromManifestPath(tc.path); got != tc.want {
+				t.Fatalf("AppDirFromManifestPath(%q) = %q, want %q", tc.path, got, tc.want)
+			}
+			git := GitSourceDef{Path: tc.path}
+			if got := git.AppDir(); got != tc.want {
+				t.Fatalf("GitSourceDef.AppDir(%q) = %q, want %q", tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestGitSourceDefTreeURL(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -7412,11 +7412,11 @@ func TestGitSourceDefTreeURL(t *testing.T) {
 		{
 			name: "github app directory",
 			git: GitSourceDef{
-				Repo: "https://github.com/example/toolshed.git",
+				Repo: "https://github.com/example/apps.git",
 				Ref:  "main",
 				Path: "apps/roadmap/manifest.yaml",
 			},
-			want: "https://github.com/example/toolshed/tree/main/apps/roadmap",
+			want: "https://github.com/example/apps/tree/main/apps/roadmap",
 		},
 		{
 			name: "github root manifest",

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -2072,6 +2072,10 @@ apps:
 			manifestPath != "apps/custom_tool/manifest.yaml" {
 			t.Fatalf("NormalizedLocationParts = (%q, %q, %q)", repo, ref, manifestPath)
 		}
+		wantTree := "https://github.com/Valon-Technologies/Gestalt-Providers/tree/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/apps/custom_tool"
+		if got := entry.SourceTreeURL(); got != wantTree {
+			t.Fatalf("SourceTreeURL = %q, want %q", got, wantTree)
+		}
 	})
 
 	t.Run("apiVersion preserves nested source auth on local release metadata sources", func(t *testing.T) {
@@ -7394,5 +7398,56 @@ func TestEffectiveHTTPBindingsOverridesStreaming(t *testing.T) {
 	bindings := entry.EffectiveHTTPBindings()
 	if bindings["echo"] == nil || !bindings["echo"].Streaming {
 		t.Fatalf("EffectiveHTTPBindings did not apply override streaming: got %+v", bindings["echo"])
+	}
+}
+
+func TestGitSourceDefTreeURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		git  GitSourceDef
+		want string
+	}{
+		{
+			name: "github app directory",
+			git: GitSourceDef{
+				Repo: "https://github.com/example/toolshed.git",
+				Ref:  "main",
+				Path: "apps/roadmap/manifest.yaml",
+			},
+			want: "https://github.com/example/toolshed/tree/main/apps/roadmap",
+		},
+		{
+			name: "github root manifest",
+			git: GitSourceDef{
+				Repo: "https://github.com/example/app.git",
+				Ref:  "abc123",
+				Path: "manifest.yaml",
+			},
+			want: "https://github.com/example/app/tree/abc123",
+		},
+		{
+			name: "non-github omitted",
+			git: GitSourceDef{
+				Repo: "https://gitlab.example.com/group/app.git",
+				Ref:  "main",
+				Path: "apps/foo/manifest.yaml",
+			},
+			want: "",
+		},
+		{
+			name: "missing repo omitted",
+			git:  GitSourceDef{Ref: "main", Path: "apps/foo/manifest.yaml"},
+			want: "",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tc.git.TreeURL(); got != tc.want {
+				t.Fatalf("TreeURL = %q, want %q", got, tc.want)
+			}
+		})
 	}
 }

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -2072,7 +2072,7 @@ apps:
 			manifestPath != "apps/custom_tool/manifest.yaml" {
 			t.Fatalf("NormalizedLocationParts = (%q, %q, %q)", repo, ref, manifestPath)
 		}
-		wantTree := "https://github.com/Valon-Technologies/Gestalt-Providers/tree/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/apps/custom_tool"
+		wantTree := "https://github.com/Valon-Technologies/Gestalt-Providers/tree/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/apps/custom_tool"
 		if got := entry.SourceTreeURL(); got != wantTree {
 			t.Fatalf("SourceTreeURL = %q, want %q", got, wantTree)
 		}
@@ -7401,6 +7401,28 @@ func TestEffectiveHTTPBindingsOverridesStreaming(t *testing.T) {
 	}
 }
 
+func TestGitSourceDefIdentity(t *testing.T) {
+	t.Parallel()
+
+	git := GitSourceDef{
+		Repo: "HTTPS://GitHub.com/Ex/App.git",
+		Ref:  "feat/ui",
+		Path: "apps/foo/manifest.yaml",
+	}
+	got, ok := git.Identity()
+	if !ok {
+		t.Fatal("Identity() = false, want GitHub checkout identity")
+	}
+	want := GitSourceIdentity{
+		Repo:   GitHubRepo{Owner: "Ex", Name: "App"},
+		Ref:    "feat/ui",
+		AppDir: "apps/foo",
+	}
+	if got != want {
+		t.Fatalf("Identity() = %+v, want %+v", got, want)
+	}
+}
+
 func TestGitSourceDefTreeURL(t *testing.T) {
 	t.Parallel()
 
@@ -7426,6 +7448,42 @@ func TestGitSourceDefTreeURL(t *testing.T) {
 				Path: "manifest.yaml",
 			},
 			want: "https://github.com/example/app/tree/abc123",
+		},
+		{
+			name: "ssh scp",
+			git: GitSourceDef{
+				Repo: "git@github.com:example/apps.git",
+				Ref:  "main",
+				Path: "apps/roadmap/manifest.yaml",
+			},
+			want: "https://github.com/example/apps/tree/main/apps/roadmap",
+		},
+		{
+			name: "http github",
+			git: GitSourceDef{
+				Repo: "http://github.com/example/apps.git",
+				Ref:  "main",
+				Path: "apps/roadmap/manifest.yaml",
+			},
+			want: "https://github.com/example/apps/tree/main/apps/roadmap",
+		},
+		{
+			name: "preserves configured ref case",
+			git: GitSourceDef{
+				Repo: "https://github.com/example/apps.git",
+				Ref:  "Release-1",
+				Path: "apps/foo/manifest.yaml",
+			},
+			want: "https://github.com/example/apps/tree/Release-1/apps/foo",
+		},
+		{
+			name: "slash in ref is one path segment",
+			git: GitSourceDef{
+				Repo: "https://github.com/example/apps.git",
+				Ref:  "feat/ui",
+				Path: "apps/roadmap/manifest.yaml",
+			},
+			want: "https://github.com/example/apps/tree/feat%2Fui/apps/roadmap",
 		},
 		{
 			name: "non-github omitted",

--- a/gestaltd/internal/config/git_source_identity.go
+++ b/gestaltd/internal/config/git_source_identity.go
@@ -27,11 +27,23 @@ func (g GitSourceDef) Identity() (GitSourceIdentity, bool) {
 	if ref == "" {
 		return GitSourceIdentity{}, false
 	}
-	appDir := path.Dir(normalizeGitLocationManifestPath(g.Path))
-	if appDir == "." {
-		appDir = ""
+	return GitSourceIdentity{Repo: repo, Ref: ref, AppDir: g.AppDir()}, true
+}
+
+// AppDir is the app directory (parent of the manifest). Empty when the
+// manifest is at the repository root.
+func (g GitSourceDef) AppDir() string {
+	return AppDirFromManifestPath(g.Path)
+}
+
+// AppDirFromManifestPath is the app directory for a git source manifest path.
+// Empty when the manifest is at the repository root.
+func AppDirFromManifestPath(manifestPath string) string {
+	dir := path.Dir(normalizeGitLocationManifestPath(manifestPath))
+	if dir == "." {
+		return ""
 	}
-	return GitSourceIdentity{Repo: repo, Ref: ref, AppDir: appDir}, true
+	return dir
 }
 
 // TreeURL is the GitHub website projection of Identity. Empty when this

--- a/gestaltd/internal/config/git_source_identity.go
+++ b/gestaltd/internal/config/git_source_identity.go
@@ -1,0 +1,64 @@
+package config
+
+import (
+	"net/url"
+	"path"
+	"strings"
+)
+
+// GitSourceIdentity is the checkout identity of a GitHub git source: the
+// repository, the configured ref, and the app directory (parent of the
+// manifest). It is not an install locator and not a published commit.
+type GitSourceIdentity struct {
+	Repo   GitHubRepo
+	Ref    string
+	AppDir string
+}
+
+// Identity is the GitHub checkout identity for this git source. False when
+// the repo is not github.com or the ref is missing. The ref is the configured
+// value, not the lowercased install-locator form from NormalizedLocationParts.
+func (g GitSourceDef) Identity() (GitSourceIdentity, bool) {
+	repo, err := ParseGitHubRepo(g.Repo)
+	if err != nil {
+		return GitSourceIdentity{}, false
+	}
+	ref := strings.TrimSpace(g.Ref)
+	if ref == "" {
+		return GitSourceIdentity{}, false
+	}
+	appDir := path.Dir(normalizeGitLocationManifestPath(g.Path))
+	if appDir == "." {
+		appDir = ""
+	}
+	return GitSourceIdentity{Repo: repo, Ref: ref, AppDir: appDir}, true
+}
+
+// TreeURL is the GitHub website projection of Identity. Empty when this
+// source has no GitHub identity. The ref is escaped as a single path
+// segment, so a slash in the ref becomes %2F.
+func (g GitSourceDef) TreeURL() string {
+	id, ok := g.Identity()
+	if !ok {
+		return ""
+	}
+	return id.TreeURL()
+}
+
+// TreeURL is https://github.com/<owner>/<name>/tree/<ref>/<appDir>.
+func (id GitSourceIdentity) TreeURL() string {
+	if id.Repo.Owner == "" || id.Repo.Name == "" || id.Ref == "" {
+		return ""
+	}
+	p := "/" + url.PathEscape(id.Repo.Owner) + "/" + url.PathEscape(id.Repo.Name) +
+		"/tree/" + url.PathEscape(id.Ref)
+	if dir := strings.Trim(id.AppDir, "/"); dir != "" {
+		for _, seg := range strings.Split(dir, "/") {
+			if seg == "" || seg == "." {
+				continue
+			}
+			p += "/" + url.PathEscape(seg)
+		}
+	}
+	return "https://github.com" + p
+}

--- a/gestaltd/internal/config/github_repo.go
+++ b/gestaltd/internal/config/github_repo.go
@@ -1,0 +1,63 @@
+package config
+
+import (
+	"fmt"
+	"net/url"
+	"path"
+	"strings"
+)
+
+// GitHubRepo is the owner/name of a github.com repository.
+type GitHubRepo struct {
+	Owner string
+	Name  string
+}
+
+// ParseGitHubRepo extracts owner and name from an http(s), ssh, or
+// git@github.com: URL. Other hosts fail; callers decide whether that is
+// omitted or an error.
+func ParseGitHubRepo(raw string) (GitHubRepo, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return GitHubRepo{}, fmt.Errorf("github repo URL is empty")
+	}
+	const sshPrefix = "git@github.com:"
+	if strings.HasPrefix(raw, sshPrefix) {
+		return gitHubRepoFromPath(strings.TrimPrefix(raw, sshPrefix))
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return GitHubRepo{}, fmt.Errorf("parse github repo URL: %w", err)
+	}
+	if !isGitHubHost(parsed.Host) {
+		return GitHubRepo{}, fmt.Errorf("not a github.com repository: %q", raw)
+	}
+	switch parsed.Scheme {
+	case "http", "https", "ssh":
+		return gitHubRepoFromPath(parsed.Path)
+	default:
+		return GitHubRepo{}, fmt.Errorf("not a github.com repository: %q", raw)
+	}
+}
+
+func isGitHubHost(host string) bool {
+	switch strings.ToLower(host) {
+	case "github.com", "www.github.com":
+		return true
+	default:
+		return false
+	}
+}
+
+func gitHubRepoFromPath(p string) (GitHubRepo, error) {
+	clean := strings.Trim(path.Clean(p), "/")
+	parts := strings.Split(clean, "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" || parts[0] == "." {
+		return GitHubRepo{}, fmt.Errorf("github repo path must be <owner>/<repo>")
+	}
+	name := strings.TrimSuffix(parts[1], ".git")
+	if name == "" {
+		return GitHubRepo{}, fmt.Errorf("github repo path must be <owner>/<repo>")
+	}
+	return GitHubRepo{Owner: parts[0], Name: name}, nil
+}

--- a/gestaltd/internal/config/github_repo.go
+++ b/gestaltd/internal/config/github_repo.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"path"
@@ -60,4 +61,29 @@ func gitHubRepoFromPath(p string) (GitHubRepo, error) {
 		return GitHubRepo{}, fmt.Errorf("github repo path must be <owner>/<repo>")
 	}
 	return GitHubRepo{Owner: parts[0], Name: name}, nil
+}
+
+const gitHubSnapshotRemoteErr = "source.git snapshots require https://github.com/<owner>/<repo>[.git]"
+
+// ParseGitHubSnapshotRemote extracts owner and name from a GitHub remote that
+// snapshots accept: https://github.com/<owner>/<repo> or git@github.com:<owner>/<repo>.
+// Other forms that ParseGitHubRepo accepts (http, ssh://, www.github.com) fail here.
+func ParseGitHubSnapshotRemote(raw string) (GitHubRepo, error) {
+	raw = strings.TrimSpace(raw)
+	if !gitHubSnapshotRemoteForm(raw) {
+		return GitHubRepo{}, errors.New(gitHubSnapshotRemoteErr)
+	}
+	repo, err := ParseGitHubRepo(raw)
+	if err != nil {
+		return GitHubRepo{}, errors.New(gitHubSnapshotRemoteErr)
+	}
+	return repo, nil
+}
+
+func gitHubSnapshotRemoteForm(raw string) bool {
+	if strings.HasPrefix(raw, "git@github.com:") {
+		return true
+	}
+	parsed, err := url.Parse(raw)
+	return err == nil && parsed.Scheme == "https" && strings.EqualFold(parsed.Host, "github.com")
 }

--- a/gestaltd/internal/config/github_repo_test.go
+++ b/gestaltd/internal/config/github_repo_test.go
@@ -1,0 +1,78 @@
+package config
+
+import "testing"
+
+func TestParseGitHubRepo(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		raw     string
+		want    GitHubRepo
+		wantErr bool
+	}{
+		{
+			name: "https with git suffix",
+			raw:  "https://github.com/example/apps.git",
+			want: GitHubRepo{Owner: "example", Name: "apps"},
+		},
+		{
+			name: "http",
+			raw:  "http://github.com/example/apps",
+			want: GitHubRepo{Owner: "example", Name: "apps"},
+		},
+		{
+			name: "www host",
+			raw:  "https://www.github.com/example/apps.git",
+			want: GitHubRepo{Owner: "example", Name: "apps"},
+		},
+		{
+			name: "ssh scp",
+			raw:  "git@github.com:example/apps.git",
+			want: GitHubRepo{Owner: "example", Name: "apps"},
+		},
+		{
+			name: "ssh url",
+			raw:  "ssh://git@github.com/example/apps.git",
+			want: GitHubRepo{Owner: "example", Name: "apps"},
+		},
+		{
+			name: "preserves owner case",
+			raw:  "https://github.com/Valon-Technologies/Gestalt-Providers.git",
+			want: GitHubRepo{Owner: "Valon-Technologies", Name: "Gestalt-Providers"},
+		},
+		{
+			name:    "gitlab omitted",
+			raw:     "https://gitlab.example.com/group/app.git",
+			wantErr: true,
+		},
+		{
+			name:    "empty",
+			raw:     "  ",
+			wantErr: true,
+		},
+		{
+			name:    "missing name",
+			raw:     "https://github.com/example",
+			wantErr: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := ParseGitHubRepo(tc.raw)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("ParseGitHubRepo(%q) = %+v, want error", tc.raw, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseGitHubRepo(%q): %v", tc.raw, err)
+			}
+			if got != tc.want {
+				t.Fatalf("ParseGitHubRepo(%q) = %+v, want %+v", tc.raw, got, tc.want)
+			}
+		})
+	}
+}

--- a/gestaltd/internal/config/github_repo_test.go
+++ b/gestaltd/internal/config/github_repo_test.go
@@ -76,3 +76,73 @@ func TestParseGitHubRepo(t *testing.T) {
 		})
 	}
 }
+
+func TestParseGitHubSnapshotRemote(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		raw     string
+		want    GitHubRepo
+		wantErr bool
+	}{
+		{
+			name: "https",
+			raw:  "https://github.com/example/apps.git",
+			want: GitHubRepo{Owner: "example", Name: "apps"},
+		},
+		{
+			name: "ssh scp",
+			raw:  "git@github.com:example/apps.git",
+			want: GitHubRepo{Owner: "example", Name: "apps"},
+		},
+		{
+			name: "preserves owner case",
+			raw:  "https://github.com/Valon-Technologies/Gestalt-Providers.git",
+			want: GitHubRepo{Owner: "Valon-Technologies", Name: "Gestalt-Providers"},
+		},
+		{
+			name:    "http rejected",
+			raw:     "http://github.com/example/apps.git",
+			wantErr: true,
+		},
+		{
+			name:    "ssh url rejected",
+			raw:     "ssh://git@github.com/example/apps.git",
+			wantErr: true,
+		},
+		{
+			name:    "www host rejected",
+			raw:     "https://www.github.com/example/apps.git",
+			wantErr: true,
+		},
+		{
+			name:    "gitlab rejected",
+			raw:     "https://gitlab.example.com/group/app.git",
+			wantErr: true,
+		},
+		{
+			name:    "empty",
+			raw:     "  ",
+			wantErr: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := ParseGitHubSnapshotRemote(tc.raw)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("ParseGitHubSnapshotRemote(%q) = %+v, want error", tc.raw, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseGitHubSnapshotRemote(%q): %v", tc.raw, err)
+			}
+			if got != tc.want {
+				t.Fatalf("ParseGitHubSnapshotRemote(%q) = %+v, want %+v", tc.raw, got, tc.want)
+			}
+		})
+	}
+}

--- a/gestaltd/internal/operator/git_source.go
+++ b/gestaltd/internal/operator/git_source.go
@@ -38,7 +38,7 @@ type SnapshotSourceRefPath struct {
 }
 
 func NewSnapshotSourceRefPath(repoURL, ref, manifestPath string) (SnapshotSourceRefPath, error) {
-	host, owner, name, err := githubRepoPath(repoURL)
+	repo, err := config.ParseGitHubSnapshotRemote(repoURL)
 	if err != nil {
 		return SnapshotSourceRefPath{}, err
 	}
@@ -47,11 +47,8 @@ func NewSnapshotSourceRefPath(repoURL, ref, manifestPath string) (SnapshotSource
 	if manifestPath == "" || manifestPath == "." || strings.HasPrefix(manifestPath, "../") || path.IsAbs(manifestPath) {
 		return SnapshotSourceRefPath{}, fmt.Errorf("source.git.path must be a clean relative path")
 	}
-	providerDir := path.Dir(manifestPath)
-	if providerDir == "." {
-		providerDir = ""
-	}
-	sourceRepository := path.Join(host, owner, name)
+	providerDir := config.AppDirFromManifestPath(manifestPath)
+	sourceRepository := path.Join("github.com", repo.Owner, repo.Name)
 	parts := []string{sourceRepository, sourceRef}
 	if providerDir != "" {
 		parts = append(parts, strings.Split(providerDir, "/")...)
@@ -177,24 +174,6 @@ func snapshotSourceFileURL(base string, snapshotPath SnapshotSourceRefPath, file
 	query.Set("sourceRef", snapshotPath.SourceRef)
 	parsed.RawQuery = query.Encode()
 	return parsed.String(), nil
-}
-
-// githubRepoPath uses the shared GitHub owner/name parser, then keeps the
-// snapshot rule: https://github.com/<owner>/<repo> or git@github.com:.
-func githubRepoPath(raw string) (string, string, string, error) {
-	raw = strings.TrimSpace(raw)
-	repo, err := config.ParseGitHubRepo(raw)
-	if err != nil {
-		return "", "", "", fmt.Errorf("source.git snapshots require https://github.com/<owner>/<repo>[.git]")
-	}
-	if strings.HasPrefix(raw, "git@github.com:") {
-		return "github.com", repo.Owner, repo.Name, nil
-	}
-	parsed, err := url.Parse(raw)
-	if err != nil || parsed.Scheme != "https" || !strings.EqualFold(parsed.Host, "github.com") {
-		return "", "", "", fmt.Errorf("source.git snapshots require https://github.com/<owner>/<repo>[.git]")
-	}
-	return "github.com", repo.Owner, repo.Name, nil
 }
 
 func (l *Lifecycle) gitSourceManifestPath(ctx context.Context, paths lifecyclePaths, entry *config.ProviderEntry) (string, error) {

--- a/gestaltd/internal/operator/git_source.go
+++ b/gestaltd/internal/operator/git_source.go
@@ -179,28 +179,22 @@ func snapshotSourceFileURL(base string, snapshotPath SnapshotSourceRefPath, file
 	return parsed.String(), nil
 }
 
+// githubRepoPath uses the shared GitHub owner/name parser, then keeps the
+// snapshot rule: https://github.com/<owner>/<repo> or git@github.com:.
 func githubRepoPath(raw string) (string, string, string, error) {
 	raw = strings.TrimSpace(raw)
-	const sshPrefix = "git@github.com:"
-	if strings.HasPrefix(raw, sshPrefix) {
-		owner, repo, ok := strings.Cut(strings.TrimPrefix(raw, sshPrefix), "/")
-		if ok && owner != "" && repo != "" {
-			return "github.com", owner, strings.TrimSuffix(repo, ".git"), nil
-		}
-	}
-	parsed, err := url.Parse(strings.TrimSpace(raw))
+	repo, err := config.ParseGitHubRepo(raw)
 	if err != nil {
-		return "", "", "", fmt.Errorf("parse source.git.repo: %w", err)
-	}
-	if parsed.Scheme != "https" || !strings.EqualFold(parsed.Host, "github.com") {
 		return "", "", "", fmt.Errorf("source.git snapshots require https://github.com/<owner>/<repo>[.git]")
 	}
-	clean := strings.Trim(path.Clean(parsed.Path), "/")
-	parts := strings.Split(clean, "/")
-	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+	if strings.HasPrefix(raw, "git@github.com:") {
+		return "github.com", repo.Owner, repo.Name, nil
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Scheme != "https" || !strings.EqualFold(parsed.Host, "github.com") {
 		return "", "", "", fmt.Errorf("source.git snapshots require https://github.com/<owner>/<repo>[.git]")
 	}
-	return "github.com", parts[0], strings.TrimSuffix(parts[1], ".git"), nil
+	return "github.com", repo.Owner, repo.Name, nil
 }
 
 func (l *Lifecycle) gitSourceManifestPath(ctx context.Context, paths lifecyclePaths, entry *config.ProviderEntry) (string, error) {

--- a/gestaltd/internal/operator/git_source_test.go
+++ b/gestaltd/internal/operator/git_source_test.go
@@ -5,6 +5,48 @@ import (
 	"testing"
 )
 
+func TestNewSnapshotSourceRefPathRemoteForm(t *testing.T) {
+	t.Parallel()
+
+	const ref = "CBF01DE477C362F96AACB814F7246F07C7ADB3A0"
+	const manifest = "app/vercel/manifest.yaml"
+	wantRepo := "github.com/example/apps"
+
+	tests := []struct {
+		name    string
+		repo    string
+		wantErr bool
+	}{
+		{name: "https", repo: "https://github.com/example/apps.git"},
+		{name: "ssh scp", repo: "git@github.com:example/apps.git"},
+		{name: "http rejected", repo: "http://github.com/example/apps.git", wantErr: true},
+		{name: "ssh url rejected", repo: "ssh://git@github.com/example/apps.git", wantErr: true},
+		{name: "www host rejected", repo: "https://www.github.com/example/apps.git", wantErr: true},
+		{name: "gitlab rejected", repo: "https://gitlab.example.com/group/app.git", wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := NewSnapshotSourceRefPath(tc.repo, ref, manifest)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("NewSnapshotSourceRefPath(%q) = %+v, want error", tc.repo, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("NewSnapshotSourceRefPath(%q): %v", tc.repo, err)
+			}
+			if got.SourceRepository != wantRepo {
+				t.Fatalf("SourceRepository = %q, want %q", got.SourceRepository, wantRepo)
+			}
+			if got.ProviderDir != "app/vercel" {
+				t.Fatalf("ProviderDir = %q, want app/vercel", got.ProviderDir)
+			}
+		})
+	}
+}
+
 func TestSnapshotSourceFileURLAddsSourceRefQuery(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -99,7 +99,7 @@ type integrationInfo struct {
 	MountedPath     string              `json:"mountedPath,omitempty"`
 	ManagementPath  string              `json:"managementPath,omitempty"`
 	Prompts         []appPromptInfo     `json:"prompts,omitempty"`
-	SourceURL       string              `json:"sourceUrl,omitempty"`
+	SourceTreeURL   string              `json:"sourceTreeUrl,omitempty"`
 	Connections     []connectionDefInfo `json:"connections"`
 	Status          string              `json:"status"`
 	CredentialState string              `json:"credentialState"`
@@ -266,10 +266,11 @@ func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 		if cat := prov.Catalog(); cat != nil {
 			info.IconSVG = cat.IconSVG
 		}
-		if entry, ok := s.pluginDefs[name]; ok && entry != nil && entry.Static != nil {
+		entry := s.pluginDefs[name]
+		if entry != nil && entry.Static != nil {
 			info.MountedPath = strings.TrimSpace(entry.Static.Mount)
 		}
-		info.SourceURL = s.appSourceTreeURL(name)
+		info.SourceTreeURL = entry.SourceTreeURL()
 		info.Prompts = s.appPrompts[name]
 		instances := connected[name]
 		authTypes := s.populateIntegrationSettings(r.Context(), &info, instances, p)
@@ -312,26 +313,14 @@ func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 			ManagementPath:  managementPath,
 			Prompts:         s.appPrompts[app.name],
 		}
-		if entry, ok := s.pluginDefs[app.name]; ok && entry != nil && entry.Static != nil {
+		entry := s.pluginDefs[app.name]
+		if entry != nil && entry.Static != nil {
 			info.MountedPath = s.integrationMountedPathForPrincipalContext(r.Context(), p, app.name, strings.TrimSpace(entry.Static.Mount))
 		}
-		info.SourceURL = s.appSourceTreeURL(app.name)
+		info.SourceTreeURL = entry.SourceTreeURL()
 		out = append(out, info)
 	}
 	writeJSON(w, http.StatusOK, out)
-}
-
-// appSourceTreeURL is the catalog source URL for an app: the GitHub tree of
-// the deploy git directory, or empty when the app has no GitHub git source.
-func (s *Server) appSourceTreeURL(name string) string {
-	if s == nil {
-		return ""
-	}
-	entry := s.pluginDefs[name]
-	if entry == nil {
-		return ""
-	}
-	return entry.SourceTreeURL()
 }
 
 func (s *Server) integrationManagementPath(ctx context.Context, p *principal.Principal, appName string) string {

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -99,6 +99,7 @@ type integrationInfo struct {
 	MountedPath     string              `json:"mountedPath,omitempty"`
 	ManagementPath  string              `json:"managementPath,omitempty"`
 	Prompts         []appPromptInfo     `json:"prompts,omitempty"`
+	SourceURL       string              `json:"sourceUrl,omitempty"`
 	Connections     []connectionDefInfo `json:"connections"`
 	Status          string              `json:"status"`
 	CredentialState string              `json:"credentialState"`
@@ -265,8 +266,11 @@ func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 		if cat := prov.Catalog(); cat != nil {
 			info.IconSVG = cat.IconSVG
 		}
-		if entry, ok := s.pluginDefs[name]; ok && entry != nil && entry.Static != nil {
-			info.MountedPath = strings.TrimSpace(entry.Static.Mount)
+		if entry, ok := s.pluginDefs[name]; ok && entry != nil {
+			if entry.Static != nil {
+				info.MountedPath = strings.TrimSpace(entry.Static.Mount)
+			}
+			info.SourceURL = entry.SourceTreeURL()
 		}
 		info.Prompts = s.appPrompts[name]
 		instances := connected[name]
@@ -310,8 +314,11 @@ func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 			ManagementPath:  managementPath,
 			Prompts:         s.appPrompts[app.name],
 		}
-		if entry, ok := s.pluginDefs[app.name]; ok && entry != nil && entry.Static != nil {
-			info.MountedPath = s.integrationMountedPathForPrincipalContext(r.Context(), p, app.name, strings.TrimSpace(entry.Static.Mount))
+		if entry, ok := s.pluginDefs[app.name]; ok && entry != nil {
+			if entry.Static != nil {
+				info.MountedPath = s.integrationMountedPathForPrincipalContext(r.Context(), p, app.name, strings.TrimSpace(entry.Static.Mount))
+			}
+			info.SourceURL = entry.SourceTreeURL()
 		}
 		out = append(out, info)
 	}

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -266,12 +266,10 @@ func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 		if cat := prov.Catalog(); cat != nil {
 			info.IconSVG = cat.IconSVG
 		}
-		if entry, ok := s.pluginDefs[name]; ok && entry != nil {
-			if entry.Static != nil {
-				info.MountedPath = strings.TrimSpace(entry.Static.Mount)
-			}
-			info.SourceURL = entry.SourceTreeURL()
+		if entry, ok := s.pluginDefs[name]; ok && entry != nil && entry.Static != nil {
+			info.MountedPath = strings.TrimSpace(entry.Static.Mount)
 		}
+		info.SourceURL = s.appSourceTreeURL(name)
 		info.Prompts = s.appPrompts[name]
 		instances := connected[name]
 		authTypes := s.populateIntegrationSettings(r.Context(), &info, instances, p)
@@ -314,15 +312,26 @@ func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 			ManagementPath:  managementPath,
 			Prompts:         s.appPrompts[app.name],
 		}
-		if entry, ok := s.pluginDefs[app.name]; ok && entry != nil {
-			if entry.Static != nil {
-				info.MountedPath = s.integrationMountedPathForPrincipalContext(r.Context(), p, app.name, strings.TrimSpace(entry.Static.Mount))
-			}
-			info.SourceURL = entry.SourceTreeURL()
+		if entry, ok := s.pluginDefs[app.name]; ok && entry != nil && entry.Static != nil {
+			info.MountedPath = s.integrationMountedPathForPrincipalContext(r.Context(), p, app.name, strings.TrimSpace(entry.Static.Mount))
 		}
+		info.SourceURL = s.appSourceTreeURL(app.name)
 		out = append(out, info)
 	}
 	writeJSON(w, http.StatusOK, out)
+}
+
+// appSourceTreeURL is the catalog source URL for an app: the GitHub tree of
+// the deploy git directory, or empty when the app has no GitHub git source.
+func (s *Server) appSourceTreeURL(name string) string {
+	if s == nil {
+		return ""
+	}
+	entry := s.pluginDefs[name]
+	if entry == nil {
+		return ""
+	}
+	return entry.SourceTreeURL()
 }
 
 func (s *Server) integrationManagementPath(ctx context.Context, p *principal.Principal, appName string) string {

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -4293,6 +4293,52 @@ func TestListIntegrations_IncludesMountedPath(t *testing.T) {
 	}
 }
 
+func TestListIntegrations_IncludesSourceURL(t *testing.T) {
+	t.Parallel()
+
+	stub := &coretesting.StubIntegration{N: "roadmap", DN: "Roadmap"}
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		defs := testPluginDefsForConnections("roadmap", "default")
+		defs["roadmap"].Source = config.ProviderSource{
+			Git: &config.GitSourceDef{
+				Repo: "https://github.com/example/toolshed.git",
+				Ref:  "main",
+				Path: "apps/roadmap/manifest.yaml",
+			},
+		}
+		cfg.AppDefs = defs
+		cfg.Services = testutil.NewStubServices(t)
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/apps", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var integrations []struct {
+		Name      string `json:"name"`
+		SourceURL string `json:"sourceUrl"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&integrations); err != nil {
+		t.Fatalf("decoding: %v", err)
+	}
+	if len(integrations) != 1 {
+		t.Fatalf("expected 1 integration, got %d", len(integrations))
+	}
+	want := "https://github.com/example/toolshed/tree/main/apps/roadmap"
+	if integrations[0].Name != "roadmap" || integrations[0].SourceURL != want {
+		t.Fatalf("integration = %+v, want sourceUrl %q", integrations[0], want)
+	}
+}
+
 func TestListIntegrations_IncludesPrompts(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -4296,17 +4296,27 @@ func TestListIntegrations_IncludesMountedPath(t *testing.T) {
 func TestListIntegrations_IncludesSourceURL(t *testing.T) {
 	t.Parallel()
 
-	stub := &coretesting.StubIntegration{N: "roadmap", DN: "Roadmap"}
+	githubApp := &coretesting.StubIntegration{N: "roadmap", DN: "Roadmap"}
+	gitlabApp := &coretesting.StubIntegration{N: "notes", DN: "Notes"}
 	ts := newTestServer(t, func(cfg *server.Config) {
-		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		cfg.Providers = testutil.NewProviderRegistry(t, githubApp, gitlabApp)
 		defs := testPluginDefsForConnections("roadmap", "default")
 		defs["roadmap"].Source = config.ProviderSource{
 			Git: &config.GitSourceDef{
-				Repo: "https://github.com/example/toolshed.git",
+				Repo: "https://github.com/example/apps.git",
 				Ref:  "main",
 				Path: "apps/roadmap/manifest.yaml",
 			},
 		}
+		notes := testPluginDefsForConnections("notes", "default")["notes"]
+		notes.Source = config.ProviderSource{
+			Git: &config.GitSourceDef{
+				Repo: "https://gitlab.example.com/group/app.git",
+				Ref:  "main",
+				Path: "apps/notes/manifest.yaml",
+			},
+		}
+		defs["notes"] = notes
 		cfg.AppDefs = defs
 		cfg.Services = testutil.NewStubServices(t)
 	})
@@ -4330,12 +4340,19 @@ func TestListIntegrations_IncludesSourceURL(t *testing.T) {
 	if err := json.NewDecoder(resp.Body).Decode(&integrations); err != nil {
 		t.Fatalf("decoding: %v", err)
 	}
-	if len(integrations) != 1 {
-		t.Fatalf("expected 1 integration, got %d", len(integrations))
+	got := map[string]string{}
+	for _, integration := range integrations {
+		got[integration.Name] = integration.SourceURL
 	}
-	want := "https://github.com/example/toolshed/tree/main/apps/roadmap"
-	if integrations[0].Name != "roadmap" || integrations[0].SourceURL != want {
-		t.Fatalf("integration = %+v, want sourceUrl %q", integrations[0], want)
+	wantGitHub := "https://github.com/example/apps/tree/main/apps/roadmap"
+	if got["roadmap"] != wantGitHub {
+		t.Fatalf("roadmap sourceUrl = %q, want %q (apps=%+v)", got["roadmap"], wantGitHub, integrations)
+	}
+	if _, ok := got["notes"]; !ok {
+		t.Fatalf("expected notes in apps list, got %+v", integrations)
+	}
+	if got["notes"] != "" {
+		t.Fatalf("notes sourceUrl = %q, want omitted empty for non-GitHub git", got["notes"])
 	}
 }
 

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -4293,7 +4293,7 @@ func TestListIntegrations_IncludesMountedPath(t *testing.T) {
 	}
 }
 
-func TestListIntegrations_IncludesSourceURL(t *testing.T) {
+func TestListIntegrations_IncludesSourceTreeURL(t *testing.T) {
 	t.Parallel()
 
 	githubApp := &coretesting.StubIntegration{N: "roadmap", DN: "Roadmap"}
@@ -4333,26 +4333,35 @@ func TestListIntegrations_IncludesSourceURL(t *testing.T) {
 		t.Fatalf("expected 200, got %d", resp.StatusCode)
 	}
 
-	var integrations []struct {
-		Name      string `json:"name"`
-		SourceURL string `json:"sourceUrl"`
-	}
+	var integrations []map[string]any
 	if err := json.NewDecoder(resp.Body).Decode(&integrations); err != nil {
 		t.Fatalf("decoding: %v", err)
 	}
-	got := map[string]string{}
+	got := map[string]map[string]any{}
 	for _, integration := range integrations {
-		got[integration.Name] = integration.SourceURL
+		name, _ := integration["name"].(string)
+		got[name] = integration
+	}
+	roadmap, ok := got["roadmap"]
+	if !ok {
+		t.Fatalf("expected roadmap in apps list, got %+v", integrations)
+	}
+	if _, exists := roadmap["sourceUrl"]; exists {
+		t.Fatalf("catalog must not emit version-commit sourceUrl: %+v", roadmap)
 	}
 	wantGitHub := "https://github.com/example/apps/tree/main/apps/roadmap"
-	if got["roadmap"] != wantGitHub {
-		t.Fatalf("roadmap sourceUrl = %q, want %q (apps=%+v)", got["roadmap"], wantGitHub, integrations)
+	if gotTree, _ := roadmap["sourceTreeUrl"].(string); gotTree != wantGitHub {
+		t.Fatalf("roadmap sourceTreeUrl = %q, want %q (apps=%+v)", gotTree, wantGitHub, integrations)
 	}
-	if _, ok := got["notes"]; !ok {
+	notes, ok := got["notes"]
+	if !ok {
 		t.Fatalf("expected notes in apps list, got %+v", integrations)
 	}
-	if got["notes"] != "" {
-		t.Fatalf("notes sourceUrl = %q, want omitted empty for non-GitHub git", got["notes"])
+	if _, exists := notes["sourceTreeUrl"]; exists {
+		t.Fatalf("notes sourceTreeUrl = %+v, want omitted for non-GitHub git", notes["sourceTreeUrl"])
+	}
+	if _, exists := notes["sourceUrl"]; exists {
+		t.Fatalf("catalog must not emit version-commit sourceUrl: %+v", notes)
 	}
 }
 


### PR DESCRIPTION
## Summary

The apps list now includes a GitHub folder link for each app that is deployed from git. Clients can send people to the directory they should clone, instead of a commit page, a package id, or a manifest file.

## Why / context

Operators looking at a running app could not tell where the source lives. Existing strings on the server answer different questions: git location includes a commit and often points at `manifest.yaml`, resolved source is a package id (and can name the wrong clone repo), and per-version source URLs are commit pages for admins.

The deploy config already stores repo, ref, and provider path. That is the canonical checkout identity. This change names that identity, then publishes a GitHub website tree URL as a projection of it. The apps list field is `sourceTreeUrl` so it cannot be confused with per-version commit `sourceUrl`.

## What changed

- `GET /api/v1/apps` may include `sourceTreeUrl` when the app has a GitHub git source.
- The URL is projected from checkout identity: owner/name, the configured ref (not the lowercased install locator), and the app directory. A slash in the ref is escaped as one path segment.
- GitHub owner/name parsing lives next to the git source in config. Snapshot loading uses a stricter snapshot-remote parser (`https://github.com` or `git@github.com:`) and the same app-directory helper as checkout identity.
- The field is omitted for local paths, GitLab, and other hosts with no adapter.

## Validation

- [x] Automated: `go test ./internal/config -run 'TestParseGitHubRepo|TestParseGitHubSnapshotRemote|TestGitSourceDefIdentity|TestGitSourceDefTreeURL|TestAppDirFromManifestPath|TestLoadSucceedsWithoutRuntimeFields'`
- [x] Automated: `go test ./internal/operator -run 'TestNewSnapshotSourceRefPath|TestSnapshotSourceFileURL'`
- [x] Automated: `go test ./internal/server -run TestListIntegrations_IncludesSourceTreeURL`
- [x] Automated: PR CI green on HEAD `0af4e0d48` (Go lint/vet, Go tests, Helm, Bugbot, Semgrep)
- [ ] Not run: live `GET /api/v1/apps` against production, because current deployments do not yet emit this field

## Reviewer focus

GitHub-only is intentional for this first host. Confirm `sourceTreeUrl` on the catalog stays distinct from admin version `sourceUrl`.

## Rollout / compatibility

Additive optional JSON field. Older clients ignore it. Rollback is revert. The companion UI reads `sourceTreeUrl`; ship this API before that Overview row can appear against a live deployment.

## Evidence / demo

No rendered UI in this repository. The Overview App folder row and recording live on the companion UI change.

## Links

Companion UI: https://github.com/valon-technologies/gestalt-providers/pull/1280
