### PR TITLE
Prefer registered app identity during authorization

### DIFF
--- a/gestaltd/services/invocation/authorization_resource_test.go
+++ b/gestaltd/services/invocation/authorization_resource_test.go
@@ -123,6 +123,32 @@ func TestBrokerInfersAppResourceFromRegisteredProvider(t *testing.T) {
 	}
 }
 
+func TestBrokerRegisteredAppOverridesStaleProviderKind(t *testing.T) {
+	t.Parallel()
+
+	authz := &authorizationCheckTestProvider{allowed: true}
+	broker := NewBroker(
+		testutil.NewProviderRegistry(t, &coretesting.StubIntegration{N: "it-account-onboarding"}),
+		nil,
+		nil,
+		WithAuthorizationProvider(authz),
+		WithProviderKinds(map[string]ProviderKind{"it-account-onboarding": ProviderKindWorkflow}),
+	)
+
+	if err := broker.CheckOperationAccess(
+		context.Background(),
+		&principal.Principal{SubjectID: "service_account:it-account-onboarding-jobs", Kind: principal.Kind("service_account")},
+		"it-account-onboarding",
+		"jobs.syncValonEmployeeRoster",
+	); err != nil {
+		t.Fatalf("CheckOperationAccess: %v", err)
+	}
+	resource := authz.lastReq.GetResource()
+	if resource.GetType() != "app" || resource.GetId() != "it-account-onboarding" {
+		t.Fatalf("Resource = %v, want app/it-account-onboarding", resource)
+	}
+}
+
 func TestBrokerPreservesDedicatedResourceForRegisteredProvider(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/services/invocation/broker.go
+++ b/gestaltd/services/invocation/broker.go
@@ -1076,13 +1076,16 @@ func (b *Broker) authorizationResource(ctx context.Context, providerName string)
 	providerName = strings.TrimSpace(providerName)
 	mapper := b.authorizationMapper()
 	if b != nil {
-		if strings.TrimSpace(b.authorizationPolicies[providerName]) != "" || b.providerKinds[providerName] != "" {
+		if strings.TrimSpace(b.authorizationPolicies[providerName]) != "" {
 			return mapper.Resource(providerName)
 		}
 		if b.providers != nil {
 			if _, err := b.providers.GetWithContext(ctx, providerName); err == nil {
 				return &proto.Resource{Type: string(ProviderKindApp), Id: providerName}
 			}
+		}
+		if b.providerKinds[providerName] != "" {
+			return mapper.Resource(providerName)
 		}
 	}
 	return mapper.Resource(providerName)


### PR DESCRIPTION
## Summary
- resolve providers present in the app registry as `app/<provider>` before consulting static kind metadata
- preserve explicit authorization-policy aliases for legacy dedicated resources
- cover workflow run-as authorization when stale metadata disagrees with the registered app identity

## Bug
Manual workflow starts pass caller authorization, then preflight each target operation as the workflow's `runAs` service account. For a registered app, the broker could trust stale static provider-kind metadata and check a provider-named authorization resource instead of `app/<provider>`. The service account's valid app relationship therefore did not match, and `StartRun` returned `403 authorization denied` before the workflow provider received the request. Scheduled runs were unaffected because they do not traverse this manual-start preflight path.

In production, the equivalent request against `app/it-account-onboarding` is allowed with the `admin` relation, while the provider-named fallback is denied.

## Test plan
- [x] `go test ./gestaltd/services/invocation ./gestaltd/services/workflows ./gestaltd/services/workflows/workflowmanager`
- [x] `git diff --check`
- [x] replay the production broker authorization request and confirm `app/it-account-onboarding` is allowed while the provider-named fallback is denied