### PR TITLE
Gate app registry remote publish behind an app allowlist

### DIFF
--- a/gestaltd/internal/appregistry/publish_errors.go
+++ b/gestaltd/internal/appregistry/publish_errors.go
@@ -12,6 +12,7 @@ var (
 	ErrPublishRequiredPlatform    = errors.New("required publish platform missing")
 	ErrPublishAppIdentityMismatch = errors.New("publish app identity mismatch")
 	ErrPublishRegistryNotEnrolled = errors.New("app is not enrolled in the registry")
+	ErrPublishAppNotAllowlisted   = errors.New("app is not allowlisted for registry publish")
 	ErrPublishIDMismatch          = errors.New("publish id mismatch")
 	ErrPublishReconcileMismatch   = errors.New("published registry entry does not match publish declaration")
 	ErrPublishIdentityMismatch    = errors.New("published entry identity mismatch")
@@ -38,6 +39,8 @@ func PublishHTTPStatus(err error) int {
 		return 409
 	case errors.Is(err, ErrPublishRegistryNotEnrolled):
 		return 404
+	case errors.Is(err, ErrPublishAppNotAllowlisted):
+		return 403
 	default:
 		return 502
 	}

--- a/gestaltd/internal/appregistry/publish_errors_test.go
+++ b/gestaltd/internal/appregistry/publish_errors_test.go
@@ -16,6 +16,14 @@ func TestPublishHTTPStatusDeclarationInvalidIs400(t *testing.T) {
 	}
 }
 
+func TestPublishHTTPStatusAppNotAllowlistedIs403(t *testing.T) {
+	t.Parallel()
+
+	if status := PublishHTTPStatus(ErrPublishAppNotAllowlisted); status != http.StatusForbidden {
+		t.Fatalf("PublishHTTPStatus = %d, want 403", status)
+	}
+}
+
 func TestPublishHTTPStatusRegistryNotEnrolledIs404(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/config/app_registry_publish_config_test.go
+++ b/gestaltd/internal/config/app_registry_publish_config_test.go
@@ -23,3 +23,21 @@ func TestAppRegistryPublishSettingsLimits(t *testing.T) {
 		t.Fatalf("limits = %#v", limits)
 	}
 }
