### PR TITLE
Fix Go race tests failing on the shared fake authorization checker

### DIFF
--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -2766,6 +2766,8 @@ func TestMountedUIAppLevelAuthorizationRelationships(t *testing.T) {
 type serverTestAuthorizationProvider struct {
 	core.AuthorizationProvider
 
+	mu sync.Mutex
+
 	resourceTypes            []*proto.AuthorizationModelResourceType
 	relationships            []*proto.Relationship
 	listRelationshipRequests []*proto.ListRelationshipsRequest
@@ -2777,8 +2779,11 @@ type serverTestAuthorizationProvider struct {
 
 // CheckAccess models the provider-owned evaluator: it expands subject sets so a
 // subject that only holds a grant through a group is allowed, exactly as the
-// real relationship-graph provider does.
+// real relationship-graph provider does. HTTP tests share one stub across
+// concurrent requests, so recordings are taken under mu.
 func (p *serverTestAuthorizationProvider) CheckAccess(_ context.Context, req *proto.CheckAccessRequest) (*proto.CheckAccessResponse, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	p.checkAccessRequests = append(p.checkAccessRequests, req)
 	return p.decide(req)
 }
@@ -2799,6 +2804,8 @@ func (p *serverTestAuthorizationProvider) decide(req *proto.CheckAccessRequest) 
 }
 
 func (p *serverTestAuthorizationProvider) CheckAccessMany(_ context.Context, req *proto.CheckAccessManyRequest) (*proto.CheckAccessManyResponse, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	p.checkAccessManyRequests = append(p.checkAccessManyRequests, req)
 	if p.checkAccessManyErr != nil {
 		return nil, p.checkAccessManyErr
@@ -2882,6 +2889,8 @@ func (p *serverTestAuthorizationProvider) targetIncludesSubject(target *proto.Re
 }
 
 func (p *serverTestAuthorizationProvider) ListRelationships(_ context.Context, req *proto.ListRelationshipsRequest) (*proto.ListRelationshipsResponse, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	p.listRelationshipRequests = append(p.listRelationshipRequests, req)
 	filter := req.GetFilter()
 	out := []*proto.Relationship{}
@@ -2897,16 +2906,21 @@ func (p *serverTestAuthorizationProvider) ListRelationships(_ context.Context, r
 type serviceAccountCredentialAuthorizationProvider struct {
 	core.AuthorizationProvider
 
+	mu       sync.Mutex
 	allowed  bool
 	requests []*proto.CheckAccessRequest
 }
 
 func (p *serviceAccountCredentialAuthorizationProvider) CheckAccess(_ context.Context, req *proto.CheckAccessRequest) (*proto.CheckAccessResponse, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	p.requests = append(p.requests, req)
 	return &proto.CheckAccessResponse{Allowed: p.allowed}, nil
 }
 
 func (p *serverTestAuthorizationProvider) ListActiveModelResourceTypes(_ context.Context, req *proto.ListActiveModelResourceTypesRequest) (*proto.ListActiveModelResourceTypesResponse, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	name := strings.TrimSpace(req.GetFilter().GetName())
 	out := []*proto.AuthorizationModelResourceType{}
 	for _, resourceType := range p.resourceTypes {
@@ -2916,6 +2930,69 @@ func (p *serverTestAuthorizationProvider) ListActiveModelResourceTypes(_ context
 		out = append(out, resourceType)
 	}
 	return &proto.ListActiveModelResourceTypesResponse{ResourceTypes: out}, nil
+}
+
+func (p *serverTestAuthorizationProvider) recordedCheckAccess() []*proto.CheckAccessRequest {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]*proto.CheckAccessRequest, len(p.checkAccessRequests))
+	copy(out, p.checkAccessRequests)
+	return out
+}
+
+func (p *serverTestAuthorizationProvider) recordedCheckAccessMany() []*proto.CheckAccessManyRequest {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]*proto.CheckAccessManyRequest, len(p.checkAccessManyRequests))
+	copy(out, p.checkAccessManyRequests)
+	return out
+}
+
+func TestServerTestAuthorizationProviderRecordsConcurrentRPCs(t *testing.T) {
+	t.Parallel()
+
+	subjectID := principal.UserSubjectID(testCanonicalAdminUserID)
+	authz := &serverTestAuthorizationProvider{
+		relationships: []*proto.Relationship{
+			testAuthorizationRelationship(subjectID, "admin", "app", "g-issues"),
+		},
+	}
+	req := &proto.CheckAccessRequest{
+		Subject:  &proto.Subject{Type: "subject", Id: subjectID},
+		Action:   &proto.Action{Name: "g-issues"},
+		Resource: &proto.Resource{Type: "app", Id: "g-issues"},
+	}
+	const n = 32
+	var wg sync.WaitGroup
+	errCh := make(chan error, n*2)
+	wg.Add(n * 2)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			if _, err := authz.CheckAccess(context.Background(), req); err != nil {
+				errCh <- err
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			if _, err := authz.CheckAccessMany(context.Background(), &proto.CheckAccessManyRequest{
+				Requests: []*proto.CheckAccessRequest{req},
+			}); err != nil {
+				errCh <- err
+			}
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Fatalf("concurrent authorization RPC: %v", err)
+	}
+	if got := len(authz.recordedCheckAccess()); got != n {
+		t.Fatalf("CheckAccess recordings = %d, want %d", got, n)
+	}
+	if got := len(authz.recordedCheckAccessMany()); got != n {
+		t.Fatalf("CheckAccessMany recordings = %d, want %d", got, n)
+	}
 }
 
 func relationshipMatchesFilter(relationship *proto.Relationship, filter *proto.RelationshipFilter) bool {

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -2932,26 +2932,29 @@ func (p *serverTestAuthorizationProvider) ListActiveModelResourceTypes(_ context
 	return &proto.ListActiveModelResourceTypesResponse{ResourceTypes: out}, nil
 }
 
-func (p *serverTestAuthorizationProvider) recordedCheckAccess() []*proto.CheckAccessRequest {
+func (p *serverTestAuthorizationProvider) checkAccessCallCount() int {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	out := make([]*proto.CheckAccessRequest, len(p.checkAccessRequests))
-	copy(out, p.checkAccessRequests)
-	return out
+	return len(p.checkAccessRequests)
 }
 
-func (p *serverTestAuthorizationProvider) recordedCheckAccessMany() []*proto.CheckAccessManyRequest {
+func (p *serverTestAuthorizationProvider) checkAccessManyCallCount() int {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	out := make([]*proto.CheckAccessManyRequest, len(p.checkAccessManyRequests))
-	copy(out, p.checkAccessManyRequests)
-	return out
+	return len(p.checkAccessManyRequests)
+}
+
+func (p *serverTestAuthorizationProvider) listRelationshipCallCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.listRelationshipRequests)
 }
 
 func TestServerTestAuthorizationProviderRecordsConcurrentRPCs(t *testing.T) {
 	t.Parallel()
 
 	subjectID := principal.UserSubjectID(testCanonicalAdminUserID)
+	resource := &proto.Resource{Type: "app", Id: "g-issues"}
 	authz := &serverTestAuthorizationProvider{
 		relationships: []*proto.Relationship{
 			testAuthorizationRelationship(subjectID, "admin", "app", "g-issues"),
@@ -2960,12 +2963,15 @@ func TestServerTestAuthorizationProviderRecordsConcurrentRPCs(t *testing.T) {
 	req := &proto.CheckAccessRequest{
 		Subject:  &proto.Subject{Type: "subject", Id: subjectID},
 		Action:   &proto.Action{Name: "g-issues"},
-		Resource: &proto.Resource{Type: "app", Id: "g-issues"},
+		Resource: resource,
+	}
+	listReq := &proto.ListRelationshipsRequest{
+		Filter: &proto.RelationshipFilter{Resource: resource},
 	}
 	const n = 32
 	var wg sync.WaitGroup
-	errCh := make(chan error, n*2)
-	wg.Add(n * 2)
+	errCh := make(chan error, n*4)
+	wg.Add(n * 4)
 	for i := 0; i < n; i++ {
 		go func() {
 			defer wg.Done()
@@ -2981,17 +2987,32 @@ func TestServerTestAuthorizationProviderRecordsConcurrentRPCs(t *testing.T) {
 				errCh <- err
 			}
 		}()
+		go func() {
+			defer wg.Done()
+			if _, err := authz.ListRelationships(context.Background(), listReq); err != nil {
+				errCh <- err
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			if _, err := authz.ListActiveModelResourceTypes(context.Background(), &proto.ListActiveModelResourceTypesRequest{}); err != nil {
+				errCh <- err
+			}
+		}()
 	}
 	wg.Wait()
 	close(errCh)
 	for err := range errCh {
 		t.Fatalf("concurrent authorization RPC: %v", err)
 	}
-	if got := len(authz.recordedCheckAccess()); got != n {
+	if got := authz.checkAccessCallCount(); got != n {
 		t.Fatalf("CheckAccess recordings = %d, want %d", got, n)
 	}
-	if got := len(authz.recordedCheckAccessMany()); got != n {
+	if got := authz.checkAccessManyCallCount(); got != n {
 		t.Fatalf("CheckAccessMany recordings = %d, want %d", got, n)
+	}
+	if got := authz.listRelationshipCallCount(); got != n {
+		t.Fatalf("ListRelationships recordings = %d, want %d", got, n)
 	}
 }
 


### PR DESCRIPTION
## Summary

CD on main could not publish the Apps directory cache because Go race tests failed on a shared test fake, not on production authorization. This makes that fake safe to call from many HTTP requests at once so race tests can pass and the cache can ship.

## Why / context

HTTP tests in the daemon share one fake authorization checker. The real checker already handles overlapping calls. The fake recorded each call by appending to a slice with no lock, which is a data race. After the cache landed, more tests ran in parallel in the same package, so the detector started failing the suite and skipped publish jobs.

Rejected alternative: stop running the catalog tests in parallel. That would hide the race and leave every other parallel HTTP test on the same unsafe fake.

## What changed

- The fake checker records and answers access checks, batched access checks, relationship listing, and model listing under one lock.
- The service-account credential fake records the same way.
- A race test fires overlapping access checks, batched access checks, relationship listing, and model listing on one fake, then checks that every recording RPC was counted.

Production authorization is unchanged.

## Validation

- [x] Automated: `go test -race ./internal/server/ -count=1 -run 'TestServerTestAuthorizationProviderRecordsConcurrentRPCs|TestAppAdminMembersList|TestAppCatalog'`
- [ ] Not run: full `go test -race ./internal/server/` package. The targeted run covers the CD failure mode.
- [ ] Not run: UI demo. This change is test-only with no rendered surface.

## Reviewer focus

The fake is a stand-in evaluator, not an HTTP helper. If a later test changes grants while requests are in flight, those writes should take the same lock.

## Rollout / compatibility

Test-only. No API, schema, or deploy order change. After this merges, pin the next green CD SHA on main for valon.tools (that SHA includes the Apps directory cache). Do not pin a SHA whose CD failed race tests.

## Evidence / demo

No rendered UI. Proof is the concurrent recording test under `go test -race`.

## Links

Follow-up to #3111.
CD failure: https://github.com/valon-technologies/gestalt/actions/runs/32156285429