### PR TITLE
Cache the Apps directory and show only apps the user may use

### DIFF
--- a/gestaltd/internal/coredata/remote_registrations.go
+++ b/gestaltd/internal/coredata/remote_registrations.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	idb "github.com/valon-technologies/gestalt/sdk/go/indexeddb"
@@ -48,8 +49,9 @@ type RemoteProvider struct {
 }
 
 type RemoteRegistrationService struct {
-	db  indexeddb.IndexedDB
-	now func() time.Time
+	db       indexeddb.IndexedDB
+	now      func() time.Time
+	topology atomic.Uint64
 }
 
 func NewRemoteRegistrationService(ds indexeddb.IndexedDB) *RemoteRegistrationService {
@@ -69,6 +71,22 @@ func (s *RemoteRegistrationService) Now() time.Time {
 		return time.Now().UTC().Truncate(time.Millisecond)
 	}
 	return normalizedRemoteTime(s.now())
+}
+
+// Topology bumps when the set of remote providers changes so cached app
+// directories can drop tunnel-shadowed copy without polling IndexedDB.
+func (s *RemoteRegistrationService) Topology() uint64 {
+	if s == nil {
+		return 0
+	}
+	return s.topology.Load()
+}
+
+func (s *RemoteRegistrationService) bumpTopology() {
+	if s == nil {
+		return
+	}
+	s.topology.Add(1)
 }
 
 func (s *RemoteRegistrationService) Replace(
@@ -206,6 +224,7 @@ func (s *RemoteRegistrationService) Replace(
 		return nil, fmt.Errorf("replace remote registration: commit: %w", err)
 	}
 	committed = true
+	s.bumpTopology()
 	return stored, nil
 }
 
@@ -487,6 +506,7 @@ func (s *RemoteRegistrationService) removeRegistrationWithGenerationCheck(ctx co
 	if err := regStore.Delete(ctx, registrationID); err != nil && !errors.Is(err, idb.ErrNotFound) {
 		return err
 	}
+	s.bumpTopology()
 	return nil
 }
 

--- a/gestaltd/internal/coredata/remote_registrations_test.go
+++ b/gestaltd/internal/coredata/remote_registrations_test.go
@@ -300,4 +300,46 @@ func TestRemoteRegistrationService(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("topology_bumps_on_replace_delete_and_expire", func(t *testing.T) {
+		t.Parallel()
+		svc := newService(start)
+		if svc.Topology() != 0 {
+			t.Fatalf("topology = %d, want 0", svc.Topology())
+		}
+		got, err := svc.Replace(ctx, "subject:alice", newRegistration("reg-1"), []*RemoteProvider{
+			newProvider("app", "test-app"),
+		}, 0)
+		if err != nil {
+			t.Fatalf("Replace: %v", err)
+		}
+		afterReplace := svc.Topology()
+		if afterReplace == 0 {
+			t.Fatal("Replace did not bump topology")
+		}
+		if err := svc.Delete(ctx, "reg-1", got.Generation); err != nil {
+			t.Fatalf("Delete: %v", err)
+		}
+		afterDelete := svc.Topology()
+		if afterDelete <= afterReplace {
+			t.Fatalf("Delete topology = %d, want > %d", afterDelete, afterReplace)
+		}
+		got, err = svc.Replace(ctx, "subject:alice", newRegistration("reg-1"), []*RemoteProvider{
+			newProvider("app", "test-app"),
+		}, 0)
+		if err != nil {
+			t.Fatalf("second Replace: %v", err)
+		}
+		afterSecondReplace := svc.Topology()
+		if afterSecondReplace <= afterDelete {
+			t.Fatalf("second Replace topology = %d, want > %d", afterSecondReplace, afterDelete)
+		}
+		svc.now = func() time.Time { return start.Add(lease) }
+		if err := svc.Expire(ctx, "reg-1", got.Generation, got.LeaseExpiresAt); err != nil {
+			t.Fatalf("Expire: %v", err)
+		}
+		if svc.Topology() <= afterSecondReplace {
+			t.Fatalf("Expire topology = %d, want > %d", svc.Topology(), afterSecondReplace)
+		}
+	})
 }

--- a/gestaltd/internal/server/app_directory.go
+++ b/gestaltd/internal/server/app_directory.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -265,9 +266,12 @@ func (s *Server) tenantAppDirectory(ctx context.Context) (*tenantAppDirectory, e
 	}
 	s.tenantDirectoryMu.Unlock()
 
-	dir, err := s.buildTenantAppDirectory(ctx)
+	dir, cacheable, err := s.buildTenantAppDirectory(ctx)
 	if err != nil {
 		return nil, err
+	}
+	if !cacheable {
+		return dir, nil
 	}
 
 	s.tenantDirectoryMu.Lock()
@@ -326,18 +330,7 @@ func (s *Server) pluginDirectoryFingerprint() string {
 				pluginDeclaredMount(plugin),
 				plugin.SourceTreeURL(),
 			)
