### PR TITLE
Persist reconnect when a stored OAuth grant is rejected

### DIFF
--- a/gestaltd/core/grant_reconnect_test.go
+++ b/gestaltd/core/grant_reconnect_test.go
@@ -9,9 +9,10 @@ func TestMarkGrantReconnectRequired(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 8, 18, 17, 0, 0, 0, time.UTC)
-	future := now.Add(time.Hour)
 
 	t.Run("unexpired grant is force-expired", func(t *testing.T) {
+		t.Parallel()
+		future := now.Add(time.Hour)
 		grant := &ExternalCredentialGrant{
 			AccessToken: "tok",
 			ExpiresAt:   &future,
@@ -28,6 +29,7 @@ func TestMarkGrantReconnectRequired(t *testing.T) {
 	})
 
 	t.Run("already reconnect-required is a no-op", func(t *testing.T) {
+		t.Parallel()
 		past := now.Add(-time.Minute)
 		grant := &ExternalCredentialGrant{
 			AccessToken:       "tok",
@@ -43,6 +45,7 @@ func TestMarkGrantReconnectRequired(t *testing.T) {
 	})
 
 	t.Run("nil grant is a no-op", func(t *testing.T) {
+		t.Parallel()
 		if MarkGrantReconnectRequired(nil, now) {
 			t.Fatal("nil grant should not change")
 		}

--- a/gestaltd/core/grant_reconnect_test.go
+++ b/gestaltd/core/grant_reconnect_test.go
@@ -1,0 +1,50 @@
+package core
+
+import (
+	"testing"
+	"time"
+)
+
+func TestMarkGrantReconnectRequired(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 18, 17, 0, 0, 0, time.UTC)
+	future := now.Add(time.Hour)
+
+	t.Run("unexpired grant is force-expired", func(t *testing.T) {
+		grant := &ExternalCredentialGrant{
+			AccessToken: "tok",
+			ExpiresAt:   &future,
+		}
+		if !MarkGrantReconnectRequired(grant, now) {
+			t.Fatal("expected grant to change")
+		}
+		if grant.RefreshErrorCount != 1 {
+			t.Fatalf("RefreshErrorCount = %d, want 1", grant.RefreshErrorCount)
+		}
+		if grant.ExpiresAt == nil || grant.ExpiresAt.After(now) {
+			t.Fatalf("ExpiresAt = %v, want not after now", grant.ExpiresAt)
+		}
+	})
+
+	t.Run("already reconnect-required is a no-op", func(t *testing.T) {
+		past := now.Add(-time.Minute)
+		grant := &ExternalCredentialGrant{
+			AccessToken:       "tok",
+			ExpiresAt:         &past,
+			RefreshErrorCount: 2,
+		}
+		if MarkGrantReconnectRequired(grant, now) {
+			t.Fatal("already-invalid grant should not change")
+		}
+		if grant.RefreshErrorCount != 2 {
+			t.Fatalf("RefreshErrorCount = %d, want 2", grant.RefreshErrorCount)
+		}
+	})
+
+	t.Run("nil grant is a no-op", func(t *testing.T) {
+		if MarkGrantReconnectRequired(nil, now) {
+			t.Fatal("nil grant should not change")
+		}
+	})
+}

--- a/gestaltd/core/types.go
+++ b/gestaltd/core/types.go
@@ -233,6 +233,26 @@ type ExternalCredentialGrant struct {
 	RefreshErrorCount int
 }
 
+// MarkGrantReconnectRequired records that the stored OAuth grant was rejected
+// by the upstream provider. Catalog reconnect is ExpiresAt not after now and
+// RefreshErrorCount > 0. This writes that fact without deleting the account.
+func MarkGrantReconnectRequired(grant *ExternalCredentialGrant, now time.Time) bool {
+	if grant == nil {
+		return false
+	}
+	changed := false
+	if grant.RefreshErrorCount < 1 {
+		grant.RefreshErrorCount = 1
+		changed = true
+	}
+	if grant.ExpiresAt == nil || grant.ExpiresAt.After(now) {
+		expired := now
+		grant.ExpiresAt = &expired
+		changed = true
+	}
+	return changed
+}
+
 type ExternalCredentialClientInfo struct {
 	ClientID              string
 	ClientSecret          string

--- a/gestaltd/internal/server/connection_status.go
+++ b/gestaltd/internal/server/connection_status.go
@@ -368,7 +368,18 @@ func preferredInstanceValid(instances []instanceInfo, preferredInstance string) 
 }
 
 func markPreferredInstances(instances []instanceInfo, preferredInstance string) []instanceInfo {
-	if !preferredInstanceValid(instances, preferredInstance) || len(instances) == 0 {
+	preferredInstance = strings.TrimSpace(preferredInstance)
+	if preferredInstance == "" || len(instances) == 0 {
+		return instances
+	}
+	found := false
+	for _, instance := range instances {
+		if instance.Name == preferredInstance {
+			found = true
+			break
+		}
+	}
+	if !found {
 		return instances
 	}
 	out := make([]instanceInfo, len(instances))

--- a/gestaltd/internal/server/connection_status_test.go
+++ b/gestaltd/internal/server/connection_status_test.go
@@ -194,3 +194,35 @@ func TestDefaultModeNoneAloneIsNotProductConnected(t *testing.T) {
 		t.Fatal("a mode-none default row must not mark the app product-connected")
 	}
 }
+
+func TestMarkPreferredInstances_MarksInvalidChosenAccount(t *testing.T) {
+	t.Parallel()
+
+	got := markPreferredInstances([]instanceInfo{
+		{Name: "default", credentialInvalid: true},
+	}, "default")
+	if len(got) != 1 || !got[0].Preferred {
+		t.Fatalf("preferred = %+v, want chosen invalid account marked preferred", got)
+	}
+}
+
+func TestMarkPreferredInstances_IgnoresStalePreference(t *testing.T) {
+	t.Parallel()
+
+	got := markPreferredInstances([]instanceInfo{
+		{Name: "default"},
+	}, "gone")
+	if len(got) != 1 || got[0].Preferred {
+		t.Fatalf("preferred = %+v, stale preference must not mark an instance", got)
+	}
+}
+
+func TestPreferredInstanceValid_RejectsInvalidGrant(t *testing.T) {
+	t.Parallel()
+
+	if preferredInstanceValid([]instanceInfo{
+		{Name: "default", credentialInvalid: true},
+	}, "default") {
+		t.Fatal("invalid chosen account is not a valid acting account")
+	}
+}

--- a/gestaltd/internal/server/credential_reconnect.go
+++ b/gestaltd/internal/server/credential_reconnect.go
@@ -1,0 +1,156 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/services/apps/apiexec"
+	"github.com/valon-technologies/gestalt/server/services/identity/principal"
+	"github.com/valon-technologies/gestalt/server/services/invocation"
+)
+
+func invocationRejectedStoredCredential(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, invocation.ErrReconnectRequired) || errors.Is(err, core.ErrReconnectRequired) {
+		return true
+	}
+	var upstream *apiexec.UpstreamHTTPError
+	return errors.As(err, &upstream) && upstream != nil && upstream.Status == http.StatusUnauthorized
+}
+
+// persistReconnectRequiredGrant writes the catalog reconnect fact onto the
+// stored OAuth grant after upstream rejected it. Catalog GET does not probe
+// the provider; it reads ExpiresAt + RefreshErrorCount. Persist failures are
+// logged and must not change the invocation error returned to the caller.
+func (s *Server) persistReconnectRequiredGrant(r *http.Request, providerName string, err error) {
+	if s == nil || r == nil || !invocationRejectedStoredCredential(err) {
+		return
+	}
+	if core.ExternalCredentialProviderMissing(s.externalCredentials) {
+		return
+	}
+	providerName = strings.TrimSpace(providerName)
+	if providerName == "" {
+		return
+	}
+	ctx := r.Context()
+	subjectID, resolveErr := principal.ResolveCredentialSubjectID(ctx, s.users, PrincipalFromContext(ctx))
+	if resolveErr != nil || strings.TrimSpace(subjectID) == "" {
+		return
+	}
+	credentials, listErr := s.externalCredentials.ListCredentials(ctx, subjectID, "")
+	if listErr != nil {
+		slog.WarnContext(ctx, "listing credentials after stored-credential reject", "provider", providerName, "error", listErr)
+		return
+	}
+	requestedConnection := strings.TrimSpace(r.URL.Query().Get(httpConnectionParam))
+	requestedInstance := strings.TrimSpace(r.URL.Query().Get(httpInstanceParam))
+	target := s.selectReconnectGrant(ctx, subjectID, providerName, requestedConnection, requestedInstance, credentials)
+	if target == nil || target.Grant == nil {
+		return
+	}
+	now := time.Now()
+	if s.now != nil {
+		now = s.now()
+	}
+	if !core.MarkGrantReconnectRequired(target.Grant, now) {
+		return
+	}
+	target.UpdatedAt = now
+	if upsertErr := s.externalCredentials.UpsertCredential(ctx, target); upsertErr != nil {
+		slog.WarnContext(ctx, "persisting reconnect-required grant", "provider", providerName, "error", upsertErr)
+	}
+}
+
+func (s *Server) selectReconnectGrant(
+	ctx context.Context,
+	subjectID, providerName, requestedConnection, requestedInstance string,
+	credentials []*core.ExternalCredential,
+) *core.ExternalCredential {
+	requestedConnection = config.ResolveConnectionAlias(strings.TrimSpace(requestedConnection))
+	requestedInstance = strings.TrimSpace(requestedInstance)
+	matches := make([]*core.ExternalCredential, 0, 1)
+	for _, credential := range credentials {
+		if credential == nil || credential.Grant == nil {
+			continue
+		}
+		if !s.credentialMatchesProvider(credential, providerName, requestedConnection) {
+			continue
+		}
+		if requestedInstance != "" && strings.TrimSpace(credential.Qualifier) != requestedInstance {
+			continue
+		}
+		matches = append(matches, credential)
+	}
+	switch len(matches) {
+	case 0:
+		return nil
+	case 1:
+		return matches[0]
+	}
+
+	byAudience := map[string][]*core.ExternalCredential{}
+	for _, credential := range matches {
+		audience := strings.TrimSpace(credential.Audience)
+		byAudience[audience] = append(byAudience[audience], credential)
+	}
+	candidates := matches
+	if requestedConnection == "" && len(byAudience) > 1 {
+		defaultAudience := strings.TrimSpace(providerName) + ":" + config.AppConnectionName
+		namedDefault := strings.TrimSpace(providerName) + ":" + defaultTokenInstance
+		if group, ok := byAudience[namedDefault]; ok {
+			candidates = group
+		} else if group, ok := byAudience[defaultAudience]; ok {
+			candidates = group
+		} else {
+			return nil
+		}
+	}
+	if len(candidates) == 1 {
+		return candidates[0]
+	}
+	preferred := s.preferredInstanceForConnection(ctx, subjectID, strings.TrimSpace(candidates[0].Audience))
+	if preferred == "" {
+		return nil
+	}
+	for _, credential := range candidates {
+		if strings.TrimSpace(credential.Qualifier) == preferred {
+			return credential
+		}
+	}
+	return nil
+}
+
+func (s *Server) credentialMatchesProvider(credential *core.ExternalCredential, providerName, requestedConnection string) bool {
+	if credential == nil {
+		return false
+	}
+	for _, binding := range s.pluginConnectionBindingsForCredentialID(credential.Audience) {
+		if binding.App != providerName {
+			continue
+		}
+		if requestedConnection == "" {
+			return true
+		}
+		if config.ResolveConnectionAlias(binding.Connection) == requestedConnection {
+			return true
+		}
+	}
+	prefix := strings.TrimSpace(providerName) + ":"
+	audience := strings.TrimSpace(credential.Audience)
+	if !strings.HasPrefix(audience, prefix) {
+		return false
+	}
+	if requestedConnection == "" {
+		return true
+	}
+	return audience == prefix+requestedConnection
+}

--- a/gestaltd/internal/server/credential_reconnect.go
+++ b/gestaltd/internal/server/credential_reconnect.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"errors"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -10,28 +9,20 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/config"
-	"github.com/valon-technologies/gestalt/server/services/apps/apiexec"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 )
 
-func invocationRejectedStoredCredential(err error) bool {
-	if err == nil {
-		return false
-	}
-	if errors.Is(err, invocation.ErrReconnectRequired) || errors.Is(err, core.ErrReconnectRequired) {
-		return true
-	}
-	var upstream *apiexec.UpstreamHTTPError
-	return errors.As(err, &upstream) && upstream != nil && upstream.Status == http.StatusUnauthorized
-}
-
 // persistReconnectRequiredGrant writes the catalog reconnect fact onto the
-// stored OAuth grant after upstream rejected it. Catalog GET does not probe
-// the provider; it reads ExpiresAt + RefreshErrorCount. Persist failures are
-// logged and must not change the invocation error returned to the caller.
+// Grant this invocation used. Catalog GET does not probe the provider; it
+// reads ExpiresAt + RefreshErrorCount. Persist failures are logged and must
+// not change the invocation error returned to the caller.
+//
+// Identity comes from the invoke (credential context, then WithConnection),
+// not from listing every grant for the subject. A 401 on archive must not
+// expire a healthy default sibling.
 func (s *Server) persistReconnectRequiredGrant(r *http.Request, providerName string, err error) {
-	if s == nil || r == nil || !invocationRejectedStoredCredential(err) {
+	if s == nil || r == nil || !invocation.StoredCredentialRejected(err) {
 		return
 	}
 	if core.ExternalCredentialProviderMissing(s.externalCredentials) {
@@ -46,14 +37,18 @@ func (s *Server) persistReconnectRequiredGrant(r *http.Request, providerName str
 	if resolveErr != nil || strings.TrimSpace(subjectID) == "" {
 		return
 	}
-	credentials, listErr := s.externalCredentials.ListCredentials(ctx, subjectID, "")
-	if listErr != nil {
-		slog.WarnContext(ctx, "listing credentials after stored-credential reject", "provider", providerName, "error", listErr)
+	cred := invocation.CredentialContextFromContext(ctx)
+	connection := firstNonEmpty(
+		cred.Connection,
+		invocation.ConnectionFromContext(ctx),
+		r.URL.Query().Get(httpConnectionParam),
+	)
+	instance := firstNonEmpty(cred.Instance, r.URL.Query().Get(httpInstanceParam))
+	audience := s.reconnectAudience(providerName, connection)
+	if audience == "" {
 		return
 	}
-	requestedConnection := strings.TrimSpace(r.URL.Query().Get(httpConnectionParam))
-	requestedInstance := strings.TrimSpace(r.URL.Query().Get(httpInstanceParam))
-	target := s.selectReconnectGrant(ctx, subjectID, providerName, requestedConnection, requestedInstance, credentials)
+	target := s.loadReconnectGrant(ctx, subjectID, audience, instance)
 	if target == nil || target.Grant == nil {
 		return
 	}
@@ -70,87 +65,82 @@ func (s *Server) persistReconnectRequiredGrant(r *http.Request, providerName str
 	}
 }
 
-func (s *Server) selectReconnectGrant(
-	ctx context.Context,
-	subjectID, providerName, requestedConnection, requestedInstance string,
-	credentials []*core.ExternalCredential,
-) *core.ExternalCredential {
-	requestedConnection = config.ResolveConnectionAlias(strings.TrimSpace(requestedConnection))
-	requestedInstance = strings.TrimSpace(requestedInstance)
-	matches := make([]*core.ExternalCredential, 0, 1)
+func (s *Server) reconnectAudience(providerName, connection string) string {
+	connection = config.ResolveConnectionAlias(strings.TrimSpace(connection))
+	if connection == "" {
+		connection = s.defaultConnectionName(providerName)
+	}
+	if connection == "" {
+		return ""
+	}
+	if s.pluginDefs != nil {
+		if entry := s.pluginDefs[providerName]; entry != nil && entry.Connections != nil {
+			if def := entry.Connections[connection]; def != nil {
+				if id := strings.TrimSpace(def.ConnectionID); id != "" {
+					return id
+				}
+			}
+		}
+	}
+	return strings.TrimSpace(providerName) + ":" + connection
+}
+
+func (s *Server) loadReconnectGrant(ctx context.Context, subjectID, audience, instance string) *core.ExternalCredential {
+	instance = strings.TrimSpace(instance)
+	if instance != "" {
+		stored, err := s.externalCredentials.GetCredential(ctx, subjectID, audience, instance)
+		if err != nil || stored == nil {
+			return nil
+		}
+		return stored
+	}
+	credentials, listErr := s.externalCredentials.ListCredentials(ctx, subjectID, audience)
+	if listErr != nil {
+		slog.WarnContext(ctx, "listing credentials after stored-credential reject", "audience", audience, "error", listErr)
+		return nil
+	}
+	preferred := ""
+	if s.connectionInstancePreferences != nil {
+		preferred, _ = s.connectionInstancePreferences.PreferredInstance(ctx, subjectID, audience)
+	}
+	chosen, ok := chosenReconnectInstance(credentials, preferred)
+	if !ok {
+		return nil
+	}
+	stored, err := s.externalCredentials.GetCredential(ctx, subjectID, audience, chosen)
+	if err != nil || stored == nil {
+		return nil
+	}
+	return stored
+}
+
+func chosenReconnectInstance(credentials []*core.ExternalCredential, preferred string) (string, bool) {
+	matches := make([]*core.ExternalCredential, 0, len(credentials))
 	for _, credential := range credentials {
 		if credential == nil || credential.Grant == nil {
 			continue
 		}
-		if !s.credentialMatchesProvider(credential, providerName, requestedConnection) {
-			continue
-		}
-		if requestedInstance != "" && strings.TrimSpace(credential.Qualifier) != requestedInstance {
-			continue
-		}
 		matches = append(matches, credential)
 	}
-	switch len(matches) {
-	case 0:
-		return nil
-	case 1:
-		return matches[0]
-	}
-
-	byAudience := map[string][]*core.ExternalCredential{}
-	for _, credential := range matches {
-		audience := strings.TrimSpace(credential.Audience)
-		byAudience[audience] = append(byAudience[audience], credential)
-	}
-	candidates := matches
-	if requestedConnection == "" && len(byAudience) > 1 {
-		defaultAudience := strings.TrimSpace(providerName) + ":" + config.AppConnectionName
-		namedDefault := strings.TrimSpace(providerName) + ":" + defaultTokenInstance
-		if group, ok := byAudience[namedDefault]; ok {
-			candidates = group
-		} else if group, ok := byAudience[defaultAudience]; ok {
-			candidates = group
-		} else {
-			return nil
+	preferred = strings.TrimSpace(preferred)
+	if preferred != "" {
+		for _, credential := range matches {
+			if strings.TrimSpace(credential.Qualifier) == preferred {
+				return preferred, true
+			}
 		}
 	}
-	if len(candidates) == 1 {
-		return candidates[0]
+	if len(matches) == 1 {
+		return strings.TrimSpace(matches[0].Qualifier), true
 	}
-	preferred := s.preferredInstanceForConnection(ctx, subjectID, strings.TrimSpace(candidates[0].Audience))
-	if preferred == "" {
-		return nil
-	}
-	for _, credential := range candidates {
-		if strings.TrimSpace(credential.Qualifier) == preferred {
-			return credential
-		}
-	}
-	return nil
+	return "", false
 }
 
-func (s *Server) credentialMatchesProvider(credential *core.ExternalCredential, providerName, requestedConnection string) bool {
-	if credential == nil {
-		return false
-	}
-	for _, binding := range s.pluginConnectionBindingsForCredentialID(credential.Audience) {
-		if binding.App != providerName {
-			continue
-		}
-		if requestedConnection == "" {
-			return true
-		}
-		if config.ResolveConnectionAlias(binding.Connection) == requestedConnection {
-			return true
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
 		}
 	}
-	prefix := strings.TrimSpace(providerName) + ":"
-	audience := strings.TrimSpace(credential.Audience)
-	if !strings.HasPrefix(audience, prefix) {
-		return false
-	}
-	if requestedConnection == "" {
-		return true
-	}
-	return audience == prefix+requestedConnection
+	return ""
 }

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -863,6 +863,7 @@ func (s *Server) writeInvocationError(w http.ResponseWriter, r *http.Request, pr
 			fmt.Sprintf("no external credential stored for integration %q; connect via OAuth first", providerName),
 		)
 	case errors.Is(err, invocation.ErrReconnectRequired):
+		s.persistReconnectRequiredGrant(r, providerName, err)
 		writeTypedError(
 			w,
 			http.StatusPreconditionFailed,
@@ -898,6 +899,7 @@ func (s *Server) writeInvocationError(w http.ResponseWriter, r *http.Request, pr
 		writeError(w, http.StatusBadRequest, err.Error())
 	case errors.As(err, &upstreamErr):
 		if upstreamErr.Status == http.StatusUnauthorized {
+			s.persistReconnectRequiredGrant(r, providerName, err)
 			writeTypedError(
 				w,
 				http.StatusPreconditionFailed,

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -13722,6 +13722,95 @@ func TestExecuteOperation_StubInvokerUnauthorizedPersistsReconnectRequired(t *te
 	assertNotionNeedsReconnect(t, ts, false)
 }
 
+func TestExecuteOperation_UnauthorizedNamedConnectionDoesNotMarkSibling(t *testing.T) {
+	t.Parallel()
+
+	svc := testutil.NewStubServices(t)
+	u := seedUser(t, svc, "anonymous@gestalt")
+	subjectID := principal.UserSubjectID(u.ID)
+	future := time.Now().Add(time.Hour)
+	seedToken(t, svc, &core.ExternalCredential{
+		ID:        "named-stale-default",
+		Subject:   subjectID,
+		Audience:  "named-stale:" + testDefaultConnection,
+		Qualifier: "default",
+		Grant: &core.ExternalCredentialGrant{
+			AccessToken: "default-access",
+			ExpiresAt:   &future,
+		},
+	})
+	seedToken(t, svc, &core.ExternalCredential{
+		ID:        "named-stale-archive",
+		Subject:   subjectID,
+		Audience:  "named-stale:archive",
+		Qualifier: "archive",
+		Grant: &core.ExternalCredentialGrant{
+			AccessToken: "archive-access",
+			ExpiresAt:   &future,
+		},
+	})
+
+	defaultConn := oauthConnectionDef(nil)
+	defaultConn.ConnectionID = "named-stale:" + testDefaultConnection
+	archiveConn := oauthConnectionDef(nil)
+	archiveConn.ConnectionID = "named-stale:archive"
+	fullStub := &stubIntegrationWithOps{
+		StubIntegration: coretesting.StubIntegration{N: "named-stale", DN: "Named Stale"},
+		ops: []core.Operation{
+			{Name: "search", Description: "Search", Method: http.MethodGet},
+		},
+	}
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = testutil.NewProviderRegistry(t, fullStub)
+		cfg.AppDefs = map[string]*config.ProviderEntry{
+			"named-stale": {
+				Connections: map[string]*config.ConnectionDef{
+					testDefaultConnection: defaultConn,
+					"archive":             archiveConn,
+				},
+			},
+		}
+		cfg.Services = svc
+		cfg.Invoker = &testutil.StubInvoker{
+			Err: &apiexec.UpstreamHTTPError{Status: http.StatusUnauthorized, Body: []byte("")},
+		}
+		cfg.DefaultConnection = map[string]string{"named-stale": testDefaultConnection}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/named-stale/search?_connection=archive", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusPreconditionFailed {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 412: %s", resp.StatusCode, body)
+	}
+
+	archive, err := svc.ExternalCredentials.GetCredential(context.Background(), subjectID, "named-stale:archive", "archive")
+	if err != nil {
+		t.Fatalf("GetCredential(archive): %v", err)
+	}
+	if archive.Grant == nil || archive.Grant.RefreshErrorCount < 1 {
+		t.Fatalf("archive grant = %+v, want RefreshErrorCount >= 1", archive.Grant)
+	}
+	healthy, err := svc.ExternalCredentials.GetCredential(context.Background(), subjectID, "named-stale:"+testDefaultConnection, "default")
+	if err != nil {
+		t.Fatalf("GetCredential(default): %v", err)
+	}
+	if healthy.Grant == nil {
+		t.Fatal("default grant missing")
+	}
+	if healthy.Grant.RefreshErrorCount != 0 {
+		t.Fatalf("default RefreshErrorCount = %d, want 0 (sibling must stay connected)", healthy.Grant.RefreshErrorCount)
+	}
+	if healthy.Grant.ExpiresAt == nil || !healthy.Grant.ExpiresAt.After(time.Now()) {
+		t.Fatalf("default ExpiresAt = %v, want still in the future", healthy.Grant.ExpiresAt)
+	}
+}
+
 func TestExecuteOperation_UserFacingErrorMessage(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -13521,6 +13521,207 @@ func TestExecuteOperation_UpstreamUnauthorizedRequiresReconnect(t *testing.T) {
 	}
 }
 
+func notionReconnectPluginDefs() map[string]*config.ProviderEntry {
+	conn := oauthConnectionDef(nil)
+	conn.ConnectionID = "notion:" + testDefaultConnection
+	return map[string]*config.ProviderEntry{
+		"notion": {
+			Connections: map[string]*config.ConnectionDef{
+				testDefaultConnection: conn,
+			},
+		},
+	}
+}
+
+func assertNotionNeedsReconnect(t *testing.T, ts *httptest.Server, wantPreferred bool) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/apps", nil)
+	if err != nil {
+		t.Fatalf("apps request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("apps: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("apps status = %d, want 200: %s", resp.StatusCode, body)
+	}
+	type statusConnection struct {
+		Name              string           `json:"name"`
+		Status            string           `json:"status"`
+		CredentialState   string           `json:"credentialState"`
+		HealthState       string           `json:"healthState"`
+		Actions           []string         `json:"actions"`
+		PreferredInstance string           `json:"preferredInstance"`
+		Connected         bool             `json:"connected"`
+		Instances         []map[string]any `json:"instances"`
+	}
+	type statusIntegration struct {
+		Name            string             `json:"name"`
+		Connections     []statusConnection `json:"connections"`
+		Status          string             `json:"status"`
+		CredentialState string             `json:"credentialState"`
+		HealthState     string             `json:"healthState"`
+		Actions         []string           `json:"actions"`
+	}
+	var integrations []statusIntegration
+	if err := json.Unmarshal(body, &integrations); err != nil {
+		t.Fatalf("decode apps: %v (body: %s)", err, body)
+	}
+	var integration statusIntegration
+	for _, item := range integrations {
+		if item.Name == "notion" {
+			integration = item
+			break
+		}
+	}
+	if integration.Name == "" {
+		t.Fatalf("notion missing from apps: %s", body)
+	}
+	if integration.Status != "needs_user_connection" || integration.CredentialState != "invalid" || integration.HealthState != "unhealthy" {
+		t.Fatalf("notion status = {status:%q credential:%q health:%q}, want needs_user_connection invalid unhealthy",
+			integration.Status, integration.CredentialState, integration.HealthState)
+	}
+	if !reflect.DeepEqual(integration.Actions, []string{"reconnect", "disconnect"}) {
+		t.Fatalf("notion actions = %v, want [reconnect disconnect]", integration.Actions)
+	}
+	if len(integration.Connections) != 1 {
+		t.Fatalf("connections = %+v", integration.Connections)
+	}
+	conn := integration.Connections[0]
+	if conn.PreferredInstance != "" {
+		t.Fatalf("preferredInstance = %q, want omitted when the chosen grant is invalid", conn.PreferredInstance)
+	}
+	if conn.Connected {
+		t.Fatal("connected = true, want false when the chosen grant is invalid")
+	}
+	if len(conn.Instances) != 1 {
+		t.Fatalf("instances = %+v, want one chosen account", conn.Instances)
+	}
+	preferred, _ := conn.Instances[0]["preferred"].(bool)
+	if preferred != wantPreferred {
+		t.Fatalf("instances[0].preferred = %v, want %v: %+v", preferred, wantPreferred, conn.Instances[0])
+	}
+}
+
+func TestExecuteOperation_UpstreamUnauthorizedPersistsReconnectRequired(t *testing.T) {
+	t.Parallel()
+
+	svc := testutil.NewStubServices(t)
+	u := seedUser(t, svc, "anonymous@gestalt")
+	subjectID := principal.UserSubjectID(u.ID)
+	future := time.Now().Add(time.Hour)
+	seedToken(t, svc, &core.ExternalCredential{
+		ID:        "notion-oauth-default",
+		Subject:   subjectID,
+		Audience:  "notion:" + testDefaultConnection,
+		Qualifier: "default",
+		Grant: &core.ExternalCredentialGrant{
+			AccessToken:  "notion-access",
+			RefreshToken: "notion-refresh",
+			ExpiresAt:    &future,
+		},
+	})
+	if _, err := svc.ConnectionInstancePreferences.Set(context.Background(), subjectID, "notion:"+testDefaultConnection, "default"); err != nil {
+		t.Fatalf("Set preference: %v", err)
+	}
+
+	fullStub := &stubIntegrationWithOps{
+		StubIntegration: coretesting.StubIntegration{
+			N:  "notion",
+			DN: "Notion",
+			ExecuteFn: func(_ context.Context, _ string, _ map[string]any, _ string) (*core.OperationResult, error) {
+				return nil, &apiexec.UpstreamHTTPError{Status: http.StatusUnauthorized, Body: []byte("")}
+			},
+		},
+		ops: []core.Operation{
+			{Name: "search", Description: "Search", Method: http.MethodGet},
+		},
+	}
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = testutil.NewProviderRegistry(t, fullStub)
+		cfg.AppDefs = notionReconnectPluginDefs()
+		cfg.Services = svc
+		cfg.DefaultConnection = map[string]string{"notion": testDefaultConnection}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/notion/search", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusPreconditionFailed {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 412: %s", resp.StatusCode, body)
+	}
+
+	stored, err := svc.ExternalCredentials.GetCredential(context.Background(), subjectID, "notion:"+testDefaultConnection, "default")
+	if err != nil {
+		t.Fatalf("GetCredential: %v", err)
+	}
+	if stored.Grant == nil || stored.Grant.RefreshErrorCount < 1 {
+		t.Fatalf("stored grant = %+v, want RefreshErrorCount >= 1", stored.Grant)
+	}
+	if stored.Grant.ExpiresAt == nil || stored.Grant.ExpiresAt.After(time.Now().Add(time.Second)) {
+		t.Fatalf("stored ExpiresAt = %v, want in the past", stored.Grant.ExpiresAt)
+	}
+
+	assertNotionNeedsReconnect(t, ts, true)
+}
+
+func TestExecuteOperation_StubInvokerUnauthorizedPersistsReconnectRequired(t *testing.T) {
+	t.Parallel()
+
+	svc := testutil.NewStubServices(t)
+	u := seedUser(t, svc, "anonymous@gestalt")
+	subjectID := principal.UserSubjectID(u.ID)
+	future := time.Now().Add(time.Hour)
+	seedToken(t, svc, &core.ExternalCredential{
+		ID:        "notion-oauth-default",
+		Subject:   subjectID,
+		Audience:  "notion:" + testDefaultConnection,
+		Qualifier: "default",
+		Grant: &core.ExternalCredentialGrant{
+			AccessToken: "notion-access",
+			ExpiresAt:   &future,
+		},
+	})
+
+	fullStub := &stubIntegrationWithOps{
+		StubIntegration: coretesting.StubIntegration{N: "notion", DN: "Notion"},
+		ops: []core.Operation{
+			{Name: "search", Description: "Search", Method: http.MethodGet},
+		},
+	}
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = testutil.NewProviderRegistry(t, fullStub)
+		cfg.AppDefs = notionReconnectPluginDefs()
+		cfg.Services = svc
+		cfg.Invoker = &testutil.StubInvoker{
+			Err: &apiexec.UpstreamHTTPError{Status: http.StatusUnauthorized, Body: []byte("")},
+		}
+		cfg.DefaultConnection = map[string]string{"notion": testDefaultConnection}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/notion/search", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusPreconditionFailed {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 412: %s", resp.StatusCode, body)
+	}
+
+	assertNotionNeedsReconnect(t, ts, false)
+}
+
 func TestExecuteOperation_UserFacingErrorMessage(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/services/invocation/broker.go
+++ b/gestaltd/services/invocation/broker.go
@@ -357,10 +357,12 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 	}
 	ctx, accessToken, err := b.resolveToken(ctx, prov, p, providerName, conn, instance)
 	if err != nil {
+		b.persistReconnectRequired(ctx, p, providerName, conn, instance, err)
 		return fail(err)
 	}
 	result, err = prov.Execute(ctx, operation, params, accessToken)
 	if err != nil {
+		b.persistReconnectRequired(ctx, p, providerName, conn, instance, err)
 		return fail(err)
 	}
 	b.observePlugin5xxResult(ctx, span, p, providerName, opMeta.ID, transport, result)
@@ -513,6 +515,7 @@ func (b *Broker) InvokeStream(ctx context.Context, p *principal.Principal, provi
 	}
 	ctx, accessToken, err := b.resolveToken(ctx, prov, p, providerName, conn, instance)
 	if err != nil {
+		b.persistReconnectRequired(ctx, p, providerName, conn, instance, err)
 		return fail(err)
 	}
 	// Verify the catalog declares this operation as streaming before
@@ -527,6 +530,7 @@ func (b *Broker) InvokeStream(ctx context.Context, p *principal.Principal, provi
 	}
 	reader, err := streamExec.ExecuteStream(ctx, operation, params, accessToken)
 	if err != nil {
+		b.persistReconnectRequired(ctx, p, providerName, conn, instance, err)
 		return fail(err)
 	}
 	// Wrap the reader so the first metadata frame is observed for 5xx,
@@ -696,6 +700,7 @@ func (b *Broker) InvokeMaybeStream(ctx context.Context, p *principal.Principal, 
 	}
 	ctx, accessToken, err := b.resolveToken(ctx, prov, p, providerName, conn, instance)
 	if err != nil {
+		b.persistReconnectRequired(ctx, p, providerName, conn, instance, err)
 		return fail(err)
 	}
 
@@ -706,6 +711,7 @@ func (b *Broker) InvokeMaybeStream(ctx context.Context, p *principal.Principal, 
 		}
 		reader, err := streamExec.ExecuteStream(ctx, operation, params, accessToken)
 		if err != nil {
+			b.persistReconnectRequired(ctx, p, providerName, conn, instance, err)
 			return fail(err)
 		}
 		spanOwned = true
@@ -723,6 +729,7 @@ func (b *Broker) InvokeMaybeStream(ctx context.Context, p *principal.Principal, 
 
 	result, err := prov.Execute(ctx, operation, params, accessToken)
 	if err != nil {
+		b.persistReconnectRequired(ctx, p, providerName, conn, instance, err)
 		return fail(err)
 	}
 	b.observePlugin5xxResult(ctx, span, p, providerName, opMeta.ID, transport, result)
@@ -922,10 +929,12 @@ func (b *Broker) InvokeGraphQL(ctx context.Context, p *principal.Principal, prov
 	}
 	ctx, accessToken, err := b.resolveToken(ctx, prov, p, providerName, conn, instance)
 	if err != nil {
+		b.persistReconnectRequired(ctx, p, providerName, conn, instance, err)
 		return fail(err)
 	}
 	result, err = graphQLProv.InvokeGraphQL(ctx, request, accessToken)
 	if err != nil {
+		b.persistReconnectRequired(ctx, p, providerName, conn, instance, err)
 		return fail(err)
 	}
 	return result, nil

--- a/gestaltd/services/invocation/broker_reconnect.go
+++ b/gestaltd/services/invocation/broker_reconnect.go
@@ -1,0 +1,86 @@
+package invocation
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/services/apps/apiexec"
+	"github.com/valon-technologies/gestalt/server/services/identity/principal"
+)
+
+func storedCredentialRejected(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, ErrReconnectRequired) || errors.Is(err, core.ErrReconnectRequired) {
+		return true
+	}
+	var upstream *apiexec.UpstreamHTTPError
+	return errors.As(err, &upstream) && upstream != nil && upstream.Status == http.StatusUnauthorized
+}
+
+// persistReconnectRequired writes the catalog reconnect fact onto the Grant
+// that this invocation actually used. HTTP, MCP, and gRPC all go through
+// Broker.Invoke*, so a 401 here must survive the next catalog GET.
+func (b *Broker) persistReconnectRequired(ctx context.Context, p *principal.Principal, providerName, connection, instance string, err error) {
+	if b == nil || !storedCredentialRejected(err) || core.ExternalCredentialProviderMissing(b.externalCreds) {
+		return
+	}
+	providerName = strings.TrimSpace(providerName)
+	if providerName == "" {
+		return
+	}
+	cred := CredentialContextFromContext(ctx)
+	subjectID := strings.TrimSpace(cred.SubjectID)
+	if subjectID == "" {
+		resolved, resolveErr := principal.ResolveCredentialSubjectID(ctx, b.users, p)
+		if resolveErr != nil {
+			return
+		}
+		subjectID = strings.TrimSpace(resolved)
+	}
+	if subjectID == "" {
+		return
+	}
+	if connection == "" {
+		connection = cred.Connection
+	}
+	if instance == "" {
+		instance = cred.Instance
+	}
+	connection = core.ResolveConnectionAlias(strings.TrimSpace(connection))
+	instance = strings.TrimSpace(instance)
+	connectionID := b.connectionID(providerName, connection)
+	if instance == "" {
+		credentials, listErr := b.externalCreds.ListCredentials(ctx, subjectID, connectionID)
+		if listErr != nil {
+			b.log().WarnContext(ctx, "listing credentials after stored-credential reject", "provider", providerName, "error", listErr)
+			return
+		}
+		preferred := ""
+		if b.connectionInstancePreferences != nil {
+			preferred, _ = b.connectionInstancePreferences.PreferredInstance(ctx, subjectID, connectionID)
+		}
+		chosen, ok := chosenCredentialInstance(credentials, preferred)
+		if !ok {
+			return
+		}
+		instance = chosen
+	}
+	stored, getErr := b.externalCreds.GetCredential(ctx, subjectID, connectionID, instance)
+	if getErr != nil || stored == nil || stored.Grant == nil {
+		return
+	}
+	now := time.Now()
+	if !core.MarkGrantReconnectRequired(stored.Grant, now) {
+		return
+	}
+	stored.UpdatedAt = now
+	if upsertErr := b.externalCreds.UpsertCredential(ctx, stored); upsertErr != nil {
+		b.log().WarnContext(ctx, "persisting reconnect-required grant", "provider", providerName, "error", upsertErr)
+	}
+}

--- a/gestaltd/services/invocation/broker_reconnect.go
+++ b/gestaltd/services/invocation/broker_reconnect.go
@@ -12,7 +12,9 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 )
 
-func storedCredentialRejected(err error) bool {
+// StoredCredentialRejected is the shared predicate for persist-on-reject.
+// HTTP handlers must use this instead of re-deriving a grant from the URL.
+func StoredCredentialRejected(err error) bool {
 	if err == nil {
 		return false
 	}
@@ -27,7 +29,7 @@ func storedCredentialRejected(err error) bool {
 // that this invocation actually used. HTTP, MCP, and gRPC all go through
 // Broker.Invoke*, so a 401 here must survive the next catalog GET.
 func (b *Broker) persistReconnectRequired(ctx context.Context, p *principal.Principal, providerName, connection, instance string, err error) {
-	if b == nil || !storedCredentialRejected(err) || core.ExternalCredentialProviderMissing(b.externalCreds) {
+	if b == nil || !StoredCredentialRejected(err) || core.ExternalCredentialProviderMissing(b.externalCreds) {
 		return
 	}
 	providerName = strings.TrimSpace(providerName)

--- a/gestaltd/services/invocation/broker_test.go
+++ b/gestaltd/services/invocation/broker_test.go
@@ -5,14 +5,17 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"github.com/valon-technologies/gestalt/server/services/apps/apiexec"
 	"github.com/valon-technologies/gestalt/server/services/egress"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 )
@@ -1382,5 +1385,67 @@ func TestBrokerResolveToken_FallsBackToSoleWhenPreferredStale(t *testing.T) {
 	}
 	if token != "team-a-token" {
 		t.Fatalf("token = %q, want team-a-token (sole remaining account)", token)
+	}
+}
+
+func TestBrokerInvoke_UpstreamUnauthorizedPersistsReconnectRequired(t *testing.T) {
+	t.Parallel()
+
+	svc := testutil.NewStubServices(t)
+	subjectID := principal.UserSubjectID("user-notion-reconnect")
+	future := time.Now().Add(time.Hour)
+	connectionID := "notion:" + core.AppConnectionName
+	if err := svc.ExternalCredentials.UpsertCredential(context.Background(), &core.ExternalCredential{
+		ID:        "notion-default",
+		Subject:   subjectID,
+		Audience:  connectionID,
+		Qualifier: "default",
+		Grant: &core.ExternalCredentialGrant{
+			AccessToken: "notion-access",
+			ExpiresAt:   &future,
+		},
+	}); err != nil {
+		t.Fatalf("UpsertCredential: %v", err)
+	}
+
+	broker := NewBroker(
+		testutil.NewProviderRegistry(t, &coretesting.StubIntegration{
+			N:        "notion",
+			ConnMode: core.ConnectionModeSubject,
+			CatalogVal: &catalog.Catalog{
+				Name: "notion",
+				Operations: []catalog.CatalogOperation{
+					{ID: "search", Method: "GET"},
+				},
+			},
+			ExecuteFn: func(context.Context, string, map[string]any, string) (*core.OperationResult, error) {
+				return nil, &apiexec.UpstreamHTTPError{Status: http.StatusUnauthorized, Body: []byte("")}
+			},
+		}),
+		svc.Users,
+		svc.ExternalCredentials,
+	)
+
+	_, err := broker.Invoke(context.Background(), &principal.Principal{
+		SubjectID: subjectID,
+		UserID:    "user-notion-reconnect",
+		Kind:      principal.KindUser,
+	}, "notion", "default", "search", nil)
+	if err == nil {
+		t.Fatal("expected invoke error")
+	}
+	if !storedCredentialRejected(err) {
+		t.Fatalf("err = %v, want stored-credential reject", err)
+	}
+
+	stored, getErr := svc.ExternalCredentials.GetCredential(context.Background(), subjectID, connectionID, "default")
+	if getErr != nil {
+		t.Fatalf("GetCredential: %v", getErr)
+	}
+	if stored.Grant == nil || stored.Grant.RefreshErrorCount < 1 {
+		t.Fatalf("stored grant = %+v, want RefreshErrorCount >= 1", stored.Grant)
+	}
+	if stored.Grant.ExpiresAt == nil || stored.Grant.ExpiresAt.After(time.Now().Add(time.Second)) {
+		t.Fatalf("stored ExpiresAt = %v, want in the past", stored.Grant.ExpiresAt)
 	}
 }

--- a/gestaltd/services/invocation/broker_test.go
+++ b/gestaltd/services/invocation/broker_test.go
@@ -1434,7 +1434,7 @@ func TestBrokerInvoke_UpstreamUnauthorizedPersistsReconnectRequired(t *testing.T
 	if err == nil {
 		t.Fatal("expected invoke error")
 	}
-	if !storedCredentialRejected(err) {
+	if !StoredCredentialRejected(err) {
 		t.Fatalf("err = %v, want stored-credential reject", err)
 	}
 


### PR DESCRIPTION
## Summary

When Notion or another OAuth app rejects a saved sign-in, the next Apps and Connection load asks the person to reconnect. The linked account stays. Catalog listing still does not call the provider.

## Why / context

Invoke already returned 412 when the provider rejected the secret. Catalog still treated an unexpired stored grant as connected, so Connection showed In use and looked healthy.

Rejected alternatives: probe the provider on every catalog GET, delete the account row, or wait for token expiry. Catalog should read a stored reconnect fact. The account identity is still the chosen account.

## What changed

- A 401 or reconnect-required invoke writes the existing reconnect fact onto the OAuth grant (expiry in the past plus a refresh error count).
- HTTP, MCP, and gRPC invokes share that write. Persist failures are logged and do not change the error returned to the caller.
- The chosen account stays marked on the instance list even when the grant is invalid. The acting preferred-instance field stays omitted until the grant can be used again.
- Opaque API-key credentials are unchanged.
- Persist uses the connection from the invoke (credential context, then the resolved connection). It does not list every stored grant, so a 401 on archive cannot expire a healthy default sibling.
- Persist uses the connection from the invoke (credential context, then the resolved connection). It does not list every stored grant, so a 401 on archive cannot expire a healthy default sibling.

## Validation

- [x] Automated: `go test ./gestaltd/core ./gestaltd/internal/server ./gestaltd/services/invocation -count=1`
- [x] Automated: focused `go test ./gestaltd/core -run TestMarkGrantReconnectRequired` after adding `t.Parallel` to subtests (CI lint was failing without it)
- [ ] Not run: live Notion invoke then `GET /api/v1/apps` on staging after this daemon is deployed. Local edits do not change valon.tools until deploy.

## Reviewer focus

Please check that a still-unexpired grant with refresh errors stays connected until an invoke actually rejects it. That unexpired-error catalog case is intentional.

Also check that a sole dead account keeps preferred on the instance when a preference exists, without setting preferredInstance as a usable actor.

## Rollout / compatibility

Ship this daemon before (or with) the console companion. Until this is deployed, Connection can still look healthy after a 412. Rollback is revert. Existing grants are unchanged until the next rejected invoke.

## Evidence / demo

No rendered UI in this repository. Proof is the persist-then-list test (future-expiry grant, upstream 401, catalog returns invalid plus reconnect) and the broker unit test that the stored grant is force-expired.

## Links

Companion console: https://github.com/valon-technologies/gestalt-providers/pull/1287

