### PR TITLE
Extract a compact app registry writer

### DIFF
--- a/gestaltd/internal/appregistry/pending_test.go
+++ b/gestaltd/internal/appregistry/pending_test.go
@@ -2,6 +2,7 @@ package appregistry
 
 import (
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -511,6 +512,43 @@ func TestUpsertAppIndex_CopiesPublishStartedAt(t *testing.T) {
 	got := index.Apps["traffic-cop"].Versions["0.0.1"]
 	if got.PublishStartedAt == nil || !got.PublishStartedAt.Equal(startedAt) {
 		t.Fatalf("index publishStartedAt = %v, want %v", got.PublishStartedAt, startedAt)
+	}
+}
+
+func TestUpsertAppIndex_RejectsStaleIdentityWithSameMetadataPath(t *testing.T) {
+	t.Parallel()
+
+	entry := testPublishEntryForUpsert(t)
+	metadataPath := AppVersionEntryPath(entry.App, entry.Version)
+	index, changed, err := UpsertAppIndex(NewEmptyIndex(), entry, metadataPath, "", "")
+	if err != nil || !changed {
+		t.Fatalf("UpsertAppIndex() = changed %v, err %v", changed, err)
+	}
+	staleEntry := entry
+	staleEntry.SourceRef = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+	_, _, err = UpsertAppIndex(index, staleEntry, metadataPath, "", "")
+	if !errors.Is(err, ErrIndexVersionConflict) {
+		t.Fatalf("UpsertAppIndex(stale) = %v, want ErrIndexVersionConflict", err)
+	}
+}
+
+func testPublishEntryForUpsert(t *testing.T) Entry {
+	t.Helper()
+	return Entry{
+		SchemaVersion: EntrySchemaVersion,
+		App:           "traffic-cop",
+		Version:       "0.0.1",
+		SourceRef:     "651a5c30feb995c9364c38f63d0d5c3880bc2055",
+		ManifestPath:  "apps/traffic-cop/manifest.yaml",
+		Repository:    "github.com/valon-technologies/valon-tools",
+		PublishedAt:   time.Date(2026, 7, 24, 19, 4, 32, 0, time.UTC),
+		Artifacts: map[string]Artifact{
+			"linux/amd64": {
+				URL:       "https://example.com/artifact.tar.gz",
+				PublicURL: "https://example.com/artifact.tar.gz",
+				SHA256:    "deadbeef",
+			},
+		},
 	}
 }
 

--- a/gestaltd/internal/appregistry/publication_metadata.go
+++ b/gestaltd/internal/appregistry/publication_metadata.go
@@ -1,0 +1,57 @@
+package appregistry
+
+import (
+	"fmt"
+	"strings"
+)
+
+// PublicationKind identifies how a registry version was published.
+type PublicationKind string
+
+const (
+	PublicationKindGitHub PublicationKind = "github"
+	PublicationKindLocal  PublicationKind = "local"
+)
+
+// LocalSourceState captures optional Git working-tree provenance for local publishes.
+type LocalSourceState struct {
+	CommitSHA string `json:"commitSha,omitempty"`
+	Dirty     bool   `json:"dirty,omitempty"`
+	Untracked bool   `json:"untracked,omitempty"`
+}
+
+func cloneLocalSourceState(value *LocalSourceState) *LocalSourceState {
+	if value == nil {
+		return nil
+	}
+	out := *value
+	return &out
+}
+
+func validatePublicationKind(kind PublicationKind) error {
+	switch kind {
+	case "", PublicationKindGitHub, PublicationKindLocal:
+		return nil
+	default:
+		return fmt.Errorf("unsupported publication kind %q", kind)
+	}
+}
+
+func validateLocalSourceState(state *LocalSourceState) error {
+	if state == nil {
+		return nil
+	}
+	if strings.TrimSpace(state.CommitSHA) == "" && !state.Dirty && !state.Untracked {
+		return fmt.Errorf("localSource must record commitSha and/or dirty/untracked state")
+	}
+	return nil
+}
+
+func publicationKindRequiresSourceRef(kind PublicationKind) bool {
+	switch kind {
+	case PublicationKindLocal:
+		return false
+	default:
+		return true
+	}
+}

--- a/gestaltd/internal/appregistry/publication_metadata_test.go
+++ b/gestaltd/internal/appregistry/publication_metadata_test.go
@@ -1,0 +1,60 @@
+package appregistry
+
+import (
+	"testing"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/internal/providerrelease"
+)
+
+func TestPublicationMetadataValidation(t *testing.T) {
+	t.Parallel()
+
+	if err := validatePublicationKind("unsupported"); err == nil {
+		t.Fatal("expected invalid publication kind to fail")
+	}
+	if err := validateLocalSourceState(&LocalSourceState{}); err == nil {
+		t.Fatal("expected empty local source state to fail")
+	}
+	if err := validateLocalSourceState(&LocalSourceState{Dirty: true}); err != nil {
+		t.Fatalf("validateLocalSourceState(dirty) = %v", err)
+	}
+}
+
+func TestBuildEntryRecordsPublicationMetadata(t *testing.T) {
+	t.Parallel()
+
+	manifest := testPublishManifest(t)
+	release := testPublishReleaseMetadata()
+	entry, err := BuildEntry(BuildEntryInput{
+		Manifest:          manifest,
+		Version:           "0.0.1",
+		SourceRef:         "651a5c30feb995c9364c38f63d0d5c3880bc2055",
+		ManifestPath:      "apps/traffic-cop/manifest.yaml",
+		PublicationKind:   PublicationKindGitHub,
+		PublishID:         "pub-123",
+		BuilderVersion:    "1.2.3",
+		DeclarationDigest: "sha256:abc",
+		LocalSource:       &LocalSourceState{CommitSHA: "651a5c30feb995c9364c38f63d0d5c3880bc2055"},
+		Release:           release,
+		Artifacts: []PublishArtifact{{
+			Target:     "linux/amd64",
+			StorageURL: "gs://bucket/apps/traffic-cop/artifacts/0.0.1/linux-amd64.tar.gz",
+			PublicURL:  "https://example.com/linux-amd64.tar.gz",
+			SHA256:     "deadbeef",
+		}},
+		PublishStartedAt: time.Date(2026, 7, 24, 19, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("BuildEntry() = %v", err)
+	}
+	if entry.PublicationKind != PublicationKindGitHub || entry.PublishID != "pub-123" || entry.BuilderVersion != "1.2.3" {
+		t.Fatalf("entry metadata = %#v", entry)
+	}
+}
+
+func testPublishReleaseMetadata() *providerrelease.Metadata {
+	return &providerrelease.Metadata{
+		StaticValidation: &providerrelease.StaticValidation{},
+	}
+}

--- a/gestaltd/internal/appregistry/publish_outcome.go
+++ b/gestaltd/internal/appregistry/publish_outcome.go
@@ -1,0 +1,38 @@
+package appregistry
+
+// ObjectWriteOutcome reports whether an immutable registry object was created or skipped.
+type ObjectWriteOutcome string
+
+const (
+	ObjectWriteOutcomeUploaded ObjectWriteOutcome = "uploaded"
+	ObjectWriteOutcomeSkipped  ObjectWriteOutcome = "skipped"
+)
+
+// CatalogWriteOutcome reports whether a mutable catalog was updated or left unchanged.
+type CatalogWriteOutcome string
+
+const (
+	CatalogWriteOutcomeUpdated      CatalogWriteOutcome = "updated"
+	CatalogWriteOutcomeUnchanged    CatalogWriteOutcome = "unchanged"
+	CatalogWriteOutcomeNotAttempted CatalogWriteOutcome = "not_attempted"
+)
+
+// ImmutableObjectOutcome records one immutable object's publish result.
+type ImmutableObjectOutcome struct {
+	StorageURL string
+	Outcome    ObjectWriteOutcome
+}
+
+// ImmutablePublishOutcome summarizes immutable artifact and entry uploads.
+type ImmutablePublishOutcome struct {
+	Artifacts []ImmutableObjectOutcome
+	Entry     ImmutableObjectOutcome
+}
+
+// PublishResult summarizes the committed outcome of each publish phase.
+type PublishResult struct {
+	Artifacts []ImmutableObjectOutcome
+	Entry     ImmutableObjectOutcome
+	Retention CatalogWriteOutcome
+	Index     CatalogWriteOutcome
+}

--- a/gestaltd/internal/appregistry/publish_plan.go
+++ b/gestaltd/internal/appregistry/publish_plan.go
@@ -1,0 +1,207 @@
+package appregistry
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+const (
+	PublishPlanSchemaVersion       = "gestaltd.app.publish.plan.v1"
+	RepublishCorruptObjectGuidance = "delete the object or entire snapshot SHA prefix and republish"
+)
+
+// BuildPublishManifestInput collects everything required to plan a registry publish.
+type BuildPublishManifestInput struct {
+	StorageRoot    string
+	PublicRoot     string
+	DisplayName    string
+	Description    string
+	EntryInput     BuildEntryInput
+	LocalArtifacts []LocalPublishArtifact
+	OnHashStart    func(fileCount int)
+	OnHashDone     func(fileCount int)
+}
+
+// LocalPublishArtifact is a release archive on disk awaiting upload.
+type LocalPublishArtifact struct {
+	Target    string
+	LocalPath string
+}
+
+// PublishObjectKind identifies immutable publish object types.
+type PublishObjectKind string
+
+const (
+	PublishObjectKindEntry   PublishObjectKind = "entry"
+	PublishObjectKindArchive PublishObjectKind = "archive"
+	PublishObjectKindIndex   PublishObjectKind = "index"
+)
+
+// PublishObject describes one registry object in a publish plan.
+type PublishObject struct {
+	Kind       PublishObjectKind `json:"kind"`
+	Target     string            `json:"target,omitempty"`
+	LocalPath  string            `json:"localPath"`
+	StorageURL string            `json:"storageUrl"`
+	PublicURL  string            `json:"publicUrl"`
+	SHA256     string            `json:"sha256,omitempty"`
+}
+
+// PublishManifest is the upload plan for one app version.
+type PublishManifest struct {
+	Schema          string          `json:"schema"`
+	AppName         string          `json:"appName"`
+	DisplayName     string          `json:"displayName,omitempty"`
+	Description     string          `json:"description,omitempty"`
+	Version         string          `json:"version"`
+	Entry           Entry           `json:"entry"`
+	EntryObject     PublishObject   `json:"entryObject"`
+	IndexObject     PublishObject   `json:"indexObject"`
+	ArtifactObjects []PublishObject `json:"artifactObjects"`
+}
+
+// BuildPublishManifest hashes local artifacts, builds version metadata, and resolves storage URLs.
+func BuildPublishManifest(input BuildPublishManifestInput) (PublishManifest, error) {
+	storageRoot := strings.TrimRight(strings.TrimSpace(input.StorageRoot), "/")
+	publicRoot := strings.TrimRight(strings.TrimSpace(input.PublicRoot), "/")
+	if storageRoot == "" {
+		return PublishManifest{}, fmt.Errorf("storage root is required")
+	}
+	if publicRoot == "" {
+		return PublishManifest{}, fmt.Errorf("public root is required")
+	}
+
+	layout, err := ResolvePublishLayout(input.EntryInput.Manifest.Source, input.EntryInput.Version)
+	if err != nil {
+		return PublishManifest{}, err
+	}
+
+	sortedArtifacts := append([]LocalPublishArtifact(nil), input.LocalArtifacts...)
+	sort.Slice(sortedArtifacts, func(i, j int) bool {
+		return filepath.Base(sortedArtifacts[i].LocalPath) < filepath.Base(sortedArtifacts[j].LocalPath)
+	})
+
+	if input.OnHashStart != nil {
+		input.OnHashStart(len(sortedArtifacts) + 1)
+	}
+
+	publishArtifacts := make([]PublishArtifact, 0, len(sortedArtifacts))
+	artifactObjects := make([]PublishObject, 0, len(sortedArtifacts))
+	for _, artifact := range sortedArtifacts {
+		filename := filepath.Base(artifact.LocalPath)
+		rel := path.Join(layout.ArtifactPrefix, filename)
+		digest, err := SHA256File(artifact.LocalPath)
+		if err != nil {
+			return PublishManifest{}, err
+		}
+		publishArtifacts = append(publishArtifacts, PublishArtifact{
+			Target:     artifact.Target,
+			LocalPath:  artifact.LocalPath,
+			Filename:   filename,
+			StorageURL: StorageURL(storageRoot, rel),
+			PublicURL:  PublicURL(publicRoot, rel),
+			SHA256:     digest,
+		})
+		artifactObjects = append(artifactObjects, PublishObject{
+			Kind:       PublishObjectKindArchive,
+			Target:     artifact.Target,
+			LocalPath:  artifact.LocalPath,
+			StorageURL: StorageURL(storageRoot, rel),
+			PublicURL:  PublicURL(publicRoot, rel),
+			SHA256:     digest,
+		})
+	}
+
+	buildInput := input.EntryInput
+	buildInput.Artifacts = publishArtifacts
+	entry, err := BuildEntry(buildInput)
+	if err != nil {
+		return PublishManifest{}, err
+	}
+
+	entryData, err := json.MarshalIndent(entry, "", "  ")
+	if err != nil {
+		return PublishManifest{}, err
+	}
+	entryPath, err := WriteTempJSON("gestalt-app-entry-*", entryData)
+	if err != nil {
+		return PublishManifest{}, err
+	}
+	entryDigest, err := SHA256File(entryPath)
+	if err != nil {
+		_ = os.Remove(entryPath)
+		return PublishManifest{}, err
+	}
+	if input.OnHashDone != nil {
+		input.OnHashDone(len(sortedArtifacts) + 1)
+	}
+
+	return PublishManifest{
+		Schema:      PublishPlanSchemaVersion,
+		AppName:     entry.App,
+		DisplayName: input.DisplayName,
+		Description: input.Description,
+		Version:     input.EntryInput.Version,
+		Entry:       entry,
+		EntryObject: PublishObject{
+			Kind:       PublishObjectKindEntry,
+			LocalPath:  entryPath,
+			StorageURL: StorageURL(storageRoot, layout.EntryPath),
+			PublicURL:  PublicURL(publicRoot, layout.EntryPath),
+			SHA256:     entryDigest,
+		},
+		IndexObject: PublishObject{
+			Kind:       PublishObjectKindIndex,
+			StorageURL: StorageURL(storageRoot, layout.IndexPath),
+			PublicURL:  PublicURL(publicRoot, layout.IndexPath),
+		},
+		ArtifactObjects: artifactObjects,
+	}, nil
+}
+
+// RetentionStorageURL derives the app retention catalog URL from an index object URL.
+func RetentionStorageURL(indexStorageURL string, appName string) string {
+	storageRoot := strings.TrimSuffix(indexStorageURL, AppIndexPath(appName))
+	return StorageURL(storageRoot, AppRetentionPath(appName))
+}
+
+// SHA256File returns the lowercase hex SHA-256 digest of a file.
+func SHA256File(path string) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = file.Close() }()
+	hasher := sha256.New()
+	if _, err := io.Copy(hasher, file); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(hasher.Sum(nil)), nil
+}
+
+// WriteTempJSON writes data to a temporary file and returns its path.
+func WriteTempJSON(pattern string, data []byte) (string, error) {
+	file, err := os.CreateTemp("", pattern)
+	if err != nil {
+		return "", err
+	}
+	path := file.Name()
+	if _, err := file.Write(data); err != nil {
+		_ = file.Close()
+		_ = os.Remove(path)
+		return "", err
+	}
+	if err := file.Close(); err != nil {
+		_ = os.Remove(path)
+		return "", err
+	}
+	return path, nil
+}

--- a/gestaltd/internal/appregistry/publish_protocol_test.go
+++ b/gestaltd/internal/appregistry/publish_protocol_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"sync"
 	"testing"
 	"time"
 )
@@ -417,5 +418,111 @@ func TestWriter_Publish_PartialEntryWithoutIndexRemainsRetryable(t *testing.T) {
 	}
 	if result.Index != CatalogWriteOutcomeUpdated {
 		t.Fatalf("retry index outcome = %q, want updated", result.Index)
+	}
+}
+
+type entryFinalizeRaceStore struct {
+	RegistryObjectStore
+	entryURL        string
+	injectLocalPath string
+	describeCount   map[string]int
+	mu              sync.Mutex
+}
+
+func (s *entryFinalizeRaceStore) DescribeObject(storageURL string) (ObjectDescription, error) {
+	s.mu.Lock()
+	if storageURL != s.entryURL {
+		s.mu.Unlock()
+		return s.RegistryObjectStore.DescribeObject(storageURL)
+	}
+	s.describeCount[storageURL]++
+	count := s.describeCount[storageURL]
+	s.mu.Unlock()
+	if count == 1 {
+		return ObjectDescription{}, nil
+	}
+	if count == 2 {
+		if err := s.WriteImmutableObject(WriteImmutableObjectInput{
+			LocalPath:  s.injectLocalPath,
+			StorageURL: s.entryURL,
+			SourceRef:  "651a5c30feb995c9364c38f63d0d5c3880bc2055",
+		}); err != nil {
+			return ObjectDescription{}, err
+		}
+	}
+	return s.RegistryObjectStore.DescribeObject(storageURL)
+}
+
+func TestWriter_uploadImmutableObjectIfNeeded_ReconcilesConcurrentEquivalentEntry(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryObjectStore()
+	manifest, _, _ := writePublishManifestFixture(t, store, "0.0.11")
+	winningPublishedAt := time.Date(2026, 8, 17, 10, 0, 0, 0, time.UTC)
+	laterPublishedAt := time.Date(2026, 8, 17, 11, 0, 0, 0, time.UTC)
+
+	winningEntry := manifest.Entry
+	winningEntry.PublishedAt = winningPublishedAt
+	winningData, err := json.MarshalIndent(winningEntry, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal winning entry: %v", err)
+	}
+	winningPath, err := WriteTempJSON("gestalt-app-entry-winning-*", append(winningData, '\n'))
+	if err != nil {
+		t.Fatalf("WriteTempJSON(): %v", err)
+	}
+
+	localEntry := manifest.Entry
+	localEntry.PublishedAt = laterPublishedAt
+	localData, err := json.MarshalIndent(localEntry, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal local entry: %v", err)
+	}
+	if err := os.WriteFile(manifest.EntryObject.LocalPath, append(localData, '\n'), 0o644); err != nil {
+		t.Fatalf("rewrite local entry: %v", err)
+	}
+
+	raceStore := &entryFinalizeRaceStore{
+		RegistryObjectStore: store,
+		entryURL:            manifest.EntryObject.StorageURL,
+		injectLocalPath:     winningPath,
+		describeCount:       map[string]int{},
+	}
+	writer := &Writer{Store: raceStore}
+	outcome, _, err := writer.uploadImmutableObjectIfNeeded(manifest.EntryObject, "651a5c30feb995c9364c38f63d0d5c3880bc2055")
+	if err != nil {
+		t.Fatalf("uploadImmutableObjectIfNeeded() = %v", err)
+	}
+	if outcome.Outcome != ObjectWriteOutcomeSkipped {
+		t.Fatalf("outcome = %q, want skipped", outcome.Outcome)
+	}
+}
+
+func TestWriter_uploadImmutableObjectIfNeeded_RejectsConcurrentConflictingEntry(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryObjectStore()
+	manifest, _, _ := writePublishManifestFixture(t, store, "0.0.12")
+	conflicting := manifest.Entry
+	conflicting.SourceRef = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+	conflictingData, err := json.MarshalIndent(conflicting, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal conflicting entry: %v", err)
+	}
+	conflictingPath, err := WriteTempJSON("gestalt-app-entry-conflicting-*", append(conflictingData, '\n'))
+	if err != nil {
+		t.Fatalf("WriteTempJSON(): %v", err)
+	}
+
+	raceStore := &entryFinalizeRaceStore{
+		RegistryObjectStore: store,
+		entryURL:            manifest.EntryObject.StorageURL,
+		injectLocalPath:     conflictingPath,
+		describeCount:       map[string]int{},
+	}
+	writer := &Writer{Store: raceStore}
+	_, _, err = writer.uploadImmutableObjectIfNeeded(manifest.EntryObject, "651a5c30feb995c9364c38f63d0d5c3880bc2055")
+	if !errors.Is(err, ErrRegistryEntryConflict) {
+		t.Fatalf("uploadImmutableObjectIfNeeded() = %v, want ErrRegistryEntryConflict", err)
 	}
 }