+
+func TestAppRegistryPublishSettingsAllowedAppSet(t *testing.T) {
+	t.Parallel()
+
+	settings := config.AppRegistryPublishSettings{
+		AllowedApps: []string{" g-issues ", "", "g-issues"},
+	}
+	allowed := settings.AllowedAppSet()
+	if len(allowed) != 1 {
+		t.Fatalf("allowed = %#v, want one app", allowed)
+	}
+	if _, ok := allowed["g-issues"]; !ok {
+		t.Fatalf("allowed = %#v", allowed)
+	}
+	if !settings.AllowsApp("g-issues") || settings.AllowsApp("hello-world") {
+		t.Fatalf("AllowsApp g-issues=%v hello-world=%v", settings.AllowsApp("g-issues"), settings.AllowsApp("hello-world"))
+	}
+}

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -2019,6 +2019,34 @@ type AppRegistryPublishSettings struct {
 	MaxArtifacts      int      `yaml:"maxArtifacts,omitempty"`
 	MaxArtifactBytes  int64    `yaml:"maxArtifactBytes,omitempty"`
 	RequiredPlatforms []string `yaml:"requiredPlatforms,omitempty"`
+	AllowedApps       []string `yaml:"allowedApps,omitempty"`
+}
+
+func (c AppRegistryPublishSettings) AllowedAppSet() map[string]struct{} {
+	if len(c.AllowedApps) == 0 {
+		return nil
+	}
+	allowed := make(map[string]struct{}, len(c.AllowedApps))
+	for _, app := range c.AllowedApps {
+		app = strings.TrimSpace(app)
+		if app == "" {
+			continue
+		}
+		allowed[app] = struct{}{}
+	}
+	if len(allowed) == 0 {
+		return nil
+	}
+	return allowed
+}
+
+func (c AppRegistryPublishSettings) AllowsApp(app string) bool {
+	allowed := c.AllowedAppSet()
+	if len(allowed) == 0 {
+		return false
+	}
+	_, ok := allowed[strings.TrimSpace(app)]
+	return ok
 }
 
 func (c AppRegistryPublishSettings) PublishLimits() (AppRegistryPublishLimits, error) {

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -312,6 +312,9 @@ func validateAppRegistryPublishSettings(cfg *Config) error {
 	if _, err := publish.PublishLimits(); err != nil {
 		return fmt.Errorf("config validation: server.appRegistry.publish: %w", err)
 	}
+	if len(publish.AllowedAppSet()) == 0 {
+		return fmt.Errorf("config validation: server.appRegistry.publish.allowedApps must list at least one app when publish is enabled")
+	}
 	return nil
 }
 

--- a/gestaltd/internal/server/handlers_app_admin_registry_publish.go
+++ b/gestaltd/internal/server/handlers_app_admin_registry_publish.go
@@ -38,6 +38,10 @@ func (s *Server) beginAppAdminRegistryPublish(w http.ResponseWriter, r *http.Req
 	if !ok {
 		return
 	}
+	if !s.appAdminPublishAllowed(w, app.name) {
+		s.auditAppRegistryPublish(r.Context(), r, subjectID, app.name, "", "app.registry.publish.begin", false, appregistry.ErrPublishAppNotAllowlisted.Error())
+		return
+	}
 	declaration, decodeErr := s.decodePublishDeclaration(w, r)
 	if decodeErr != "" {
 		s.auditAppRegistryPublish(r.Context(), r, subjectID, app.name, "", "app.registry.publish.begin", false, decodeErr)
@@ -71,6 +75,10 @@ func (s *Server) finalizeAppAdminRegistryPublish(w http.ResponseWriter, r *http.
 	publishID := strings.TrimSpace(chi.URLParam(r, "publishID"))
 	if publishID == "" {
 		writeError(w, http.StatusBadRequest, "publishID is required")
+		return
+	}
+	if !s.appAdminPublishAllowed(w, app.name) {
+		s.auditAppRegistryPublish(r.Context(), r, subjectID, app.name, publishID, "app.registry.publish.finalize", false, appregistry.ErrPublishAppNotAllowlisted.Error())
 		return
 	}
 	declaration, decodeErr := s.decodePublishDeclaration(w, r)
@@ -139,6 +147,18 @@ func (s *Server) appAdminPublishService(w http.ResponseWriter) (*appregistry.Sta
 		return nil, false
 	}
 	return s.appRegistryPublish, true
+}
+
+func (s *Server) appAdminPublishAllowed(w http.ResponseWriter, app string) bool {
+	if len(s.appRegistryPublishAllowedApps) == 0 {
+		writeError(w, http.StatusServiceUnavailable, appregistry.ErrPublishUnavailable.Error())
+		return false
+	}
+	if _, ok := s.appRegistryPublishAllowedApps[app]; !ok {
+		writeError(w, appregistry.PublishHTTPStatus(appregistry.ErrPublishAppNotAllowlisted), appregistry.ErrPublishAppNotAllowlisted.Error())
+		return false
+	}
+	return true
 }
 
 func (s *Server) appAdminPublisherSubjectID(w http.ResponseWriter, r *http.Request) (string, bool) {

--- a/gestaltd/internal/server/handlers_app_admin_registry_publish_test.go
+++ b/gestaltd/internal/server/handlers_app_admin_registry_publish_test.go
@@ -43,6 +43,7 @@ func TestAppAdminRegistryPublishCreateReturnsUploadHeaders(t *testing.T) {
 		}
 		cfg.AppRegistries = map[string]config.AppRegistryConfig{"toolshed": harness.registry}
 		cfg.AppRegistryPublish = harness.service
+		withAppRegistryPublishAllowlist(cfg, "g-issues")
 	})
 	testutil.CloseOnCleanup(t, ts)
 
@@ -96,6 +97,7 @@ func TestAppAdminRegistryPublishFlow(t *testing.T) {
 		cfg.AppRegistries = map[string]config.AppRegistryConfig{"toolshed": harness.registry}
 		cfg.AppRegistryReader = harness.reader
 		cfg.AppRegistryPublish = harness.service
+		withAppRegistryPublishAllowlist(cfg, "g-issues")
 	})
 	testutil.CloseOnCleanup(t, ts)
 
@@ -131,6 +133,7 @@ func TestAppAdminRegistryPublishConcurrentFinalizeMatching(t *testing.T) {
 		}
 		cfg.AppRegistries = map[string]config.AppRegistryConfig{"toolshed": harness.registry}
 		cfg.AppRegistryPublish = harness.service
+		withAppRegistryPublishAllowlist(cfg, "g-issues")
 	})
 	testutil.CloseOnCleanup(t, ts)
 
