### PR TITLE
Forward verified email alias on identity grant RPCs

### DIFF
--- a/gestaltd/internal/server/grant_email_alias.go
+++ b/gestaltd/internal/server/grant_email_alias.go
@@ -1,0 +1,37 @@
+package server
+
+import (
+	"context"
+	"strings"
+
+	gestalt "github.com/valon-technologies/gestalt/sdk/go"
+	"github.com/valon-technologies/gestalt/server/services/identity/principal"
+)
+
+// attachGrantEmailSubjectAlias records the verified mailbox subject alongside
+// the canonical user UUID so identity grant RPCs can list tokens stored under
+// either alias.
+func attachGrantEmailSubjectAlias(ctx context.Context, p *principal.Principal) context.Context {
+	if p == nil || p.Identity == nil {
+		return ctx
+	}
+	email := strings.TrimSpace(p.Identity.Email)
+	if email == "" || !strings.Contains(email, "@") {
+		return ctx
+	}
+	canonical := principal.Canonicalized(p)
+	canonicalID := strings.TrimSpace(canonical.SubjectID)
+	emailSubject := principal.UserSubjectID(email)
+	if emailSubject == "" || emailSubject == canonicalID {
+		return ctx
+	}
+	call := gestalt.IdentityCallContextFromContext(ctx)
+	if strings.TrimSpace(call.CallerSubjectID) == "" {
+		call.CallerSubjectID = canonicalID
+	}
+	call.Introspection = &gestalt.IntrospectResponse{
+		Active:  true,
+		Subject: emailSubject,
+	}
+	return gestalt.WithIdentityCallContext(ctx, call)
+}

--- a/gestaltd/internal/server/grant_email_alias_test.go
+++ b/gestaltd/internal/server/grant_email_alias_test.go
@@ -1,0 +1,60 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	gestalt "github.com/valon-technologies/gestalt/sdk/go"
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/services/identity/principal"
+)
+
+func TestAttachGrantEmailSubjectAlias(t *testing.T) {
+	t.Parallel()
+
+	canonical := "user:11111111-1111-1111-1111-111111111111"
+	emailSubject := "user:owner@example.com"
+	ctx := attachGrantEmailSubjectAlias(context.Background(), &principal.Principal{
+		SubjectID: canonical,
+		Kind:      principal.KindUser,
+		Identity:  &core.UserIdentity{Email: "owner@example.com"},
+	})
+
+	call := gestalt.IdentityCallContextFromContext(ctx)
+	if call.CallerSubjectID != canonical {
+		t.Fatalf("CallerSubjectID = %q, want %q", call.CallerSubjectID, canonical)
+	}
+	if call.Introspection == nil || !call.Introspection.Active {
+		t.Fatal("Introspection missing or inactive")
+	}
+	if call.Introspection.Subject != emailSubject {
+		t.Fatalf("Introspection.Subject = %q, want %q", call.Introspection.Subject, emailSubject)
+	}
+}
+
+func TestCallerAuthContextAttachesEmailAlias(t *testing.T) {
+	t.Parallel()
+
+	s := &Server{}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tokens", nil)
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: "session-token"})
+	canonical := "user:11111111-1111-1111-1111-111111111111"
+	emailSubject := "user:owner@example.com"
+	ctx := principal.WithPrincipal(req.Context(), &principal.Principal{
+		SubjectID: canonical,
+		UserID:    "11111111-1111-1111-1111-111111111111",
+		Kind:      principal.KindUser,
+		Identity:  &core.UserIdentity{Email: "owner@example.com"},
+	})
+
+	got := s.callerAuthContext(ctx, req)
+	call := gestalt.IdentityCallContextFromContext(got)
+	if call.CallerSubjectID != canonical {
+		t.Fatalf("CallerSubjectID = %q, want %q", call.CallerSubjectID, canonical)
+	}
+	if call.Introspection == nil || call.Introspection.Subject != emailSubject {
+		t.Fatalf("Introspection.Subject = %q, want %q", call.Introspection.Subject, emailSubject)
+	}
+}

--- a/gestaltd/internal/server/grant_helpers.go
+++ b/gestaltd/internal/server/grant_helpers.go
@@ -32,14 +32,15 @@ func (s *Server) callerAuthContext(ctx context.Context, r *http.Request) context
 	if p == nil {
 		return ctx
 	}
-	subject := strings.TrimSpace(principal.Canonicalized(p).SubjectID)
-	if subject == "" {
+	subjectID, err := principal.ResolveAuthorizationSubjectID(ctx, s.users, p)
+	if err != nil || strings.TrimSpace(subjectID) == "" {
 		return ctx
 	}
 	call := gestalt.IdentityCallContextFromContext(ctx)
-	call.CallerSubjectID = subject
+	call.CallerSubjectID = subjectID
 	ctx = gestalt.WithIdentityCallContext(ctx, call)
-	return gestalt.WithTrustedCallerSubject(ctx, subject)
+	ctx = gestalt.WithTrustedCallerSubject(ctx, subjectID)
+	return attachGrantEmailSubjectAlias(ctx, p)
 }
 
 func (s *Server) callerBearerToken(r *http.Request) (string, error) {

--- a/gestaltd/internal/server/public_grpc.go
+++ b/gestaltd/internal/server/public_grpc.go
@@ -105,6 +105,7 @@ func publicPrepareUnaryInterceptor(transport *providergateway.ProviderGatewayTra
 			ctx = principal.WithPrincipal(ctx, canonical)
 			if subjectID := strings.TrimSpace(canonical.SubjectID); subjectID != "" {
 				ctx = gestalt.WithTrustedCallerSubject(ctx, subjectID)
+				ctx = attachGrantEmailSubjectAlias(ctx, canonical)
 			}
 			return handler(ctx, adapted)
 		}
@@ -153,6 +154,7 @@ func (s *publicAuthStream) Context() context.Context {
 		ctx = principal.WithPrincipal(ctx, canonical)
 		if subjectID := strings.TrimSpace(canonical.SubjectID); subjectID != "" {
 			ctx = gestalt.WithTrustedCallerSubject(ctx, subjectID)
+			ctx = attachGrantEmailSubjectAlias(ctx, canonical)
 		}
 	}
 	return ctx


### PR DESCRIPTION
## Summary

- Resolve the canonical user UUID in `callerAuthContext` via `ResolveAuthorizationSubjectID`
- Forward the verified mailbox subject on identity grant RPCs so OIDC can match email-stored grants
- Apply the same alias forwarding on public gRPC identity calls (Settings list path)

## Why / context

#3094 forwarded the canonical caller on token create, but OIDC login stores claims and some grants under `user:email@…` while Settings lists by `user:<uuid>`. Recording the email alias on identity call context lets the OIDC provider query both keys.

Pairs with gestalt-providers oidc grant-subject alias follow-up.

## Test plan

- [x] `go test ./internal/server -run 'Grant|CallerAuth'`
- [ ] Bump `GESTALTD_PINNED_SHA` after merge and deploy Valon Tools
- [ ] Create a token at `/settings/tokens/new` and confirm it appears on `/settings/tokens`


Made with [Cursor](https://cursor.com)