--- a/gestaltd/internal/appregistry/publish_protocol_test.go
+++ b/gestaltd/internal/appregistry/publish_protocol_test.go
@@ -1,0 +1,204 @@
+package appregistry
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+)
+
+type catalogWriteRecorder struct {
+	RegistryObjectStore
+	writes []string
+}
+
+func (s *catalogWriteRecorder) WriteCatalogObject(input WriteCatalogObjectInput) error {
+	s.writes = append(s.writes, input.StorageURL)
+	return s.RegistryObjectStore.WriteCatalogObject(input)
+}
+
+type retentionFailStore struct {
+	RegistryObjectStore
+	retentionURL string
+}
+
+func (s *retentionFailStore) WriteCatalogObject(input WriteCatalogObjectInput) error {
+	if input.StorageURL == s.retentionURL {
+		return fmt.Errorf("%w: simulated retention failure", ErrObjectPreconditionFailed)
+	}
+	return s.RegistryObjectStore.WriteCatalogObject(input)
+}
+
+func TestWriter_Publish_CommitsRetentionBeforeIndex(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryObjectStore()
+	manifest, _, _ := writePublishManifestFixture(t, store, "0.0.3")
+	recorder := &catalogWriteRecorder{RegistryObjectStore: store}
+	writer := &Writer{Store: recorder}
+	req := PublishRequest{
+		Manifest:  manifest,
+		SourceRef: "651a5c30feb995c9364c38f63d0d5c3880bc2055",
+	}
+
+	result, err := writer.Publish(req, PublishProgress{})
+	if err != nil {
+		t.Fatalf("Publish() = %v", err)
+	}
+	if result.Retention != CatalogWriteOutcomeUpdated {
+		t.Fatalf("retention outcome = %q, want updated", result.Retention)
+	}
+	if result.Index != CatalogWriteOutcomeUpdated {
+		t.Fatalf("index outcome = %q, want updated", result.Index)
+	}
+	if len(recorder.writes) != 2 {
+		t.Fatalf("catalog writes = %#v, want 2", recorder.writes)
+	}
+	retentionURL := RetentionStorageURL(manifest.IndexObject.StorageURL, manifest.AppName)
+	if recorder.writes[0] != retentionURL {
+		t.Fatalf("first catalog write = %q, want retention %q", recorder.writes[0], retentionURL)
+	}
+	if recorder.writes[1] != manifest.IndexObject.StorageURL {
+		t.Fatalf("second catalog write = %q, want index %q", recorder.writes[1], manifest.IndexObject.StorageURL)
+	}
+}
+
+func TestWriter_Publish_RetentionFailureLeavesIndexUnchanged(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryObjectStore()
+	manifest, _, _ := writePublishManifestFixture(t, store, "0.0.4")
+	retentionURL := RetentionStorageURL(manifest.IndexObject.StorageURL, manifest.AppName)
+	failStore := &retentionFailStore{
+		RegistryObjectStore: store,
+		retentionURL:        retentionURL,
+	}
+	writer := &Writer{Store: failStore}
+	req := PublishRequest{
+		Manifest:  manifest,
+		SourceRef: "651a5c30feb995c9364c38f63d0d5c3880bc2055",
+	}
+
+	result, err := writer.Publish(req, PublishProgress{})
+	if err == nil {
+		t.Fatal("expected retention failure")
+	}
+	if result.Retention != CatalogWriteOutcomeNotAttempted {
+		t.Fatalf("retention outcome = %q, want not_attempted", result.Retention)
+	}
+	if result.Index != CatalogWriteOutcomeNotAttempted {
+		t.Fatalf("index outcome = %q, want not_attempted", result.Index)
+	}
+	if result.Entry.Outcome != ObjectWriteOutcomeUploaded {
+		t.Fatalf("entry outcome = %q, want uploaded", result.Entry.Outcome)
+	}
+
+	_, indexData, err := store.ReadObject(manifest.IndexObject.StorageURL)
+	if err != nil {
+		t.Fatalf("ReadObject(index): %v", err)
+	}
+	if len(indexData) != 0 {
+		t.Fatalf("index changed after retention failure: %s", string(indexData))
+	}
+}
+
+func TestWriter_Publish_UsesEntryPublishedAtForIndexAndRetention(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryObjectStore()
+	manifest, _, _ := writePublishManifestFixture(t, store, "0.0.5")
+	publishedAt := time.Date(2026, 8, 17, 12, 34, 56, 0, time.UTC)
+	manifest.Entry.PublishedAt = publishedAt
+
+	writer := &Writer{Store: store}
+	result, err := writer.Publish(PublishRequest{
+		Manifest:  manifest,
+		SourceRef: "651a5c30feb995c9364c38f63d0d5c3880bc2055",
+	}, PublishProgress{})
+	if err != nil {
+		t.Fatalf("Publish() = %v", err)
+	}
+	if result.Index != CatalogWriteOutcomeUpdated || result.Retention != CatalogWriteOutcomeUpdated {
+		t.Fatalf("result = %#v", result)
+	}
+
+	retentionURL := RetentionStorageURL(manifest.IndexObject.StorageURL, manifest.AppName)
+	_, retentionData, err := store.ReadObject(retentionURL)
+	if err != nil {
+		t.Fatalf("ReadObject(retention): %v", err)
+	}
+	retention, err := DecodeRetentionIndex(retentionData)
+	if err != nil {
+		t.Fatalf("DecodeRetentionIndex(): %v", err)
+	}
+	retentionVersion, ok := retention.Versions["0.0.5"]
+	if !ok {
+		t.Fatalf("retention versions = %#v", retention.Versions)
+	}
+	if !retentionVersion.PublishedAt.Equal(publishedAt) {
+		t.Fatalf("retention publishedAt = %v, want %v", retentionVersion.PublishedAt, publishedAt)
+	}
+
+	_, indexData, err := store.ReadObject(manifest.IndexObject.StorageURL)
+	if err != nil {
+		t.Fatalf("ReadObject(index): %v", err)
+	}
+	index, err := DecodeIndex(indexData)
+	if err != nil {
+		t.Fatalf("DecodeIndex(): %v", err)
+	}
+	indexVersion, ok := index.Apps[manifest.AppName].Versions["0.0.5"]
+	if !ok {
+		t.Fatalf("index versions = %#v", index.Apps[manifest.AppName].Versions)
+	}
+	if !indexVersion.PublishedAt.Equal(publishedAt) {
+		t.Fatalf("index publishedAt = %v, want %v", indexVersion.PublishedAt, publishedAt)
+	}
+}
+
+func TestWriter_Publish_ReturnsTypedOutcomeOnPartialFailure(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryObjectStore()
+	manifest, _, _ := writePublishManifestFixture(t, store, "0.0.6")
+	indexPath := manifest.IndexObject.StorageURL
+	failStore := &catalogConflictStore{
+		RegistryObjectStore: store,
+		failURL:             indexPath,
+		failRemaining:       1,
+	}
+	writer := &Writer{Store: failStore, CatalogAttempts: 1}
+	result, err := writer.Publish(PublishRequest{
+		Manifest:  manifest,
+		SourceRef: "651a5c30feb995c9364c38f63d0d5c3880bc2055",
+	}, PublishProgress{})
+	if err == nil {
+		t.Fatal("expected index failure")
+	}
+	if result.Retention != CatalogWriteOutcomeUpdated {
+		t.Fatalf("retention outcome = %q, want updated", result.Retention)
+	}
+	if result.Index != CatalogWriteOutcomeNotAttempted {
+		t.Fatalf("index outcome = %q, want not_attempted", result.Index)
+	}
+
+	retentionURL := RetentionStorageURL(indexPath, manifest.AppName)
+	_, retentionData, err := store.ReadObject(retentionURL)
+	if err != nil {
+		t.Fatalf("ReadObject(retention): %v", err)
+	}
+	var retention RetentionIndex
+	if err := json.Unmarshal(retentionData, &retention); err != nil {
+		t.Fatalf("unmarshal retention: %v", err)
+	}
+	if _, ok := retention.Versions["0.0.6"]; !ok {
+		t.Fatalf("retention missing version after index failure: %#v", retention.Versions)
+	}
+	_, indexData, err := store.ReadObject(indexPath)
+	if err != nil {
+		t.Fatalf("ReadObject(index): %v", err)
+	}
+	if len(indexData) != 0 {
+		t.Fatalf("index changed before successful commit: %s", string(indexData))
+	}
+}

--- a/gestaltd/internal/appregistry/publish_protocol_test.go
+++ b/gestaltd/internal/appregistry/publish_protocol_test.go
@@ -2,7 +2,9 @@ package appregistry
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"os"
 	"testing"
 	"time"
 )
@@ -109,6 +111,13 @@ func TestWriter_Publish_UsesEntryPublishedAtForIndexAndRetention(t *testing.T) {
 	manifest, _, _ := writePublishManifestFixture(t, store, "0.0.5")
 	publishedAt := time.Date(2026, 8, 17, 12, 34, 56, 0, time.UTC)
 	manifest.Entry.PublishedAt = publishedAt
+	entryData, err := json.MarshalIndent(manifest.Entry, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal entry: %v", err)
+	}
+	if err := os.WriteFile(manifest.EntryObject.LocalPath, append(entryData, '\n'), 0o644); err != nil {
+		t.Fatalf("rewrite entry file: %v", err)
+	}
 
 	writer := &Writer{Store: store}
 	result, err := writer.Publish(PublishRequest{
@@ -200,5 +209,213 @@ func TestWriter_Publish_ReturnsTypedOutcomeOnPartialFailure(t *testing.T) {
 	}
 	if len(indexData) != 0 {
 		t.Fatalf("index changed before successful commit: %s", string(indexData))
+	}
+}
+
+func TestWriter_Publish_ConcurrentWritersUseWinningPublishedAt(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryObjectStore()
+	manifestA, _, _ := writePublishManifestFixture(t, store, "0.0.7")
+	winningPublishedAt := time.Date(2026, 8, 17, 10, 0, 0, 0, time.UTC)
+	laterPublishedAt := time.Date(2026, 8, 17, 11, 0, 0, 0, time.UTC)
+	manifestA.Entry.PublishedAt = winningPublishedAt
+	entryData, err := json.MarshalIndent(manifestA.Entry, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal entry: %v", err)
+	}
+	if err := os.WriteFile(manifestA.EntryObject.LocalPath, append(entryData, '\n'), 0o644); err != nil {
+		t.Fatalf("rewrite entry file: %v", err)
+	}
+
+	writer := &Writer{Store: store}
+	if _, err := writer.Publish(PublishRequest{
+		Manifest:  manifestA,
+		SourceRef: "651a5c30feb995c9364c38f63d0d5c3880bc2055",
+	}, PublishProgress{}); err != nil {
+		t.Fatalf("first Publish() = %v", err)
+	}
+
+	manifestB, _, _ := writePublishManifestFixture(t, store, "0.0.7")
+	manifestB.Entry.PublishedAt = laterPublishedAt
+	entryData, err = json.MarshalIndent(manifestB.Entry, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal entry: %v", err)
+	}
+	if err := os.WriteFile(manifestB.EntryObject.LocalPath, append(entryData, '\n'), 0o644); err != nil {
+		t.Fatalf("rewrite entry file: %v", err)
+	}
+	result, err := writer.Publish(PublishRequest{
+		Manifest:  manifestB,
+		SourceRef: "651a5c30feb995c9364c38f63d0d5c3880bc2055",
+	}, PublishProgress{})
+	if err != nil {
+		t.Fatalf("second Publish() = %v", err)
+	}
+	if result.Entry.Outcome != ObjectWriteOutcomeSkipped {
+		t.Fatalf("second entry outcome = %q, want skipped", result.Entry.Outcome)
+	}
+
+	_, indexData, err := store.ReadObject(manifestA.IndexObject.StorageURL)
+	if err != nil {
+		t.Fatalf("ReadObject(index): %v", err)
+	}
+	index, err := DecodeIndex(indexData)
+	if err != nil {
+		t.Fatalf("DecodeIndex(): %v", err)
+	}
+	indexVersion := index.Apps[manifestA.AppName].Versions["0.0.7"]
+	if !indexVersion.PublishedAt.Equal(winningPublishedAt) {
+		t.Fatalf("index publishedAt = %v, want winning %v", indexVersion.PublishedAt, winningPublishedAt)
+	}
+
+	retentionURL := RetentionStorageURL(manifestA.IndexObject.StorageURL, manifestA.AppName)
+	_, retentionData, err := store.ReadObject(retentionURL)
+	if err != nil {
+		t.Fatalf("ReadObject(retention): %v", err)
+	}
+	retention, err := DecodeRetentionIndex(retentionData)
+	if err != nil {
+		t.Fatalf("DecodeRetentionIndex(): %v", err)
+	}
+	retentionVersion := retention.Versions["0.0.7"]
+	if !retentionVersion.PublishedAt.Equal(winningPublishedAt) {
+		t.Fatalf("retention publishedAt = %v, want winning %v", retentionVersion.PublishedAt, winningPublishedAt)
+	}
+}
+
+func TestWriter_Publish_IndexIdentityMismatchFails(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryObjectStore()
+	manifest, _, _ := writePublishManifestFixture(t, store, "0.0.8")
+	metadataPath := AppVersionEntryPath(manifest.AppName, manifest.Version)
+	index := NewEmptyIndex()
+	entry := manifest.Entry
+	if _, changed, err := UpsertAppIndex(index, entry, metadataPath, "", ""); err != nil || !changed {
+		t.Fatalf("seed index: changed=%v err=%v", changed, err)
+	}
+	index.Apps[manifest.AppName].Versions[manifest.Version] = indexVersionFromEntry(entry, metadataPath)
+	app := index.Apps[manifest.AppName]
+	version := app.Versions[manifest.Version]
+	version.SourceRef = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+	app.Versions[manifest.Version] = version
+	index.Apps[manifest.AppName] = app
+	indexData, err := json.MarshalIndent(index, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal index: %v", err)
+	}
+	indexPath, err := WriteTempJSON("gestalt-app-index-stale-*", append(indexData, '\n'))
+	if err != nil {
+		t.Fatalf("WriteTempJSON(): %v", err)
+	}
+	if err := store.WriteCatalogObject(WriteCatalogObjectInput{
+		LocalPath:  indexPath,
+		StorageURL: manifest.IndexObject.StorageURL,
+		SourceRef:  "651a5c30feb995c9364c38f63d0d5c3880bc2055",
+		Generation: 0,
+	}); err != nil {
+		t.Fatalf("seed stale index: %v", err)
+	}
+
+	writer := &Writer{Store: store}
+	_, err = writer.Publish(PublishRequest{
+		Manifest:  manifest,
+		SourceRef: "651a5c30feb995c9364c38f63d0d5c3880bc2055",
+	}, PublishProgress{})
+	if !errors.Is(err, ErrIndexVersionConflict) {
+		t.Fatalf("Publish() = %v, want ErrIndexVersionConflict", err)
+	}
+}
+
+func TestWriter_Publish_ConflictingEntryIdentityFails(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryObjectStore()
+	manifest, _, _ := writePublishManifestFixture(t, store, "0.0.9")
+	conflicting := manifest.Entry
+	conflicting.SourceRef = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+	entryData, err := json.MarshalIndent(conflicting, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal entry: %v", err)
+	}
+	entryPath, err := WriteTempJSON("gestalt-app-entry-conflict-*", append(entryData, '\n'))
+	if err != nil {
+		t.Fatalf("WriteTempJSON(): %v", err)
+	}
+	if err := store.WriteImmutableObject(WriteImmutableObjectInput{
+		LocalPath:  entryPath,
+		StorageURL: manifest.EntryObject.StorageURL,
+		SourceRef:  "651a5c30feb995c9364c38f63d0d5c3880bc2055",
+	}); err != nil {
+		t.Fatalf("seed conflicting entry: %v", err)
+	}
+
+	writer := &Writer{Store: store}
+	err = writer.Preflight(PublishRequest{
+		Manifest:  manifest,
+		SourceRef: "651a5c30feb995c9364c38f63d0d5c3880bc2055",
+	}, PublishProgress{})
+	if !errors.Is(err, ErrRegistryEntryConflict) {
+		t.Fatalf("Preflight() = %v, want ErrRegistryEntryConflict", err)
+	}
+	_, err = writer.Publish(PublishRequest{
+		Manifest:  manifest,
+		SourceRef: "651a5c30feb995c9364c38f63d0d5c3880bc2055",
+	}, PublishProgress{})
+	if !errors.Is(err, ErrRegistryEntryConflict) {
+		t.Fatalf("Publish() = %v, want ErrRegistryEntryConflict", err)
+	}
+}
+
+func TestWriter_Publish_PartialEntryWithoutIndexRemainsRetryable(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryObjectStore()
+	manifest, _, _ := writePublishManifestFixture(t, store, "0.0.10")
+	retentionURL := RetentionStorageURL(manifest.IndexObject.StorageURL, manifest.AppName)
+	failStore := &retentionFailStore{
+		RegistryObjectStore: store,
+		retentionURL:        retentionURL,
+	}
+	writer := &Writer{Store: failStore}
+	result, err := writer.Publish(PublishRequest{
+		Manifest:  manifest,
+		SourceRef: "651a5c30feb995c9364c38f63d0d5c3880bc2055",
+	}, PublishProgress{})
+	if err == nil {
+		t.Fatal("expected retention failure")
+	}
+	if result.Entry.Outcome != ObjectWriteOutcomeUploaded {
+		t.Fatalf("entry outcome = %q, want uploaded", result.Entry.Outcome)
+	}
+	if result.Index != CatalogWriteOutcomeNotAttempted {
+		t.Fatalf("index outcome = %q, want not_attempted", result.Index)
+	}
+	described, err := store.DescribeObject(manifest.EntryObject.StorageURL)
+	if err != nil || described.Generation == 0 {
+		t.Fatalf("entry object missing after partial publish: %#v err=%v", described, err)
+	}
+	_, indexData, err := store.ReadObject(manifest.IndexObject.StorageURL)
+	if err != nil {
+		t.Fatalf("ReadObject(index): %v", err)
+	}
+	if len(indexData) != 0 {
+		t.Fatalf("index changed after partial publish: %s", string(indexData))
+	}
+
+	writer = &Writer{Store: store}
+	result, err = writer.Publish(PublishRequest{
+		Manifest:  manifest,
+		SourceRef: "651a5c30feb995c9364c38f63d0d5c3880bc2055",
+	}, PublishProgress{})
+	if err != nil {
+		t.Fatalf("retry Publish() = %v", err)
+	}
+	if result.Entry.Outcome != ObjectWriteOutcomeSkipped {
+		t.Fatalf("retry entry outcome = %q, want skipped", result.Entry.Outcome)
+	}
+	if result.Index != CatalogWriteOutcomeUpdated {
+		t.Fatalf("retry index outcome = %q, want updated", result.Index)
 	}
 }

--- a/gestaltd/internal/appregistry/publish_protocol_test.go
+++ b/gestaltd/internal/appregistry/publish_protocol_test.go
@@ -526,3 +526,123 @@ func TestWriter_uploadImmutableObjectIfNeeded_RejectsConcurrentConflictingEntry(
 		t.Fatalf("uploadImmutableObjectIfNeeded() = %v, want ErrRegistryEntryConflict", err)
 	}
 }
+
+type entryWriteCollisionStore struct {
+	RegistryObjectStore
+	entryURL        string
+	injectLocalPath string
+	mu              sync.Mutex
+}
+
+func (s *entryWriteCollisionStore) WriteImmutableObject(input WriteImmutableObjectInput) error {
+	if input.StorageURL != s.entryURL {
+		return s.RegistryObjectStore.WriteImmutableObject(input)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.RegistryObjectStore.WriteImmutableObject(WriteImmutableObjectInput{
+		LocalPath:  s.injectLocalPath,
+		StorageURL: s.entryURL,
+		SourceRef:  input.SourceRef,
+	}); err != nil {
+		return err
+	}
+	return fmt.Errorf("%w: %s", ErrObjectPreconditionFailed, input.StorageURL)
+}
+
+func TestWriter_uploadImmutableObjectIfNeeded_ReconcilesWriteCollisionEquivalentEntry(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryObjectStore()
+	manifest, _, _ := writePublishManifestFixture(t, store, "0.0.13")
+	winningPublishedAt := time.Date(2026, 8, 17, 10, 0, 0, 0, time.UTC)
+	laterPublishedAt := time.Date(2026, 8, 17, 11, 0, 0, 0, time.UTC)
+
+	winningEntry := manifest.Entry
+	winningEntry.PublishedAt = winningPublishedAt
+	winningData, err := json.MarshalIndent(winningEntry, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal winning entry: %v", err)
+	}
+	winningPath, err := WriteTempJSON("gestalt-app-entry-winning-*", append(winningData, '\n'))
+	if err != nil {
+		t.Fatalf("WriteTempJSON(): %v", err)
+	}
+
+	localEntry := manifest.Entry
+	localEntry.PublishedAt = laterPublishedAt
+	localData, err := json.MarshalIndent(localEntry, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal local entry: %v", err)
+	}
+	if err := os.WriteFile(manifest.EntryObject.LocalPath, append(localData, '\n'), 0o644); err != nil {
+		t.Fatalf("rewrite local entry: %v", err)
+	}
+
+	collisionStore := &entryWriteCollisionStore{
+		RegistryObjectStore: store,
+		entryURL:            manifest.EntryObject.StorageURL,
+		injectLocalPath:     winningPath,
+	}
+	writer := &Writer{Store: collisionStore}
+	outcome, _, err := writer.uploadImmutableObjectIfNeeded(manifest.EntryObject, "651a5c30feb995c9364c38f63d0d5c3880bc2055")
+	if err != nil {
+		t.Fatalf("uploadImmutableObjectIfNeeded() = %v", err)
+	}
+	if outcome.Outcome != ObjectWriteOutcomeSkipped {
+		t.Fatalf("outcome = %q, want skipped", outcome.Outcome)
+	}
+}
+
+func TestWriter_uploadImmutableObjectIfNeeded_RejectsWriteCollisionConflictingEntry(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryObjectStore()
+	manifest, _, _ := writePublishManifestFixture(t, store, "0.0.14")
+	conflicting := manifest.Entry
+	conflicting.SourceRef = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+	conflictingData, err := json.MarshalIndent(conflicting, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal conflicting entry: %v", err)
+	}
+	conflictingPath, err := WriteTempJSON("gestalt-app-entry-conflicting-*", append(conflictingData, '\n'))
+	if err != nil {
+		t.Fatalf("WriteTempJSON(): %v", err)
+	}
+
+	collisionStore := &entryWriteCollisionStore{
+		RegistryObjectStore: store,
+		entryURL:            manifest.EntryObject.StorageURL,
+		injectLocalPath:     conflictingPath,
+	}
+	writer := &Writer{Store: collisionStore}
+	_, _, err = writer.uploadImmutableObjectIfNeeded(manifest.EntryObject, "651a5c30feb995c9364c38f63d0d5c3880bc2055")
+	if !errors.Is(err, ErrRegistryEntryConflict) {
+		t.Fatalf("uploadImmutableObjectIfNeeded() = %v, want ErrRegistryEntryConflict", err)
+	}
+}
+
+func TestWriter_uploadImmutableObjectIfNeeded_FailsClosedOnWriteCollisionMalformedEntry(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryObjectStore()
+	manifest, _, _ := writePublishManifestFixture(t, store, "0.0.15")
+	malformedPath, err := WriteTempJSON("gestalt-app-entry-malformed-*", []byte("{not-json\n"))
+	if err != nil {
+		t.Fatalf("WriteTempJSON(): %v", err)
+	}
+
+	collisionStore := &entryWriteCollisionStore{
+		RegistryObjectStore: store,
+		entryURL:            manifest.EntryObject.StorageURL,
+		injectLocalPath:     malformedPath,
+	}
+	writer := &Writer{Store: collisionStore}
+	_, _, err = writer.uploadImmutableObjectIfNeeded(manifest.EntryObject, "651a5c30feb995c9364c38f63d0d5c3880bc2055")
+	if err == nil {
+		t.Fatal("expected malformed winning entry to fail closed")
+	}
+	if errors.Is(err, ErrRegistryEntryConflict) || errors.Is(err, ErrObjectPreconditionFailed) {
+		t.Fatalf("uploadImmutableObjectIfNeeded() = %v, want decode/read failure", err)
+	}
+}

--- a/gestaltd/internal/appregistry/publish_protocol_test.go
+++ b/gestaltd/internal/appregistry/publish_protocol_test.go
@@ -531,6 +531,7 @@ type entryWriteCollisionStore struct {
 	RegistryObjectStore
 	entryURL        string
 	injectLocalPath string
+	preconditionErr error
 	mu              sync.Mutex
 }
 
@@ -546,6 +547,9 @@ func (s *entryWriteCollisionStore) WriteImmutableObject(input WriteImmutableObje
 		SourceRef:  input.SourceRef,
 	}); err != nil {
 		return err
+	}
+	if s.preconditionErr != nil {
+		return s.preconditionErr
 	}
 	return fmt.Errorf("%w: %s", ErrObjectPreconditionFailed, input.StorageURL)
 }
