### PR TITLE
Fix new API tokens missing from Settings

### DIFF
--- a/gestaltd/internal/server/grant_helpers.go
+++ b/gestaltd/internal/server/grant_helpers.go
@@ -7,8 +7,10 @@ import (
 	"strings"
 	"time"
 
+	gestalt "github.com/valon-technologies/gestalt/sdk/go"
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/services/identity"
+	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 )
 
 type createGrantResponse struct {
@@ -24,7 +26,20 @@ func (s *Server) callerAuthContext(ctx context.Context, r *http.Request) context
 	if err != nil || strings.TrimSpace(token) == "" {
 		return ctx
 	}
-	return identity.WithCallerBearerToken(ctx, token)
+	token = strings.TrimSpace(token)
+	ctx = identity.WithCallerBearerToken(ctx, token)
+	p := PrincipalFromContext(ctx)
+	if p == nil {
+		return ctx
+	}
+	subject := strings.TrimSpace(principal.Canonicalized(p).SubjectID)
+	if subject == "" {
+		return ctx
+	}
+	call := gestalt.IdentityCallContextFromContext(ctx)
+	call.CallerSubjectID = subject
+	ctx = gestalt.WithIdentityCallContext(ctx, call)
+	return gestalt.WithTrustedCallerSubject(ctx, subject)
 }
 
 func (s *Server) callerBearerToken(r *http.Request) (string, error) {

--- a/gestaltd/internal/server/grant_helpers_test.go
+++ b/gestaltd/internal/server/grant_helpers_test.go
@@ -1,10 +1,39 @@
 package server
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	gestalt "github.com/valon-technologies/gestalt/sdk/go"
 	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 )