-			connNames := make([]string, 0, len(plugin.Connections))
-			for connName := range plugin.Connections {
-				connNames = append(connNames, connName)
-			}
-			slices.Sort(connNames)
-			for _, connName := range connNames {
-				mode := ""
-				if def := plugin.Connections[connName]; def != nil {
-					mode = string(def.Mode)
-				}
-				fmt.Fprintf(&b, ",%s=%s", connName, mode)
-			}
+			appendConnectionSchemaFingerprint(&b, s.connectionSchemasFromAdvertised(name, s.advertisedConnectionsForPlugin(name, plugin)))
 		}
 		for _, prompt := range s.appPrompts[name] {
 			fmt.Fprintf(&b, "#%s=%s", prompt.ID, prompt.Text)
@@ -346,7 +339,38 @@ func (s *Server) pluginDirectoryFingerprint() string {
 	return b.String()
 }
 
-func (s *Server) buildTenantAppDirectory(ctx context.Context) (*tenantAppDirectory, error) {
+func appendConnectionSchemaFingerprint(b *strings.Builder, schemas []connectionSchemaInfo) {
+	if b == nil || len(schemas) == 0 {
+		return
+	}
+	ordered := append([]connectionSchemaInfo(nil), schemas...)
+	slices.SortFunc(ordered, func(a, b connectionSchemaInfo) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+	for _, schema := range ordered {
+		fmt.Fprintf(b, ",%s=%s:%s", schema.Name, schema.Mode, schema.DisplayName)
+		authTypes := append([]string(nil), schema.AuthTypes...)
+		slices.Sort(authTypes)
+		for _, authType := range authTypes {
+			b.WriteByte('|')
+			b.WriteString(authType)
+		}
+		paramNames := make([]string, 0, len(schema.ConnectionParams))
+		for name := range schema.ConnectionParams {
+			paramNames = append(paramNames, name)
+		}
+		slices.Sort(paramNames)
+		for _, name := range paramNames {
+			param := schema.ConnectionParams[name]
+			fmt.Fprintf(b, "@%s=%t:%s:%s", name, param.Required, param.Description, param.Default)
+		}
+		for _, field := range schema.CredentialFields {
+			fmt.Fprintf(b, "$%s=%s:%s", field.Name, field.Label, field.Description)
+		}
+	}
+}
+
+func (s *Server) buildTenantAppDirectory(ctx context.Context) (*tenantAppDirectory, bool, error) {
 	names := []string{}
 	if s.providers != nil {
 		names = s.providers.List()
@@ -354,10 +378,15 @@ func (s *Server) buildTenantAppDirectory(ctx context.Context) (*tenantAppDirecto
 	registryApps := s.configuredRegistryApps()
 	seen := make(map[string]struct{}, len(names)+len(registryApps))
 	dir := &tenantAppDirectory{entries: make([]tenantAppDirectoryEntry, 0, len(names)+len(registryApps))}
+	cacheable := true
 	for _, name := range names {
 		entry, ok, err := s.tenantProviderDirectoryEntry(ctx, name)
 		if err != nil {
-			return nil, err
+			if ctx.Err() != nil {
+				return nil, false, err
+			}
+			cacheable = false
+			continue
 		}
 		if !ok {
 			continue
@@ -374,7 +403,7 @@ func (s *Server) buildTenantAppDirectory(ctx context.Context) (*tenantAppDirecto
 		}
 		dir.entries = append(dir.entries, s.tenantRegistryDirectoryEntry(app.name))
 	}
-	return dir, nil
+	return dir, cacheable, nil
 }
 
 func (s *Server) tenantProviderDirectoryEntry(ctx context.Context, name string) (tenantAppDirectoryEntry, bool, error) {
@@ -383,7 +412,10 @@ func (s *Server) tenantProviderDirectoryEntry(ctx context.Context, name string) 
 	}
 	prov, err := s.providers.GetWithContext(ctx, name)
 	if err != nil {
-		return tenantAppDirectoryEntry{}, false, nil
+		if errors.Is(err, core.ErrNotFound) {
+			return tenantAppDirectoryEntry{}, false, nil
+		}
+		return tenantAppDirectoryEntry{}, false, fmt.Errorf("resolve app %q: %w", name, err)
 	}
 	plugin := s.pluginDefs[name]
 	entry := tenantAppDirectoryEntry{

--- a/gestaltd/internal/server/app_directory.go
+++ b/gestaltd/internal/server/app_directory.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 
 	"github.com/valon-technologies/gestalt/server/core"
@@ -13,9 +14,11 @@ import (
 
 const appCatalogIconPathPrefix = "/api/v1/catalog/apps/"
 
-// appDirectory is the tenant app directory for one viewer: identity, display,
-// connection schema, and which surfaces this principal may see. It does not
-// include this subject's stored credentials or derived connection status.
+// appDirectory is a list of apps. The tenant snapshot has identity, copy,
+// icons, and connection fields for every installed app. A viewer copy is that
+// list filtered to apps this signed-in user may use, with their mount and
+// admin paths filled in. It does not include saved accounts or connection
+// status — those belong on the overlay.
 type appDirectory struct {
 	entries []appDirectoryEntry
 }
@@ -25,6 +28,7 @@ type appDirectoryEntry struct {
 	DisplayName      string
 	Description      string
 	IconSVG          string
+	DeclaredMount    string
 	MountedPath      string
 	ManagementPath   string
 	Prompts          []appPromptInfo
@@ -198,79 +202,107 @@ func appConnectionStatusesFrom(infos []integrationInfo) []appConnectionStatus {
 }
 
 func (s *Server) assembleAppDirectory(r *http.Request) (*appDirectory, error) {
-	p := PrincipalFromContext(r.Context())
-	names := s.providers.List()
-	registryApps := s.configuredRegistryApps()
-
-	ctx, _ := withListingDecisionCache(r.Context())
-	r = r.WithContext(ctx)
-	prefetchNames := make([]string, 0, len(names)+len(registryApps))
-	prefetchNames = append(prefetchNames, names...)
-	for _, app := range registryApps {
-		prefetchNames = append(prefetchNames, app.name)
+	snapshot, err := s.tenantAppDirectory(r.Context())
+	if err != nil {
+		return nil, err
 	}
-	s.prefetchIntegrationListingDecisions(ctx, p, prefetchNames)
+	return s.projectViewerAppDirectory(r, snapshot)
+}
 
-	seen := make(map[string]struct{}, len(names))
-	dir := &appDirectory{entries: make([]appDirectoryEntry, 0, len(names))}
+func (s *Server) tenantAppDirectory(ctx context.Context) (*appDirectory, error) {
+	key := s.tenantDirectoryFingerprint()
+	s.tenantDirectoryMu.Lock()
+	if s.tenantDirectory != nil && s.tenantDirectoryKey == key {
+		dir := s.tenantDirectory
+		s.tenantDirectoryMu.Unlock()
+		return dir, nil
+	}
+	s.tenantDirectoryMu.Unlock()
+
+	dir, err := s.buildTenantAppDirectory(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	s.tenantDirectoryMu.Lock()
+	defer s.tenantDirectoryMu.Unlock()
+	if s.tenantDirectory != nil && s.tenantDirectoryKey == key {
+		return s.tenantDirectory, nil
+	}
+	s.tenantDirectory = dir
+	s.tenantDirectoryKey = key
+	return dir, nil
+}
+
+func (s *Server) tenantDirectoryFingerprint() string {
+	var b strings.Builder
+	if s.providers != nil {
+		fmt.Fprintf(&b, "g:%d", s.providers.Generation())
+		for _, name := range s.providers.List() {
+			b.WriteByte(',')
+			b.WriteString(name)
+		}
+	}
+	names := make([]string, 0, len(s.pluginDefs))
+	for name := range s.pluginDefs {
+		names = append(names, name)
+	}
+	slices.Sort(names)
 	for _, name := range names {
-		prov, ok := s.lookupProviderDirectory(r, name)
+		b.WriteByte(';')
+		b.WriteString(name)
+		plugin := s.pluginDefs[name]
+		if plugin == nil {
+			continue
+		}
+		fmt.Fprintf(&b, ":%s:%t", strings.TrimSpace(plugin.DisplayName), s.integrationHiddenFromCatalog(name))
+		if plugin.Static != nil {
+			b.WriteByte(':')
+			b.WriteString(strings.TrimSpace(plugin.Static.Mount))
+		}
+	}
+	return b.String()
+}
+
+func (s *Server) buildTenantAppDirectory(ctx context.Context) (*appDirectory, error) {
+	names := []string{}
+	if s.providers != nil {
+		names = s.providers.List()
+	}
+	registryApps := s.configuredRegistryApps()
+	seen := make(map[string]struct{}, len(names)+len(registryApps))
+	dir := &appDirectory{entries: make([]appDirectoryEntry, 0, len(names)+len(registryApps))}
+	for _, name := range names {
+		entry, ok, err := s.tenantProviderDirectoryEntry(ctx, name)
+		if err != nil {
+			return nil, err
+		}
 		if !ok {
 			continue
 		}
 		seen[name] = struct{}{}
-		entry, visible, err := s.completeProviderDirectoryEntry(r, p, name, prov)
-		if err != nil {
-			return nil, err
-		}
-		if !visible {
-			continue
-		}
 		dir.entries = append(dir.entries, entry)
 	}
 	for _, app := range registryApps {
-		if s.integrationHiddenFromCatalog(app.name) {
-			continue
-		}
 		if _, ok := seen[app.name]; ok {
 			continue
 		}
-		managementPath := s.integrationManagementPath(r.Context(), p, app.name)
-		if managementPath == "" {
+		if s.integrationHiddenFromCatalog(app.name) {
 			continue
 		}
-		plugin := s.pluginDefs[app.name]
-		entry := appDirectoryEntry{
-			Name:           app.name,
-			DisplayName:    app.name,
-			ManagementPath: managementPath,
-			Prompts:        s.appPrompts[app.name],
-			SourceTreeURL:  plugin.SourceTreeURL(),
-		}
-		s.attachDirectoryConnections(&entry, plugin)
-		if plugin != nil && strings.TrimSpace(plugin.DisplayName) != "" {
-			entry.DisplayName = strings.TrimSpace(plugin.DisplayName)
-		}
-		if plugin != nil && plugin.Static != nil {
-			entry.MountedPath = s.integrationMountedPathForPrincipalContext(r.Context(), p, app.name, strings.TrimSpace(plugin.Static.Mount))
-		}
-		dir.entries = append(dir.entries, entry)
+		dir.entries = append(dir.entries, s.tenantRegistryDirectoryEntry(app.name))
 	}
 	return dir, nil
 }
 
-func (s *Server) lookupProviderDirectory(r *http.Request, name string) (core.Provider, bool) {
+func (s *Server) tenantProviderDirectoryEntry(ctx context.Context, name string) (appDirectoryEntry, bool, error) {
 	if s.integrationHiddenFromCatalog(name) {
-		return nil, false
+		return appDirectoryEntry{}, false, nil
 	}
-	prov, err := s.providers.GetWithContext(r.Context(), name)
+	prov, err := s.providers.GetWithContext(ctx, name)
 	if err != nil {
-		return nil, false
+		return appDirectoryEntry{}, false, nil
 	}
-	return prov, true
-}
-
-func (s *Server) completeProviderDirectoryEntry(r *http.Request, p *principal.Principal, name string, prov core.Provider) (appDirectoryEntry, bool, error) {
 	plugin := s.pluginDefs[name]
 	entry := appDirectoryEntry{
 		Name:          name,
@@ -284,24 +316,58 @@ func (s *Server) completeProviderDirectoryEntry(r *http.Request, p *principal.Pr
 	if cat := prov.Catalog(); cat != nil {
 		entry.IconSVG = cat.IconSVG
 	}
-	mountedPath := ""
 	if plugin != nil && plugin.Static != nil {
-		mountedPath = strings.TrimSpace(plugin.Static.Mount)
-	}
-	entry.MountedPath = s.integrationMountedPathForPrincipalContext(r.Context(), p, name, mountedPath)
-	entry.ManagementPath = s.integrationManagementPath(r.Context(), p, name)
-	usable, err := s.directoryEntryUsable(r.Context(), p, entry)
-	if err != nil {
-		return appDirectoryEntry{}, false, &appListingError{
-			status: http.StatusServiceUnavailable,
-			public: "failed to authorize app access",
-			err:    fmt.Errorf("authorizing app %q: %w", name, err),
-		}
-	}
-	if !usable {
-		return appDirectoryEntry{}, false, nil
+		entry.DeclaredMount = strings.TrimSpace(plugin.Static.Mount)
 	}
 	return entry, true, nil
+}
+
+func (s *Server) tenantRegistryDirectoryEntry(name string) appDirectoryEntry {
+	plugin := s.pluginDefs[name]
+	entry := appDirectoryEntry{
+		Name:          name,
+		DisplayName:   name,
+		Prompts:       s.appPrompts[name],
+		SourceTreeURL: plugin.SourceTreeURL(),
+	}
+	s.attachDirectoryConnections(&entry, plugin)
+	if plugin != nil && strings.TrimSpace(plugin.DisplayName) != "" {
+		entry.DisplayName = strings.TrimSpace(plugin.DisplayName)
+	}
+	if plugin != nil && plugin.Static != nil {
+		entry.DeclaredMount = strings.TrimSpace(plugin.Static.Mount)
+	}
+	return entry
+}
+
+func (s *Server) projectViewerAppDirectory(r *http.Request, snapshot *appDirectory) (*appDirectory, error) {
+	if snapshot == nil {
+		return &appDirectory{entries: []appDirectoryEntry{}}, nil
+	}
+	p := PrincipalFromContext(r.Context())
+	ctx, _ := withListingDecisionCache(r.Context())
+	r = r.WithContext(ctx)
+	names := make([]string, 0, len(snapshot.entries))
+	for i := range snapshot.entries {
+		names = append(names, snapshot.entries[i].Name)
+	}
+	s.prefetchIntegrationListingDecisions(ctx, p, names)
+
+	out := &appDirectory{entries: make([]appDirectoryEntry, 0, len(snapshot.entries))}
+	for i := range snapshot.entries {
+		entry := snapshot.entries[i]
+		entry.MountedPath = s.integrationMountedPathForPrincipalContext(ctx, p, entry.Name, entry.DeclaredMount)
+		entry.ManagementPath = s.integrationManagementPath(ctx, p, entry.Name)
+		usable, err := s.directoryEntryUsable(ctx, p, entry)
+		if err != nil {
+			return nil, err
+		}
+		if !usable {
+			continue
+		}
+		out.entries = append(out.entries, entry)
+	}
+	return out, nil
 }
 
 func (s *Server) visibleProviderDirectoryEntry(r *http.Request, name string) (appDirectoryEntry, bool, error) {
@@ -309,41 +375,55 @@ func (s *Server) visibleProviderDirectoryEntry(r *http.Request, name string) (ap
 	if name == "" {
 		return appDirectoryEntry{}, false, nil
 	}
-	p := PrincipalFromContext(r.Context())
-	ctx, _ := withListingDecisionCache(r.Context())
-	r = r.WithContext(ctx)
-	s.prefetchIntegrationListingDecisions(ctx, p, []string{name})
-	prov, ok := s.lookupProviderDirectory(r, name)
+	snapshot, err := s.tenantAppDirectory(r.Context())
+	if err != nil {
+		return appDirectoryEntry{}, false, err
+	}
+	var found appDirectoryEntry
+	ok := false
+	for i := range snapshot.entries {
+		if snapshot.entries[i].Name == name {
+			found = snapshot.entries[i]
+			ok = true
+			break
+		}
+	}
 	if !ok {
 		return appDirectoryEntry{}, false, nil
 	}
-	return s.completeProviderDirectoryEntry(r, p, name, prov)
+	viewer, err := s.projectViewerAppDirectory(r, &appDirectory{entries: []appDirectoryEntry{found}})
+	if err != nil {
+		return appDirectoryEntry{}, false, err
+	}
+	if viewer == nil || len(viewer.entries) == 0 {
+		return appDirectoryEntry{}, false, nil
+	}
+	return viewer.entries[0], true, nil
 }
 
 func (s *Server) directoryEntryUsable(ctx context.Context, p *principal.Principal, entry appDirectoryEntry) (bool, error) {
+	// Registry-only rows (no loaded provider) stay admin-only. Loaded apps
+	// appear when this user may use them (Admin people/groups), including
+	// opening the web UI or the admin page. One callable HTTP operation is
+	// not enough to put the app in Apps.
+	if entry.Provider == nil {
+		return entry.ManagementPath != "", nil
+	}
 	if entry.MountedPath != "" || entry.ManagementPath != "" {
 		return true, nil
 	}
-	if s.directoryHasSettingsSurface(p, entry) {
-		settingsAccessible, err := s.integrationSettingsAccessibleContext(ctx, p, entry.Name)
-		if err != nil {
-			return false, err
+	if s.authorization == nil {
+		return true, nil
+	}
+	settingsAccessible, err := s.integrationSettingsAccessibleContext(ctx, p, entry.Name)
+	if err != nil {
+		return false, &appListingError{
+			status: http.StatusServiceUnavailable,
+			public: "failed to authorize app access",
+			err:    fmt.Errorf("authorizing app %q: %w", entry.Name, err),
 		}
-		if settingsAccessible {
-			return true, nil
-		}
 	}
-	return s.integrationHasVisibleHTTPOperationsContext(ctx, p, entry.Name, entry.Provider)
-}
-
-func (s *Server) directoryHasSettingsSurface(p *principal.Principal, entry appDirectoryEntry) bool {
-	if principal.IsNonUserPrincipal(p) {
-		return false
-	}
-	if len(entry.ConnectionSchema) > 0 {
-		return true
-	}
-	return entry.Provider != nil && core.NormalizeConnectionMode(entry.Provider.ConnectionMode()) == core.ConnectionModeNone
+	return settingsAccessible, nil
 }
 
 func (s *Server) projectComposedAppListing(r *http.Request, dir *appDirectory) ([]integrationInfo, error) {

--- a/gestaltd/internal/server/app_directory.go
+++ b/gestaltd/internal/server/app_directory.go
@@ -9,16 +9,45 @@ import (
 	"strings"
 
 	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 )
 
 const appCatalogIconPathPrefix = "/api/v1/catalog/apps/"
 
-// appDirectory is a list of apps. The tenant snapshot has identity, copy,
-// icons, and connection fields for every installed app. A viewer copy is that
-// list filtered to apps this signed-in user may use, with their mount and
-// admin paths filled in. It does not include saved accounts or connection
-// status — those belong on the overlay.
+// tenantAppDirectory is the process-wide Apps snapshot: names, copy, icons,
+// and connection schema. It never holds a live Provider. Tunnel proxies are
+// bound to one HTTP request and must be resolved again for overlay status.
+type tenantAppDirectory struct {
+	entries []tenantAppDirectoryEntry
+}
+
+type tenantAppDirectoryEntry struct {
+	Name             string
+	DisplayName      string
+	Description      string
+	IconSVG          string
+	DeclaredMount    string
+	Prompts          []appPromptInfo
+	SourceTreeURL    string
+	Advertised       []advertisedConnection
+	ConnectionSchema []connectionSchemaInfo
+	Loaded           bool
+}
+
+// tenantAppDirectoryEpoch is the cheap invalidation key for the tenant
+// snapshot. providers is ProviderMap.Generation. remote is the tunnel
+// registration topology. plugins covers catalog-relevant plugin config so an
+// in-place AppDefs edit does not leave stale connection schema in the cache.
+type tenantAppDirectoryEpoch struct {
+	providers uint64
+	remote    uint64
+	plugins   string
+}
+
+// appDirectory is one signed-in viewer's slice of the tenant snapshot, with
+// mount and admin paths filled in. It still does not include saved accounts
+// or connection status, and it still does not hold a live Provider.
 type appDirectory struct {
 	entries []appDirectoryEntry
 }
@@ -35,7 +64,7 @@ type appDirectoryEntry struct {
 	SourceTreeURL    string
 	Advertised       []advertisedConnection
 	ConnectionSchema []connectionSchemaInfo
-	Provider         core.Provider
+	Loaded           bool
 }
 
 type connectionSchemaInfo struct {
@@ -147,6 +176,23 @@ func (dir *appDirectory) catalogJSON() []appCatalogEntry {
 	return out
 }
 
+func viewerDirectoryEntry(entry tenantAppDirectoryEntry, mountedPath, managementPath string) appDirectoryEntry {
+	return appDirectoryEntry{
+		Name:             entry.Name,
+		DisplayName:      entry.DisplayName,
+		Description:      entry.Description,
+		IconSVG:          entry.IconSVG,
+		DeclaredMount:    entry.DeclaredMount,
+		MountedPath:      mountedPath,
+		ManagementPath:   managementPath,
+		Prompts:          entry.Prompts,
+		SourceTreeURL:    entry.SourceTreeURL,
+		Advertised:       entry.Advertised,
+		ConnectionSchema: entry.ConnectionSchema,
+		Loaded:           entry.Loaded,
+	}
+}
+
 func connectionStatusViews(connections []connectionDefInfo) []connectionStatusView {
 	if connections == nil {
 		return []connectionStatusView{}
@@ -209,10 +255,10 @@ func (s *Server) assembleAppDirectory(r *http.Request) (*appDirectory, error) {
 	return s.projectViewerAppDirectory(r, snapshot)
 }
 
-func (s *Server) tenantAppDirectory(ctx context.Context) (*appDirectory, error) {
-	key := s.tenantDirectoryFingerprint()
+func (s *Server) tenantAppDirectory(ctx context.Context) (*tenantAppDirectory, error) {
+	epoch := s.tenantAppDirectoryEpoch()
 	s.tenantDirectoryMu.Lock()
-	if s.tenantDirectory != nil && s.tenantDirectoryKey == key {
+	if s.tenantDirectory != nil && s.tenantDirectoryEpoch == epoch {
 		dir := s.tenantDirectory
 		s.tenantDirectoryMu.Unlock()
 		return dir, nil
@@ -226,52 +272,88 @@ func (s *Server) tenantAppDirectory(ctx context.Context) (*appDirectory, error) 
 
 	s.tenantDirectoryMu.Lock()
 	defer s.tenantDirectoryMu.Unlock()
-	if s.tenantDirectory != nil && s.tenantDirectoryKey == key {
+	if s.tenantDirectory != nil && s.tenantDirectoryEpoch == epoch {
 		return s.tenantDirectory, nil
 	}
 	s.tenantDirectory = dir
-	s.tenantDirectoryKey = key
+	s.tenantDirectoryEpoch = epoch
 	return dir, nil
 }
 
-func (s *Server) tenantDirectoryFingerprint() string {
-	var b strings.Builder
+func (s *Server) tenantAppDirectoryEpoch() tenantAppDirectoryEpoch {
+	var providers uint64
 	if s.providers != nil {
-		fmt.Fprintf(&b, "g:%d", s.providers.Generation())
-		for _, name := range s.providers.List() {
-			b.WriteByte(',')
-			b.WriteString(name)
-		}
+		providers = s.providers.Generation()
 	}
-	names := make([]string, 0, len(s.pluginDefs))
+	return tenantAppDirectoryEpoch{
+		providers: providers,
+		remote:    s.remoteDirectoryTopology(),
+		plugins:   s.pluginDirectoryFingerprint(),
+	}
+}
+
+func (s *Server) remoteDirectoryTopology() uint64 {
+	if s == nil || s.tunnelResolver == nil {
+		return 0
+	}
+	return s.tunnelResolver.cfg.RemoteRegistrations.Topology()
+}
+
+func (s *Server) pluginDirectoryFingerprint() string {
+	names := make([]string, 0, len(s.pluginDefs)+len(s.appPrompts))
+	seen := make(map[string]struct{}, len(s.pluginDefs)+len(s.appPrompts))
 	for name := range s.pluginDefs {
+		names = append(names, name)
+		seen[name] = struct{}{}
+	}
+	for name := range s.appPrompts {
+		if _, ok := seen[name]; ok {
+			continue
+		}
 		names = append(names, name)
 	}
 	slices.Sort(names)
+	var b strings.Builder
 	for _, name := range names {
 		b.WriteByte(';')
 		b.WriteString(name)
 		plugin := s.pluginDefs[name]
-		if plugin == nil {
-			continue
+		if plugin != nil {
+			fmt.Fprintf(&b, ":%s:%s:%t:%s:%s",
+				strings.TrimSpace(plugin.DisplayName),
+				strings.TrimSpace(plugin.Description),
+				s.integrationHiddenFromCatalog(name),
+				pluginDeclaredMount(plugin),
+				plugin.SourceTreeURL(),
+			)
+			connNames := make([]string, 0, len(plugin.Connections))
+			for connName := range plugin.Connections {
+				connNames = append(connNames, connName)
+			}
+			slices.Sort(connNames)
+			for _, connName := range connNames {
+				mode := ""
+				if def := plugin.Connections[connName]; def != nil {
+					mode = string(def.Mode)
+				}
+				fmt.Fprintf(&b, ",%s=%s", connName, mode)
+			}
 		}
-		fmt.Fprintf(&b, ":%s:%t", strings.TrimSpace(plugin.DisplayName), s.integrationHiddenFromCatalog(name))
-		if plugin.Static != nil {
-			b.WriteByte(':')
-			b.WriteString(strings.TrimSpace(plugin.Static.Mount))
+		for _, prompt := range s.appPrompts[name] {
+			fmt.Fprintf(&b, "#%s=%s", prompt.ID, prompt.Text)
 		}
 	}
 	return b.String()
 }
 
-func (s *Server) buildTenantAppDirectory(ctx context.Context) (*appDirectory, error) {
+func (s *Server) buildTenantAppDirectory(ctx context.Context) (*tenantAppDirectory, error) {
 	names := []string{}
 	if s.providers != nil {
 		names = s.providers.List()
 	}
 	registryApps := s.configuredRegistryApps()
 	seen := make(map[string]struct{}, len(names)+len(registryApps))
-	dir := &appDirectory{entries: make([]appDirectoryEntry, 0, len(names)+len(registryApps))}
+	dir := &tenantAppDirectory{entries: make([]tenantAppDirectoryEntry, 0, len(names)+len(registryApps))}
 	for _, name := range names {
 		entry, ok, err := s.tenantProviderDirectoryEntry(ctx, name)
 		if err != nil {
@@ -295,58 +377,68 @@ func (s *Server) buildTenantAppDirectory(ctx context.Context) (*appDirectory, er
 	return dir, nil
 }
 
-func (s *Server) tenantProviderDirectoryEntry(ctx context.Context, name string) (appDirectoryEntry, bool, error) {
+func (s *Server) tenantProviderDirectoryEntry(ctx context.Context, name string) (tenantAppDirectoryEntry, bool, error) {
 	if s.integrationHiddenFromCatalog(name) {
-		return appDirectoryEntry{}, false, nil
+		return tenantAppDirectoryEntry{}, false, nil
 	}
 	prov, err := s.providers.GetWithContext(ctx, name)
 	if err != nil {
-		return appDirectoryEntry{}, false, nil
+		return tenantAppDirectoryEntry{}, false, nil
 	}
 	plugin := s.pluginDefs[name]
-	entry := appDirectoryEntry{
-		Name:          name,
-		DisplayName:   prov.DisplayName(),
-		Description:   prov.Description(),
-		Prompts:       s.appPrompts[name],
-		SourceTreeURL: plugin.SourceTreeURL(),
-		Provider:      prov,
+	entry := tenantAppDirectoryEntry{
+		Name:        name,
+		DisplayName: prov.DisplayName(),
+		Description: prov.Description(),
+		Loaded:      true,
 	}
+	s.applyPluginDirectoryFields(&entry, plugin)
 	s.attachDirectoryConnections(&entry, plugin)
 	if cat := prov.Catalog(); cat != nil {
 		entry.IconSVG = cat.IconSVG
 	}
-	if plugin != nil && plugin.Static != nil {
-		entry.DeclaredMount = strings.TrimSpace(plugin.Static.Mount)
-	}
 	return entry, true, nil
 }
 
-func (s *Server) tenantRegistryDirectoryEntry(name string) appDirectoryEntry {
+func (s *Server) tenantRegistryDirectoryEntry(name string) tenantAppDirectoryEntry {
 	plugin := s.pluginDefs[name]
-	entry := appDirectoryEntry{
-		Name:          name,
-		DisplayName:   name,
-		Prompts:       s.appPrompts[name],
-		SourceTreeURL: plugin.SourceTreeURL(),
+	entry := tenantAppDirectoryEntry{
+		Name:        name,
+		DisplayName: name,
 	}
-	s.attachDirectoryConnections(&entry, plugin)
+	s.applyPluginDirectoryFields(&entry, plugin)
 	if plugin != nil && strings.TrimSpace(plugin.DisplayName) != "" {
 		entry.DisplayName = strings.TrimSpace(plugin.DisplayName)
 	}
-	if plugin != nil && plugin.Static != nil {
-		entry.DeclaredMount = strings.TrimSpace(plugin.Static.Mount)
-	}
+	s.attachDirectoryConnections(&entry, plugin)
 	return entry
 }
 
-func (s *Server) projectViewerAppDirectory(r *http.Request, snapshot *appDirectory) (*appDirectory, error) {
+func (s *Server) applyPluginDirectoryFields(entry *tenantAppDirectoryEntry, plugin *config.ProviderEntry) {
+	if entry == nil {
+		return
+	}
+	entry.Prompts = s.appPrompts[entry.Name]
+	if plugin == nil {
+		return
+	}
+	entry.SourceTreeURL = plugin.SourceTreeURL()
+	entry.DeclaredMount = pluginDeclaredMount(plugin)
+}
+
+func pluginDeclaredMount(plugin *config.ProviderEntry) string {
+	if plugin == nil || plugin.Static == nil {
+		return ""
+	}
+	return strings.TrimSpace(plugin.Static.Mount)
+}
+
+func (s *Server) projectViewerAppDirectory(r *http.Request, snapshot *tenantAppDirectory) (*appDirectory, error) {
 	if snapshot == nil {
 		return &appDirectory{entries: []appDirectoryEntry{}}, nil
 	}
 	p := PrincipalFromContext(r.Context())
 	ctx, _ := withListingDecisionCache(r.Context())
-	r = r.WithContext(ctx)
 	names := make([]string, 0, len(snapshot.entries))
 	for i := range snapshot.entries {
 		names = append(names, snapshot.entries[i].Name)
@@ -355,9 +447,7 @@ func (s *Server) projectViewerAppDirectory(r *http.Request, snapshot *appDirecto
 
 	out := &appDirectory{entries: make([]appDirectoryEntry, 0, len(snapshot.entries))}
 	for i := range snapshot.entries {
-		entry := snapshot.entries[i]
-		entry.MountedPath = s.integrationMountedPathForPrincipalContext(ctx, p, entry.Name, entry.DeclaredMount)
-		entry.ManagementPath = s.integrationManagementPath(ctx, p, entry.Name)
+		entry := s.viewerDirectoryEntry(ctx, p, snapshot.entries[i])
 		usable, err := s.directoryEntryUsable(ctx, p, entry)
 		if err != nil {
 			return nil, err
@@ -370,6 +460,14 @@ func (s *Server) projectViewerAppDirectory(r *http.Request, snapshot *appDirecto
 	return out, nil
 }
 
+func (s *Server) viewerDirectoryEntry(ctx context.Context, p *principal.Principal, entry tenantAppDirectoryEntry) appDirectoryEntry {
+	return viewerDirectoryEntry(
+		entry,
+		s.integrationMountedPathForPrincipalContext(ctx, p, entry.Name, entry.DeclaredMount),
+		s.integrationManagementPath(ctx, p, entry.Name),
+	)
+}
+
 func (s *Server) visibleProviderDirectoryEntry(r *http.Request, name string) (appDirectoryEntry, bool, error) {
 	name = strings.TrimSpace(name)
 	if name == "" {
@@ -379,7 +477,7 @@ func (s *Server) visibleProviderDirectoryEntry(r *http.Request, name string) (ap
 	if err != nil {
 		return appDirectoryEntry{}, false, err
 	}
-	var found appDirectoryEntry
+	var found tenantAppDirectoryEntry
 	ok := false
 	for i := range snapshot.entries {
 		if snapshot.entries[i].Name == name {
@@ -391,22 +489,26 @@ func (s *Server) visibleProviderDirectoryEntry(r *http.Request, name string) (ap
 	if !ok {
 		return appDirectoryEntry{}, false, nil
 	}
-	viewer, err := s.projectViewerAppDirectory(r, &appDirectory{entries: []appDirectoryEntry{found}})
+	p := PrincipalFromContext(r.Context())
+	ctx, _ := withListingDecisionCache(r.Context())
+	s.prefetchIntegrationListingDecisions(ctx, p, []string{found.Name})
+	entry := s.viewerDirectoryEntry(ctx, p, found)
+	usable, err := s.directoryEntryUsable(ctx, p, entry)
 	if err != nil {
 		return appDirectoryEntry{}, false, err
 	}
-	if viewer == nil || len(viewer.entries) == 0 {
+	if !usable {
 		return appDirectoryEntry{}, false, nil
 	}
-	return viewer.entries[0], true, nil
+	return entry, true, nil
 }
 
 func (s *Server) directoryEntryUsable(ctx context.Context, p *principal.Principal, entry appDirectoryEntry) (bool, error) {
-	// Registry-only rows (no loaded provider) stay admin-only. Loaded apps
-	// appear when this user may use them (Admin people/groups), including
-	// opening the web UI or the admin page. One callable HTTP operation is
-	// not enough to put the app in Apps.
-	if entry.Provider == nil {
+	// Registry-only rows stay admin-only. Loaded apps appear when this user
+	// may use them (Admin people/groups), including opening the web UI or
+	// the admin page. One callable HTTP operation is not enough to put the
+	// app in Apps.
+	if !entry.Loaded {
 		return entry.ManagementPath != "", nil
 	}
 	if entry.MountedPath != "" || entry.ManagementPath != "" {
@@ -460,8 +562,19 @@ func (s *Server) projectComposedAppListing(r *http.Request, dir *appDirectory) (
 		instances := connected[entry.Name]
 		info.Connections = s.connectionInfosFromAdvertised(r.Context(), entry.Name, entry.Advertised, instances, p)
 		authTypes := resolvedAuthTypesFromConnections(info.Connections)
-		s.applyIntegrationConnectionStatus(&info, entry.Provider, instances, authTypes, p)
+		s.applyIntegrationConnectionStatus(&info, s.liveProviderForListing(r.Context(), entry), instances, authTypes, p)
 		out = append(out, info)
 	}
 	return out, nil
+}
+
+func (s *Server) liveProviderForListing(ctx context.Context, entry *appDirectoryEntry) core.Provider {
+	if entry == nil || !entry.Loaded || s == nil || s.providers == nil {
+		return nil
+	}
+	prov, err := s.providers.GetWithContext(ctx, entry.Name)
+	if err != nil {
+		return nil
+	}
+	return prov
 }

--- a/gestaltd/internal/server/app_directory_test.go
+++ b/gestaltd/internal/server/app_directory_test.go
@@ -1,0 +1,47 @@
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+	coredata "github.com/valon-technologies/gestalt/server/internal/coredata"
+)
+
+func TestTenantAppDirectoryEpochIncludesRemoteTopology(t *testing.T) {
+	t.Parallel()
+
+	services, err := coredata.New(&coretesting.StubIndexedDB{})
+	if err != nil {
+		t.Fatalf("coredata.New: %v", err)
+	}
+	s := &Server{
+		tunnelResolver: newTunnelProviderResolver(TunnelResolverConfig{
+			RemoteRegistrations: services.RemoteRegistrations,
+			ConnectAddr:         "127.0.0.1:1",
+		}),
+	}
+	first := s.tenantAppDirectoryEpoch()
+	if first.remote != 0 {
+		t.Fatalf("remote topology = %d, want 0", first.remote)
+	}
+	_, err = services.RemoteRegistrations.Replace(context.Background(), "subject:alice", &coredata.RemoteRegistration{
+		ID:                "reg-1",
+		TunnelHost:        "tunnel.example.test",
+		TunnelCertificate: []byte("cert"),
+		ServerSPKISHA256:  "spki",
+		LeaseExpiresAt:    time.Now().Add(time.Minute),
+	}, []*coredata.RemoteProvider{{
+		ProviderKind: "app",
+		ProviderName: "slack",
+		Definition:   map[string]any{"displayName": "Slack"},
+	}}, 0)
+	if err != nil {
+		t.Fatalf("Replace: %v", err)
+	}
+	second := s.tenantAppDirectoryEpoch()
+	if second.remote == first.remote {
+		t.Fatal("tunnel register left the tenant directory epoch unchanged")
+	}
+}

--- a/gestaltd/internal/server/authorization_listing_test.go
+++ b/gestaltd/internal/server/authorization_listing_test.go
@@ -212,7 +212,7 @@ func TestAppsListingFallsBackWhenBatchFails(t *testing.T) {
 	}
 }
 
-func TestAppsListingFallsThroughDeniedSettingsToAuthorizedOperations(t *testing.T) {
+func TestAppsListingDoesNotAdvertiseOperationOnlyAccess(t *testing.T) {
 	t.Parallel()
 
 	subjectID := principal.UserSubjectID(testCanonicalViewerUserID)
@@ -239,11 +239,11 @@ func TestAppsListingFallsThroughDeniedSettingsToAuthorizedOperations(t *testing.
 	testutil.CloseOnCleanup(t, ts)
 
 	integrations := listIntegrationsForTest(t, ts)
-	if _, ok := mountedPathFor(integrations, "sampleApp"); !ok {
-		t.Fatalf("operation-authorized app missing from listing: %#v", integrations)
+	if _, ok := mountedPathFor(integrations, "sampleApp"); ok {
+		t.Fatalf("operation-only access must not put the app in Apps: %#v", integrations)
 	}
-	if checker.calls != 1 || checker.queries != 1 {
-		t.Fatalf("operation checks = {%d calls, %d queries}, want {1, 1}", checker.calls, checker.queries)
+	if checker.calls != 0 {
+		t.Fatalf("Apps listing asked operation access %d times, want 0", checker.calls)
 	}
 }
 

--- a/gestaltd/internal/server/authorization_listing_test.go
+++ b/gestaltd/internal/server/authorization_listing_test.go
@@ -242,6 +242,14 @@ func TestAppsListingDoesNotAdvertiseOperationOnlyAccess(t *testing.T) {
 	if _, ok := mountedPathFor(integrations, "sampleApp"); ok {
 		t.Fatalf("operation-only access must not put the app in Apps: %#v", integrations)
 	}
+	catalog := getJSONPath(t, ts, "/api/v1/catalog/apps", http.StatusOK, "Bearer listing-token")
+	var catalogApps []listedIntegration
+	if err := json.Unmarshal(catalog, &catalogApps); err != nil {
+		t.Fatalf("decode catalog: %v", err)
+	}
+	if _, ok := mountedPathFor(catalogApps, "sampleApp"); ok {
+		t.Fatalf("operation-only access must not put the app in catalog: %#v", catalogApps)
+	}
 	if checker.calls != 0 {
 		t.Fatalf("Apps listing asked operation access %d times, want 0", checker.calls)
 	}

--- a/gestaltd/internal/server/handlers_app_catalog_test.go
+++ b/gestaltd/internal/server/handlers_app_catalog_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	"github.com/valon-technologies/gestalt/server/core"
@@ -532,6 +533,47 @@ func TestAppOverlayNoAuthIsNotProductConnected(t *testing.T) {
 		if connection.Connected {
 			t.Fatalf("composed no-auth connection[%d] must not be product-connected: %s", i, composed)
 		}
+	}
+}
+
+type countingMissResolver struct {
+	calls atomic.Int32
+}
+
+func (c *countingMissResolver) ResolveProvider(context.Context, string) (core.Provider, error) {
+	c.calls.Add(1)
+	return nil, core.ErrNotFound
+}
+
+func TestAppCatalogReusesTenantDirectoryAcrossRequests(t *testing.T) {
+	t.Parallel()
+
+	resolver := &countingMissResolver{}
+	providers := testutil.NewProviderRegistry(t, &coretesting.StubIntegration{N: "slack", DN: "Slack"})
+	providers.SetRemoteResolver(resolver)
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = providers
+		cfg.AppDefs = testPluginDefsForConnections("slack", "default")
+		cfg.Services = testutil.NewStubServices(t)
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	first := getJSONPath(t, ts, "/api/v1/catalog/apps", http.StatusOK, "")
+	afterCatalog := resolver.calls.Load()
+	if afterCatalog == 0 {
+		t.Fatal("catalog snapshot never resolved providers")
+	}
+	second := getJSONPath(t, ts, "/api/v1/catalog/apps", http.StatusOK, "")
+	if resolver.calls.Load() != afterCatalog {
+		t.Fatalf("second catalog rebuilt the tenant directory: resolver calls %d after first, %d after second", afterCatalog, resolver.calls.Load())
+	}
+	_ = getJSONPath(t, ts, "/api/v1/me/app-connections", http.StatusOK, "")
+	if resolver.calls.Load() != afterCatalog {
+		t.Fatalf("connection overlay rebuilt the tenant directory: resolver calls %d after catalog, %d after overlay", afterCatalog, resolver.calls.Load())
+	}
+	if string(first) != string(second) {
+		t.Fatalf("cached catalog changed: %s vs %s", first, second)
 	}
 }
 

--- a/gestaltd/internal/server/handlers_app_catalog_test.go
+++ b/gestaltd/internal/server/handlers_app_catalog_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"sync/atomic"
 	"testing"
 
@@ -569,12 +570,239 @@ func TestAppCatalogReusesTenantDirectoryAcrossRequests(t *testing.T) {
 		t.Fatalf("second catalog rebuilt the tenant directory: resolver calls %d after first, %d after second", afterCatalog, resolver.calls.Load())
 	}
 	_ = getJSONPath(t, ts, "/api/v1/me/app-connections", http.StatusOK, "")
-	if resolver.calls.Load() != afterCatalog {
-		t.Fatalf("connection overlay rebuilt the tenant directory: resolver calls %d after catalog, %d after overlay", afterCatalog, resolver.calls.Load())
+	afterOverlay := resolver.calls.Load()
+	if afterOverlay <= afterCatalog {
+		t.Fatal("connection overlay must resolve a live provider instead of reusing the snapshot handle")
+	}
+	_ = getJSONPath(t, ts, "/api/v1/catalog/apps", http.StatusOK, "")
+	if resolver.calls.Load() != afterOverlay {
+		t.Fatalf("catalog after overlay rebuilt the tenant directory: resolver calls %d after overlay, %d after later catalog", afterOverlay, resolver.calls.Load())
 	}
 	if string(first) != string(second) {
 		t.Fatalf("cached catalog changed: %s vs %s", first, second)
 	}
+}
+
+type requestScopedStubResolver struct {
+	stub  *coretesting.StubIntegration
+	calls atomic.Int32
+}
+
+type requestScopedStub struct {
+	*coretesting.StubIntegration
+	closed atomic.Bool
+}
+
+func (p *requestScopedStub) Close() error {
+	p.closed.Store(true)
+	return nil
+}
+
+func (p *requestScopedStub) ConnectionMode() core.ConnectionMode {
+	if p.closed.Load() {
+		panic("ConnectionMode on closed provider")
+	}
+	return p.StubIntegration.ConnectionMode()
+}
+
+func (r *requestScopedStubResolver) ResolveProvider(ctx context.Context, _ string) (core.Provider, error) {
+	r.calls.Add(1)
+	p := &requestScopedStub{StubIntegration: r.stub}
+	context.AfterFunc(ctx, func() { _ = p.Close() })
+	return p, nil
+}
+
+func TestAppCatalogDoesNotCacheRequestScopedProviders(t *testing.T) {
+	t.Parallel()
+
+	resolver := &requestScopedStubResolver{
+		stub: &coretesting.StubIntegration{N: "slack", DN: "Slack", ConnMode: core.ConnectionModeNone},
+	}
+	providers := testutil.NewProviderRegistry(t, &coretesting.StubIntegration{N: "slack", DN: "Local Slack", ConnMode: core.ConnectionModeNone})
+	providers.SetRemoteResolver(resolver)
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = providers
+		cfg.AppDefs = testPluginDefsForConnections("slack", "default")
+		cfg.Services = testutil.NewStubServices(t)
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	first := getJSONPath(t, ts, "/api/v1/catalog/apps", http.StatusOK, "")
+	afterCatalog := resolver.calls.Load()
+	if afterCatalog == 0 {
+		t.Fatal("catalog snapshot never resolved providers")
+	}
+	overlay := getJSONPath(t, ts, "/api/v1/me/app-connections", http.StatusOK, "")
+	if resolver.calls.Load() <= afterCatalog {
+		t.Fatal("overlay reused a closed snapshot provider instead of resolving a live one")
+	}
+	var statuses []struct {
+		Name   string `json:"name"`
+		Status string `json:"status"`
+	}
+	if err := json.Unmarshal(overlay, &statuses); err != nil {
+		t.Fatalf("decode overlay: %v", err)
+	}
+	if len(statuses) != 1 || statuses[0].Name != "slack" || statuses[0].Status == "" {
+		t.Fatalf("overlay = %s", overlay)
+	}
+	second := getJSONPath(t, ts, "/api/v1/catalog/apps", http.StatusOK, "")
+	if string(first) != string(second) {
+		t.Fatalf("cached catalog changed: %s vs %s", first, second)
+	}
+}
+
+func TestAppCatalogRefreshesAfterProviderGenerationBump(t *testing.T) {
+	t.Parallel()
+
+	providers := testutil.NewProviderRegistry(t, &coretesting.StubIntegration{N: "slack", DN: "Slack", ConnMode: core.ConnectionModeNone})
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = providers
+		cfg.AppDefs = testPluginDefsForConnections("slack", "default")
+		cfg.Services = testutil.NewStubServices(t)
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	first := getJSONPath(t, ts, "/api/v1/catalog/apps", http.StatusOK, "")
+	var firstApps []appCatalogName
+	if err := json.Unmarshal(first, &firstApps); err != nil {
+		t.Fatalf("decode first catalog: %v", err)
+	}
+	if len(firstApps) != 1 || firstApps[0].DisplayName != "Slack" {
+		t.Fatalf("first catalog = %s", first)
+	}
+	if err := providers.Replace("slack", &coretesting.StubIntegration{N: "slack", DN: "Slack Workspace", ConnMode: core.ConnectionModeNone}); err != nil {
+		t.Fatalf("replace provider: %v", err)
+	}
+	second := getJSONPath(t, ts, "/api/v1/catalog/apps", http.StatusOK, "")
+	var secondApps []appCatalogName
+	if err := json.Unmarshal(second, &secondApps); err != nil {
+		t.Fatalf("decode second catalog: %v", err)
+	}
+	if len(secondApps) != 1 || secondApps[0].DisplayName != "Slack Workspace" {
+		t.Fatalf("second catalog = %s, want Slack Workspace after generation bump", second)
+	}
+}
+
+func TestAppCatalogRefreshesAfterPluginConnectionChange(t *testing.T) {
+	t.Parallel()
+
+	defs := testPluginDefsForConnections("slack", "default")
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = testutil.NewProviderRegistry(t, &coretesting.StubIntegration{N: "slack", DN: "Slack", ConnMode: core.ConnectionModeNone})
+		cfg.AppDefs = defs
+		cfg.Services = testutil.NewStubServices(t)
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	first := getJSONPath(t, ts, "/api/v1/catalog/apps", http.StatusOK, "")
+	if connectionNamesFromCatalog(t, first, "slack")["workspace"] {
+		t.Fatalf("first catalog already has workspace: %s", first)
+	}
+	defs["slack"].Connections["workspace"] = &config.ConnectionDef{
+		ConnectionID: "slack:workspace",
+		DisplayName:  "Workspace",
+		Mode:         providermanifestv1.ConnectionModeSubject,
+		Auth: config.ConnectionAuthDef{
+			Type: providermanifestv1.AuthTypeManual,
+		},
+	}
+	second := getJSONPath(t, ts, "/api/v1/catalog/apps", http.StatusOK, "")
+	if !connectionNamesFromCatalog(t, second, "slack")["workspace"] {
+		t.Fatalf("second catalog missing workspace after plugin edit: %s", second)
+	}
+}
+
+func TestAppCatalogSharesTenantSnapshotAcrossViewers(t *testing.T) {
+	t.Parallel()
+
+	aliceID := principal.UserSubjectID(testCanonicalViewerUserID)
+	bobID := principal.UserSubjectID(testCanonicalAdminUserID)
+	resolver := &countingMissResolver{}
+	providers := testutil.NewProviderRegistry(t, &coretesting.StubIntegration{N: "slack", DN: "Slack", ConnMode: core.ConnectionModeNone})
+	providers.SetRemoteResolver(resolver)
+
+	rootDir := t.TempDir()
+	writeTestUIAsset(t, filepath.Join(rootDir, "index.html"), "<html>app</html>")
+	authz := &serverTestAuthorizationProvider{
+		relationships: subjectSetGrant(aliceID, "viewer", "app", "slack"),
+	}
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = testAuthStubWithIntrospect(func(_ context.Context, token string) (*core.IntrospectResponse, error) {
+			switch token {
+			case "alice-token":
+				return testIntrospectActive(aliceID, ""), nil
+			case "bob-token":
+				return testIntrospectActive(bobID, ""), nil
+			default:
+				return &core.IntrospectResponse{Active: false}, nil
+			}
+		})
+		cfg.Authorization = authz
+		cfg.Providers = providers
+		cfg.AppDefs = map[string]*config.ProviderEntry{
+			"slack": {
+				Static:             &config.AppStaticConfig{Mount: "/slack"},
+				ResolvedStaticRoot: rootDir,
+			},
+		}
+		cfg.Services = testutil.NewStubServices(t)
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	alice := getJSONPath(t, ts, "/api/v1/catalog/apps", http.StatusOK, "Bearer alice-token")
+	afterAlice := resolver.calls.Load()
+	if afterAlice == 0 {
+		t.Fatal("alice catalog never resolved providers")
+	}
+	var aliceApps []listedIntegration
+	if err := json.Unmarshal(alice, &aliceApps); err != nil {
+		t.Fatalf("decode alice catalog: %v", err)
+	}
+	if mounted, ok := mountedPathFor(aliceApps, "slack"); !ok || mounted == "" {
+		t.Fatalf("alice catalog missing granted app: %s", alice)
+	}
+
+	bob := getJSONPath(t, ts, "/api/v1/catalog/apps", http.StatusOK, "Bearer bob-token")
+	if resolver.calls.Load() != afterAlice {
+		t.Fatalf("bob catalog rebuilt the tenant directory: resolver calls %d after alice, %d after bob", afterAlice, resolver.calls.Load())
+	}
+	var bobApps []listedIntegration
+	if err := json.Unmarshal(bob, &bobApps); err != nil {
+		t.Fatalf("decode bob catalog: %v", err)
+	}
+	if _, ok := mountedPathFor(bobApps, "slack"); ok {
+		t.Fatalf("bob catalog advertised an app they cannot use: %s", bob)
+	}
+}
+
+type appCatalogName struct {
+	Name        string `json:"name"`
+	DisplayName string `json:"displayName"`
+}
+
+func connectionNamesFromCatalog(t *testing.T, body []byte, app string) map[string]bool {
+	t.Helper()
+	var apps []struct {
+		Name        string `json:"name"`
+		Connections []struct {
+			Name string `json:"name"`
+		} `json:"connections"`
+	}
+	if err := json.Unmarshal(body, &apps); err != nil {
+		t.Fatalf("decode catalog connections: %v", err)
+	}
+	out := map[string]bool{}
+	for _, entry := range apps {
+		if entry.Name != app {
+			continue
+		}
+		for _, connection := range entry.Connections {
+			out[connection.Name] = true
+		}
+	}
+	return out
 }
 
 func getJSONPath(t *testing.T, ts *httptest.Server, path string, wantStatus int, authorization string) []byte {

--- a/gestaltd/internal/server/handlers_app_catalog_test.go
+++ b/gestaltd/internal/server/handlers_app_catalog_test.go
@@ -714,6 +714,86 @@ func TestAppCatalogRefreshesAfterPluginConnectionChange(t *testing.T) {
 	}
 }
 
+func TestAppCatalogRefreshesAfterConnectionSchemaChange(t *testing.T) {
+	t.Parallel()
+
+	defs := testPluginDefsForConnections("slack", "default")
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = testutil.NewProviderRegistry(t, &coretesting.StubIntegration{N: "slack", DN: "Slack", ConnMode: core.ConnectionModeNone})
+		cfg.AppDefs = defs
+		cfg.Services = testutil.NewStubServices(t)
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	first := getJSONPath(t, ts, "/api/v1/catalog/apps", http.StatusOK, "")
+	if got := connectionDisplayNameFromCatalog(t, first, "slack", "default"); got != "" && got != "default" {
+		t.Fatalf("first catalog default displayName = %q: %s", got, first)
+	}
+	defs["slack"].Connections["default"].DisplayName = "Workspace"
+	second := getJSONPath(t, ts, "/api/v1/catalog/apps", http.StatusOK, "")
+	if got := connectionDisplayNameFromCatalog(t, second, "slack", "default"); got != "Workspace" {
+		t.Fatalf("second catalog default displayName = %q, want Workspace after schema edit: %s", got, second)
+	}
+}
+
+type oneShotFailResolver struct {
+	failName string
+	failed   atomic.Bool
+}
+
+func (r *oneShotFailResolver) ResolveProvider(_ context.Context, name string) (core.Provider, error) {
+	if name == r.failName && r.failed.CompareAndSwap(false, true) {
+		return nil, fmt.Errorf("tunnel dial failed")
+	}
+	return nil, core.ErrNotFound
+}
+
+func TestAppCatalogDoesNotCacheFailedProviderResolve(t *testing.T) {
+	t.Parallel()
+
+	resolver := &oneShotFailResolver{failName: "slack"}
+	providers := testutil.NewProviderRegistry(t,
+		&coretesting.StubIntegration{N: "slack", DN: "Slack", ConnMode: core.ConnectionModeNone},
+		&coretesting.StubIntegration{N: "email", DN: "Email", ConnMode: core.ConnectionModeNone},
+	)
+	providers.SetRemoteResolver(resolver)
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = providers
+		cfg.AppDefs = map[string]*config.ProviderEntry{
+			"slack": testPluginDefsForConnections("slack", "default")["slack"],
+			"email": testPluginDefsForConnections("email", "default")["email"],
+		}
+		cfg.Services = testutil.NewStubServices(t)
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	first := getJSONPath(t, ts, "/api/v1/catalog/apps", http.StatusOK, "")
+	var firstApps []appCatalogName
+	if err := json.Unmarshal(first, &firstApps); err != nil {
+		t.Fatalf("decode first catalog: %v", err)
+	}
+	if _, ok := catalogNameSet(firstApps)["slack"]; ok {
+		t.Fatalf("first catalog included slack after resolve failure: %s", first)
+	}
+	if _, ok := catalogNameSet(firstApps)["email"]; !ok {
+		t.Fatalf("first catalog missing email: %s", first)
+	}
+
+	second := getJSONPath(t, ts, "/api/v1/catalog/apps", http.StatusOK, "")
+	var secondApps []appCatalogName
+	if err := json.Unmarshal(second, &secondApps); err != nil {
+		t.Fatalf("decode second catalog: %v", err)
+	}
+	names := catalogNameSet(secondApps)
+	if _, ok := names["slack"]; !ok {
+		t.Fatalf("second catalog still missing slack after failed resolve was not cached: %s", second)
+	}
+	if _, ok := names["email"]; !ok {
+		t.Fatalf("second catalog missing email: %s", second)
+	}
+}
+
 func TestAppCatalogSharesTenantSnapshotAcrossViewers(t *testing.T) {
 	t.Parallel()
 
@@ -787,7 +867,8 @@ func connectionNamesFromCatalog(t *testing.T, body []byte, app string) map[strin
 	var apps []struct {
 		Name        string `json:"name"`
 		Connections []struct {
-			Name string `json:"name"`
+			Name        string `json:"name"`
+			DisplayName string `json:"displayName"`
 		} `json:"connections"`
 	}
 	if err := json.Unmarshal(body, &apps); err != nil {
@@ -801,6 +882,39 @@ func connectionNamesFromCatalog(t *testing.T, body []byte, app string) map[strin
 		for _, connection := range entry.Connections {
 			out[connection.Name] = true
 		}
+	}
+	return out
+}
+
+func connectionDisplayNameFromCatalog(t *testing.T, body []byte, app, connection string) string {
+	t.Helper()
+	var apps []struct {
+		Name        string `json:"name"`
+		Connections []struct {
+			Name        string `json:"name"`
+			DisplayName string `json:"displayName"`
+		} `json:"connections"`
+	}
+	if err := json.Unmarshal(body, &apps); err != nil {
+		t.Fatalf("decode catalog connections: %v", err)
+	}
+	for _, entry := range apps {
+		if entry.Name != app {
+			continue
+		}
+		for _, conn := range entry.Connections {
+			if conn.Name == connection {
+				return conn.DisplayName
+			}
+		}
+	}
+	return ""
+}
+
+func catalogNameSet(apps []appCatalogName) map[string]struct{} {
+	out := make(map[string]struct{}, len(apps))
+	for _, app := range apps {
+		out[app.Name] = struct{}{}
 	}
 	return out
 }

--- a/gestaltd/internal/server/handlers_tokens.go
+++ b/gestaltd/internal/server/handlers_tokens.go
@@ -168,7 +168,7 @@ func (s *Server) revokeAPIToken(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"status": "revoked"})
 }
 
-func (s *Server) attachDirectoryConnections(entry *appDirectoryEntry, plugin *config.ProviderEntry) {
+func (s *Server) attachDirectoryConnections(entry *tenantAppDirectoryEntry, plugin *config.ProviderEntry) {
 	if entry == nil {
 		return
 	}

--- a/gestaltd/internal/server/integration_visibility.go
+++ b/gestaltd/internal/server/integration_visibility.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"strings"
 
-	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 )
@@ -39,29 +38,11 @@ func (s *Server) integrationSettingsAccessibleContext(ctx context.Context, p *pr
 	return decision.Allowed, nil
 }
 
-// integrationHasVisibleHTTPOperationsContext reports whether the principal can
-// invoke any of this app's public HTTP operations. The filter is a batched
-// evaluator decision, so an app whose every operation the caller would be
-// denied is not advertised. An evaluator failure is surfaced as an error, not
-// as "no operations": hiding an app on a transport error is exactly the silent
-// access loss this must not cause.
-func (s *Server) integrationHasVisibleHTTPOperationsContext(ctx context.Context, p *principal.Principal, provider string, prov core.Provider) (bool, error) {
-	cat := prov.Catalog()
-	if cat == nil {
-		return false, nil
-	}
-	cat, err := invocation.FilterCatalogForPrincipal(ctx, cat, provider, p, s.operationAccess)
-	if err != nil {
-		return false, err
-	}
-	return len(s.publicHTTPOperations(provider, prov, cat.Operations)) > 0, nil
-}
-
 // prefetchIntegrationListingDecisions answers every authorization question the
-// /apps listing is about to ask - one mounted-UI question and one app-admin
-// question per app - with a single batched evaluator call. The per-app handlers
-// below are unchanged and still ask checkResourceAccess; they simply find the
-// answer already cached.
+// Apps list is about to ask — may they use this app, open its web UI, or
+// admin it — with a single batched evaluator call. The per-app handlers
+// below still ask checkResourceAccess; they simply find the answer already
+// cached.
 func (s *Server) prefetchIntegrationListingDecisions(ctx context.Context, p *principal.Principal, appNames []string) {
 	if s == nil || s.authorization == nil || p == nil || principal.IsNonUserPrincipal(p) {
 		return

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -134,8 +134,8 @@ type Server struct {
 	agentRuns                     agentmanager.Service
 	providers                     *registry.ProviderMap[core.Provider]
 	tenantDirectoryMu             sync.Mutex
-	tenantDirectoryKey            string
-	tenantDirectory               *appDirectory
+	tenantDirectoryEpoch          tenantAppDirectoryEpoch
+	tenantDirectory               *tenantAppDirectory
 	workflow                      bootstrap.WorkflowControl
 	pluginRuntimes                bootstrap.RuntimeInspector
 	resolver                      *principal.Resolver

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -133,6 +133,9 @@ type Server struct {
 	workflowSchedules             *workflowmanager.Manager
 	agentRuns                     agentmanager.Service
 	providers                     *registry.ProviderMap[core.Provider]
+	tenantDirectoryMu             sync.Mutex
+	tenantDirectoryKey            string
+	tenantDirectory               *appDirectory
 	workflow                      bootstrap.WorkflowControl
 	pluginRuntimes                bootstrap.RuntimeInspector
 	resolver                      *principal.Resolver
@@ -215,8 +218,9 @@ type Config struct {
 	ProviderKinds         map[string]invocation.ProviderKind
 	AuthorizationPolicies map[string]string
 	// OperationAccessChecker answers batched operation-access questions for
-	// catalog listing. Nil disables catalog filtering; invoke-time
-	// enforcement is unaffected either way.
+	// GET /apps/{app}/operations. Nil disables that filter; invoke-time
+	// enforcement is unaffected either way. Apps catalog membership uses
+	// app-level use grants, not this checker.
 	OperationAccessChecker invocation.OperationAccessChecker
 	// UserLookup gates resolving other people's identities on an explicit
 	// employee operator role.

--- a/gestaltd/services/apps/registry/registry.go
+++ b/gestaltd/services/apps/registry/registry.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"slices"
 	"sync"
+	"sync/atomic"
 
 	"github.com/valon-technologies/gestalt/server/core"
 )
@@ -21,10 +22,11 @@ type RemoteResolver[T any] interface {
 
 // ProviderMap is a thread-safe, named collection of providers of a single type.
 type ProviderMap[T any] struct {
-	mu       sync.RWMutex
-	items    map[string]T
-	kind     string
-	resolver RemoteResolver[T]
+	mu         sync.RWMutex
+	items      map[string]T
+	kind       string
+	resolver   RemoteResolver[T]
+	generation atomic.Uint64
 }
 
 func newProviderMap[T any](kind string) ProviderMap[T] {
@@ -38,6 +40,7 @@ func (m *ProviderMap[T]) Register(name string, val T) error {
 		return fmt.Errorf("%s %q: %w", m.kind, name, core.ErrAlreadyRegistered)
 	}
 	m.items[name] = val
+	m.generation.Add(1)
 	return nil
 }
 
@@ -48,6 +51,7 @@ func (m *ProviderMap[T]) Replace(name string, val T) error {
 		return fmt.Errorf("%s %q: %w", m.kind, name, core.ErrNotFound)
 	}
 	m.items[name] = val
+	m.generation.Add(1)
 	return nil
 }
 
@@ -55,6 +59,16 @@ func (m *ProviderMap[T]) Remove(name string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	delete(m.items, name)
+	m.generation.Add(1)
+}
+
+// Generation bumps whenever the local map or remote resolver changes so
+// callers can drop a cached directory instead of serving replaced apps.
+func (m *ProviderMap[T]) Generation() uint64 {
+	if m == nil {
+		return 0
+	}
+	return m.generation.Load()
 }
 
 func (m *ProviderMap[T]) Get(name string) (T, error) {
@@ -99,6 +113,7 @@ func (m *ProviderMap[T]) SetRemoteResolver(r RemoteResolver[T]) {
 	m.mu.Lock()
 	m.resolver = r
 	m.mu.Unlock()
+	m.generation.Add(1)
 }
 
 // List returns all registered names, sorted alphabetically.

--- a/gestaltd/services/apps/registry/registry_test.go
+++ b/gestaltd/services/apps/registry/registry_test.go
@@ -96,3 +96,34 @@ func TestProviderMapRemoteResolverNonErrNotFoundErrorPropagates(t *testing.T) {
 		t.Fatalf("Get should propagate the resolver error, got: %v", err)
 	}
 }
+
+func TestProviderMapGenerationBumpsOnMutations(t *testing.T) {
+	t.Parallel()
+	m := newProviderMap[int]("test")
+	if m.Generation() != 0 {
+		t.Fatalf("empty generation = %d, want 0", m.Generation())
+	}
+	if err := m.Register("foo", 1); err != nil {
+		t.Fatal(err)
+	}
+	afterRegister := m.Generation()
+	if afterRegister == 0 {
+		t.Fatal("register did not bump generation")
+	}
+	if err := m.Replace("foo", 2); err != nil {
+		t.Fatal(err)
+	}
+	if m.Generation() == afterRegister {
+		t.Fatal("replace did not bump generation")
+	}
+	afterReplace := m.Generation()
+	m.Remove("foo")
+	if m.Generation() == afterReplace {
+		t.Fatal("remove did not bump generation")
+	}
+	afterRemove := m.Generation()
+	m.SetRemoteResolver(&stubRemoteResolver[int]{err: core.ErrNotFound})
+	if m.Generation() == afterRemove {
+		t.Fatal("SetRemoteResolver did not bump generation")
+	}
+}


### PR DESCRIPTION
## Summary

Opening Apps still rebuilt the full app list for every person, so the page waited about as long as before the catalog split. The daemon now keeps one shared directory for the company, reuses it for catalog and connection status, and shows only the apps this signed-in user may use.

## Why / context

The earlier catalog split made the JSON smaller by dropping saved accounts and inline icons. It still walked every app and guessed visibility from web UIs, admin pages, and HTTP operations. That work is what made `GET /api/v1/catalog/apps` take about three seconds on valon.tools.

Admin already picks people and groups who may use each app. Catalog membership should use that rule, not "can they call one API." Connection status stays a second call and must not rebuild the directory.

Rejected alternative: only start catalog and overlay in parallel in the console. That cannot make the first names appear until the catalog handler finishes.

## What changed

- The daemon builds a shared Apps directory (names, copy, icons, connection fields) and keeps it until apps are added, replaced, or removed.
- Catalog, connection overlay, and the old combined apps list all start from that directory, then filter by the existing use grants (including group membership and an "everyone" default role).
- An app you can only invoke through one HTTP operation no longer appears in Apps. Operation listing on that app is unchanged.
- Apps that are configured but not loaded still show only to app admins.
- The second catalog request and the connection overlay do not rebuild the shared directory.

## Validation

- [x] Automated: `go test ./internal/server/ -count=1`
- [x] Automated: `go test ./services/apps/registry/ -count=1`
- [ ] Not run: live `GET /api/v1/catalog/apps` on valon.tools after this daemon is deployed. Confirm names appear without a three-second rebuild, and Connect/Connected still come from the overlay.

## Reviewer focus

- Catalog and overlay must share one directory snapshot. Overlay still lists saved accounts.
- Browse rights are the Admin use grants, not operation access.
- Registry-only rows without a loaded provider stay admin-only, even when everyone may use loaded apps.

## Rollout / compatibility

JSON shapes stay the same. After deploy, some apps that only showed because of a callable API may disappear from Apps until an Admin use grant exists. Older consoles that still call `GET /api/v1/apps` get the same filter. Rollback is revert. Ship this daemon to see the faster catalog; the console already reads catalog plus overlay.

## Evidence / demo

No rendered UI in this repository. The user-visible outcome is a faster Apps list after deploy. Proof is the directory-reuse test, the operation-only hide test, and the existing group-grant listing tests.

## Links

Follow-up to #3092.
Companion console: https://github.com/valon-technologies/gestalt-providers/pull/1277


Made with [Cursor](https://cursor.com)