@@ -642,7 +646,128 @@ func TestWriter_uploadImmutableObjectIfNeeded_FailsClosedOnWriteCollisionMalform
 	if err == nil {
 		t.Fatal("expected malformed winning entry to fail closed")
 	}
-	if errors.Is(err, ErrRegistryEntryConflict) || errors.Is(err, ErrObjectPreconditionFailed) {
+	if errors.Is(err, ErrRegistryEntryConflict) || isObjectGenerationPreconditionFailed(err) {
 		t.Fatalf("uploadImmutableObjectIfNeeded() = %v, want decode/read failure", err)
+	}
+}
+
+func TestWriter_uploadImmutableObjectIfNeeded_ReconcilesWriteCollisionRawGcloud412(t *testing.T) {
+	t.Parallel()
+
+	rawGcloud412 := errors.New("412 Precondition Failed")
+	winningPublishedAt := time.Date(2026, 8, 17, 10, 0, 0, 0, time.UTC)
+	laterPublishedAt := time.Date(2026, 8, 17, 11, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name         string
+		prepare      func(t *testing.T, manifest PublishManifest) (injectLocalPath string, mutateLocal func() error)
+		wantSkipped  bool
+		wantConflict bool
+		wantErr      bool
+	}{
+		{
+			name: "equivalent",
+			prepare: func(t *testing.T, manifest PublishManifest) (string, func() error) {
+				t.Helper()
+				winningEntry := manifest.Entry
+				winningEntry.PublishedAt = winningPublishedAt
+				winningData, err := json.MarshalIndent(winningEntry, "", "  ")
+				if err != nil {
+					t.Fatalf("marshal winning entry: %v", err)
+				}
+				winningPath, err := WriteTempJSON("gestalt-app-entry-winning-*", append(winningData, '\n'))
+				if err != nil {
+					t.Fatalf("WriteTempJSON(): %v", err)
+				}
+				return winningPath, func() error {
+					localEntry := manifest.Entry
+					localEntry.PublishedAt = laterPublishedAt
+					localData, err := json.MarshalIndent(localEntry, "", "  ")
+					if err != nil {
+						return err
+					}
+					return os.WriteFile(manifest.EntryObject.LocalPath, append(localData, '\n'), 0o644)
+				}
+			},
+			wantSkipped: true,
+		},
+		{
+			name: "conflicting",
+			prepare: func(t *testing.T, manifest PublishManifest) (string, func() error) {
+				t.Helper()
+				conflicting := manifest.Entry
+				conflicting.SourceRef = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+				conflictingData, err := json.MarshalIndent(conflicting, "", "  ")
+				if err != nil {
+					t.Fatalf("marshal conflicting entry: %v", err)
+				}
+				conflictingPath, err := WriteTempJSON("gestalt-app-entry-conflicting-*", append(conflictingData, '\n'))
+				if err != nil {
+					t.Fatalf("WriteTempJSON(): %v", err)
+				}
+				return conflictingPath, func() error { return nil }
+			},
+			wantConflict: true,
+		},
+		{
+			name: "malformed",
+			prepare: func(t *testing.T, manifest PublishManifest) (string, func() error) {
+				t.Helper()
+				malformedPath, err := WriteTempJSON("gestalt-app-entry-malformed-*", []byte("{not-json\n"))
+				if err != nil {
+					t.Fatalf("WriteTempJSON(): %v", err)
+				}
+				return malformedPath, func() error { return nil }
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			store := NewMemoryObjectStore()
+			manifest, _, _ := writePublishManifestFixture(t, store, "0.0.16-"+tc.name)
+			injectLocalPath, mutateLocal := tc.prepare(t, manifest)
+			if mutateLocal != nil {
+				if err := mutateLocal(); err != nil {
+					t.Fatalf("mutate local entry: %v", err)
+				}
+			}
+
+			collisionStore := &entryWriteCollisionStore{
+				RegistryObjectStore: store,
+				entryURL:            manifest.EntryObject.StorageURL,
+				injectLocalPath:     injectLocalPath,
+				preconditionErr:     rawGcloud412,
+			}
+			writer := &Writer{Store: collisionStore}
+			outcome, _, err := writer.uploadImmutableObjectIfNeeded(manifest.EntryObject, "651a5c30feb995c9364c38f63d0d5c3880bc2055")
+
+			switch {
+			case tc.wantSkipped:
+				if err != nil {
+					t.Fatalf("uploadImmutableObjectIfNeeded() = %v", err)
+				}
+				if outcome.Outcome != ObjectWriteOutcomeSkipped {
+					t.Fatalf("outcome = %q, want skipped", outcome.Outcome)
+				}
+			case tc.wantConflict:
+				if !errors.Is(err, ErrRegistryEntryConflict) {
+					t.Fatalf("uploadImmutableObjectIfNeeded() = %v, want ErrRegistryEntryConflict", err)
+				}
+			case tc.wantErr:
+				if err == nil {
+					t.Fatal("expected malformed winning entry to fail closed")
+				}
+				if errors.Is(err, ErrRegistryEntryConflict) || isObjectGenerationPreconditionFailed(err) {
+					t.Fatalf("uploadImmutableObjectIfNeeded() = %v, want decode/read failure", err)
+				}
+			default:
+				t.Fatal("test case missing expectation")
+			}
+		})
 	}
 }

--- a/gestaltd/internal/appregistry/publish_validation.go
+++ b/gestaltd/internal/appregistry/publish_validation.go
@@ -1,0 +1,129 @@
+package appregistry
+
+import (
+	"fmt"
+	"strings"
+
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	"github.com/valon-technologies/gestalt/server/services/apps/source"
+)
+
+// PublishValidationOptions controls publication-kind-specific validation.
+type PublishValidationOptions struct {
+	PublicationKind PublicationKind
+}
+
+func ValidatePublishInput(manifest *providermanifestv1.Manifest, version, sourceRef string) error {
+	return ValidatePublishInputWithOptions(manifest, version, sourceRef, PublishValidationOptions{})
+}
+
+func ValidatePublishInputWithOptions(manifest *providermanifestv1.Manifest, version, sourceRef string, opts PublishValidationOptions) error {
+	if manifest == nil {
+		return fmt.Errorf("manifest is required")
+	}
+	if providermanifestv1.NormalizeKind(manifest.Kind) != providermanifestv1.KindApp {
+		return fmt.Errorf("app registry publish only supports kind %q, got %q", providermanifestv1.KindApp, manifest.Kind)
+	}
+	if err := source.ValidateVersion(strings.TrimSpace(version)); err != nil {
+		return fmt.Errorf("invalid version: %w", err)
+	}
+	if err := validatePublicationKind(opts.PublicationKind); err != nil {
+		return fmt.Errorf("publication kind: %w", err)
+	}
+	sourceRef = strings.ToLower(strings.TrimSpace(sourceRef))
+	if publicationKindRequiresSourceRef(opts.PublicationKind) {
+		if err := validateSourceRef(sourceRef); err != nil {
+			return err
+		}
+	} else if sourceRef != "" {
+		if err := validateSourceRef(sourceRef); err != nil {
+			return err
+		}
+	}
+	if strings.TrimSpace(manifest.Source) == "" {
+		return fmt.Errorf("manifest source is required")
+	}
+	if _, _, err := parseAppSource(manifest.Source); err != nil {
+		return fmt.Errorf("invalid manifest source: %w", err)
+	}
+	return nil
+}
+
+func validateSourceRef(sourceRef string) error {
+	sourceRef = strings.TrimSpace(sourceRef)
+	if len(sourceRef) != 40 {
+		return fmt.Errorf("must be a 40-character commit SHA")
+	}
+	for _, r := range sourceRef {
+		if (r < '0' || r > '9') && (r < 'a' || r > 'f') {
+			return fmt.Errorf("must be a 40-character lowercase commit SHA")
+		}
+	}
+	return nil
+}
+
+func validateEntrySourceRef(entry *Entry) error {
+	if entry == nil {
+		return fmt.Errorf("registry entry is required")
+	}
+	sourceRef := strings.TrimSpace(entry.SourceRef)
+	if sourceRef != "" {
+		if err := validateSourceRef(sourceRef); err != nil {
+			return fmt.Errorf("registry entry sourceRef: %w", err)
+		}
+		return nil
+	}
+	if entry.PublicationKind == PublicationKindLocal {
+		return nil
+	}
+	return fmt.Errorf("registry entry sourceRef is required")
+}
+
+func validateEntryRepositoryField(entry *Entry) error {
+	repository := strings.TrimSpace(entry.Repository)
+	if repository == "" {
+		if strings.TrimSpace(entry.SourceRef) != "" {
+			return fmt.Errorf("is required")
+		}
+		return nil
+	}
+	return validateEntryRepository(repository, entry.App)
+}
+
+func validateEntryPublicationMetadata(entry *Entry) error {
+	if err := validatePublicationKind(entry.PublicationKind); err != nil {
+		return fmt.Errorf("registry entry publicationKind: %w", err)
+	}
+	if err := validateLocalSourceState(entry.LocalSource); err != nil {
+		return fmt.Errorf("registry entry localSource: %w", err)
+	}
+	return nil
+}
+
+func validateIndexVersionSourceRef(appName, version string, release IndexVersion) error {
+	sourceRef := strings.TrimSpace(release.SourceRef)
+	repository := strings.TrimSpace(release.Repository)
+	if sourceRef != "" && repository == "" {
+		return fmt.Errorf("app registry index app %q version %q sourceRef requires repository", appName, version)
+	}
+	if sourceRef != "" {
+		if err := validateSourceRef(sourceRef); err != nil {
+			return fmt.Errorf("app registry index app %q version %q sourceRef: %w", appName, version, err)
+		}
+	}
+	if repository != "" {
+		if err := validateEntryRepository(repository, appName); err != nil {
+			return fmt.Errorf("app registry index app %q version %q repository: %w", appName, version, err)
+		}
+	}
+	if release.PublicationKind == PublicationKindGitHub && sourceRef == "" {
+		return fmt.Errorf("app registry index app %q version %q sourceRef is required", appName, version)
+	}
+	if err := validatePublicationKind(release.PublicationKind); err != nil {
+		return fmt.Errorf("app registry index app %q version %q publicationKind: %w", appName, version, err)
+	}
+	if err := validateLocalSourceState(release.LocalSource); err != nil {
+		return fmt.Errorf("app registry index app %q version %q localSource: %w", appName, version, err)
+	}
+	return nil
+}

--- a/gestaltd/internal/appregistry/registry.go
+++ b/gestaltd/internal/appregistry/registry.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -25,6 +26,11 @@ const (
 	EntrySchemaVersion  = 1
 	IndexFileName       = "index.json"
 	appSourcePathPrefix = "apps/"
+)
+
+var (
+	ErrRegistryEntryConflict = errors.New("registry entry conflict")
+	ErrIndexVersionConflict  = errors.New("app registry index version conflict")
 )
 
 type Index struct {
@@ -543,6 +549,41 @@ func applyAppIndexAppMetadata(app *AppVersions, displayName, description string)
 	return changed
 }
 