+
+func TestCallerAuthContextAttachesCanonicalSubject(t *testing.T) {
+	t.Parallel()
+
+	s := &Server{}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tokens", nil)
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: "session-token"})
+	canonical := "user:11111111-1111-1111-1111-111111111111"
+	ctx := principal.WithPrincipal(req.Context(), &principal.Principal{
+		SubjectID: canonical,
+		Kind:      principal.KindUser,
+	})
+
+	got := s.callerAuthContext(ctx, req)
+	call := gestalt.IdentityCallContextFromContext(got)
+	if call.CallerBearerToken != "session-token" {
+		t.Fatalf("CallerBearerToken = %q, want session-token", call.CallerBearerToken)
+	}
+	if call.CallerSubjectID != canonical {
+		t.Fatalf("CallerSubjectID = %q, want %q", call.CallerSubjectID, canonical)
+	}
+	if gestalt.TrustedCallerSubjectFromContext(got) != canonical {
+		t.Fatalf("TrustedCallerSubject = %q, want %q", gestalt.TrustedCallerSubjectFromContext(got), canonical)
+	}
+}
 
 func TestTokenExpiresIn(t *testing.T) {
 	t.Parallel()

--- a/gestaltd/internal/server/handlers_tokens_test.go
+++ b/gestaltd/internal/server/handlers_tokens_test.go
@@ -87,6 +87,9 @@ func TestCreateAPITokenForwardsExpiresIn(t *testing.T) {
 	if stub.lastTokenExchangeReq == nil {
 		t.Fatal("token exchange request was not captured")
 	}
+	if stub.lastTokenExchangeCaller == "" {
+		t.Fatal("token exchange CallerSubjectID was empty")
+	}
 	if stub.lastTokenExchangeReq.ExpiresIn != 7776000 {
 		t.Fatalf("ExpiresIn = %d, want 7776000", stub.lastTokenExchangeReq.ExpiresIn)
 	}

--- a/gestaltd/internal/server/handlers_tokens_test.go
+++ b/gestaltd/internal/server/handlers_tokens_test.go
@@ -87,8 +87,8 @@ func TestCreateAPITokenForwardsExpiresIn(t *testing.T) {
 	if stub.lastTokenExchangeReq == nil {
 		t.Fatal("token exchange request was not captured")
 	}
-	if stub.lastTokenExchangeCaller == "" {
-		t.Fatal("token exchange CallerSubjectID was empty")
+	if stub.lastTokenExchangeCaller != "user:test-user" {
+		t.Fatalf("token exchange CallerSubjectID = %q, want user:test-user", stub.lastTokenExchangeCaller)
 	}
 	if stub.lastTokenExchangeReq.ExpiresIn != 7776000 {
 		t.Fatalf("ExpiresIn = %d, want 7776000", stub.lastTokenExchangeReq.ExpiresIn)

--- a/gestaltd/internal/server/test_auth_stubs_test.go
+++ b/gestaltd/internal/server/test_auth_stubs_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	gestalt "github.com/valon-technologies/gestalt/sdk/go"
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/session"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
@@ -71,12 +72,13 @@ func testIntrospectActive(subjectID, scope string) *core.IntrospectResponse {
 
 type grantTrackingAuthStub struct {
 	coretesting.StubAuthProvider
-	mu                   sync.Mutex
-	grants               map[string]*core.GetGrantResponse
-	revoked              map[string]struct{}
-	pendingScope         string
-	pendingState         string
-	lastTokenExchangeReq *core.TokenRequest
+	mu                      sync.Mutex
+	grants                  map[string]*core.GetGrantResponse
+	revoked                 map[string]struct{}
+	pendingScope            string
+	pendingState            string
+	lastTokenExchangeReq    *core.TokenRequest
+	lastTokenExchangeCaller string
 }
 
 func newGrantTrackingAuthStub() *grantTrackingAuthStub {
@@ -117,7 +119,7 @@ func newGrantTrackingAuthStub() *grantTrackingAuthStub {
 			return &core.IntrospectResponse{Active: false}, nil
 		}
 	}
-	stub.TokenFn = func(_ context.Context, req *core.TokenRequest) (*core.TokenResponse, error) {
+	stub.TokenFn = func(ctx context.Context, req *core.TokenRequest) (*core.TokenResponse, error) {
 		if req == nil {
 			return nil, fmt.Errorf("token request is required")
 		}
@@ -131,6 +133,7 @@ func newGrantTrackingAuthStub() *grantTrackingAuthStub {
 				copied := *req
 				stub.lastTokenExchangeReq = &copied
 			}
+			stub.lastTokenExchangeCaller = gestalt.IdentityCallContextFromContext(ctx).CallerSubjectID
 			intro, introErr := stub.IntrospectFn(context.Background(), &core.IntrospectRequest{Token: req.SubjectToken})
 			if introErr != nil || intro == nil || !intro.Active {
 				return nil, fmt.Errorf("inactive subject token")

--- a/gestaltd/services/identity/caller_bearer_token_test.go
+++ b/gestaltd/services/identity/caller_bearer_token_test.go
@@ -1,0 +1,28 @@
+package identity
+
+import (
+	"context"
+	"testing"
+
+	gestalt "github.com/valon-technologies/gestalt/sdk/go"
+)
+
+func TestWithCallerBearerTokenPreservesCallerSubject(t *testing.T) {
+	t.Parallel()
+
+	ctx := gestalt.WithIdentityCallContext(context.Background(), gestalt.IdentityCallContext{
+		CallerSubjectID: "user:11111111-1111-1111-1111-111111111111",
+		Introspection:   &gestalt.IntrospectResponse{Active: true, Subject: "user:login@example.test"},
+	})
+	got := WithCallerBearerToken(ctx, "session-token")
+	call := gestalt.IdentityCallContextFromContext(got)
+	if call.CallerBearerToken != "session-token" {
+		t.Fatalf("CallerBearerToken = %q, want session-token", call.CallerBearerToken)
+	}
+	if call.CallerSubjectID != "user:11111111-1111-1111-1111-111111111111" {
+		t.Fatalf("CallerSubjectID = %q, want canonical user id", call.CallerSubjectID)
+	}
+	if call.Introspection == nil || !call.Introspection.Active {
+		t.Fatal("Introspection was dropped")
+	}
+}

--- a/gestaltd/services/identity/caller_subject_hop_test.go
+++ b/gestaltd/services/identity/caller_subject_hop_test.go
@@ -53,7 +53,7 @@ func (p *recordingIdentityProvider) Authorize(context.Context, *gestalt.Authoriz
 }
 
 func (p *recordingIdentityProvider) Token(ctx context.Context, _ *gestalt.TokenRequest) (*gestalt.TokenResponse, error) {
-	call := gestalt.IdentityCallContextFromContext(gestalt.AuthCallContextFromIncoming(ctx))
+	call := gestalt.IdentityCallContextFromContext(ctx)
 	p.mu.Lock()
 	p.callerSubjectID = call.CallerSubjectID
 	p.mu.Unlock()

--- a/gestaltd/services/identity/caller_subject_hop_test.go
+++ b/gestaltd/services/identity/caller_subject_hop_test.go
@@ -52,8 +52,12 @@ func (p *recordingIdentityProvider) Authorize(context.Context, *gestalt.Authoriz
 	return nil, status.Error(codes.Unimplemented, "not implemented")
 }
 
-func (p *recordingIdentityProvider) Token(context.Context, *gestalt.TokenRequest) (*gestalt.TokenResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "not implemented")
+func (p *recordingIdentityProvider) Token(ctx context.Context, _ *gestalt.TokenRequest) (*gestalt.TokenResponse, error) {
+	call := gestalt.IdentityCallContextFromContext(gestalt.AuthCallContextFromIncoming(ctx))
+	p.mu.Lock()
+	p.callerSubjectID = call.CallerSubjectID
+	p.mu.Unlock()
+	return &gestalt.TokenResponse{AccessToken: "hop-token", TokenType: "Bearer", GrantID: "grant-hop"}, nil
 }
 
 func (p *recordingIdentityProvider) Introspect(context.Context, *gestalt.IntrospectRequest) (*gestalt.IntrospectResponse, error) {
@@ -175,6 +179,16 @@ func TestHostServiceIdentityHopPropagatesCallerSubject(t *testing.T) {
 	}
 	if got := recording.callerSubject(); got != "user:hop-caller" {
 		t.Fatalf("executable provider CallerSubjectID = %q, want user:hop-caller", got)
+	}
+
+	_, err = proto.NewIdentityClient(hostConn).Token(rpcCtx, &proto.TokenRequest{
+		GrantType: "urn:ietf:params:oauth:grant-type:token-exchange",
+	})
+	if err != nil {
+		t.Fatalf("Token via host service: %v", err)
+	}
+	if got := recording.callerSubject(); got != "user:hop-caller" {
+		t.Fatalf("Token() executable provider CallerSubjectID = %q, want user:hop-caller", got)
 	}
 }
 

--- a/gestaltd/services/identity/client.go
+++ b/gestaltd/services/identity/client.go
@@ -373,9 +373,12 @@ func userInfoResponseFromProto(resp *proto.UserInfoResponse) *core.UserInfoRespo
 	}
 }
 
-// WithCallerBearerToken attaches the caller bearer token for caller-relative RPCs.
+// WithCallerBearerToken attaches the caller bearer token for caller-relative RPCs
+// without dropping an existing CallerSubjectID or Introspection.
 func WithCallerBearerToken(ctx context.Context, token string) context.Context {
-	ctx = gestalt.WithIdentityCallContext(ctx, gestalt.IdentityCallContext{CallerBearerToken: token})
+	call := gestalt.IdentityCallContextFromContext(ctx)
+	call.CallerBearerToken = token
+	ctx = gestalt.WithIdentityCallContext(ctx, call)
 	return metadata.AppendToOutgoingContext(ctx, gestalt.CallerBearerTokenMetadataKey, token)
 }
 

--- a/gestaltd/services/identity/client.go
+++ b/gestaltd/services/identity/client.go
@@ -164,6 +164,7 @@ func (p *remoteIdentityProvider) Authorize(ctx context.Context, req *core.Author
 func (p *remoteIdentityProvider) Token(ctx context.Context, req *core.TokenRequest) (*core.TokenResponse, error) {
 	ctx, cancel := runtimehost.ProviderCallContext(ctx)
 	defer cancel()
+	ctx = p.outgoingIdentityCallContext(ctx)
 
 	resp, err := p.client.Token(ctx, tokenRequestToProto(req))
 	if err != nil {

--- a/gestaltd/services/identity/server.go
+++ b/gestaltd/services/identity/server.go
@@ -44,7 +44,7 @@ func (s *providerServer) Token(ctx context.Context, req *proto.TokenRequest) (*p
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "request is required")
 	}
-	resp, err := s.provider.Token(ctx, tokenRequestFromProto(req))
+	resp, err := s.provider.Token(gestalt.AuthCallContextFromIncoming(ctx), tokenRequestFromProto(req))
 	if err != nil {
 		return nil, identityToGRPCError("token", err)
 	}

--- a/sdk/go/identity_server.go
+++ b/sdk/go/identity_server.go
@@ -35,7 +35,7 @@ func (s *authServer) Token(ctx context.Context, req *proto.TokenRequest) (*proto
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "request is required")
 	}
-	resp, err := s.auth.Token(ctx, tokenRequestFromProto(req))
+	resp, err := s.auth.Token(AuthCallContextFromIncoming(ctx), tokenRequestFromProto(req))
 	if err != nil {
 		return nil, providerRPCError("token", err)
 	}

--- a/sdk/go/identity_transport_test.go
+++ b/sdk/go/identity_transport_test.go
@@ -22,9 +22,10 @@ type configCall struct {
 
 type fullIdentityProvider struct {
 	closeTracker
-	configured []configCall
-	started    int
-	revoked    []string
+	configured         []configCall
+	started            int
+	revoked            []string
+	tokenCallerSubject string
 }
 
 func (p *fullIdentityProvider) Configure(_ context.Context, name string, config map[string]any) error {
@@ -63,7 +64,8 @@ func (p *fullIdentityProvider) Authorize(_ context.Context, req *gestalt.Authori
 	}, nil
 }
 
-func (p *fullIdentityProvider) Token(_ context.Context, req *gestalt.TokenRequest) (*gestalt.TokenResponse, error) {
+func (p *fullIdentityProvider) Token(ctx context.Context, req *gestalt.TokenRequest) (*gestalt.TokenResponse, error) {
+	p.tokenCallerSubject = gestalt.IdentityCallContextFromContext(ctx).CallerSubjectID
 	if req == nil || req.Code != "auth-code" {
 		return nil, status.Error(codes.InvalidArgument, "invalid authorization code")
 	}
@@ -335,6 +337,19 @@ func TestIdentityProviderRoundTrip(t *testing.T) {
 	}
 	if proofSubjectUserInfo.SubjectID != "user:user@example.test" {
 		t.Fatalf("userinfo(validated caller proof) subject_id = %q, want %q", proofSubjectUserInfo.SubjectID, "user:user@example.test")
+	}
+
+	tokenWithSubjectCtx := metadata.AppendToOutgoingContext(rpcCtx, gestalt.TrustedCallerSubjectMetadataKey, "user:user@example.test")
+	if _, err := authClient.Token(tokenWithSubjectCtx, &proto.TokenRequest{
+		GrantType:   "authorization_code",
+		Code:        "auth-code",
+		RedirectUri: "https://app.example.test/callback",
+		ClientId:    "gestaltd",
+	}); err != nil {
+		t.Fatalf("Token(trusted caller subject metadata): %v", err)
+	}
+	if provider.tokenCallerSubject != "user:user@example.test" {
+		t.Fatalf("Token CallerSubjectID = %q, want user:user@example.test", provider.tokenCallerSubject)
 	}
 
 	_, err = authClient.RevokeGrant(grantCtx, &proto.RevokeGrantRequest{GrantId: "grant-1"})


### PR DESCRIPTION
## Summary

Creating an API token from Settings succeeds, then the list cannot find the new row. Token create now forwards the signed-in user the same way the list already does, so the grant is stored under the same identity the list queries.

## Why / context

Follow-up to #3090. The list path already sends the verified user to the identity provider. Token create only sent the session cookie, so identity minted the grant under the login email. Settings then listed by user id and the new row never appeared.

The identity provider must also treat that verified user as the grant owner. Creating tokens from Settings will keep looking empty until this change and the companion identity-provider change are both deployed.

## What changed

- After attaching the session cookie, token create also attaches the canonical user id from the already-resolved signed-in principal. Ingress still owns email-to-user-id resolution so this path does not query the user store again.
- Attaching the cookie no longer replaces the whole identity call context. An existing user id and introspection stay in place.
- The identity Token RPC forwards that caller on the host hop and on the SDK provider server, matching ListGrants, UserInfo, GetGrant, and RevokeGrant.
- Tests cover subject attachment, cookie-helper merge, exact token-exchange caller, and the Token hop.

## Validation

- [x] Automated: `go test ./gestaltd/services/identity ./gestaltd/internal/server`
- [x] Automated: `go test . -run 'TestIdentityProviderRoundTrip|TestAuthCallContextFromIncoming|TestAppendIdentityCallMetadata'` (from `sdk/go`)
- [x] Automated: `git diff --check`
- [ ] Manual: create a token in Settings after this and the companion identity-provider change are deployed, then confirm the new row appears

## Reviewer focus

Grant ownership is the verified signed-in user, not the session token's introspected email. Canonicalization stays at auth ingress. This change copies that user onto the identity call and stops the cookie helper from wiping it.

## Rollout / compatibility

Deploy with the companion gestalt-providers PR. Either change alone is not enough. Tokens created before deploy stay stored under the login email and will not show in Settings.

## Evidence / demo

No rendered UI in this change. The user-visible outcome is Settings listing a token that already existed after create. Proof is the subject-attachment, cookie-helper merge, and Token-hop tests. A screen recording is not applicable without an authenticated Settings session and the companion identity-provider deploy.

## Links

Companion: https://github.com/valon-technologies/gestalt-providers/pull/1282
Follow-up to #3090