@@ -171,6 +174,7 @@ func TestAppAdminRegistryPublishRejectsNonAdmin(t *testing.T) {
 		}
 		cfg.AppRegistries = map[string]config.AppRegistryConfig{"toolshed": harness.registry}
 		cfg.AppRegistryPublish = harness.service
+		withAppRegistryPublishAllowlist(cfg, "g-issues")
 	})
 	testutil.CloseOnCleanup(t, ts)
 
@@ -210,6 +214,7 @@ func TestAppAdminRegistryPublishRejectsWrongWritableRegistry(t *testing.T) {
 			"toolshed":       harness.registry,
 		}
 		cfg.AppRegistryPublish = harness.service
+		withAppRegistryPublishAllowlist(cfg, "g-issues")
 	})
 	testutil.CloseOnCleanup(t, ts)
 
@@ -246,6 +251,7 @@ func TestAppAdminRegistryPublishRejectsZeroArtifactSize(t *testing.T) {
 		}
 		cfg.AppRegistries = map[string]config.AppRegistryConfig{"toolshed": harness.registry}
 		cfg.AppRegistryPublish = harness.service
+		withAppRegistryPublishAllowlist(cfg, "g-issues")
 	})
 	testutil.CloseOnCleanup(t, ts)
 
@@ -286,6 +292,7 @@ func TestAppAdminRegistryPublishRejectsCrossAppFinalize(t *testing.T) {
 		}
 		cfg.AppRegistries = map[string]config.AppRegistryConfig{"toolshed": harness.registry}
 		cfg.AppRegistryPublish = harness.service
+		withAppRegistryPublishAllowlist(cfg, "g-issues")
 	})
 	testutil.CloseOnCleanup(t, ts)
 
@@ -296,8 +303,44 @@ func TestAppAdminRegistryPublishRejectsCrossAppFinalize(t *testing.T) {
 		Version: harness.declaration.Manifest.Version, Spec: &providermanifestv1.Spec{},
 	}
 	status := postPublishFinalizeStatusForApp(t, ts.URL, "other-app", created.PublishID, &otherDecl)
-	if status != http.StatusBadRequest {
-		t.Fatalf("cross-app finalize status = %d, want 400", status)
+	if status != http.StatusForbidden {
+		t.Fatalf("cross-app finalize status = %d, want 403", status)
+	}
+}
+
+func TestAppAdminRegistryPublishRejectsNonAllowlistedApp(t *testing.T) {
+	t.Parallel()
+
+	harness := newRegistryPublishHarness(t)
+	subjectID := principal.UserSubjectID(testCanonicalAdminUserID)
+	authz := &serverTestAuthorizationProvider{
+		relationships: []*proto.Relationship{
+			testAuthorizationRelationship(subjectID, "admin", "app", "hello-world"),
+		},
+	}
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = authStubWithSessionTokenIntrospect("alice-token", subjectID, "")
+		cfg.Authorization = authz
+		cfg.AppDefs = map[string]*config.ProviderEntry{
+			"hello-world": {Source: config.ProviderSource{Registry: "toolshed"}},
+		}
+		cfg.AppRegistries = map[string]config.AppRegistryConfig{"toolshed": harness.registry}
+		cfg.AppRegistryPublish = harness.service
+		withAppRegistryPublishAllowlist(cfg, "g-issues")
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	createBody, _ := json.Marshal(map[string]any{"declaration": harness.declaration})
+	createReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/apps/hello-world/admin/registry/publishes", bytes.NewReader(createBody))
+	createReq.Header.Set("Authorization", "Bearer alice-token")
+	createReq.Header.Set("Content-Type", "application/json")
+	createResp, err := http.DefaultClient.Do(createReq)
+	if err != nil {
+		t.Fatalf("POST publish begin: %v", err)
+	}
+	defer func() { _ = createResp.Body.Close() }()
+	if createResp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", createResp.StatusCode)
 	}
 }
 
