### PR TITLE
Fix authorization resource mapping for dynamic apps

### DIFF
--- a/gestaltd/internal/bootstrap/authorization_bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/authorization_bootstrap_test.go
@@ -577,6 +577,16 @@ func TestProviderAuthorizationPolicies(t *testing.T) {
 		Apps: map[string]*config.ProviderEntry{
 			"shared": {AuthorizationPolicy: " workspace "},
 			"own":    {},
+			"legacy": {},
+		},
+		Authorization: config.AuthorizationConfig{
+			Models: map[string]config.AuthorizationModelDef{
+				"default": {
+					ResourceTypes: map[string]config.AuthorizationResourceTypeDef{
+						"legacy": {},
+					},
+				},
+			},
 		},
 	}
 
@@ -586,6 +596,9 @@ func TestProviderAuthorizationPolicies(t *testing.T) {
 	}
 	if _, ok := got["own"]; ok {
 		t.Fatal("own app should use its app name instead of an explicit policy")
+	}
+	if got["legacy"] != "legacy" {
+		t.Fatalf("legacy policy = %q, want self-alias", got["legacy"])
 	}
 }
 

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -2489,9 +2489,14 @@ func ProviderAuthorizationPolicies(cfg *config.Config) map[string]string {
 	if cfg == nil {
 		return policies
 	}
+	dedicatedResourceTypes := AuthorizationResourceTypeNames(cfg)
 	for name, app := range cfg.Apps {
 		if policy := strings.TrimSpace(app.AuthorizationPolicy); policy != "" {
 			policies[name] = policy
+			continue
+		}
+		if _, hasDedicatedResourceType := dedicatedResourceTypes[name]; hasDedicatedResourceType {
+			policies[name] = name
 		}
 	}
 	return policies

--- a/gestaltd/services/invocation/authorization_batch.go
+++ b/gestaltd/services/invocation/authorization_batch.go
@@ -150,7 +150,7 @@ func (b *Broker) CheckOperationAccessMany(
 		reqs = append(reqs, ResourceAccessRequest{
 			SubjectID:         subjectID,
 			Action:            queries[i].Operation,
-			Resource:          b.authorizationResource(queries[i].Provider),
+			Resource:          b.authorizationResource(ctx, queries[i].Provider),
 			AllowedRoles:      queries[i].AllowedRoles,
 			SubjectProperties: properties,
 		})

--- a/gestaltd/services/invocation/authorization_resource_test.go
+++ b/gestaltd/services/invocation/authorization_resource_test.go
@@ -1,7 +1,12 @@
 package invocation
 
 import (
+	"context"
 	"testing"
+
+	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
+	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 )
 
 func TestAuthorizationResource(t *testing.T) {
@@ -86,5 +91,34 @@ func TestAuthorizationResourceMapperZeroValueIsUsable(t *testing.T) {
 	resource := mapper.Resource("unknown")
 	if resource.GetType() != "unknown" || resource.GetId() != "unknown" {
 		t.Fatalf("Resource = %v, want unknown/unknown", resource)
+	}
+}
+
+func TestBrokerInfersAppResourceFromRegisteredProvider(t *testing.T) {
+	t.Parallel()
+
+	authz := &authorizationCheckTestProvider{allowed: true}
+	broker := NewBroker(
+		testutil.NewProviderRegistry(t, &coretesting.StubIntegration{N: "it-account-onboarding"}),
+		nil,
+		nil,
+		WithAuthorizationProvider(authz),
+	)
+	p := &principal.Principal{
+		SubjectID: "service_account:it-account-onboarding-jobs",
+		Kind:      principal.Kind("service_account"),
+	}
+
+	if err := broker.CheckOperationAccess(
+		context.Background(),
+		p,
+		"it-account-onboarding",
+		"jobs.syncValonEmployeeRoster",
+	); err != nil {
+		t.Fatalf("CheckOperationAccess: %v", err)
+	}
+	resource := authz.lastReq.GetResource()
+	if resource.GetType() != "app" || resource.GetId() != "it-account-onboarding" {
+		t.Fatalf("Resource = %v, want app/it-account-onboarding", resource)
 	}
 }

--- a/gestaltd/services/invocation/authorization_resource_test.go
+++ b/gestaltd/services/invocation/authorization_resource_test.go
@@ -122,3 +122,29 @@ func TestBrokerInfersAppResourceFromRegisteredProvider(t *testing.T) {
 		t.Fatalf("Resource = %v, want app/it-account-onboarding", resource)
 	}
 }
+
+func TestBrokerPreservesDedicatedResourceForRegisteredProvider(t *testing.T) {
+	t.Parallel()
+
+	authz := &authorizationCheckTestProvider{allowed: true}
+	broker := NewBroker(
+		testutil.NewProviderRegistry(t, &coretesting.StubIntegration{N: "legacy"}),
+		nil,
+		nil,
+		WithAuthorizationProvider(authz),
+		WithAuthorizationPolicies(map[string]string{"legacy": "legacy"}),
+	)
+
+	if err := broker.CheckOperationAccess(
+		context.Background(),
+		&principal.Principal{SubjectID: "service_account:job", Kind: principal.Kind("service_account")},
+		"legacy",
+		"run",
+	); err != nil {
+		t.Fatalf("CheckOperationAccess: %v", err)
+	}
+	resource := authz.lastReq.GetResource()
+	if resource.GetType() != "legacy" || resource.GetId() != "legacy" {
+		t.Fatalf("Resource = %v, want legacy/legacy", resource)
+	}
+}

--- a/gestaltd/services/invocation/broker.go
+++ b/gestaltd/services/invocation/broker.go
@@ -1052,7 +1052,7 @@ func (b *Broker) authorizationDecision(
 	if err != nil {
 		return nil, err
 	}
-	resource := b.authorizationResource(providerName)
+	resource := b.authorizationResource(ctx, providerName)
 	return b.authorization.CheckAccess(
 		ctx,
 		accessRequest(p, subjectID, resource, operationID),
@@ -1072,8 +1072,20 @@ func (b *Broker) authorizationPolicy(providerName string) string {
 	return b.authorizationMapper().Policy(providerName)
 }
 
-func (b *Broker) authorizationResource(providerName string) *proto.Resource {
-	return b.authorizationMapper().Resource(providerName)
+func (b *Broker) authorizationResource(ctx context.Context, providerName string) *proto.Resource {
+	providerName = strings.TrimSpace(providerName)
+	mapper := b.authorizationMapper()
+	if b != nil {
+		if strings.TrimSpace(b.authorizationPolicies[providerName]) != "" || b.providerKinds[providerName] != "" {
+			return mapper.Resource(providerName)
+		}
+		if b.providers != nil {
+			if _, err := b.providers.GetWithContext(ctx, providerName); err == nil {
+				return &proto.Resource{Type: string(ProviderKindApp), Id: providerName}
+			}
+		}
+	}
+	return mapper.Resource(providerName)
 }
 
 func (b *Broker) CheckOperationAccess(ctx context.Context, p *principal.Principal, providerName, operationID string) error {


### PR DESCRIPTION
## Summary
- resolve dynamically registered providers through the shared `app/<provider>` authorization resource when no static kind entry exists
- represent dedicated legacy app resource types as explicit self-alias policies so the fallback cannot change their authorization behavior
- keep single and batched operation checks on the same mapping and cover both standard and dedicated app cases

## Test plan
- [x] `go test ./gestaltd/services/invocation ./gestaltd/services/workflows/workflowmanager ./gestaltd/internal/bootstrap`
- [ ] deploy Gestalt and retry the roster workflow `StartRun` endpoint