+func indexVersionFromEntry(entry Entry, metadataPath string) IndexVersion {
+	platforms := artifactPlatforms(entry.Artifacts)
+	sort.Strings(platforms)
+	indexVersion := IndexVersion{
+		Metadata:          strings.TrimSpace(metadataPath),
+		Platforms:         platforms,
+		PublishedAt:       entry.PublishedAt.UTC(),
+		SourceRef:         strings.TrimSpace(entry.SourceRef),
+		Repository:        strings.TrimSpace(entry.Repository),
+		Publication:       clonePublication(entry.Publication),
+		PublicationKind:   entry.PublicationKind,
+		PublishID:         strings.TrimSpace(entry.PublishID),
+		BuilderVersion:    strings.TrimSpace(entry.BuilderVersion),
+		DeclarationDigest: strings.TrimSpace(entry.DeclarationDigest),
+		LocalSource:       cloneLocalSourceState(entry.LocalSource),
+	}
+	if entry.PublishStartedAt != nil && !entry.PublishStartedAt.IsZero() {
+		startedAt := entry.PublishStartedAt.UTC()
+		indexVersion.PublishStartedAt = &startedAt
+	}
+	return indexVersion
+}
+
+func indexVersionsEqual(a, b IndexVersion) bool {
+	aData, err := json.Marshal(a)
+	if err != nil {
+		return false
+	}
+	bData, err := json.Marshal(b)
+	if err != nil {
+		return false
+	}
+	return bytes.Equal(aData, bData)
+}
+
 // UpsertAppIndex updates the per-app index for a published version. The second
 // return value reports whether the index was modified.
 func UpsertAppIndex(index *Index, entry Entry, metadataPath string, displayName, description string) (*Index, bool, error) {
@@ -567,6 +608,10 @@ func UpsertAppIndex(index *Index, entry Entry, metadataPath string, displayName,
 		if strings.TrimSpace(existing.Metadata) != strings.TrimSpace(metadataPath) {
 			return nil, false, fmt.Errorf("app %q version %q is already indexed", appName, entry.Version)
 		}
+		expected := indexVersionFromEntry(entry, metadataPath)
+		if !indexVersionsEqual(existing, expected) {
+			return nil, false, fmt.Errorf("app %q version %q index identity mismatch: %w; %s", appName, entry.Version, ErrIndexVersionConflict, RepublishCorruptObjectGuidance)
+		}
 		changed := applyAppIndexAppMetadata(&app, displayName, description)
 		if !changed {
 			return index, false, nil
@@ -578,26 +623,7 @@ func UpsertAppIndex(index *Index, entry Entry, metadataPath string, displayName,
 		return index, true, nil
 	}
 	applyAppIndexAppMetadata(&app, displayName, description)
-	platforms := artifactPlatforms(entry.Artifacts)
-	sort.Strings(platforms)
-	indexVersion := IndexVersion{
-		Metadata:          strings.TrimSpace(metadataPath),
-		Platforms:         platforms,
-		PublishedAt:       entry.PublishedAt.UTC(),
-		SourceRef:         strings.TrimSpace(entry.SourceRef),
-		Repository:        strings.TrimSpace(entry.Repository),
-		Publication:       clonePublication(entry.Publication),
-		PublicationKind:   entry.PublicationKind,
-		PublishID:         strings.TrimSpace(entry.PublishID),
-		BuilderVersion:    strings.TrimSpace(entry.BuilderVersion),
-		DeclarationDigest: strings.TrimSpace(entry.DeclarationDigest),
-		LocalSource:       cloneLocalSourceState(entry.LocalSource),
-	}
-	if entry.PublishStartedAt != nil && !entry.PublishStartedAt.IsZero() {
-		startedAt := entry.PublishStartedAt.UTC()
-		indexVersion.PublishStartedAt = &startedAt
-	}
-	app.Versions[entry.Version] = indexVersion
+	app.Versions[entry.Version] = indexVersionFromEntry(entry, metadataPath)
 	index.Apps[appName] = app
 	if err := validateIndex(index); err != nil {
 		return nil, false, err

--- a/gestaltd/internal/appregistry/registry.go
+++ b/gestaltd/internal/appregistry/registry.go
@@ -39,29 +39,39 @@ type AppVersions struct {
 }
 
 type IndexVersion struct {
-	Metadata         string       `json:"metadata"`
-	Platforms        []string     `json:"platforms,omitempty"`
-	PublishedAt      time.Time    `json:"publishedAt"`
-	PublishStartedAt *time.Time   `json:"publishStartedAt,omitempty"`
-	SourceRef        string       `json:"sourceRef,omitempty"`
-	Repository       string       `json:"repository,omitempty"`
-	Publication      *Publication `json:"publication,omitempty"`
+	Metadata          string            `json:"metadata"`
+	Platforms         []string          `json:"platforms,omitempty"`
+	PublishedAt       time.Time         `json:"publishedAt"`
+	PublishStartedAt  *time.Time        `json:"publishStartedAt,omitempty"`
+	SourceRef         string            `json:"sourceRef,omitempty"`
+	Repository        string            `json:"repository,omitempty"`
+	Publication       *Publication      `json:"publication,omitempty"`
+	PublicationKind   PublicationKind   `json:"publicationKind,omitempty"`
+	PublishID         string            `json:"publishId,omitempty"`
+	BuilderVersion    string            `json:"builderVersion,omitempty"`
+	DeclarationDigest string            `json:"declarationDigest,omitempty"`
+	LocalSource       *LocalSourceState `json:"localSource,omitempty"`
 }
 
 type Entry struct {
-	SchemaVersion    int                 `json:"schemaVersion"`
-	App              string              `json:"app"`
-	Version          string              `json:"version"`
-	SourceRef        string              `json:"sourceRef"`
-	ManifestPath     string              `json:"manifestPath"`
-	Repository       string              `json:"repository"`
-	Publication      *Publication        `json:"publication,omitempty"`
-	Artifacts        map[string]Artifact `json:"artifacts"`
-	Interface        Interface           `json:"interface,omitempty"`
-	Requires         Requires            `json:"requires,omitempty"`
-	Compatibility    Compatibility       `json:"compatibility,omitempty"`
-	PublishedAt      time.Time           `json:"publishedAt"`
-	PublishStartedAt *time.Time          `json:"publishStartedAt,omitempty"`
+	SchemaVersion     int                 `json:"schemaVersion"`
+	App               string              `json:"app"`
+	Version           string              `json:"version"`
+	SourceRef         string              `json:"sourceRef"`
+	ManifestPath      string              `json:"manifestPath"`
+	Repository        string              `json:"repository"`
+	Publication       *Publication        `json:"publication,omitempty"`
+	PublicationKind   PublicationKind     `json:"publicationKind,omitempty"`
+	PublishID         string              `json:"publishId,omitempty"`
+	BuilderVersion    string              `json:"builderVersion,omitempty"`
+	DeclarationDigest string              `json:"declarationDigest,omitempty"`
+	LocalSource       *LocalSourceState   `json:"localSource,omitempty"`
+	Artifacts         map[string]Artifact `json:"artifacts"`
+	Interface         Interface           `json:"interface,omitempty"`
+	Requires          Requires            `json:"requires,omitempty"`
+	Compatibility     Compatibility       `json:"compatibility,omitempty"`
+	PublishedAt       time.Time           `json:"publishedAt"`
+	PublishStartedAt  *time.Time          `json:"publishStartedAt,omitempty"`
 }
 
 type Publication struct {
@@ -201,30 +211,10 @@ func requirementForApp(requires Requires, targetApp string) (AppRequirement, boo
 	return AppRequirement{}, false
 }
 
-func ValidatePublishInput(manifest *providermanifestv1.Manifest, version, sourceRef string) error {
-	if manifest == nil {
-		return fmt.Errorf("manifest is required")
-	}
-	if providermanifestv1.NormalizeKind(manifest.Kind) != providermanifestv1.KindApp {
-		return fmt.Errorf("app registry publish only supports kind %q, got %q", providermanifestv1.KindApp, manifest.Kind)
-	}
-	if err := source.ValidateVersion(strings.TrimSpace(version)); err != nil {
-		return fmt.Errorf("invalid version: %w", err)
-	}
-	if err := validateSourceRef(strings.ToLower(strings.TrimSpace(sourceRef))); err != nil {
-		return err
-	}
-	if strings.TrimSpace(manifest.Source) == "" {
-		return fmt.Errorf("manifest source is required")
-	}
-	if _, _, err := parseAppSource(manifest.Source); err != nil {
-		return fmt.Errorf("invalid manifest source: %w", err)
-	}
-	return nil
-}
-
 func BuildEntry(input BuildEntryInput) (Entry, error) {
-	if err := ValidatePublishInput(input.Manifest, input.Version, input.SourceRef); err != nil {
+	if err := ValidatePublishInputWithOptions(input.Manifest, input.Version, input.SourceRef, PublishValidationOptions{
+		PublicationKind: input.PublicationKind,
+	}); err != nil {
 		return Entry{}, err
 	}
 	if input.Release == nil {
@@ -245,18 +235,23 @@ func BuildEntry(input BuildEntryInput) (Entry, error) {
 		publishedAt = time.Now().UTC()
 	}
 	entry := Entry{
-		SchemaVersion: EntrySchemaVersion,
-		App:           appName,
-		Version:       strings.TrimSpace(input.Version),
-		SourceRef:     strings.ToLower(strings.TrimSpace(input.SourceRef)),
-		ManifestPath:  strings.TrimSpace(input.ManifestPath),
-		Repository:    repository,
-		Publication:   clonePublication(input.Publication),
-		Artifacts:     artifacts,
-		Interface:     InterfaceFromRelease(input.Release),
-		Requires:      requires,
-		Compatibility: compatibility,
-		PublishedAt:   publishedAt.UTC(),
+		SchemaVersion:     EntrySchemaVersion,
+		App:               appName,
+		Version:           strings.TrimSpace(input.Version),
+		SourceRef:         strings.ToLower(strings.TrimSpace(input.SourceRef)),
+		ManifestPath:      strings.TrimSpace(input.ManifestPath),
+		Repository:        repository,
+		Publication:       clonePublication(input.Publication),
+		PublicationKind:   input.PublicationKind,
+		PublishID:         strings.TrimSpace(input.PublishID),
+		BuilderVersion:    strings.TrimSpace(input.BuilderVersion),
+		DeclarationDigest: strings.TrimSpace(input.DeclarationDigest),
+		LocalSource:       cloneLocalSourceState(input.LocalSource),
+		Artifacts:         artifacts,
+		Interface:         InterfaceFromRelease(input.Release),
+		Requires:          requires,
+		Compatibility:     compatibility,
+		PublishedAt:       publishedAt.UTC(),
 	}
 	if !input.PublishStartedAt.IsZero() {
 		startedAt := input.PublishStartedAt.UTC()
@@ -269,15 +264,20 @@ func BuildEntry(input BuildEntryInput) (Entry, error) {
 }
 
 type BuildEntryInput struct {
-	Manifest         *providermanifestv1.Manifest
-	Version          string
-	SourceRef        string
-	ManifestPath     string
-	Publication      *Publication
-	Release          *providerrelease.Metadata
-	Artifacts        []PublishArtifact
-	PublishedAt      time.Time
-	PublishStartedAt time.Time
+	Manifest          *providermanifestv1.Manifest
+	Version           string
+	SourceRef         string
+	ManifestPath      string
+	Publication       *Publication
+	PublicationKind   PublicationKind
+	PublishID         string
+	BuilderVersion    string
+	DeclarationDigest string
+	LocalSource       *LocalSourceState
+	Release           *providerrelease.Metadata
+	Artifacts         []PublishArtifact
+	PublishedAt       time.Time
+	PublishStartedAt  time.Time
 }
 
 func buildArtifacts(artifacts []PublishArtifact) (map[string]Artifact, error) {
@@ -422,17 +422,20 @@ func validateEntry(entry *Entry) error {
 	if err := source.ValidateVersion(strings.TrimSpace(entry.Version)); err != nil {
 		return fmt.Errorf("registry entry version: %w", err)
 	}
-	if err := validateSourceRef(entry.SourceRef); err != nil {
-		return fmt.Errorf("registry entry sourceRef: %w", err)
+	if err := validateEntrySourceRef(entry); err != nil {
+		return err
 	}
 	if strings.TrimSpace(entry.ManifestPath) == "" {
 		return fmt.Errorf("registry entry manifestPath is required")
 	}
-	if err := validateEntryRepository(entry.Repository, entry.App); err != nil {
+	if err := validateEntryRepositoryField(entry); err != nil {
 		return fmt.Errorf("registry entry repository: %w", err)
 	}
 	if err := validatePublication(entry.Publication); err != nil {
 		return fmt.Errorf("registry entry publication: %w", err)
+	}
+	if err := validateEntryPublicationMetadata(entry); err != nil {
+		return err
 	}
 	if len(entry.Artifacts) == 0 {
 		return fmt.Errorf("registry entry artifacts are required")
@@ -479,18 +482,8 @@ func validateIndex(index *Index) error {
 			if release.PublishedAt.IsZero() {
 				return fmt.Errorf("app registry index app %q version %q publishedAt is required", appName, version)
 			}
-			hasSourceRef := strings.TrimSpace(release.SourceRef) != ""
-			hasRepository := strings.TrimSpace(release.Repository) != ""
-			if hasSourceRef != hasRepository {
-				return fmt.Errorf("app registry index app %q version %q sourceRef and repository must be recorded together", appName, version)
-			}
-			if hasSourceRef {
-				if err := validateSourceRef(release.SourceRef); err != nil {
-					return fmt.Errorf("app registry index app %q version %q sourceRef: %w", appName, version, err)
-				}
-				if err := validateEntryRepository(release.Repository, appName); err != nil {
-					return fmt.Errorf("app registry index app %q version %q repository: %w", appName, version, err)
-				}
+			if err := validateIndexVersionSourceRef(appName, version, release); err != nil {
+				return err
 			}
 			if err := validatePublication(release.Publication); err != nil {
 				return fmt.Errorf("app registry index app %q version %q publication: %w", appName, version, err)
@@ -588,12 +581,17 @@ func UpsertAppIndex(index *Index, entry Entry, metadataPath string, displayName,
 	platforms := artifactPlatforms(entry.Artifacts)
 	sort.Strings(platforms)
 	indexVersion := IndexVersion{
-		Metadata:    strings.TrimSpace(metadataPath),
-		Platforms:   platforms,
-		PublishedAt: entry.PublishedAt.UTC(),
-		SourceRef:   strings.TrimSpace(entry.SourceRef),
-		Repository:  strings.TrimSpace(entry.Repository),
-		Publication: clonePublication(entry.Publication),
+		Metadata:          strings.TrimSpace(metadataPath),
+		Platforms:         platforms,
+		PublishedAt:       entry.PublishedAt.UTC(),
+		SourceRef:         strings.TrimSpace(entry.SourceRef),
+		Repository:        strings.TrimSpace(entry.Repository),
+		Publication:       clonePublication(entry.Publication),
+		PublicationKind:   entry.PublicationKind,
+		PublishID:         strings.TrimSpace(entry.PublishID),
+		BuilderVersion:    strings.TrimSpace(entry.BuilderVersion),
+		DeclarationDigest: strings.TrimSpace(entry.DeclarationDigest),
+		LocalSource:       cloneLocalSourceState(entry.LocalSource),
 	}
 	if entry.PublishStartedAt != nil && !entry.PublishStartedAt.IsZero() {
 		startedAt := entry.PublishStartedAt.UTC()
@@ -666,19 +664,6 @@ func validateEntryRepository(repository, appName string) error {
 	}
 	if parsedApp != appName {
 		return fmt.Errorf("does not match app %q", appName)
-	}
-	return nil
-}
-
-func validateSourceRef(sourceRef string) error {
-	sourceRef = strings.TrimSpace(sourceRef)
-	if len(sourceRef) != 40 {
-		return fmt.Errorf("must be a 40-character commit SHA")
-	}
-	for _, r := range sourceRef {
-		if (r < '0' || r > '9') && (r < 'a' || r > 'f') {
-			return fmt.Errorf("must be a 40-character lowercase commit SHA")
-		}
 	}
 	return nil
 }

--- a/gestaltd/internal/appregistry/writer.go
+++ b/gestaltd/internal/appregistry/writer.go
@@ -55,13 +55,17 @@ func (w *Writer) Preflight(req PublishRequest, progress PublishProgress) error {
 	if progress.Start != nil {
 		progress.Start("Checking %d remote app objects before upload", objectCount)
 	}
-	if err := w.preflightIndex(plan); err != nil {
-		return err
-	}
 	for _, object := range append([]PublishObject{plan.EntryObject}, plan.ArtifactObjects...) {
 		if err := w.preflightImmutableObject(object); err != nil {
 			return err
 		}
+	}
+	winningEntry, err := w.resolveWinningEntry(plan)
+	if err != nil {
+		return err
+	}
+	if err := w.preflightIndex(plan, winningEntry); err != nil {
+		return err
 	}
 	if progress.Done != nil {
 		progress.Done("Checked %d remote app objects", objectCount)
@@ -83,13 +87,18 @@ func (w *Writer) Publish(req PublishRequest, progress PublishProgress) (PublishR
 	result.Artifacts = immutable.Artifacts
 	result.Entry = immutable.Entry
 
-	retentionOutcome, err := w.uploadRetention(req, progress)
+	winningEntry, err := w.resolveWinningEntry(req.Manifest)
+	if err != nil {
+		return result, err
+	}
+
+	retentionOutcome, err := w.uploadRetention(req, winningEntry, progress)
 	result.Retention = retentionOutcome
 	if err != nil {
 		return result, err
 	}
 
-	indexOutcome, err := w.uploadIndex(req, progress)
+	indexOutcome, err := w.uploadIndex(req, winningEntry, progress)
 	result.Index = indexOutcome
 	if err != nil {
 		return result, err
@@ -97,7 +106,7 @@ func (w *Writer) Publish(req PublishRequest, progress PublishProgress) (PublishR
 	return result, nil
 }
 
-func (w *Writer) preflightIndex(plan PublishManifest) error {
+func (w *Writer) preflightIndex(plan PublishManifest, entry Entry) error {
 	_, existing, err := w.Store.ReadObject(plan.IndexObject.StorageURL)
 	if err != nil {
 		return err
@@ -107,8 +116,26 @@ func (w *Writer) preflightIndex(plan PublishManifest) error {
 		return fmt.Errorf("decode existing app index: %w", err)
 	}
 	metadataPath := AppVersionEntryPath(plan.AppName, plan.Version)
-	_, _, err = UpsertAppIndex(index, plan.Entry, metadataPath, plan.DisplayName, plan.Description)
+	_, _, err = UpsertAppIndex(index, entry, metadataPath, plan.DisplayName, plan.Description)
 	return err
+}
+
+func (w *Writer) resolveWinningEntry(plan PublishManifest) (Entry, error) {
+	_, existing, err := w.Store.ReadObject(plan.EntryObject.StorageURL)
+	if err != nil {
+		return Entry{}, err
+	}
+	if len(existing) == 0 {
+		return plan.Entry, nil
+	}
+	winning, err := DecodeEntry(existing)
+	if err != nil {
+		return Entry{}, fmt.Errorf("decode winning entry: %w", err)
+	}
+	if !EntriesEqualIgnoringPublishedAt(plan.Entry, *winning) {
+		return Entry{}, fmt.Errorf("%s: %w; %s", plan.EntryObject.StorageURL, ErrRegistryEntryConflict, RepublishCorruptObjectGuidance)
+	}
+	return *winning, nil
 }
 
 func (w *Writer) preflightImmutableObject(object PublishObject) error {
@@ -125,6 +152,9 @@ func (w *Writer) preflightImmutableObject(object PublishObject) error {
 	}
 	if described.Generation == 0 {
 		return nil
+	}
+	if object.Kind == PublishObjectKindEntry {
+		return fmt.Errorf("%s: %w; %s", object.StorageURL, ErrRegistryEntryConflict, RepublishCorruptObjectGuidance)
 	}
 	return fmt.Errorf("%s already exists; %s", object.StorageURL, RepublishCorruptObjectGuidance)
 }
@@ -179,6 +209,13 @@ func (w *Writer) uploadImmutableObjectIfNeeded(object PublishObject, sourceRef s
 			Outcome:    ObjectWriteOutcomeSkipped,
 		}, fmt.Sprintf("skipped existing %s", object.StorageURL), nil
 	}
+	described, err := w.Store.DescribeObject(object.StorageURL)
+	if err != nil {
+		return ImmutableObjectOutcome{}, "", err
+	}
+	if described.Generation != 0 && object.Kind == PublishObjectKindEntry {
+		return ImmutableObjectOutcome{}, "", fmt.Errorf("%s: %w; %s", object.StorageURL, ErrRegistryEntryConflict, RepublishCorruptObjectGuidance)
+	}
 	if err := w.Store.WriteImmutableObject(WriteImmutableObjectInput{
 		LocalPath:  object.LocalPath,
 		StorageURL: object.StorageURL,
@@ -214,7 +251,7 @@ func (w *Writer) immutableObjectMatchesExisting(object PublishObject) (bool, err
 	return false, nil
 }
 
-func (w *Writer) uploadIndex(req PublishRequest, progress PublishProgress) (CatalogWriteOutcome, error) {
+func (w *Writer) uploadIndex(req PublishRequest, entry Entry, progress PublishProgress) (CatalogWriteOutcome, error) {
 	plan := req.Manifest
 	indexPath := plan.IndexObject.StorageURL
 	if progress.Start != nil {
@@ -233,7 +270,7 @@ func (w *Writer) uploadIndex(req PublishRequest, progress PublishProgress) (Cata
 			return CatalogWriteOutcomeNotAttempted, fmt.Errorf("decode existing app index: %w", err)
 		}
 		metadataPath := AppVersionEntryPath(plan.AppName, plan.Version)
-		updated, changed, err := UpsertAppIndex(index, plan.Entry, metadataPath, plan.DisplayName, plan.Description)
+		updated, changed, err := UpsertAppIndex(index, entry, metadataPath, plan.DisplayName, plan.Description)
 		if err != nil {
 			return CatalogWriteOutcomeNotAttempted, err
 		}
@@ -281,10 +318,10 @@ func (w *Writer) uploadIndex(req PublishRequest, progress PublishProgress) (Cata
 	return CatalogWriteOutcomeNotAttempted, fmt.Errorf("update %s: exceeded retry limit after concurrent index updates", indexPath)
 }
 
-func (w *Writer) uploadRetention(req PublishRequest, progress PublishProgress) (CatalogWriteOutcome, error) {
+func (w *Writer) uploadRetention(req PublishRequest, entry Entry, progress PublishProgress) (CatalogWriteOutcome, error) {
 	plan := req.Manifest
 	retentionPath := RetentionStorageURL(plan.IndexObject.StorageURL, plan.AppName)
-	publishedAt := plan.Entry.PublishedAt
+	publishedAt := entry.PublishedAt
 	if progress.Start != nil {
 		progress.Start("Updating app registry retention catalog")
 	}

--- a/gestaltd/internal/appregistry/writer.go
+++ b/gestaltd/internal/appregistry/writer.go
@@ -154,11 +154,11 @@ func (w *Writer) preflightImmutableObject(object PublishObject) error {
 		return nil
 	}
 	if object.Kind == PublishObjectKindEntry {
-		matches, err := w.entryObjectMatchesExistingBytes(object)
+		skipped, err := w.reconcileExistingEntryObject(object)
 		if err != nil {
 			return err
 		}
-		if matches {
+		if skipped {
 			return nil
 		}
 		return fmt.Errorf("%s: %w; %s", object.StorageURL, ErrRegistryEntryConflict, RepublishCorruptObjectGuidance)
@@ -221,15 +221,13 @@ func (w *Writer) uploadImmutableObjectIfNeeded(object PublishObject, sourceRef s
 		return ImmutableObjectOutcome{}, "", err
 	}
 	if described.Generation != 0 && object.Kind == PublishObjectKindEntry {
-		matches, err := w.entryObjectMatchesExistingBytes(object)
+		skipped, err := w.reconcileExistingEntryObject(object)
 		if err != nil {
 			return ImmutableObjectOutcome{}, "", err
 		}
-		if matches {
-			return ImmutableObjectOutcome{
-				StorageURL: object.StorageURL,
-				Outcome:    ObjectWriteOutcomeSkipped,
-			}, fmt.Sprintf("skipped existing %s", object.StorageURL), nil
+		if skipped {
+			outcome, line := entryObjectSkippedOutcome(object)
+			return outcome, line, nil
 		}
 		return ImmutableObjectOutcome{}, "", fmt.Errorf("%s: %w; %s", object.StorageURL, ErrRegistryEntryConflict, RepublishCorruptObjectGuidance)
 	}
@@ -239,6 +237,17 @@ func (w *Writer) uploadImmutableObjectIfNeeded(object PublishObject, sourceRef s
 		SourceRef:  sourceRef,
 		SHA256:     object.SHA256,
 	}); err != nil {
+		if object.Kind == PublishObjectKindEntry && errors.Is(err, ErrObjectPreconditionFailed) {
+			skipped, reconcileErr := w.reconcileExistingEntryObject(object)
+			if reconcileErr != nil {
+				return ImmutableObjectOutcome{}, "", reconcileErr
+			}
+			if skipped {
+				outcome, line := entryObjectSkippedOutcome(object)
+				return outcome, line, nil
+			}
+			return ImmutableObjectOutcome{}, "", fmt.Errorf("%s: %w; %s", object.StorageURL, ErrRegistryEntryConflict, RepublishCorruptObjectGuidance)
+		}
 		return ImmutableObjectOutcome{}, "", err
 	}
 	return ImmutableObjectOutcome{
@@ -276,6 +285,21 @@ func (w *Writer) entryObjectMatchesExistingBytes(object PublishObject) (bool, er
 		return false, nil
 	}
 	return EntryFileEquivalentIgnoringPublishedAt(object.LocalPath, existing)
+}
+
+func entryObjectSkippedOutcome(object PublishObject) (ImmutableObjectOutcome, string) {
+	return ImmutableObjectOutcome{
+		StorageURL: object.StorageURL,
+		Outcome:    ObjectWriteOutcomeSkipped,
+	}, fmt.Sprintf("skipped existing %s", object.StorageURL)
+}
+
+func (w *Writer) reconcileExistingEntryObject(object PublishObject) (bool, error) {
+	matches, err := w.entryObjectMatchesExistingBytes(object)
+	if err != nil {
+		return false, err
+	}
+	return matches, nil
 }
 
 func (w *Writer) uploadIndex(req PublishRequest, entry Entry, progress PublishProgress) (CatalogWriteOutcome, error) {

--- a/gestaltd/internal/appregistry/writer.go
+++ b/gestaltd/internal/appregistry/writer.go
@@ -154,6 +154,13 @@ func (w *Writer) preflightImmutableObject(object PublishObject) error {
 		return nil
 	}
 	if object.Kind == PublishObjectKindEntry {
+		matches, err := w.entryObjectMatchesExistingBytes(object)
+		if err != nil {
+			return err
+		}
+		if matches {
+			return nil
+		}
 		return fmt.Errorf("%s: %w; %s", object.StorageURL, ErrRegistryEntryConflict, RepublishCorruptObjectGuidance)
 	}
 	return fmt.Errorf("%s already exists; %s", object.StorageURL, RepublishCorruptObjectGuidance)
@@ -214,6 +221,16 @@ func (w *Writer) uploadImmutableObjectIfNeeded(object PublishObject, sourceRef s
 		return ImmutableObjectOutcome{}, "", err
 	}
 	if described.Generation != 0 && object.Kind == PublishObjectKindEntry {
+		matches, err := w.entryObjectMatchesExistingBytes(object)
+		if err != nil {
+			return ImmutableObjectOutcome{}, "", err
+		}
+		if matches {
+			return ImmutableObjectOutcome{
+				StorageURL: object.StorageURL,
+				Outcome:    ObjectWriteOutcomeSkipped,
+			}, fmt.Sprintf("skipped existing %s", object.StorageURL), nil
+		}
 		return ImmutableObjectOutcome{}, "", fmt.Errorf("%s: %w; %s", object.StorageURL, ErrRegistryEntryConflict, RepublishCorruptObjectGuidance)
 	}
 	if err := w.Store.WriteImmutableObject(WriteImmutableObjectInput{
@@ -242,13 +259,23 @@ func (w *Writer) immutableObjectMatchesExisting(object PublishObject) (bool, err
 		return true, nil
 	}
 	if object.Kind == PublishObjectKindEntry && object.LocalPath != "" {
-		_, existing, err := w.Store.ReadObject(object.StorageURL)
-		if err != nil {
-			return false, err
-		}
-		return EntryFileEquivalentIgnoringPublishedAt(object.LocalPath, existing)
+		return w.entryObjectMatchesExistingBytes(object)
 	}
 	return false, nil
+}
+
+func (w *Writer) entryObjectMatchesExistingBytes(object PublishObject) (bool, error) {
+	if object.Kind != PublishObjectKindEntry || object.LocalPath == "" {
+		return false, nil
+	}
+	_, existing, err := w.Store.ReadObject(object.StorageURL)
+	if err != nil {
+		return false, err
+	}
+	if len(existing) == 0 {
+		return false, nil
+	}
+	return EntryFileEquivalentIgnoringPublishedAt(object.LocalPath, existing)
 }
 
 func (w *Writer) uploadIndex(req PublishRequest, entry Entry, progress PublishProgress) (CatalogWriteOutcome, error) {

--- a/gestaltd/internal/appregistry/writer.go
+++ b/gestaltd/internal/appregistry/writer.go
@@ -1,0 +1,386 @@
+package appregistry
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+)
+
+const defaultCatalogUpdateAttempts = 5
+
+// PublishProgress reports publish lifecycle events to callers such as the CLI.
+type PublishProgress struct {
+	Start  func(format string, args ...any)
+	Status func(format string, args ...any)
+	Done   func(format string, args ...any)
+	Log    func(line string)
+}
+
+// Writer publishes immutable app registry versions through a RegistryObjectStore.
+type Writer struct {
+	Store           RegistryObjectStore
+	CatalogAttempts int
+	RetentionPolicy RetentionPolicy
+}
+
+// PublishRequest is the typed input for Writer.Publish and Writer.Preflight.
+type PublishRequest struct {
+	Manifest  PublishManifest
+	SourceRef string
+}
+
+func (w *Writer) catalogAttempts() int {
+	if w == nil || w.CatalogAttempts <= 0 {
+		return defaultCatalogUpdateAttempts
+	}
+	return w.CatalogAttempts
+}
+
+func (w *Writer) retentionPolicy() RetentionPolicy {
+	if w == nil || (w.RetentionPolicy.UnusedRetention == 0 && w.RetentionPolicy.DeployedRetention == 0) {
+		return DefaultRetentionPolicy()
+	}
+	return w.RetentionPolicy
+}
+
+// Preflight validates that immutable objects can be created and the index update would succeed.
+func (w *Writer) Preflight(req PublishRequest, progress PublishProgress) error {
+	if w == nil || w.Store == nil {
+		return fmt.Errorf("registry writer store is required")
+	}
+	plan := req.Manifest
+	objectCount := len(plan.ArtifactObjects) + 2
+	if progress.Start != nil {
+		progress.Start("Checking %d remote app objects before upload", objectCount)
+	}
+	if err := w.preflightIndex(plan); err != nil {
+		return err
+	}
+	for _, object := range append([]PublishObject{plan.EntryObject}, plan.ArtifactObjects...) {
+		if err := w.preflightImmutableObject(object); err != nil {
+			return err
+		}
+	}
+	if progress.Done != nil {
+		progress.Done("Checked %d remote app objects", objectCount)
+	}
+	return nil
+}
+
+// Publish uploads immutable objects, updates the retention catalog, and commits
+// the index last so no fallible registry write occurs after index commit.
+func (w *Writer) Publish(req PublishRequest, progress PublishProgress) (PublishResult, error) {
+	result := PublishResult{
+		Retention: CatalogWriteOutcomeNotAttempted,
+		Index:     CatalogWriteOutcomeNotAttempted,
+	}
+	immutable, err := w.uploadImmutableObjects(req, progress)
+	if err != nil {
+		return result, err
+	}
+	result.Artifacts = immutable.Artifacts
+	result.Entry = immutable.Entry
+
+	retentionOutcome, err := w.uploadRetention(req, progress)
+	result.Retention = retentionOutcome
+	if err != nil {
+		return result, err
+	}
+
+	indexOutcome, err := w.uploadIndex(req, progress)
+	result.Index = indexOutcome
+	if err != nil {
+		return result, err
+	}
+	return result, nil
+}
+
+func (w *Writer) preflightIndex(plan PublishManifest) error {
+	_, existing, err := w.Store.ReadObject(plan.IndexObject.StorageURL)
+	if err != nil {
+		return err
+	}
+	index, err := decodeIndexOrEmpty(existing)
+	if err != nil {
+		return fmt.Errorf("decode existing app index: %w", err)
+	}
+	metadataPath := AppVersionEntryPath(plan.AppName, plan.Version)
+	_, _, err = UpsertAppIndex(index, plan.Entry, metadataPath, plan.DisplayName, plan.Description)
+	return err
+}
+
+func (w *Writer) preflightImmutableObject(object PublishObject) error {
+	matches, err := w.immutableObjectMatchesExisting(object)
+	if err != nil {
+		return err
+	}
+	if matches {
+		return nil
+	}
+	described, err := w.Store.DescribeObject(object.StorageURL)
+	if err != nil {
+		return err
+	}
+	if described.Generation == 0 {
+		return nil
+	}
+	return fmt.Errorf("%s already exists; %s", object.StorageURL, RepublishCorruptObjectGuidance)
+}
+
+func (w *Writer) uploadImmutableObjects(req PublishRequest, progress PublishProgress) (ImmutablePublishOutcome, error) {
+	plan := req.Manifest
+	objectCount := len(plan.ArtifactObjects) + 1
+	if progress.Start != nil {
+		progress.Start("Uploading %d immutable app objects", objectCount)
+	}
+	stdoutLines := make([]string, 0, objectCount)
+	outcome := ImmutablePublishOutcome{
+		Artifacts: make([]ImmutableObjectOutcome, 0, len(plan.ArtifactObjects)),
+	}
+	for _, object := range plan.ArtifactObjects {
+		objectOutcome, line, err := w.uploadImmutableObjectIfNeeded(object, req.SourceRef)
+		if err != nil {
+			return ImmutablePublishOutcome{}, err
+		}
+		outcome.Artifacts = append(outcome.Artifacts, objectOutcome)
+		if line != "" {
+			stdoutLines = append(stdoutLines, line)
+		}
+	}
+	entryOutcome, line, err := w.uploadImmutableObjectIfNeeded(plan.EntryObject, req.SourceRef)
+	if err != nil {
+		return ImmutablePublishOutcome{}, err
+	}
+	outcome.Entry = entryOutcome
+	if line != "" {
+		stdoutLines = append(stdoutLines, line)
+	}
+	if progress.Done != nil {
+		progress.Done("Processed %d immutable app objects", objectCount)
+	}
+	for _, line := range stdoutLines {
+		if progress.Log != nil {
+			progress.Log(line)
+		}
+	}
+	return outcome, nil
+}
+
+func (w *Writer) uploadImmutableObjectIfNeeded(object PublishObject, sourceRef string) (ImmutableObjectOutcome, string, error) {
+	matches, err := w.immutableObjectMatchesExisting(object)
+	if err != nil {
+		return ImmutableObjectOutcome{}, "", err
+	}
+	if matches {
+		return ImmutableObjectOutcome{
+			StorageURL: object.StorageURL,
+			Outcome:    ObjectWriteOutcomeSkipped,
+		}, fmt.Sprintf("skipped existing %s", object.StorageURL), nil
+	}
+	if err := w.Store.WriteImmutableObject(WriteImmutableObjectInput{
+		LocalPath:  object.LocalPath,
+		StorageURL: object.StorageURL,
+		SourceRef:  sourceRef,
+		SHA256:     object.SHA256,
+	}); err != nil {
+		return ImmutableObjectOutcome{}, "", err
+	}
+	return ImmutableObjectOutcome{
+		StorageURL: object.StorageURL,
+		Outcome:    ObjectWriteOutcomeUploaded,
+	}, fmt.Sprintf("uploaded %s", object.StorageURL), nil
+}
+
+func (w *Writer) immutableObjectMatchesExisting(object PublishObject) (bool, error) {
+	described, err := w.Store.DescribeObject(object.StorageURL)
+	if err != nil {
+		return false, err
+	}
+	if described.Generation == 0 {
+		return false, nil
+	}
+	if object.SHA256 != "" && described.SHA256 == object.SHA256 {
+		return true, nil
+	}
+	if object.Kind == PublishObjectKindEntry && object.LocalPath != "" {
+		_, existing, err := w.Store.ReadObject(object.StorageURL)
+		if err != nil {
+			return false, err
+		}
+		return EntryFileEquivalentIgnoringPublishedAt(object.LocalPath, existing)
+	}
+	return false, nil
+}
+
+func (w *Writer) uploadIndex(req PublishRequest, progress PublishProgress) (CatalogWriteOutcome, error) {
+	plan := req.Manifest
+	indexPath := plan.IndexObject.StorageURL
+	if progress.Start != nil {
+		progress.Start("Updating app registry index")
+	}
+	for attempt := 1; attempt <= w.catalogAttempts(); attempt++ {
+		if attempt > 1 && progress.Status != nil {
+			progress.Status("App registry index changed concurrently; retrying attempt %d/%d", attempt, w.catalogAttempts())
+		}
+		generation, existing, err := w.Store.ReadObject(indexPath)
+		if err != nil {
+			return CatalogWriteOutcomeNotAttempted, err
+		}
+		index, err := decodeIndexOrEmpty(existing)
+		if err != nil {
+			return CatalogWriteOutcomeNotAttempted, fmt.Errorf("decode existing app index: %w", err)
+		}
+		metadataPath := AppVersionEntryPath(plan.AppName, plan.Version)
+		updated, changed, err := UpsertAppIndex(index, plan.Entry, metadataPath, plan.DisplayName, plan.Description)
+		if err != nil {
+			return CatalogWriteOutcomeNotAttempted, err
+		}
+		if !changed {
+			if progress.Done != nil {
+				progress.Done("App registry index unchanged")
+			}
+			if progress.Log != nil {
+				progress.Log(fmt.Sprintf("skipped unchanged index for %s %s", plan.AppName, plan.Version))
+			}
+			return CatalogWriteOutcomeUnchanged, nil
+		}
+		data, err := json.MarshalIndent(updated, "", "  ")
+		if err != nil {
+			return CatalogWriteOutcomeNotAttempted, err
+		}
+		tmpPath, err := WriteTempJSON("gestalt-app-index-*", append(data, '\n'))
+		if err != nil {
+			return CatalogWriteOutcomeNotAttempted, err
+		}
+		err = w.Store.WriteCatalogObject(WriteCatalogObjectInput{
+			LocalPath:  tmpPath,
+			StorageURL: indexPath,
+			SourceRef:  req.SourceRef,
+			Generation: generation,
+		})
+		_ = os.Remove(tmpPath)
+		if err != nil {
+			if isCatalogPreconditionFailed(err) && attempt < w.catalogAttempts() {
+				if progress.Status != nil {
+					progress.Status("App registry index update conflict; retrying")
+				}
+				continue
+			}
+			return CatalogWriteOutcomeNotAttempted, err
+		}
+		if progress.Done != nil {
+			progress.Done("Updated app registry index")
+		}
+		if progress.Log != nil {
+			progress.Log(fmt.Sprintf("updated %s", indexPath))
+		}
+		return CatalogWriteOutcomeUpdated, nil
+	}
+	return CatalogWriteOutcomeNotAttempted, fmt.Errorf("update %s: exceeded retry limit after concurrent index updates", indexPath)
+}
+
+func (w *Writer) uploadRetention(req PublishRequest, progress PublishProgress) (CatalogWriteOutcome, error) {
+	plan := req.Manifest
+	retentionPath := RetentionStorageURL(plan.IndexObject.StorageURL, plan.AppName)
+	publishedAt := plan.Entry.PublishedAt
+	if progress.Start != nil {
+		progress.Start("Updating app registry retention catalog")
+	}
+	for attempt := 1; attempt <= w.catalogAttempts(); attempt++ {
+		if attempt > 1 && progress.Status != nil {
+			progress.Status("App registry retention catalog changed concurrently; retrying attempt %d/%d", attempt, w.catalogAttempts())
+		}
+		generation, existing, err := w.Store.ReadObject(retentionPath)
+		if err != nil {
+			return CatalogWriteOutcomeNotAttempted, err
+		}
+		index, err := decodeRetentionIndexOrEmpty(existing)
+		if err != nil {
+			return CatalogWriteOutcomeNotAttempted, fmt.Errorf("decode existing retention index: %w", err)
+		}
+		if !UpsertPublishedRetention(index, plan.Version, publishedAt, w.retentionPolicy()) {
+			if progress.Done != nil {
+				progress.Done("App registry retention catalog unchanged")
+			}
+			return CatalogWriteOutcomeUnchanged, nil
+		}
+		data, err := json.MarshalIndent(index, "", "  ")
+		if err != nil {
+			return CatalogWriteOutcomeNotAttempted, err
+		}
+		tmpPath, err := WriteTempJSON("gestalt-app-retention-*", append(data, '\n'))
+		if err != nil {
+			return CatalogWriteOutcomeNotAttempted, err
+		}
+		err = w.Store.WriteCatalogObject(WriteCatalogObjectInput{
+			LocalPath:  tmpPath,
+			StorageURL: retentionPath,
+			SourceRef:  req.SourceRef,
+			Generation: generation,
+		})
+		_ = os.Remove(tmpPath)
+		if err != nil {
+			if isCatalogPreconditionFailed(err) && attempt < w.catalogAttempts() {
+				continue
+			}
+			return CatalogWriteOutcomeNotAttempted, err
+		}
+		if progress.Done != nil {
+			progress.Done("Updated app registry retention catalog")
+		}
+		if progress.Log != nil {
+			progress.Log(fmt.Sprintf("updated %s", retentionPath))
+		}
+		return CatalogWriteOutcomeUpdated, nil
+	}
+	return CatalogWriteOutcomeNotAttempted, fmt.Errorf("update %s: exceeded retry limit after concurrent retention updates", retentionPath)
+}
+
+// LoadPublishStartedAt reads pending.json for an in-flight publish startedAt timestamp.
+func LoadPublishStartedAt(store RegistryObjectStore, storageRoot, appName, version string) time.Time {
+	if store == nil {
+		return time.Time{}
+	}
+	pendingURL := StorageURL(storageRoot, AppPendingPath(appName))
+	_, pendingData, err := store.ReadObject(pendingURL)
+	if err != nil || len(pendingData) == 0 {
+		return time.Time{}
+	}
+	pending, err := DecodePendingIndex(pendingData)
+	if err != nil {
+		return time.Time{}
+	}
+	startedAt, ok := PublishStartedAtFromPending(pending, version)
+	if !ok {
+		return time.Time{}
+	}
+	return startedAt
+}
+
+func decodeIndexOrEmpty(existing []byte) (*Index, error) {
+	if len(existing) == 0 {
+		return NewEmptyIndex(), nil
+	}
+	return DecodeIndex(existing)
+}
+
+func decodeRetentionIndexOrEmpty(existing []byte) (*RetentionIndex, error) {
+	if len(existing) == 0 {
+		return NewEmptyRetentionIndex(), nil
+	}
+	return DecodeRetentionIndex(existing)
+}
+
+func isCatalogPreconditionFailed(err error) bool {
+	if errors.Is(err, ErrObjectPreconditionFailed) {
+		return true
+	}
+	return gcloudPreconditionFailed(err)
+}
+
+// CatalogPreconditionFailed reports whether err is a generation/precondition conflict.
+func CatalogPreconditionFailed(err error) bool {
+	return isCatalogPreconditionFailed(err)
+}

--- a/gestaltd/internal/appregistry/writer.go
+++ b/gestaltd/internal/appregistry/writer.go
@@ -237,7 +237,7 @@ func (w *Writer) uploadImmutableObjectIfNeeded(object PublishObject, sourceRef s
 		SourceRef:  sourceRef,
 		SHA256:     object.SHA256,
 	}); err != nil {
-		if object.Kind == PublishObjectKindEntry && errors.Is(err, ErrObjectPreconditionFailed) {
+		if object.Kind == PublishObjectKindEntry && isObjectGenerationPreconditionFailed(err) {
 			skipped, reconcileErr := w.reconcileExistingEntryObject(object)
 			if reconcileErr != nil {
 				return ImmutableObjectOutcome{}, "", reconcileErr
@@ -350,7 +350,7 @@ func (w *Writer) uploadIndex(req PublishRequest, entry Entry, progress PublishPr
 		})
 		_ = os.Remove(tmpPath)
 		if err != nil {
-			if isCatalogPreconditionFailed(err) && attempt < w.catalogAttempts() {
+			if isObjectGenerationPreconditionFailed(err) && attempt < w.catalogAttempts() {
 				if progress.Status != nil {
 					progress.Status("App registry index update conflict; retrying")
 				}
@@ -410,7 +410,7 @@ func (w *Writer) uploadRetention(req PublishRequest, entry Entry, progress Publi
 		})
 		_ = os.Remove(tmpPath)
 		if err != nil {
-			if isCatalogPreconditionFailed(err) && attempt < w.catalogAttempts() {
+			if isObjectGenerationPreconditionFailed(err) && attempt < w.catalogAttempts() {
 				continue
 			}
 			return CatalogWriteOutcomeNotAttempted, err
@@ -461,7 +461,7 @@ func decodeRetentionIndexOrEmpty(existing []byte) (*RetentionIndex, error) {
 	return DecodeRetentionIndex(existing)
 }
 
-func isCatalogPreconditionFailed(err error) bool {
+func isObjectGenerationPreconditionFailed(err error) bool {
 	if errors.Is(err, ErrObjectPreconditionFailed) {
 		return true
 	}
@@ -470,5 +470,5 @@ func isCatalogPreconditionFailed(err error) bool {
 
 // CatalogPreconditionFailed reports whether err is a generation/precondition conflict.
 func CatalogPreconditionFailed(err error) bool {
-	return isCatalogPreconditionFailed(err)
+	return isObjectGenerationPreconditionFailed(err)
 }

--- a/gestaltd/internal/appregistry/writer_gcloud.go
+++ b/gestaltd/internal/appregistry/writer_gcloud.go
@@ -1,0 +1,145 @@
+package appregistry
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// CommandRunner executes external commands such as gcloud storage.
+type CommandRunner interface {
+	Run(name string, args ...string) (stdout string, err error)
+}
+
+// GcloudObjectStore implements RegistryObjectStore via gcloud storage commands.
+type GcloudObjectStore struct {
+	Runner CommandRunner
+}
+
+func (s *GcloudObjectStore) DescribeObject(storageURL string) (ObjectDescription, error) {
+	if s == nil || s.Runner == nil {
+		return ObjectDescription{}, fmt.Errorf("gcloud object store runner is required")
+	}
+	out, err := s.Runner.Run("gcloud", "storage", "objects", "describe", storageURL, "--format=json")
+	if err != nil {
+		if gcloudObjectNotFound(err) {
+			return ObjectDescription{}, nil
+		}
+		return ObjectDescription{}, err
+	}
+	var described gcloudObjectDescription
+	if err := json.Unmarshal([]byte(out), &described); err != nil {
+		return ObjectDescription{}, fmt.Errorf("parse object metadata for %s: %w", storageURL, err)
+	}
+	return ObjectDescription{
+		Generation: int64(described.Generation),
+		SHA256:     strings.TrimSpace(described.Metadata["sha256"]),
+	}, nil
+}
+
+func (s *GcloudObjectStore) ReadObject(storageURL string) (int64, []byte, error) {
+	described, err := s.DescribeObject(storageURL)
+	if err != nil {
+		return 0, nil, err
+	}
+	if described.Generation == 0 {
+		return 0, nil, nil
+	}
+	out, err := s.Runner.Run("gcloud", "storage", "cat", storageURL)
+	if err != nil {
+		return 0, nil, err
+	}
+	return described.Generation, []byte(out), nil
+}
+
+func (s *GcloudObjectStore) WriteImmutableObject(input WriteImmutableObjectInput) error {
+	metadata := fmt.Sprintf("source-ref=%s", input.SourceRef)
+	if input.SHA256 != "" {
+		metadata += ",sha256=" + input.SHA256
+	}
+	_, err := s.Runner.Run(
+		"gcloud", "storage", "cp",
+		"--if-generation-match=0",
+		"--custom-metadata="+metadata,
+		input.LocalPath,
+		input.StorageURL,
+	)
+	return err
+}
+
+func (s *GcloudObjectStore) WriteCatalogObject(input WriteCatalogObjectInput) error {
+	args := []string{
+		"storage", "cp",
+		"--custom-metadata=source-ref=" + input.SourceRef,
+		input.LocalPath,
+		input.StorageURL,
+	}
+	if input.Generation == 0 {
+		args = append(args, "--if-generation-match=0")
+	} else {
+		args = append(args, "--if-generation-match="+strconv.FormatInt(input.Generation, 10))
+	}
+	_, err := s.Runner.Run("gcloud", args...)
+	return err
+}
+
+type gcsObjectGeneration int64
+
+func (g *gcsObjectGeneration) UnmarshalJSON(data []byte) error {
+	data = bytes.TrimSpace(data)
+	if len(data) == 0 || string(data) == "null" {
+		*g = 0
+		return nil
+	}
+	if data[0] == '"' {
+		var value string
+		if err := json.Unmarshal(data, &value); err != nil {
+			return err
+		}
+		value = strings.TrimSpace(value)
+		if value == "" {
+			*g = 0
+			return nil
+		}
+		parsed, err := strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			return fmt.Errorf("parse generation %q: %w", value, err)
+		}
+		*g = gcsObjectGeneration(parsed)
+		return nil
+	}
+	var parsed int64
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return fmt.Errorf("parse generation: %w", err)
+	}
+	*g = gcsObjectGeneration(parsed)
+	return nil
+}
+
+type gcloudObjectDescription struct {
+	Generation gcsObjectGeneration `json:"generation"`
+	Metadata   map[string]string   `json:"metadata"`
+}
+
+func gcloudObjectNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	text := strings.ToLower(err.Error())
+	return strings.Contains(text, "not found") ||
+		strings.Contains(text, "404") ||
+		os.IsNotExist(err)
+}
+
+func gcloudPreconditionFailed(err error) bool {
+	if err == nil {
+		return false
+	}
+	text := strings.ToLower(err.Error())
+	return strings.Contains(text, "precondition") ||
+		strings.Contains(text, "generation") ||
+		strings.Contains(text, "412")
+}

--- a/gestaltd/internal/appregistry/writer_storage.go
+++ b/gestaltd/internal/appregistry/writer_storage.go
@@ -1,0 +1,127 @@
+package appregistry
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+)
+
+var (
+	ErrObjectNotFound           = errors.New("registry object not found")
+	ErrObjectPreconditionFailed = errors.New("registry object precondition failed")
+)
+
+// ObjectDescription reports remote object metadata used for idempotent publish checks.
+type ObjectDescription struct {
+	Generation int64
+	SHA256     string
+}
+
+// RegistryObjectStore reads and writes registry bucket objects. Implementations must
+// never delete objects; the registry writer only creates immutable objects and
+// performs compare-and-swap updates on catalog files.
+type RegistryObjectStore interface {
+	DescribeObject(storageURL string) (ObjectDescription, error)
+	ReadObject(storageURL string) (generation int64, data []byte, err error)
+	WriteImmutableObject(input WriteImmutableObjectInput) error
+	WriteCatalogObject(input WriteCatalogObjectInput) error
+}
+
+// WriteImmutableObjectInput creates an object only when it does not already exist.
+type WriteImmutableObjectInput struct {
+	LocalPath  string
+	StorageURL string
+	SourceRef  string
+	SHA256     string
+}
+
+// WriteCatalogObjectInput replaces a catalog object with generation preconditions.
+type WriteCatalogObjectInput struct {
+	LocalPath  string
+	StorageURL string
+	SourceRef  string
+	Generation int64
+}
+
+type memoryStoredObject struct {
+	generation int64
+	data       []byte
+	sha256     string
+}
+
+// MemoryObjectStore is an in-memory RegistryObjectStore for unit tests.
+type MemoryObjectStore struct {
+	mu      sync.Mutex
+	objects map[string]memoryStoredObject
+	nextGen int64
+}
+
+func NewMemoryObjectStore() *MemoryObjectStore {
+	return &MemoryObjectStore{
+		objects: map[string]memoryStoredObject{},
+		nextGen: 1,
+	}
+}
+
+func (s *MemoryObjectStore) DescribeObject(storageURL string) (ObjectDescription, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	object, ok := s.objects[storageURL]
+	if !ok {
+		return ObjectDescription{}, nil
+	}
+	return ObjectDescription{Generation: object.generation, SHA256: object.sha256}, nil
+}
+
+func (s *MemoryObjectStore) ReadObject(storageURL string) (int64, []byte, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	object, ok := s.objects[storageURL]
+	if !ok {
+		return 0, nil, nil
+	}
+	data := append([]byte(nil), object.data...)
+	return object.generation, data, nil
+}
+
+func (s *MemoryObjectStore) WriteImmutableObject(input WriteImmutableObjectInput) error {
+	data, err := os.ReadFile(input.LocalPath)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", input.LocalPath, err)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if existing, ok := s.objects[input.StorageURL]; ok && existing.generation != 0 {
+		return fmt.Errorf("%w: %s", ErrObjectPreconditionFailed, input.StorageURL)
+	}
+	s.nextGen++
+	s.objects[input.StorageURL] = memoryStoredObject{
+		generation: s.nextGen,
+		data:       data,
+		sha256:     strings.TrimSpace(input.SHA256),
+	}
+	return nil
+}
+
+func (s *MemoryObjectStore) WriteCatalogObject(input WriteCatalogObjectInput) error {
+	data, err := os.ReadFile(input.LocalPath)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", input.LocalPath, err)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	existing, ok := s.objects[input.StorageURL]
+	switch {
+	case input.Generation == 0:
+		if ok && existing.generation != 0 {
+			return fmt.Errorf("%w: %s", ErrObjectPreconditionFailed, input.StorageURL)
+		}
+	case !ok || existing.generation != input.Generation:
+		return fmt.Errorf("%w: %s", ErrObjectPreconditionFailed, input.StorageURL)
+	}
+	s.nextGen++
+	s.objects[input.StorageURL] = memoryStoredObject{generation: s.nextGen, data: data}
+	return nil
+}

--- a/gestaltd/internal/appregistry/writer_test.go
+++ b/gestaltd/internal/appregistry/writer_test.go
@@ -328,7 +328,10 @@ func TestGcloudPreconditionFailed(t *testing.T) {
 	if !gcloudPreconditionFailed(errors.New("412 Precondition Failed")) {
 		t.Fatal("expected gcloud precondition detection")
 	}
-	if !isCatalogPreconditionFailed(fmt.Errorf("wrap: %w", ErrObjectPreconditionFailed)) {
+	if !isObjectGenerationPreconditionFailed(fmt.Errorf("wrap: %w", ErrObjectPreconditionFailed)) {
 		t.Fatal("expected memory store precondition detection")
+	}
+	if !isObjectGenerationPreconditionFailed(errors.New("412 Precondition Failed")) {
+		t.Fatal("expected raw gcloud precondition detection")
 	}
 }

--- a/gestaltd/internal/appregistry/writer_test.go
+++ b/gestaltd/internal/appregistry/writer_test.go
@@ -1,0 +1,334 @@
+package appregistry
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core/catalog"
+	"github.com/valon-technologies/gestalt/server/internal/providerrelease"
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+)
+
+func TestValidatePublishInput_RequiresSourceRefForGitHub(t *testing.T) {
+	t.Parallel()
+
+	manifest := testPublishManifest(t)
+	if err := ValidatePublishInputWithOptions(manifest, "0.0.1", "", PublishValidationOptions{
+		PublicationKind: PublicationKindGitHub,
+	}); err == nil {
+		t.Fatal("expected github publish to require sourceRef")
+	}
+}
+
+func TestValidatePublishInput_AllowsMissingSourceRefForLocal(t *testing.T) {
+	t.Parallel()
+
+	manifest := testPublishManifest(t)
+	if err := ValidatePublishInputWithOptions(manifest, "0.0.1", "", PublishValidationOptions{
+		PublicationKind: PublicationKindLocal,
+	}); err != nil {
+		t.Fatalf("ValidatePublishInputWithOptions() = %v", err)
+	}
+}
+
+func TestDecodeEntry_OldMetadataWithoutNewFields(t *testing.T) {
+	t.Parallel()
+
+	const legacy = `{
+  "schemaVersion": 1,
+  "app": "traffic-cop",
+  "version": "0.0.1",
+  "sourceRef": "651a5c30feb995c9364c38f63d0d5c3880bc2055",
+  "manifestPath": "apps/traffic-cop/manifest.yaml",
+  "repository": "github.com/valon-technologies/valon-tools",
+  "publishedAt": "2026-07-24T19:04:32Z",
+  "artifacts": {
+    "linux/amd64": {
+      "url": "https://example.com/artifact.tar.gz",
+      "publicUrl": "https://example.com/artifact.tar.gz",
+      "sha256": "deadbeef"
+    }
+  }
+}`
+	entry, err := DecodeEntry([]byte(legacy))
+	if err != nil {
+		t.Fatalf("DecodeEntry() = %v", err)
+	}
+	if entry.PublicationKind != "" || entry.PublishID != "" || entry.LocalSource != nil {
+		t.Fatalf("legacy entry decoded unexpected new fields: %#v", entry)
+	}
+}
+
+func TestDecodeEntry_LocalPublicationWithoutSourceRef(t *testing.T) {
+	t.Parallel()
+
+	entry := testPublishEntry(t)
+	entry.SourceRef = ""
+	entry.PublicationKind = PublicationKindLocal
+	entry.LocalSource = &LocalSourceState{CommitSHA: "651a5c30feb995c9364c38f63d0d5c3880bc2055", Dirty: true}
+	data, err := json.Marshal(entry)
+	if err != nil {
+		t.Fatalf("marshal entry: %v", err)
+	}
+	decoded, err := DecodeEntry(data)
+	if err != nil {
+		t.Fatalf("DecodeEntry() = %v", err)
+	}
+	if decoded.SourceRef != "" || decoded.PublicationKind != PublicationKindLocal || decoded.LocalSource == nil {
+		t.Fatalf("decoded = %#v", decoded)
+	}
+}
+
+func TestWriter_Publish_IdempotentRetry(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryObjectStore()
+	writer := &Writer{Store: store}
+	manifest, entryPath, artifactPath := writePublishManifestFixture(t, store, "0.0.1")
+	req := PublishRequest{Manifest: manifest, SourceRef: "651a5c30feb995c9364c38f63d0d5c3880bc2055"}
+
+	result, err := writer.Publish(req, PublishProgress{})
+	if err != nil {
+		t.Fatalf("first Publish() = %v", err)
+	}
+	if result.Entry.Outcome != ObjectWriteOutcomeUploaded {
+		t.Fatalf("first entry outcome = %q, want uploaded", result.Entry.Outcome)
+	}
+	if result.Retention != CatalogWriteOutcomeUpdated {
+		t.Fatalf("first retention outcome = %q, want updated", result.Retention)
+	}
+	if result.Index != CatalogWriteOutcomeUpdated {
+		t.Fatalf("first index outcome = %q, want updated", result.Index)
+	}
+	result, err = writer.Publish(req, PublishProgress{})
+	if err != nil {
+		t.Fatalf("retry Publish() = %v", err)
+	}
+	if result.Entry.Outcome != ObjectWriteOutcomeSkipped {
+		t.Fatalf("retry entry outcome = %q, want skipped", result.Entry.Outcome)
+	}
+	if result.Retention != CatalogWriteOutcomeUnchanged {
+		t.Fatalf("retry retention outcome = %q, want unchanged", result.Retention)
+	}
+	if result.Index != CatalogWriteOutcomeUnchanged {
+		t.Fatalf("retry index outcome = %q, want unchanged", result.Index)
+	}
+
+	described, err := store.DescribeObject(manifest.EntryObject.StorageURL)
+	if err != nil || described.Generation == 0 {
+		t.Fatalf("entry object missing: %#v err=%v", described, err)
+	}
+	_, indexData, err := store.ReadObject(manifest.IndexObject.StorageURL)
+	if err != nil {
+		t.Fatalf("ReadObject(index): %v", err)
+	}
+	index, err := DecodeIndex(indexData)
+	if err != nil {
+		t.Fatalf("DecodeIndex(): %v", err)
+	}
+	if len(index.Apps[manifest.AppName].Versions) != 1 {
+		t.Fatalf("index versions = %#v", index.Apps[manifest.AppName].Versions)
+	}
+	_ = entryPath
+	_ = artifactPath
+}
+
+func TestWriter_Preflight_RejectsConflictingBytes(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryObjectStore()
+	manifest, _, artifactPath := writePublishManifestFixture(t, store, "0.0.1")
+	if err := store.WriteImmutableObject(WriteImmutableObjectInput{
+		LocalPath:  artifactPath,
+		StorageURL: manifest.ArtifactObjects[0].StorageURL,
+		SourceRef:  "651a5c30feb995c9364c38f63d0d5c3880bc2055",
+		SHA256:     "different",
+	}); err != nil {
+		t.Fatalf("seed conflicting artifact: %v", err)
+	}
+	writer := &Writer{Store: store}
+	err := writer.Preflight(PublishRequest{
+		Manifest:  manifest,
+		SourceRef: "651a5c30feb995c9364c38f63d0d5c3880bc2055",
+	}, PublishProgress{})
+	if err == nil {
+		t.Fatal("expected conflicting artifact preflight to fail")
+	}
+}
+
+func TestWriter_Publish_IndexCASPreservesConcurrentVersions(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryObjectStore()
+	manifest, _, _ := writePublishManifestFixture(t, store, "0.0.2")
+
+	existing := NewEmptyIndex()
+	otherEntry := testPublishEntry(t)
+	otherEntry.Version = "0.0.1"
+	updated, changed, err := UpsertAppIndex(existing, otherEntry, AppVersionEntryPath(manifest.AppName, "0.0.1"), "", "")
+	if err != nil || !changed {
+		t.Fatalf("UpsertAppIndex(existing): changed=%v err=%v", changed, err)
+	}
+	indexData, err := json.MarshalIndent(updated, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal index: %v", err)
+	}
+	indexPath, err := WriteTempJSON("gestalt-app-index-seed-*", append(indexData, '\n'))
+	if err != nil {
+		t.Fatalf("WriteTempJSON(): %v", err)
+	}
+	if err := store.WriteCatalogObject(WriteCatalogObjectInput{
+		LocalPath:  indexPath,
+		StorageURL: manifest.IndexObject.StorageURL,
+		SourceRef:  "651a5c30feb995c9364c38f63d0d5c3880bc2055",
+		Generation: 0,
+	}); err != nil {
+		t.Fatalf("seed index: %v", err)
+	}
+
+	failStore := &catalogConflictStore{
+		RegistryObjectStore: store,
+		failURL:             manifest.IndexObject.StorageURL,
+		failRemaining:       1,
+	}
+	writer := &Writer{Store: failStore}
+	if _, err := writer.Publish(PublishRequest{
+		Manifest:  manifest,
+		SourceRef: "651a5c30feb995c9364c38f63d0d5c3880bc2055",
+	}, PublishProgress{}); err != nil {
+		t.Fatalf("Publish() = %v", err)
+	}
+
+	_, indexData, err = store.ReadObject(manifest.IndexObject.StorageURL)
+	if err != nil {
+		t.Fatalf("ReadObject(index): %v", err)
+	}
+	index, err := DecodeIndex(indexData)
+	if err != nil {
+		t.Fatalf("DecodeIndex(): %v", err)
+	}
+	versions := index.Apps[manifest.AppName].Versions
+	if len(versions) != 2 {
+		t.Fatalf("index versions = %#v, want 2", versions)
+	}
+	if _, ok := versions["0.0.1"]; !ok {
+		t.Fatalf("missing concurrent version 0.0.1: %#v", versions)
+	}
+	if _, ok := versions["0.0.2"]; !ok {
+		t.Fatalf("missing published version 0.0.2: %#v", versions)
+	}
+}
+
+type catalogConflictStore struct {
+	RegistryObjectStore
+	failURL       string
+	failRemaining int
+}
+
+func (s *catalogConflictStore) WriteCatalogObject(input WriteCatalogObjectInput) error {
+	if s.failRemaining > 0 && input.StorageURL == s.failURL {
+		s.failRemaining--
+		return fmt.Errorf("%w: simulated index conflict", ErrObjectPreconditionFailed)
+	}
+	return s.RegistryObjectStore.WriteCatalogObject(input)
+}
+
+func writePublishManifestFixture(t *testing.T, store RegistryObjectStore, version string) (PublishManifest, string, string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	artifactPath := filepath.Join(dir, "linux-amd64.tar.gz")
+	if err := os.WriteFile(artifactPath, []byte("artifact-bytes"), 0o644); err != nil {
+		t.Fatalf("write artifact: %v", err)
+	}
+	manifest := testPublishManifest(t)
+	release := &providerrelease.Metadata{
+		StaticValidation: &providerrelease.StaticValidation{
+			Catalog: &catalog.Catalog{Name: "provider"},
+		},
+	}
+	entryInput := BuildEntryInput{
+		Manifest:         manifest,
+		Version:          version,
+		SourceRef:        "651a5c30feb995c9364c38f63d0d5c3880bc2055",
+		ManifestPath:     "apps/traffic-cop/manifest.yaml",
+		PublicationKind:  PublicationKindGitHub,
+		Release:          release,
+		PublishStartedAt: time.Date(2026, 7, 24, 19, 0, 0, 0, time.UTC),
+	}
+	plan, err := BuildPublishManifest(BuildPublishManifestInput{
+		StorageRoot: "gs://gestalt-app-registry",
+		PublicRoot:  "https://storage.googleapis.com/gestalt-app-registry",
+		EntryInput:  entryInput,
+		LocalArtifacts: []LocalPublishArtifact{{
+			Target:    "linux/amd64",
+			LocalPath: artifactPath,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("BuildPublishManifest(): %v", err)
+	}
+	_ = store
+	return plan, plan.EntryObject.LocalPath, artifactPath
+}
+
+func testPublishManifest(t *testing.T) *providermanifestv1.Manifest {
+	t.Helper()
+	return &providermanifestv1.Manifest{
+		Kind:   providermanifestv1.KindApp,
+		Source: "github.com/valon-technologies/valon-tools/apps/traffic-cop",
+	}
+}
+
+func testPublishEntry(t *testing.T) Entry {
+	t.Helper()
+	return Entry{
+		SchemaVersion: EntrySchemaVersion,
+		App:           "traffic-cop",
+		Version:       "0.0.1",
+		SourceRef:     "651a5c30feb995c9364c38f63d0d5c3880bc2055",
+		ManifestPath:  "apps/traffic-cop/manifest.yaml",
+		Repository:    "github.com/valon-technologies/valon-tools",
+		PublishedAt:   time.Date(2026, 7, 24, 19, 4, 32, 0, time.UTC),
+		Artifacts: map[string]Artifact{
+			"linux/amd64": {
+				URL:       "https://example.com/artifact.tar.gz",
+				PublicURL: "https://example.com/artifact.tar.gz",
+				SHA256:    "deadbeef",
+			},
+		},
+	}
+}
+
+func TestWriter_NeverDeletesObjects(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryObjectStore()
+	writer := &Writer{Store: store}
+	manifest, _, _ := writePublishManifestFixture(t, store, "0.0.1")
+	if _, err := writer.Publish(PublishRequest{
+		Manifest:  manifest,
+		SourceRef: "651a5c30feb995c9364c38f63d0d5c3880bc2055",
+	}, PublishProgress{}); err != nil {
+		t.Fatalf("Publish() = %v", err)
+	}
+	if _, ok := store.objects[manifest.EntryObject.StorageURL]; !ok {
+		t.Fatal("writer removed entry object")
+	}
+}
+
+func TestGcloudPreconditionFailed(t *testing.T) {
+	t.Parallel()
+
+	if !gcloudPreconditionFailed(errors.New("412 Precondition Failed")) {
+		t.Fatal("expected gcloud precondition detection")
+	}
+	if !isCatalogPreconditionFailed(fmt.Errorf("wrap: %w", ErrObjectPreconditionFailed)) {
+		t.Fatal("expected memory store precondition detection")
+	}
+}

--- a/gestaltd/internal/daemon/app_publish.go
+++ b/gestaltd/internal/daemon/app_publish.go
@@ -1,17 +1,13 @@
 package daemon
 
 import (
-	"bytes"
 	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
 	"io/fs"
 	"os"
-	"path"
 	"path/filepath"
-	"sort"
-	"strconv"
 	"strings"
 	"time"
 
@@ -22,8 +18,6 @@ import (
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"github.com/valon-technologies/gestalt/server/services/apps/providerpkg"
 )
-
-const appPublishPlanSchema = "gestaltd.app.publish.plan.v1"
 
 type appPublishDistDirs []string
 
@@ -38,29 +32,6 @@ func (d *appPublishDistDirs) Set(value string) error {
 	}
 	*d = append(*d, value)
 	return nil
-}
-
-type appPublishPlan struct {
-	Schema          string             `json:"schema"`
-	AppName         string             `json:"appName"`
-	DisplayName     string             `json:"displayName,omitempty"`
-	Description     string             `json:"description,omitempty"`
-	Version         string             `json:"version"`
-	Entry           appregistry.Entry  `json:"entry"`
-	EntryObject     appPublishObject   `json:"entryObject"`
-	IndexObject     appPublishObject   `json:"indexObject"`
-	ArtifactObjects []appPublishObject `json:"artifactObjects"`
-}
-
-const appPublishIndexUpdateAttempts = 5
-
-type appPublishObject struct {
-	Kind       string `json:"kind"`
-	Target     string `json:"target,omitempty"`
-	LocalPath  string `json:"localPath"`
-	StorageURL string `json:"storageUrl"`
-	PublicURL  string `json:"publicUrl"`
-	SHA256     string `json:"sha256,omitempty"`
 }
 
 func runAppPublish(args []string) error {
@@ -146,7 +117,9 @@ func runAppPublishCommand(commandName string, usage func(io.Writer), args []stri
 	if err := validateProviderPublishManifest(sourceManifest, releaseManifest, releaseVersion, *version); err != nil {
 		return err
 	}
-	if err := appregistry.ValidatePublishInput(sourceManifest, *version, sourceRef); err != nil {
+	if err := appregistry.ValidatePublishInputWithOptions(sourceManifest, *version, sourceRef, appregistry.PublishValidationOptions{
+		PublicationKind: appregistry.PublicationKindGitHub,
+	}); err != nil {
 		return err
 	}
 
@@ -173,21 +146,31 @@ func runAppPublishCommand(commandName string, usage func(io.Writer), args []stri
 		return err
 	}
 
-	publishStartedAt := loadAppRegistryPublishStartedAt(registry, strings.TrimSpace(*appName), strings.TrimSpace(*version))
+	storageRoot, err := registry.StorageURL()
+	if err != nil {
+		return err
+	}
+	publicRoot, err := registry.PublicURL()
+	if err != nil {
+		return err
+	}
 
-	plan, err := buildAppPublishPlan(appPublishPlanInput{
-		Registry:         registry,
-		DisplayName:      sourceManifest.DisplayName,
-		Description:      sourceManifest.Description,
-		Version:          *version,
-		SourceRef:        sourceRef,
-		ManifestPath:     sourceInfo.ManifestPath,
-		Publication:      publication,
-		Manifest:         sourceManifest,
-		Release:          releaseMetadata,
-		Archives:         releaseArchives,
-		MetadataPath:     filepath.Join(tmpDir, providerrelease.MetadataFile),
-		PublishStartedAt: publishStartedAt,
+	writer := newAppRegistryWriter()
+	publishStartedAt := appregistry.LoadPublishStartedAt(writer.Store, storageRoot, strings.TrimSpace(*appName), strings.TrimSpace(*version))
+
+	plan, err := buildAppPublishManifest(buildAppPublishManifestInput{
+		StorageRoot:  storageRoot,
+		PublicRoot:   publicRoot,
+		DisplayName:  sourceManifest.DisplayName,
+		Description:  sourceManifest.Description,
+		Version:      *version,
+		SourceRef:    sourceRef,
+		ManifestPath: sourceInfo.ManifestPath,
+		Publication:  publication,
+		Manifest:     sourceManifest,
+		Release:      releaseMetadata,
+		Archives:     releaseArchives,
+		StartedAt:    publishStartedAt,
 	})
 	if err != nil {
 		return err
@@ -197,10 +180,64 @@ func runAppPublishCommand(commandName string, usage func(io.Writer), args []stri
 	if *dryRun {
 		return printAppPublishPlanJSON(plan)
 	}
-	if err := preflightAppPublishPlan(plan); err != nil {
+	progress := newAppPublishProgressReporter()
+	req := appregistry.PublishRequest{Manifest: plan, SourceRef: sourceRef}
+	if err := writer.Preflight(req, progress.progress()); err != nil {
 		return err
 	}
-	return uploadAppPublishPlan(plan, sourceRef)
+	_, err = writer.Publish(req, progress.progress())
+	return err
+}
+
+type buildAppPublishManifestInput struct {
+	StorageRoot  string
+	PublicRoot   string
+	DisplayName  string
+	Description  string
+	Version      string
+	SourceRef    string
+	ManifestPath string
+	Publication  *appregistry.Publication
+	Manifest     *providermanifestv1.Manifest
+	Release      *providerrelease.Metadata
+	Archives     []releaseArchive
+	StartedAt    time.Time
+}
+
+func buildAppPublishManifest(input buildAppPublishManifestInput) (appregistry.PublishManifest, error) {
+	localArtifacts := make([]appregistry.LocalPublishArtifact, 0, len(input.Archives))
+	for _, archive := range input.Archives {
+		localArtifacts = append(localArtifacts, appregistry.LocalPublishArtifact{
+			Target:    archive.Target,
+			LocalPath: archive.Path,
+		})
+	}
+	var hashProgress *commandProgress
+	return appregistry.BuildPublishManifest(appregistry.BuildPublishManifestInput{
+		StorageRoot: input.StorageRoot,
+		PublicRoot:  input.PublicRoot,
+		DisplayName: input.DisplayName,
+		Description: input.Description,
+		EntryInput: appregistry.BuildEntryInput{
+			Manifest:         input.Manifest,
+			Version:          input.Version,
+			SourceRef:        input.SourceRef,
+			ManifestPath:     input.ManifestPath,
+			Publication:      input.Publication,
+			PublicationKind:  appregistry.PublicationKindGitHub,
+			Release:          input.Release,
+			PublishStartedAt: input.StartedAt,
+		},
+		LocalArtifacts: localArtifacts,
+		OnHashStart: func(fileCount int) {
+			hashProgress = startCommandProgress("Hashing %d app publish files", fileCount)
+		},
+		OnHashDone: func(fileCount int) {
+			if hashProgress != nil {
+				hashProgress.done("Hashed %d app publish files", fileCount)
+			}
+		},
+	})
 }
 
 func readProviderReleaseMetadata(path string) ([]byte, error) {
@@ -333,496 +370,7 @@ func gitRootFromWorkingDirectory() (string, error) {
 	return gitRoot, nil
 }
 
-type appPublishPlanInput struct {
-	Registry         config.AppRegistryConfig
-	DisplayName      string
-	Description      string
-	Version          string
-	SourceRef        string
-	ManifestPath     string
-	Publication      *appregistry.Publication
-	Manifest         *providermanifestv1.Manifest
-	Release          *providerrelease.Metadata
-	Archives         []releaseArchive
-	MetadataPath     string
-	PublishStartedAt time.Time
-}
-
-func buildAppPublishPlan(input appPublishPlanInput) (appPublishPlan, error) {
-	storageRoot, err := input.Registry.StorageURL()
-	if err != nil {
-		return appPublishPlan{}, err
-	}
-	publicRoot, err := input.Registry.PublicURL()
-	if err != nil {
-		return appPublishPlan{}, err
-	}
-	storageRoot = strings.TrimRight(storageRoot, "/")
-	publicRoot = strings.TrimRight(publicRoot, "/")
-
-	layout, err := appregistry.ResolvePublishLayout(input.Manifest.Source, input.Version)
-	if err != nil {
-		return appPublishPlan{}, err
-	}
-
-	artifactPrefix := layout.ArtifactPrefix
-	sortedArchives := append([]releaseArchive(nil), input.Archives...)
-	sort.Slice(sortedArchives, func(i, j int) bool {
-		return filepath.Base(sortedArchives[i].Path) < filepath.Base(sortedArchives[j].Path)
-	})
-
-	publishArtifacts := make([]appregistry.PublishArtifact, 0, len(sortedArchives))
-	artifactObjects := make([]appPublishObject, 0, len(sortedArchives))
-	hashProgress := startCommandProgress("Hashing %d app publish files", len(sortedArchives)+1)
-	for _, archive := range sortedArchives {
-		filename := filepath.Base(archive.Path)
-		rel := path.Join(artifactPrefix, filename)
-		digest, err := sha256File(archive.Path)
-		if err != nil {
-			return appPublishPlan{}, err
-		}
-		publishArtifacts = append(publishArtifacts, appregistry.PublishArtifact{
-			Target:     archive.Target,
-			LocalPath:  archive.Path,
-			Filename:   filename,
-			StorageURL: appregistry.StorageURL(storageRoot, rel),
-			PublicURL:  appregistry.PublicURL(publicRoot, rel),
-			SHA256:     digest,
-		})
-		artifactObjects = append(artifactObjects, appPublishObject{
-			Kind:       providerPublishFileKindArchive,
-			Target:     archive.Target,
-			LocalPath:  archive.Path,
-			StorageURL: appregistry.StorageURL(storageRoot, rel),
-			PublicURL:  appregistry.PublicURL(publicRoot, rel),
-			SHA256:     digest,
-		})
-	}
-
-	entry, err := appregistry.BuildEntry(appregistry.BuildEntryInput{
-		Manifest:         input.Manifest,
-		Version:          input.Version,
-		SourceRef:        input.SourceRef,
-		ManifestPath:     input.ManifestPath,
-		Publication:      input.Publication,
-		Release:          input.Release,
-		Artifacts:        publishArtifacts,
-		PublishStartedAt: input.PublishStartedAt,
-	})
-	if err != nil {
-		return appPublishPlan{}, err
-	}
-
-	entryRel := layout.EntryPath
-	entryData, err := json.MarshalIndent(entry, "", "  ")
-	if err != nil {
-		return appPublishPlan{}, err
-	}
-	entryPath, err := writeTempJSON("gestalt-app-entry-*", entryData)
-	if err != nil {
-		return appPublishPlan{}, err
-	}
-	entryDigest, err := sha256File(entryPath)
-	if err != nil {
-		return appPublishPlan{}, err
-	}
-	hashProgress.done("Hashed %d app publish files", len(sortedArchives)+1)
-
-	indexRel := layout.IndexPath
-	return appPublishPlan{
-		Schema:      appPublishPlanSchema,
-		AppName:     entry.App,
-		DisplayName: input.DisplayName,
-		Description: input.Description,
-		Version:     input.Version,
-		Entry:       entry,
-		EntryObject: appPublishObject{
-			Kind:       "entry",
-			LocalPath:  entryPath,
-			StorageURL: appregistry.StorageURL(storageRoot, entryRel),
-			PublicURL:  appregistry.PublicURL(publicRoot, entryRel),
-			SHA256:     entryDigest,
-		},
-		IndexObject: appPublishObject{
-			Kind:       "index",
-			StorageURL: appregistry.StorageURL(storageRoot, indexRel),
-			PublicURL:  appregistry.PublicURL(publicRoot, indexRel),
-		},
-		ArtifactObjects: artifactObjects,
-	}, nil
-}
-
-func writeTempJSON(pattern string, data []byte) (string, error) {
-	file, err := os.CreateTemp("", pattern)
-	if err != nil {
-		return "", err
-	}
-	path := file.Name()
-	if _, err := file.Write(data); err != nil {
-		_ = file.Close()
-		_ = os.Remove(path)
-		return "", err
-	}
-	if err := file.Close(); err != nil {
-		_ = os.Remove(path)
-		return "", err
-	}
-	return path, nil
-}
-
-func preflightAppPublishPlan(plan appPublishPlan) error {
-	objectCount := len(plan.ArtifactObjects) + 2 // artifacts, entry metadata, and the app index
-	progress := startCommandProgress("Checking %d remote app objects before upload", objectCount)
-	if err := preflightAppRegistryIndex(plan); err != nil {
-		return err
-	}
-	for _, object := range append([]appPublishObject{plan.EntryObject}, plan.ArtifactObjects...) {
-		if err := preflightAppPublishObject(object); err != nil {
-			return err
-		}
-	}
-	progress.done("Checked %d remote app objects", objectCount)
-	return nil
-}
-
-func preflightAppRegistryIndex(plan appPublishPlan) error {
-	_, existing, err := downloadAppRegistryObject(plan.IndexObject.StorageURL)
-	if err != nil {
-		return err
-	}
-	var index *appregistry.Index
-	if len(existing) == 0 {
-		index = appregistry.NewEmptyIndex()
-	} else {
-		index, err = appregistry.DecodeIndex(existing)
-		if err != nil {
-			return fmt.Errorf("decode existing app index: %w", err)
-		}
-	}
-	metadataPath := appregistry.AppVersionEntryPath(plan.AppName, plan.Version)
-	_, _, err = appregistry.UpsertAppIndex(index, plan.Entry, metadataPath, plan.DisplayName, plan.Description)
-	return err
-}
-
-func preflightAppPublishObject(object appPublishObject) error {
-	matches, err := appPublishObjectMatchesExisting(object)
-	if err != nil {
-		return err
-	}
-	if matches {
-		return nil
-	}
-	generation, _, err := describeAppPublishObject(object.StorageURL)
-	if err != nil {
-		return err
-	}
-	if generation == 0 {
-		return nil
-	}
-	return fmt.Errorf("%s already exists; %s", object.StorageURL, republishCorruptObjectGuidance)
-}
-
-func uploadAppPublishPlan(plan appPublishPlan, sourceRef string) error {
-	if err := uploadAppPublishImmutableObjects(plan, sourceRef); err != nil {
-		return err
-	}
-	if err := uploadAppRegistryIndex(plan, sourceRef); err != nil {
-		return err
-	}
-	return uploadAppRegistryRetention(plan, sourceRef)
-}
-
-func uploadAppPublishImmutableObjects(plan appPublishPlan, sourceRef string) error {
-	objectCount := len(plan.ArtifactObjects) + 1
-	progress := startCommandProgress("Uploading %d immutable app objects", objectCount)
-	stdoutLines := make([]string, 0, objectCount)
-	for _, object := range plan.ArtifactObjects {
-		line, err := uploadAppPublishObjectIfNeeded(object, sourceRef)
-		if err != nil {
-			return err
-		}
-		if line != "" {
-			stdoutLines = append(stdoutLines, line)
-		}
-	}
-	line, err := uploadAppPublishObjectIfNeeded(plan.EntryObject, sourceRef)
-	if err != nil {
-		return err
-	}
-	if line != "" {
-		stdoutLines = append(stdoutLines, line)
-	}
-	progress.done("Processed %d immutable app objects", objectCount)
-	for _, line := range stdoutLines {
-		_, _ = fmt.Fprintln(os.Stdout, line)
-	}
-	return nil
-}
-
-func uploadAppPublishObjectIfNeeded(object appPublishObject, sourceRef string) (string, error) {
-	matches, err := appPublishObjectMatchesExisting(object)
-	if err != nil {
-		return "", err
-	}
-	if matches {
-		return fmt.Sprintf("skipped existing %s", object.StorageURL), nil
-	}
-	if err := uploadAppPublishObject(object, sourceRef); err != nil {
-		return "", err
-	}
-	return fmt.Sprintf("uploaded %s", object.StorageURL), nil
-}
-
-func appPublishObjectMatchesExisting(object appPublishObject) (bool, error) {
-	generation, existingSHA, err := describeAppPublishObject(object.StorageURL)
-	if err != nil {
-		return false, err
-	}
-	if generation == 0 {
-		return false, nil
-	}
-	if object.SHA256 != "" && existingSHA == object.SHA256 {
-		return true, nil
-	}
-	if object.Kind == "entry" && object.LocalPath != "" {
-		_, existing, err := downloadAppRegistryObject(object.StorageURL)
-		if err != nil {
-			return false, err
-		}
-		return appregistry.EntryFileEquivalentIgnoringPublishedAt(object.LocalPath, existing)
-	}
-	return false, nil
-}
-
-func uploadAppPublishObject(object appPublishObject, sourceRef string) error {
-	metadata := fmt.Sprintf("source-ref=%s", sourceRef)
-	if object.SHA256 != "" {
-		metadata += ",sha256=" + object.SHA256
-	}
-	if _, err := runProviderPublishCommand("gcloud", "storage", "cp", "--if-generation-match=0", "--custom-metadata="+metadata, object.LocalPath, object.StorageURL); err != nil {
-		return err
-	}
-	return nil
-}
-
-func uploadAppRegistryIndex(plan appPublishPlan, sourceRef string) error {
-	indexPath := plan.IndexObject.StorageURL
-	progress := startCommandProgress("Updating app registry index")
-	for attempt := 1; attempt <= appPublishIndexUpdateAttempts; attempt++ {
-		if attempt > 1 {
-			progress.status("App registry index changed concurrently; retrying attempt %d/%d", attempt, appPublishIndexUpdateAttempts)
-		}
-		generation, existing, err := downloadAppRegistryObject(indexPath)
-		if err != nil {
-			return err
-		}
-		var index *appregistry.Index
-		if len(existing) == 0 {
-			index = appregistry.NewEmptyIndex()
-		} else {
-			index, err = appregistry.DecodeIndex(existing)
-			if err != nil {
-				return fmt.Errorf("decode existing app index: %w", err)
-			}
-		}
-		metadataPath := appregistry.AppVersionEntryPath(plan.AppName, plan.Version)
-		updated, changed, err := appregistry.UpsertAppIndex(index, plan.Entry, metadataPath, plan.DisplayName, plan.Description)
-		if err != nil {
-			return err
-		}
-		if !changed {
-			progress.done("App registry index unchanged")
-			_, _ = fmt.Fprintf(os.Stdout, "skipped unchanged index for %s %s\n", plan.AppName, plan.Version)
-			return nil
-		}
-		data, err := json.MarshalIndent(updated, "", "  ")
-		if err != nil {
-			return err
-		}
-		tmpPath, err := writeTempJSON("gestalt-app-index-*", append(data, '\n'))
-		if err != nil {
-			return err
-		}
-		if err := uploadAppRegistryIndexFile(tmpPath, indexPath, sourceRef, generation); err != nil {
-			_ = os.Remove(tmpPath)
-			if appPublishPreconditionFailed(err) && attempt < appPublishIndexUpdateAttempts {
-				progress.status("App registry index update conflict; retrying")
-				continue
-			}
-			return err
-		}
-		_ = os.Remove(tmpPath)
-		progress.done("Updated app registry index")
-		_, _ = fmt.Fprintf(os.Stdout, "updated %s\n", indexPath)
-		return nil
-	}
-	return fmt.Errorf("update %s: exceeded retry limit after concurrent index updates", indexPath)
-}
-
-func uploadAppRegistryRetention(plan appPublishPlan, sourceRef string) error {
-	storageRoot := strings.TrimSuffix(plan.IndexObject.StorageURL, appregistry.AppIndexPath(plan.AppName))
-	retentionPath := appregistry.StorageURL(storageRoot, appregistry.AppRetentionPath(plan.AppName))
-	progress := startCommandProgress("Updating app registry retention catalog")
-	for attempt := 1; attempt <= appPublishIndexUpdateAttempts; attempt++ {
-		if attempt > 1 {
-			progress.status("App registry retention catalog changed concurrently; retrying attempt %d/%d", attempt, appPublishIndexUpdateAttempts)
-		}
-		generation, existing, err := downloadAppRegistryObject(retentionPath)
-		if err != nil {
-			return err
-		}
-		var index *appregistry.RetentionIndex
-		if len(existing) == 0 {
-			index = appregistry.NewEmptyRetentionIndex()
-		} else {
-			index, err = appregistry.DecodeRetentionIndex(existing)
-			if err != nil {
-				return fmt.Errorf("decode existing retention index: %w", err)
-			}
-		}
-		if !appregistry.UpsertPublishedRetention(index, plan.Version, plan.Entry.PublishedAt, appregistry.DefaultRetentionPolicy()) {
-			progress.done("App registry retention catalog unchanged")
-			return nil
-		}
-		data, err := json.MarshalIndent(index, "", "  ")
-		if err != nil {
-			return err
-		}
-		tmpPath, err := writeTempJSON("gestalt-app-retention-*", append(data, '\n'))
-		if err != nil {
-			return err
-		}
-		if err := uploadAppRegistryIndexFile(tmpPath, retentionPath, sourceRef, generation); err != nil {
-			_ = os.Remove(tmpPath)
-			if appPublishPreconditionFailed(err) && attempt < appPublishIndexUpdateAttempts {
-				continue
-			}
-			return err
-		}
-		_ = os.Remove(tmpPath)
-		progress.done("Updated app registry retention catalog")
-		_, _ = fmt.Fprintf(os.Stdout, "updated %s\n", retentionPath)
-		return nil
-	}
-	return fmt.Errorf("update %s: exceeded retry limit after concurrent retention updates", retentionPath)
-}
-
-func uploadAppRegistryIndexFile(localPath, storageURL, sourceRef string, generation int64) error {
-	args := []string{
-		"storage", "cp",
-		"--custom-metadata=source-ref=" + sourceRef,
-		localPath,
-		storageURL,
-	}
-	if generation == 0 {
-		args = append(args, "--if-generation-match=0")
-	} else {
-		args = append(args, "--if-generation-match="+strconv.FormatInt(generation, 10))
-	}
-	_, err := runProviderPublishCommand("gcloud", args...)
-	return err
-}
-
-func appPublishPreconditionFailed(err error) bool {
-	if err == nil {
-		return false
-	}
-	text := strings.ToLower(err.Error())
-	return strings.Contains(text, "precondition") ||
-		strings.Contains(text, "generation") ||
-		strings.Contains(text, "412")
-}
-
-func loadAppRegistryPublishStartedAt(registry config.AppRegistryConfig, appName, version string) time.Time {
-	storageRoot, err := registry.StorageURL()
-	if err != nil {
-		return time.Time{}
-	}
-	pendingURL := appregistry.StorageURL(storageRoot, appregistry.AppPendingPath(appName))
-	_, pendingData, err := downloadAppRegistryObject(pendingURL)
-	if err != nil || len(pendingData) == 0 {
-		return time.Time{}
-	}
-	pending, err := appregistry.DecodePendingIndex(pendingData)
-	if err != nil {
-		return time.Time{}
-	}
-	startedAt, ok := appregistry.PublishStartedAtFromPending(pending, version)
-	if !ok {
-		return time.Time{}
-	}
-	return startedAt
-}
-
-func downloadAppRegistryObject(storageURL string) (int64, []byte, error) {
-	generation, _, err := describeAppPublishObject(storageURL)
-	if err != nil {
-		return 0, nil, err
-	}
-	if generation == 0 {
-		return 0, nil, nil
-	}
-	out, err := runProviderPublishCommand("gcloud", "storage", "cat", storageURL)
-	if err != nil {
-		return 0, nil, err
-	}
-	return generation, []byte(out), nil
-}
-
-type gcsObjectGeneration int64
-
-func (g *gcsObjectGeneration) UnmarshalJSON(data []byte) error {
-	data = bytes.TrimSpace(data)
-	if len(data) == 0 || string(data) == "null" {
-		*g = 0
-		return nil
-	}
-	if data[0] == '"' {
-		var value string
-		if err := json.Unmarshal(data, &value); err != nil {
-			return err
-		}
-		value = strings.TrimSpace(value)
-		if value == "" {
-			*g = 0
-			return nil
-		}
-		parsed, err := strconv.ParseInt(value, 10, 64)
-		if err != nil {
-			return fmt.Errorf("parse generation %q: %w", value, err)
-		}
-		*g = gcsObjectGeneration(parsed)
-		return nil
-	}
-	var parsed int64
-	if err := json.Unmarshal(data, &parsed); err != nil {
-		return fmt.Errorf("parse generation: %w", err)
-	}
-	*g = gcsObjectGeneration(parsed)
-	return nil
-}
-
-type appPublishObjectDescription struct {
-	Generation gcsObjectGeneration `json:"generation"`
-	Metadata   map[string]string   `json:"metadata"`
-}
-
-func describeAppPublishObject(storageURL string) (int64, string, error) {
-	out, err := runProviderPublishCommand("gcloud", "storage", "objects", "describe", storageURL, "--format=json")
-	if err != nil {
-		if providerPublishObjectNotFound(err) {
-			return 0, "", nil
-		}
-		return 0, "", err
-	}
-	var described appPublishObjectDescription
-	if err := json.Unmarshal([]byte(out), &described); err != nil {
-		return 0, "", fmt.Errorf("parse object metadata for %s: %w", storageURL, err)
-	}
-	return int64(described.Generation), strings.TrimSpace(described.Metadata["sha256"]), nil
-}
-
-func printAppPublishPlanJSON(plan appPublishPlan) error {
+func printAppPublishPlanJSON(plan appregistry.PublishManifest) error {
 	encoder := json.NewEncoder(os.Stdout)
 	encoder.SetIndent("", "  ")
 	return encoder.Encode(plan)
@@ -885,4 +433,46 @@ func appPublishPublication(workflowRunURL string, triggerPRNumber int, triggerPR
 	}
 	publication.TriggerCommit = &appregistry.PublicationCommit{SHA: triggerCommitSHA, URL: triggerCommitURL}
 	return publication, nil
+}
+
+type appRegistryCommandRunner struct{}
+
+func (appRegistryCommandRunner) Run(name string, args ...string) (string, error) {
+	return runProviderPublishCommand(name, args...)
+}
+
+func newAppRegistryWriter() *appregistry.Writer {
+	return &appregistry.Writer{Store: appRegistryObjectStore()}
+}
+
+type appPublishProgressReporter struct {
+	current *commandProgress
+}
+
+func newAppPublishProgressReporter() *appPublishProgressReporter {
+	return &appPublishProgressReporter{}
+}
+
+func (r *appPublishProgressReporter) progress() appregistry.PublishProgress {
+	return appregistry.PublishProgress{
+		Start: func(format string, args ...any) {
+			r.current = startCommandProgress(format, args...)
+		},
+		Status: func(format string, args ...any) {
+			if r.current != nil {
+				r.current.status(format, args...)
+				return
+			}
+			progressStatus(format, args...)
+		},
+		Done: func(format string, args ...any) {
+			if r.current != nil {
+				r.current.done(format, args...)
+				r.current = nil
+			}
+		},
+		Log: func(line string) {
+			_, _ = fmt.Fprintln(os.Stdout, line)
+		},
+	}
 }

--- a/gestaltd/internal/daemon/app_registry_storage.go
+++ b/gestaltd/internal/daemon/app_registry_storage.go
@@ -1,0 +1,28 @@
+package daemon
+
+import "github.com/valon-technologies/gestalt/server/internal/appregistry"
+
+func appRegistryObjectStore() *appregistry.GcloudObjectStore {
+	return &appregistry.GcloudObjectStore{Runner: appRegistryCommandRunner{}}
+}
+
+func downloadAppRegistryObject(storageURL string) (int64, []byte, error) {
+	return appRegistryObjectStore().ReadObject(storageURL)
+}
+
+func uploadAppRegistryIndexFile(localPath, storageURL, sourceRef string, generation int64) error {
+	return appRegistryObjectStore().WriteCatalogObject(appregistry.WriteCatalogObjectInput{
+		LocalPath:  localPath,
+		StorageURL: storageURL,
+		SourceRef:  sourceRef,
+		Generation: generation,
+	})
+}
+
+func writeTempJSON(pattern string, data []byte) (string, error) {
+	return appregistry.WriteTempJSON(pattern, data)
+}
+
+func appPublishPreconditionFailed(err error) bool {
+	return appregistry.CatalogPreconditionFailed(err)
+}


### PR DESCRIPTION
## Summary
- move existing registry mutation into a reusable appregistry writer without changing direct-GCS publishing
- commit immutable objects and retention before the index visibility marker
- add backward-compatible publication metadata for stateless admin publishing

## Test plan
- [x] `golangci-lint run ./internal/appregistry/... ./internal/daemon/...`
- [x] `go vet ./internal/appregistry/... ./internal/daemon/...`
- [x] `go test ./internal/appregistry/...`
- [x] daemon app-publish tests
- [x] `go build ./...`

Made with [Cursor](https://cursor.com)