@@ -325,6 +368,7 @@ func TestBootstrapAppRegistryPublishFailsWhenSigningUnavailable(t *testing.T) {
 	}
 	cfg.Server.AppRegistry.Publish.Enabled = true
 	cfg.Server.AppRegistry.Publish.WritableRegistry = "toolshed"
+	cfg.Server.AppRegistry.Publish.AllowedApps = []string{"g-issues"}
 
 	restorePermissions := stubCheckGCSRegistryPermissions(t, nil)
 	defer restorePermissions()
@@ -349,6 +393,7 @@ func TestBootstrapAppRegistryPublishFailsWhenObjectPermissionsUnavailable(t *tes
 	}
 	cfg.Server.AppRegistry.Publish.Enabled = true
 	cfg.Server.AppRegistry.Publish.WritableRegistry = "toolshed"
+	cfg.Server.AppRegistry.Publish.AllowedApps = []string{"g-issues"}
 
 	restorePermissions := stubCheckGCSRegistryPermissions(t, errors.New("storage.objects.get denied"))
 	defer restorePermissions()
@@ -500,6 +545,14 @@ func postPublishFinalizeStatusForApp(t *testing.T, baseURL, app, publishID strin
 	return resp.StatusCode
 }
 
+func withAppRegistryPublishAllowlist(cfg *server.Config, apps ...string) {
+	allowed := make(map[string]struct{}, len(apps))
+	for _, app := range apps {
+		allowed[app] = struct{}{}
+	}
+	cfg.AppRegistryPublishAllowedApps = allowed
+}
+
 func TestAppAdminRegistryPublishRejectsMissingBuilderVersion(t *testing.T) {
 	t.Parallel()
 
@@ -518,6 +571,7 @@ func TestAppAdminRegistryPublishRejectsMissingBuilderVersion(t *testing.T) {
 		}
 		cfg.AppRegistries = map[string]config.AppRegistryConfig{"toolshed": harness.registry}
 		cfg.AppRegistryPublish = harness.service
+		withAppRegistryPublishAllowlist(cfg, "g-issues")
 	})
 	testutil.CloseOnCleanup(t, ts)
 

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -172,6 +172,7 @@ func run(ctx context.Context, cfg *config.Config, result *bootstrap.Result, gest
 		return err
 	}
 	baseConfig.AppRegistryPublish = publishService
