### PR TITLE
Fix matching concurrent publishes failing as a version conflict

### DIFF
--- a/gestaltd/internal/appregistry/pending_test.go
+++ b/gestaltd/internal/appregistry/pending_test.go
@@ -532,6 +532,34 @@ func TestUpsertAppIndex_RejectsStaleIdentityWithSameMetadataPath(t *testing.T) {
 	}
 }
 
+func TestUpsertAppIndex_MatchingRepublishKeepsFirstPublishedAt(t *testing.T) {
+	t.Parallel()
+
+	entry := testPublishEntryForUpsert(t)
+	metadataPath := AppVersionEntryPath(entry.App, entry.Version)
+	index, changed, err := UpsertAppIndex(NewEmptyIndex(), entry, metadataPath, "", "")
+	if err != nil || !changed {
+		t.Fatalf("UpsertAppIndex() = changed %v, err %v", changed, err)
+	}
+	firstPublishedAt := index.Apps[entry.App].Versions[entry.Version].PublishedAt
+
+	retry := entry
+	retry.PublishedAt = entry.PublishedAt.Add(3 * time.Second)
+	startedAt := retry.PublishedAt.Add(-time.Minute)
+	retry.PublishStartedAt = &startedAt
+	updated, changed, err := UpsertAppIndex(index, retry, metadataPath, "", "")
+	if err != nil {
+		t.Fatalf("UpsertAppIndex(matching republish) = %v", err)
+	}
+	if changed {
+		t.Fatal("matching republish with a later clock should not rewrite the index")
+	}
+	got := updated.Apps[entry.App].Versions[entry.Version]
+	if !got.PublishedAt.Equal(firstPublishedAt) {
+		t.Fatalf("publishedAt = %v, want first writer %v", got.PublishedAt, firstPublishedAt)
+	}
+}
+
 func testPublishEntryForUpsert(t *testing.T) Entry {
 	t.Helper()
 	return Entry{

--- a/gestaltd/internal/appregistry/pending_test.go
+++ b/gestaltd/internal/appregistry/pending_test.go
@@ -541,7 +541,7 @@ func TestUpsertAppIndex_MatchingRepublishKeepsFirstPublishedAt(t *testing.T) {
 	if err != nil || !changed {
 		t.Fatalf("UpsertAppIndex() = changed %v, err %v", changed, err)
 	}
-	firstPublishedAt := index.Apps[entry.App].Versions[entry.Version].PublishedAt
+	first := index.Apps[entry.App].Versions[entry.Version]
 
 	retry := entry
 	retry.PublishedAt = entry.PublishedAt.Add(3 * time.Second)
@@ -555,8 +555,11 @@ func TestUpsertAppIndex_MatchingRepublishKeepsFirstPublishedAt(t *testing.T) {
 		t.Fatal("matching republish with a later clock should not rewrite the index")
 	}
 	got := updated.Apps[entry.App].Versions[entry.Version]
-	if !got.PublishedAt.Equal(firstPublishedAt) {
-		t.Fatalf("publishedAt = %v, want first writer %v", got.PublishedAt, firstPublishedAt)
+	if !got.PublishedAt.Equal(first.PublishedAt) {
+		t.Fatalf("publishedAt = %v, want first writer %v", got.PublishedAt, first.PublishedAt)
+	}
+	if first.PublishStartedAt != nil || got.PublishStartedAt != nil {
+		t.Fatalf("publishStartedAt = %v, want first writer %v", got.PublishStartedAt, first.PublishStartedAt)
 	}
 }
 

--- a/gestaltd/internal/appregistry/registry.go
+++ b/gestaltd/internal/appregistry/registry.go
@@ -579,8 +579,21 @@ func indexVersionsEqual(a, b IndexVersion) bool {
 	return bytes.Equal(aData, bData)
 }
 
+// indexVersionsEqualIgnoringPublishedAt reports whether two index rows name the
+// same published version. publishedAt and publishStartedAt are facts of the
+// first writer, not identity, so matching republishes keep the stored clock.
+func indexVersionsEqualIgnoringPublishedAt(a, b IndexVersion) bool {
+	a.PublishedAt = time.Time{}
+	b.PublishedAt = time.Time{}
+	a.PublishStartedAt = nil
+	b.PublishStartedAt = nil
+	return indexVersionsEqual(a, b)
+}
+
 // UpsertAppIndex updates the per-app index for a published version. The second
-// return value reports whether the index was modified.
+// return value reports whether the index was modified. A matching republish
+// (same declaration identity, different clock) keeps the first writer's
+// publishedAt and is not a conflict.
 func UpsertAppIndex(index *Index, entry Entry, metadataPath string, displayName, description string) (*Index, bool, error) {
 	if index == nil {
 		index = &Index{
@@ -604,7 +617,7 @@ func UpsertAppIndex(index *Index, entry Entry, metadataPath string, displayName,
 			return nil, false, fmt.Errorf("app %q version %q is already indexed", appName, entry.Version)
 		}
 		expected := indexVersionFromEntry(entry, metadataPath)
-		if !indexVersionsEqual(existing, expected) {
+		if !indexVersionsEqualIgnoringPublishedAt(existing, expected) {
 			return nil, false, fmt.Errorf("app %q version %q index identity mismatch: %w; %s", appName, entry.Version, ErrIndexVersionConflict, RepublishCorruptObjectGuidance)
 		}
 		changed := applyAppIndexAppMetadata(&app, displayName, description)


### PR DESCRIPTION
## Summary

Two matching finalize calls for the same app version were racing on the clock. The second call treated a later `publishedAt` as a different version and failed with an index identity mismatch. This keeps the first writer's timestamp, the same way the version entry already does.

## Why / context

CD on `main` after #3091 failed twice in Go race tests on `TestStatelessPublishConcurrentFinalizeMatching` and `TestAppAdminRegistryPublishConcurrentFinalizeMatching`. Those tests intentionally give each overlapping finalize a different clock. The index compared the full row, including `publishedAt`, so a matching republish looked like a conflict. The stored version JSON already ignores that clock for idempotent checks.

## What changed

- The app index now compares a published version's identity without `publishedAt` and `publishStartedAt`.
- A matching republish keeps the first writer's timestamp and does not rewrite the index.
- A different source or declaration for the same version path still conflicts.

## Validation

- [x] Automated: `go test -race -count=30 -run TestStatelessPublishConcurrentFinalizeMatching ./internal/appregistry`
- [x] Automated: `go test -race -count=20 -run TestAppAdminRegistryPublishConcurrentFinalizeMatching ./internal/server`
- [x] Automated: `go test -count=1 -run 'TestUpsertAppIndex_|TestWriter_Publish_UsesEntryPublishedAt|TestStatelessPublish' ./internal/appregistry`
- [ ] Not run: full CD (gestaltd) race matrix. That is the merge gate.

## Reviewer focus

Confirm a real identity change (different source ref or declaration digest) still returns `ErrIndexVersionConflict`.

## Rollout / compatibility

No API or config change. Existing index rows stay as they are. After merge, pin and deploy as usual.

## Links

Unblocks deploying #3091 (`GET /admin/api/v1/platform-admins`) by letting gestalt CD publish artifacts.


Made with [Cursor](https://cursor.com)