+	baseConfig.AppRegistryPublishAllowedApps = cfg.Server.AppRegistry.Publish.AllowedAppSet()
 
 	result.RegistryAppStartup = registryAppStartup(cfg, result, nil)
 	if err := result.Start(ctx); err != nil {

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -226,59 +226,59 @@ type Config struct {
 	OperationAccessChecker invocation.OperationAccessChecker
 	// UserLookup gates resolving other people's identities on an explicit
 	// employee operator role.
-	UserLookup              UserLookupRouteConfig
-	AuditSink               core.AuditSink
-	Services                *coredata.Services
-	Providers               *registry.ProviderMap[core.Provider]
-	Agent                   bootstrap.AgentControl
-	AgentManager            agentmanager.Service
-	Workflow                bootstrap.WorkflowControl
-	Runtimes                bootstrap.RuntimeInspector
-	Invoker                 invocation.Invoker
-	AppInvocation           invocation.Invoker
-	DefaultConnection       map[string]string
-	CatalogConnection       map[string]string
-	MCPConnection           map[string]string
-	ConnectionAuth          func() map[string]map[string]bootstrap.OAuthHandler
-	ManualConnectionAuth    func() map[string]map[string]bootstrap.ManualTokenExchanger
-	AppDefs                 map[string]*config.ProviderEntry
-	PublicBaseURL           string
-	ManagementBaseURL       string
-	SecureCookies           bool
-	StateSecret             []byte
-	APIRouteTimeout         time.Duration
-	Now                     func() time.Time
-	Readiness               ReadinessChecker
-	PrometheusMetrics       http.Handler
-	MCPHandler              http.Handler
-	PublicHostServices      *runtimehost.PublicHostServiceRegistry
-	PublicGatewayTransport  *providergateway.ProviderGatewayTransport
-	S3                      map[string]s3sdk.S3
-	MountedUIs              []MountedUI
-	DevHandlerResolver      func(name string) http.Handler
-	Admin                   AdminRouteConfig
-	AdminUI                 http.Handler
-	BuiltinAdminUI          *BuiltinAdminUIOptions
-	AppRegistries           map[string]config.AppRegistryConfig
-	AppRegistryReader       *appregistry.RegistryReader
+	UserLookup                    UserLookupRouteConfig
+	AuditSink                     core.AuditSink
+	Services                      *coredata.Services
+	Providers                     *registry.ProviderMap[core.Provider]
+	Agent                         bootstrap.AgentControl
+	AgentManager                  agentmanager.Service
+	Workflow                      bootstrap.WorkflowControl
+	Runtimes                      bootstrap.RuntimeInspector
+	Invoker                       invocation.Invoker
+	AppInvocation                 invocation.Invoker
+	DefaultConnection             map[string]string
+	CatalogConnection             map[string]string
+	MCPConnection                 map[string]string
+	ConnectionAuth                func() map[string]map[string]bootstrap.OAuthHandler
+	ManualConnectionAuth          func() map[string]map[string]bootstrap.ManualTokenExchanger
+	AppDefs                       map[string]*config.ProviderEntry
+	PublicBaseURL                 string
+	ManagementBaseURL             string
+	SecureCookies                 bool
+	StateSecret                   []byte
+	APIRouteTimeout               time.Duration
+	Now                           func() time.Time
+	Readiness                     ReadinessChecker
+	PrometheusMetrics             http.Handler
+	MCPHandler                    http.Handler
+	PublicHostServices            *runtimehost.PublicHostServiceRegistry
+	PublicGatewayTransport        *providergateway.ProviderGatewayTransport
+	S3                            map[string]s3sdk.S3
+	MountedUIs                    []MountedUI
+	DevHandlerResolver            func(name string) http.Handler
+	Admin                         AdminRouteConfig
+	AdminUI                       http.Handler
+	BuiltinAdminUI                *BuiltinAdminUIOptions
+	AppRegistries                 map[string]config.AppRegistryConfig
+	AppRegistryReader             *appregistry.RegistryReader
 	AppRegistryPublish            *appregistry.StatelessPublishService
 	AppRegistryPublishAllowedApps map[string]struct{}
 	AppFleetProjector             *appregistry.FleetProjector
-	AppRegistryHeartbeatTTL time.Duration
-	AppRegistryRolloutMode  config.AppRegistryRolloutMode
-	ArtifactsDir            string
-	GestaltdVersion         string
-	SourceVersion           string
-	AppRuntimeState         AppRuntimeState
-	RouteProfile            RouteProfile
-	MeterProvider           metric.MeterProvider
-	TracerProvider          trace.TracerProvider
-	ActivateAppProviders    func(context.Context)
-	IndexedDB               indexeddb.IndexedDB
-	RemoteManagement        proto.RemoteManagementServer
-	FrpsHandler             http.Handler
-	FrpsConnectHandler      http.Handler
-	TunnelResolver          TunnelResolverConfig
+	AppRegistryHeartbeatTTL       time.Duration
+	AppRegistryRolloutMode        config.AppRegistryRolloutMode
+	ArtifactsDir                  string
+	GestaltdVersion               string
+	SourceVersion                 string
+	AppRuntimeState               AppRuntimeState
+	RouteProfile                  RouteProfile
+	MeterProvider                 metric.MeterProvider
+	TracerProvider                trace.TracerProvider
+	ActivateAppProviders          func(context.Context)
+	IndexedDB                     indexeddb.IndexedDB
+	RemoteManagement              proto.RemoteManagementServer
+	FrpsHandler                   http.Handler
+	FrpsConnectHandler            http.Handler
+	TunnelResolver                TunnelResolverConfig
 	// AppAutoDeployNotify requests prompt auto-deploy reconciliation for an app.
 	AppAutoDeployNotify func(app string)
 }

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -184,6 +184,7 @@ type Server struct {
 	appRegistryReader             *appregistry.RegistryReader
 	appRegistryInstaller          *appregistry.Installer
 	appRegistryPublish            *appregistry.StatelessPublishService
+	appRegistryPublishAllowedApps map[string]struct{}
 	appFleetProjector             *appregistry.FleetProjector
 	appVersionChanges             *coredata.AppVersionChangeRequestService
 	gestaltdSourceVersions        *coredata.GestaltdSourceVersionService
@@ -260,8 +261,9 @@ type Config struct {
 	BuiltinAdminUI          *BuiltinAdminUIOptions
 	AppRegistries           map[string]config.AppRegistryConfig
 	AppRegistryReader       *appregistry.RegistryReader
-	AppRegistryPublish      *appregistry.StatelessPublishService
-	AppFleetProjector       *appregistry.FleetProjector
+	AppRegistryPublish            *appregistry.StatelessPublishService
+	AppRegistryPublishAllowedApps map[string]struct{}
+	AppFleetProjector             *appregistry.FleetProjector
 	AppRegistryHeartbeatTTL time.Duration
 	AppRegistryRolloutMode  config.AppRegistryRolloutMode
 	ArtifactsDir            string
@@ -514,6 +516,7 @@ func New(cfg Config) (*Server, error) {
 		appRegistryReader:             cfg.AppRegistryReader,
 		appRegistryInstaller:          newAppRegistryInstaller(cfg),
 		appRegistryPublish:            cfg.AppRegistryPublish,
+		appRegistryPublishAllowedApps: cloneStringSet(cfg.AppRegistryPublishAllowedApps),
 		appFleetProjector:             fleetProjector,
 		appVersionChanges:             cfg.Services.AppVersionChangeRequests,
 		gestaltdSourceVersions:        cfg.Services.GestaltdSourceVersionState,
@@ -588,6 +591,17 @@ func (s *Server) Close() {
 		s.publicGatewayConn.Close()
 		s.publicGatewayConn = nil
 	}
+}
+
+func cloneStringSet(src map[string]struct{}) map[string]struct{} {
+	if len(src) == 0 {
+		return nil
+	}
+	out := make(map[string]struct{}, len(src))
+	for key := range src {
+		out[key] = struct{}{}
+	}
+	return out
 }
 
 func withRequestTelemetryProviders(next http.Handler, meterProvider metric.MeterProvider, tracerProvider trace.TracerProvider) http.Handler {


### PR DESCRIPTION
## Summary

- Add `server.appRegistry.publish.allowedApps` to deploy config
- Require a non-empty allowlist when remote publish is enabled
- Reject begin/finalize with 403 for apps outside the allowlist

Prerequisite for toolshed PR 5 (`g-issues` remote publish pilot).

## Test plan

- [x] `go test ./internal/server/... -run Publish -count=1`
- [x] `go test ./internal/config/... -run AppRegistryPublish -count=1`
- [x] `go test ./internal/appregistry/... -run PublishHTTPStatus -count=1`


Made with [Cursor](https://cursor.com)