### PR TITLE
mcp: return a static tool list so hosts can finish connecting

### DIFF
--- a/gestaltd/internal/server/conformance_test.go
+++ b/gestaltd/internal/server/conformance_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -475,14 +476,9 @@ func (h *conformanceHarness) mcpToolNames(t *testing.T, cred conformanceCredenti
 
 func requireWorkspaceFrontDoor(t *testing.T, names []string) {
 	t.Helper()
-	want := []string{gestaltmcp.DescribeToolName, gestaltmcp.InvokeToolName, gestaltmcp.SearchToolName}
-	if len(names) != len(want) {
+	want := gestaltmcp.WorkspaceFrontDoorToolNames()
+	if !slices.Equal(names, want) {
 		t.Fatalf("tools/list = %v, want workspace front door %v", names, want)
-	}
-	for i := range want {
-		if names[i] != want[i] {
-			t.Fatalf("tools/list = %v, want workspace front door %v", names, want)
-		}
 	}
 }
 

--- a/gestaltd/internal/server/conformance_test.go
+++ b/gestaltd/internal/server/conformance_test.go
@@ -499,26 +499,9 @@ func (h *conformanceHarness) mcpSearchOperations(t *testing.T, cred conformanceC
 		"jsonrpc": "2.0", "id": 3, "method": "tools/call",
 		"params": map[string]any{"name": gestaltmcp.SearchToolName, "arguments": args},
 	})
-	if rpcErr, ok := envelope["error"]; ok {
-		t.Fatalf("gestalt_search error: %v", rpcErr)
-	}
-	result, _ := envelope["result"].(map[string]any)
-	if isError, _ := result["isError"].(bool); isError {
-		t.Fatalf("gestalt_search tool error: %v", result)
-	}
-	content, _ := result["content"].([]any)
-	if len(content) == 0 {
-		return nil
-	}
-	block, _ := content[0].(map[string]any)
-	text, _ := block["text"].(string)
-	var body struct {
-		Results []struct {
-			Operation string `json:"operation"`
-		} `json:"results"`
-	}
-	if err := json.Unmarshal([]byte(text), &body); err != nil {
-		t.Fatalf("decode gestalt_search: %v body=%s", err, text)
+	body, err := gestaltmcp.DecodeSearchToolResult(envelope)
+	if err != nil {
+		t.Fatalf("%v", err)
 	}
 	names := make([]string, 0, len(body.Results))
 	for _, hit := range body.Results {

--- a/gestaltd/internal/server/conformance_test.go
+++ b/gestaltd/internal/server/conformance_test.go
@@ -473,6 +473,64 @@ func (h *conformanceHarness) mcpToolNames(t *testing.T, cred conformanceCredenti
 	return names
 }
 
+func requireWorkspaceFrontDoor(t *testing.T, names []string) {
+	t.Helper()
+	want := []string{gestaltmcp.DescribeToolName, gestaltmcp.InvokeToolName, gestaltmcp.SearchToolName}
+	if len(names) != len(want) {
+		t.Fatalf("tools/list = %v, want workspace front door %v", names, want)
+	}
+	for i := range want {
+		if names[i] != want[i] {
+			t.Fatalf("tools/list = %v, want workspace front door %v", names, want)
+		}
+	}
+}
+
+func conformanceFlattenedListTool() string {
+	return conformanceMountedApp + "_items_list"
+}
+
+func (h *conformanceHarness) mcpSearchOperations(t *testing.T, cred conformanceCredential, query, app string) []string {
+	t.Helper()
+	args := map[string]any{}
+	if query != "" {
+		args["query"] = query
+	}
+	if app != "" {
+		args["app"] = app
+	}
+	envelope := h.mcp(t, cred, map[string]any{
+		"jsonrpc": "2.0", "id": 3, "method": "tools/call",
+		"params": map[string]any{"name": gestaltmcp.SearchToolName, "arguments": args},
+	})
+	if rpcErr, ok := envelope["error"]; ok {
+		t.Fatalf("gestalt_search error: %v", rpcErr)
+	}
+	result, _ := envelope["result"].(map[string]any)
+	if isError, _ := result["isError"].(bool); isError {
+		t.Fatalf("gestalt_search tool error: %v", result)
+	}
+	content, _ := result["content"].([]any)
+	if len(content) == 0 {
+		return nil
+	}
+	block, _ := content[0].(map[string]any)
+	text, _ := block["text"].(string)
+	var body struct {
+		Results []struct {
+			Operation string `json:"operation"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal([]byte(text), &body); err != nil {
+		t.Fatalf("decode gestalt_search: %v body=%s", err, text)
+	}
+	names := make([]string, 0, len(body.Results))
+	for _, hit := range body.Results {
+		names = append(names, hit.Operation)
+	}
+	return names
+}
+
 // mcpCallSucceeds reports whether tools/call for the list operation ran. A
 // denied call comes back as a JSON-RPC error or an isError result.
 func (h *conformanceHarness) mcpCallSucceeds(t *testing.T, cred conformanceCredential, toolName string) bool {
@@ -509,18 +567,6 @@ func (h *conformanceHarness) invokeOperation(t *testing.T, appName string, cred 
 		t.Fatalf("POST operation status = %d: %s", status, body)
 		return false
 	}
-}
-
-// conformanceListToolName finds the list tool's prefixed MCP name.
-func conformanceListToolName(t *testing.T, names []string) string {
-	t.Helper()
-	for _, name := range names {
-		if strings.Contains(name, "items") {
-			return name
-		}
-	}
-	t.Fatalf("list tool not found in %v", names)
-	return ""
 }
 
 // --- grant shapes ----------------------------------------------------------
@@ -907,11 +953,8 @@ func TestConformanceEmployeeUsesDefaultRole(t *testing.T) {
 	if got := harness.mountedPaths(t, cred)[conformanceMountedApp]; got == "" {
 		t.Fatal("defaultRole employee lost the mounted path in /apps")
 	}
-	names := harness.mcpToolNames(t, cred)
-	if len(names) == 0 {
-		t.Fatal("defaultRole employee saw no MCP tools")
-	}
-	if !harness.mcpCallSucceeds(t, cred, conformanceListToolName(t, names)) {
+	requireWorkspaceFrontDoor(t, harness.mcpToolNames(t, cred))
+	if !harness.mcpCallSucceeds(t, cred, conformanceFlattenedListTool()) {
 		t.Fatal("defaultRole employee could not call an MCP tool")
 	}
 	if !harness.invokeOperation(t, conformanceMountedApp, cred) {
@@ -972,10 +1015,7 @@ func TestConformanceElevatedAdminPassesEveryGate(t *testing.T) {
 	if status, _ := harness.members(t, conformanceAdminApp, cred); status != http.StatusOK {
 		t.Fatalf("app admin status = %d, want 200", status)
 	}
-	names := harness.mcpToolNames(t, cred)
-	if len(names) == 0 {
-		t.Fatal("admin saw no MCP tools")
-	}
+	requireWorkspaceFrontDoor(t, harness.mcpToolNames(t, cred))
 }
 
 // TestConformanceUngrantedExternalIsDeniedEverywhere is the baseline external
@@ -998,10 +1038,11 @@ func TestConformanceUngrantedExternalIsDeniedEverywhere(t *testing.T) {
 	if status, _ := harness.members(t, conformanceAdminApp, cred); status != http.StatusForbidden {
 		t.Fatalf("app admin status = %d, want 403", status)
 	}
-	if names := harness.mcpToolNames(t, cred); len(names) != 0 {
-		t.Fatalf("tools/list exposed %v to an ungranted external user", names)
+	requireWorkspaceFrontDoor(t, harness.mcpToolNames(t, cred))
+	if ops := harness.mcpSearchOperations(t, cred, "items", conformanceMountedApp); len(ops) != 0 {
+		t.Fatalf("gestalt_search exposed %v to an ungranted external user", ops)
 	}
-	if harness.mcpCallSucceeds(t, cred, conformanceMountedApp+"_items_list") {
+	if harness.mcpCallSucceeds(t, cred, conformanceFlattenedListTool()) {
 		t.Fatal("tools/call succeeded for an ungranted external user")
 	}
 	if harness.invokeOperation(t, conformanceMountedApp, cred) {
@@ -1038,11 +1079,11 @@ func TestConformanceGrantedExternalIsAllowedOnEverySurface(t *testing.T) {
 	if paths[conformanceOtherApp] != "" {
 		t.Fatalf("/apps exposed ungranted app %q", conformanceOtherApp)
 	}
-	names := harness.mcpToolNames(t, cred)
-	if len(names) == 0 {
-		t.Fatal("tools/list hid every tool from a granted external user")
+	requireWorkspaceFrontDoor(t, harness.mcpToolNames(t, cred))
+	if ops := harness.mcpSearchOperations(t, cred, "items", conformanceMountedApp); len(ops) == 0 {
+		t.Fatal("gestalt_search hid every operation from a granted external user")
 	}
-	if !harness.mcpCallSucceeds(t, cred, conformanceListToolName(t, names)) {
+	if !harness.mcpCallSucceeds(t, cred, conformanceFlattenedListTool()) {
 		t.Fatal("tools/call denied a granted external user")
 	}
 	if !harness.invokeOperation(t, conformanceMountedApp, cred) {
@@ -1075,7 +1116,8 @@ func TestConformanceRevokedExternalIsDeniedPromptly(t *testing.T) {
 	if status, body := harness.mountedUI(t, conformanceGatedSamplePath, cred); status != http.StatusOK {
 		t.Fatalf("pre-revoke mounted UI status = %d, want 200: %s", status, body)
 	}
-	toolName := conformanceListToolName(t, harness.mcpToolNames(t, cred))
+	requireWorkspaceFrontDoor(t, harness.mcpToolNames(t, cred))
+	toolName := conformanceFlattenedListTool()
 
 	harness.authz.revoke(t, membership)
 
@@ -1085,8 +1127,9 @@ func TestConformanceRevokedExternalIsDeniedPromptly(t *testing.T) {
 	if got := harness.mountedPaths(t, cred)[conformanceMountedApp]; got != "" {
 		t.Fatalf("post-revoke /apps still exposed mounted path %q", got)
 	}
-	if names := harness.mcpToolNames(t, cred); len(names) != 0 {
-		t.Fatalf("post-revoke tools/list still exposed %v", names)
+	requireWorkspaceFrontDoor(t, harness.mcpToolNames(t, cred))
+	if ops := harness.mcpSearchOperations(t, cred, "items", conformanceMountedApp); len(ops) != 0 {
+		t.Fatalf("post-revoke gestalt_search still exposed %v", ops)
 	}
 	if harness.mcpCallSucceeds(t, cred, toolName) {
 		t.Fatal("post-revoke tools/call still succeeded")
@@ -1135,8 +1178,9 @@ func TestConformanceExternalAppAdminIsIsolated(t *testing.T) {
 	if got := harness.mountedPaths(t, cred)[conformanceMountedApp]; got != "" {
 		t.Fatalf("/apps exposed an unadministered app's mounted path %q", got)
 	}
-	if names := harness.mcpToolNames(t, cred); len(names) != 0 {
-		t.Fatalf("tools/list exposed %v to an admin of a different app", names)
+	requireWorkspaceFrontDoor(t, harness.mcpToolNames(t, cred))
+	if ops := harness.mcpSearchOperations(t, cred, "items", conformanceMountedApp); len(ops) != 0 {
+		t.Fatalf("gestalt_search exposed %v to an admin of a different app", ops)
 	}
 }
 
@@ -1257,7 +1301,8 @@ func TestConformanceCredentialSurfacesAgree(t *testing.T) {
 			t.Fatalf("%s: /apps hid the mounted path from a granted user", name)
 		}
 	}
-	toolName := conformanceListToolName(t, harness.mcpToolNames(t, cliToken))
+	requireWorkspaceFrontDoor(t, harness.mcpToolNames(t, cliToken))
+	toolName := conformanceFlattenedListTool()
 	if !harness.mcpCallSucceeds(t, cliToken, toolName) {
 		t.Fatal("CLI exchanged token: tools/call denied a granted user")
 	}
@@ -1277,8 +1322,9 @@ func TestConformanceCredentialSurfacesAgree(t *testing.T) {
 			t.Fatalf("%s: /apps still exposed mounted path %q after revoke", name, got)
 		}
 	}
-	if names := harness.mcpToolNames(t, cliToken); len(names) != 0 {
-		t.Fatalf("CLI exchanged token: tools/list still exposed %v after revoke", names)
+	requireWorkspaceFrontDoor(t, harness.mcpToolNames(t, cliToken))
+	if ops := harness.mcpSearchOperations(t, cliToken, "items", conformanceMountedApp); len(ops) != 0 {
+		t.Fatalf("CLI exchanged token: gestalt_search still exposed %v after revoke", ops)
 	}
 	if harness.mcpCallSucceeds(t, cliToken, toolName) {
 		t.Fatal("CLI exchanged token: tools/call still succeeded after revoke")
@@ -1290,9 +1336,9 @@ func TestConformanceCredentialSurfacesAgree(t *testing.T) {
 	}
 }
 
-// TestConformanceMCPListingAndCallAgree closes the listing/invocation gap: a
-// tool the caller cannot invoke must not appear in tools/list, and a tool that
-// does appear must be callable. Both answers come from the same evaluator.
+// TestConformanceMCPListingAndCallAgree proves the workspace front door is
+// listed to every authenticated caller, while app operations stay fail-closed
+// on search and invoke using the same evaluator as the REST surface.
 func TestConformanceMCPListingAndCallAgree(t *testing.T) {
 	t.Parallel()
 
@@ -1311,17 +1357,22 @@ func TestConformanceMCPListingAndCallAgree(t *testing.T) {
 	granted := conformanceBearer(conformanceExternalToken)
 	ungranted := conformanceBearer(conformanceOutsiderToken)
 
-	names := harness.mcpToolNames(t, granted)
-	if len(names) == 0 {
-		t.Fatal("tools/list hid every tool from a granted caller")
-	}
-	toolName := conformanceListToolName(t, names)
-	if !harness.mcpCallSucceeds(t, granted, toolName) {
-		t.Fatalf("tools/list offered %q but tools/call denied it", toolName)
+	requireWorkspaceFrontDoor(t, harness.mcpToolNames(t, granted))
+	requireWorkspaceFrontDoor(t, harness.mcpToolNames(t, ungranted))
+	if !harness.mcpCallSucceeds(t, granted, gestaltmcp.SearchToolName) {
+		t.Fatal("tools/list offered gestalt_search but tools/call denied it")
 	}
 
-	if listed := harness.mcpToolNames(t, ungranted); len(listed) != 0 {
-		t.Fatalf("tools/list offered %v to an ungranted caller", listed)
+	toolName := conformanceFlattenedListTool()
+	if ops := harness.mcpSearchOperations(t, granted, "items", conformanceMountedApp); len(ops) == 0 {
+		t.Fatal("gestalt_search hid the granted list operation")
+	}
+	if !harness.mcpCallSucceeds(t, granted, toolName) {
+		t.Fatalf("granted caller could not invoke %q", toolName)
+	}
+
+	if ops := harness.mcpSearchOperations(t, ungranted, "items", conformanceMountedApp); len(ops) != 0 {
+		t.Fatalf("gestalt_search offered %v to an ungranted caller", ops)
 	}
 	if harness.mcpCallSucceeds(t, ungranted, toolName) {
 		t.Fatalf("tools/call ran %q for an ungranted caller", toolName)

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -12429,6 +12429,71 @@ func newMCPHandler(t *testing.T, providers *registry.ProviderMap[core.Provider],
 	})
 }
 
+func mcpListedToolNames(t *testing.T, resp map[string]any) []string {
+	t.Helper()
+	result, _ := resp["result"].(map[string]any)
+	tools, _ := result["tools"].([]any)
+	names := make([]string, 0, len(tools))
+	for _, raw := range tools {
+		tool, _ := raw.(map[string]any)
+		if name, ok := tool["name"].(string); ok {
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
+func requireMCPFrontDoor(t *testing.T, resp map[string]any) {
+	t.Helper()
+	names := mcpListedToolNames(t, resp)
+	want := []string{gestaltmcp.DescribeToolName, gestaltmcp.InvokeToolName, gestaltmcp.SearchToolName}
+	if !reflect.DeepEqual(names, want) {
+		t.Fatalf("tools/list = %v, want workspace front door %v", names, want)
+	}
+}
+
+func mcpSearchOperations(t *testing.T, ts *httptest.Server, headers map[string]string, args map[string]any) []string {
+	t.Helper()
+	status, resp := mcpJSONRPC(t, ts, headers, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name":      gestaltmcp.SearchToolName,
+			"arguments": args,
+		},
+	})
+	if status != http.StatusOK {
+		t.Fatalf("gestalt_search status = %d: %v", status, resp)
+	}
+	if rpcErr, ok := resp["error"]; ok {
+		t.Fatalf("gestalt_search rpc error: %v", rpcErr)
+	}
+	result, _ := resp["result"].(map[string]any)
+	if result["isError"] == true {
+		t.Fatalf("gestalt_search tool error: %v", result)
+	}
+	content, _ := result["content"].([]any)
+	if len(content) == 0 {
+		t.Fatalf("gestalt_search missing content: %v", result)
+	}
+	block, _ := content[0].(map[string]any)
+	text, _ := block["text"].(string)
+	var body struct {
+		Results []struct {
+			Operation string `json:"operation"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal([]byte(text), &body); err != nil {
+		t.Fatalf("decode gestalt_search: %v body=%s", err, text)
+	}
+	names := make([]string, 0, len(body.Results))
+	for _, hit := range body.Results {
+		names = append(names, hit.Operation)
+	}
+	return names
+}
+
 func TestMCPEndpoint_InitializeAndListTools(t *testing.T) {
 	t.Parallel()
 
@@ -12500,13 +12565,10 @@ func TestMCPEndpoint_InitializeAndListTools(t *testing.T) {
 	if !ok || len(tools) == 0 {
 		t.Fatalf("tools/list: expected non-empty tools, got %v", result)
 	}
-	firstTool := tools[0].(map[string]any)
-	if firstTool["name"] != "linear_search_issues" {
-		t.Fatalf("expected tool linear_search_issues, got %v", firstTool["name"])
-	}
+	requireMCPFrontDoor(t, resp)
 }
 
-func TestMCPEndpoint_EmptyAllowedProvidersExposesNoTools(t *testing.T) {
+func TestMCPEndpoint_EmptyAllowedProvidersRejectsAppToolCalls(t *testing.T) {
 	t.Parallel()
 
 	stub := &stubIntegrationWithOps{
@@ -12540,17 +12602,7 @@ func TestMCPEndpoint_EmptyAllowedProvidersExposesNoTools(t *testing.T) {
 	if status != http.StatusOK {
 		t.Fatalf("tools/list status = %d, want 200", status)
 	}
-	result, ok := resp["result"].(map[string]any)
-	if !ok {
-		t.Fatalf("expected result object, got %v", resp)
-	}
-	tools, ok := result["tools"].([]any)
-	if !ok {
-		t.Fatalf("expected tools list, got %v", result["tools"])
-	}
-	if len(tools) != 0 {
-		t.Fatalf("tools = %v, want empty list", tools)
-	}
+	requireMCPFrontDoor(t, resp)
 
 	status, resp = mcpJSONRPC(t, ts, nil, map[string]any{
 		"jsonrpc": "2.0",
@@ -12612,17 +12664,7 @@ func TestMCPEndpoint_ListUsesStrictCatalogResolution(t *testing.T) {
 	if status != http.StatusOK {
 		t.Fatalf("tools/list status = %d, want 200", status)
 	}
-	result, ok := resp["result"].(map[string]any)
-	if !ok {
-		t.Fatalf("expected result object, got %v", resp)
-	}
-	tools, ok := result["tools"].([]any)
-	if !ok {
-		t.Fatalf("expected tools list, got %v", result["tools"])
-	}
-	if len(tools) != 0 {
-		t.Fatalf("tools = %v, want empty list when strict catalog resolution fails", tools)
-	}
+	requireMCPFrontDoor(t, resp)
 
 	status, resp = mcpJSONRPC(t, ts, map[string]string{
 		"Authorization": "Bearer session-token",
@@ -12638,7 +12680,7 @@ func TestMCPEndpoint_ListUsesStrictCatalogResolution(t *testing.T) {
 	if status != http.StatusOK {
 		t.Fatalf("tools/call status = %d, want 200", status)
 	}
-	result, ok = resp["result"].(map[string]any)
+	result, ok := resp["result"].(map[string]any)
 	if !ok {
 		t.Fatalf("expected tool result object, got %v", resp)
 	}
@@ -12957,11 +12999,23 @@ func TestMCPEndpoint_IgnoresSessionIDForDynamicCatalogIsolation(t *testing.T) {
 		return names
 	}
 
-	if got := listToolNames("auth-a"); !reflect.DeepEqual(got, []string{"sample_only_a"}) {
-		t.Fatalf("auth-a tools = %v, want [sample_only_a]", got)
+	if got := listToolNames("auth-a"); !reflect.DeepEqual(got, []string{gestaltmcp.DescribeToolName, gestaltmcp.InvokeToolName, gestaltmcp.SearchToolName}) {
+		t.Fatalf("auth-a tools/list = %v, want workspace front door", got)
 	}
-	if got := listToolNames("auth-b"); !reflect.DeepEqual(got, []string{"sample_only_b"}) {
-		t.Fatalf("auth-b tools = %v, want [sample_only_b]", got)
+	if got := listToolNames("auth-b"); !reflect.DeepEqual(got, []string{gestaltmcp.DescribeToolName, gestaltmcp.InvokeToolName, gestaltmcp.SearchToolName}) {
+		t.Fatalf("auth-b tools/list = %v, want workspace front door", got)
+	}
+	searchHeaders := func(authToken string) map[string]string {
+		return map[string]string{
+			"Authorization":  "Bearer " + authToken,
+			"Mcp-Session-Id": "shared-session-id",
+		}
+	}
+	if got := mcpSearchOperations(t, ts, searchHeaders("auth-a"), map[string]any{"app": "sample"}); !reflect.DeepEqual(got, []string{"only_a"}) {
+		t.Fatalf("auth-a search = %v, want [only_a]", got)
+	}
+	if got := mcpSearchOperations(t, ts, searchHeaders("auth-b"), map[string]any{"app": "sample"}); !reflect.DeepEqual(got, []string{"only_b"}) {
+		t.Fatalf("auth-b search = %v, want [only_b]", got)
 	}
 }
 
@@ -13306,10 +13360,7 @@ func TestMCPEndpoint_DirectPassthrough(t *testing.T) {
 	if !ok || len(tools) == 0 {
 		t.Fatalf("expected tools, got %v", result)
 	}
-	firstTool := tools[0].(map[string]any)
-	if firstTool["name"] != "clickhouse_run_query" {
-		t.Fatalf("expected clickhouse_run_query, got %v", firstTool["name"])
-	}
+	requireMCPFrontDoor(t, resp)
 
 	status, resp = mcpJSONRPC(t, ts, headers, map[string]any{
 		"jsonrpc": "2.0",

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -12446,7 +12446,7 @@ func mcpListedToolNames(t *testing.T, resp map[string]any) []string {
 func requireMCPFrontDoor(t *testing.T, resp map[string]any) {
 	t.Helper()
 	names := mcpListedToolNames(t, resp)
-	want := []string{gestaltmcp.DescribeToolName, gestaltmcp.InvokeToolName, gestaltmcp.SearchToolName}
+	want := gestaltmcp.WorkspaceFrontDoorToolNames()
 	if !reflect.DeepEqual(names, want) {
 		t.Fatalf("tools/list = %v, want workspace front door %v", names, want)
 	}
@@ -12999,10 +12999,10 @@ func TestMCPEndpoint_IgnoresSessionIDForDynamicCatalogIsolation(t *testing.T) {
 		return names
 	}
 
-	if got := listToolNames("auth-a"); !reflect.DeepEqual(got, []string{gestaltmcp.DescribeToolName, gestaltmcp.InvokeToolName, gestaltmcp.SearchToolName}) {
+	if got := listToolNames("auth-a"); !reflect.DeepEqual(got, gestaltmcp.WorkspaceFrontDoorToolNames()) {
 		t.Fatalf("auth-a tools/list = %v, want workspace front door", got)
 	}
-	if got := listToolNames("auth-b"); !reflect.DeepEqual(got, []string{gestaltmcp.DescribeToolName, gestaltmcp.InvokeToolName, gestaltmcp.SearchToolName}) {
+	if got := listToolNames("auth-b"); !reflect.DeepEqual(got, gestaltmcp.WorkspaceFrontDoorToolNames()) {
 		t.Fatalf("auth-b tools/list = %v, want workspace front door", got)
 	}
 	searchHeaders := func(authToken string) map[string]string {
@@ -13010,6 +13010,9 @@ func TestMCPEndpoint_IgnoresSessionIDForDynamicCatalogIsolation(t *testing.T) {
 			"Authorization":  "Bearer " + authToken,
 			"Mcp-Session-Id": "shared-session-id",
 		}
+	}
+	if got := mcpSearchOperations(t, ts, searchHeaders("auth-a"), map[string]any{"query": "sample"}); len(got) != 0 {
+		t.Fatalf("auth-a query-only search = %v, want empty static catalog", got)
 	}
 	if got := mcpSearchOperations(t, ts, searchHeaders("auth-a"), map[string]any{"app": "sample"}); !reflect.DeepEqual(got, []string{"only_a"}) {
 		t.Fatalf("auth-a search = %v, want [only_a]", got)

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -12466,26 +12466,9 @@ func mcpSearchOperations(t *testing.T, ts *httptest.Server, headers map[string]s
 	if status != http.StatusOK {
 		t.Fatalf("gestalt_search status = %d: %v", status, resp)
 	}
-	if rpcErr, ok := resp["error"]; ok {
-		t.Fatalf("gestalt_search rpc error: %v", rpcErr)
-	}
-	result, _ := resp["result"].(map[string]any)
-	if result["isError"] == true {
-		t.Fatalf("gestalt_search tool error: %v", result)
-	}
-	content, _ := result["content"].([]any)
-	if len(content) == 0 {
-		t.Fatalf("gestalt_search missing content: %v", result)
-	}
-	block, _ := content[0].(map[string]any)
-	text, _ := block["text"].(string)
-	var body struct {
-		Results []struct {
-			Operation string `json:"operation"`
-		} `json:"results"`
-	}
-	if err := json.Unmarshal([]byte(text), &body); err != nil {
-		t.Fatalf("decode gestalt_search: %v body=%s", err, text)
+	body, err := gestaltmcp.DecodeSearchToolResult(resp)
+	if err != nil {
+		t.Fatalf("%v", err)
 	}
 	names := make([]string, 0, len(body.Results))
 	for _, hit := range body.Results {
@@ -12533,6 +12516,12 @@ func TestMCPEndpoint_InitializeAndListTools(t *testing.T) {
 	}
 	if result["serverInfo"] == nil {
 		t.Fatal("initialize: missing serverInfo")
+	}
+	instructions, _ := result["instructions"].(string)
+	for _, name := range gestaltmcp.WorkspaceFrontDoorToolNames() {
+		if !strings.Contains(instructions, name) {
+			t.Fatalf("initialize instructions %q missing %s", instructions, name)
+		}
 	}
 	if got := header.Get("Mcp-Session-Id"); got != "" {
 		t.Fatalf("initialize returned MCP session id %q, want none", got)

--- a/gestaltd/services/apps/mcp/binding.go
+++ b/gestaltd/services/apps/mcp/binding.go
@@ -25,10 +25,11 @@ type Config struct {
 	IncludeREST       map[string]bool
 	MCPConnection     map[string]string
 	CatalogProjection func(provName string, prov core.Provider, cat *catalog.Catalog) *catalog.Catalog
-	// OperationAccess answers tools/list authorization questions in one
-	// batched evaluator call, using the same decision path tools/call uses.
-	// Nil means tools/list is not authorization-filtered; tools/call
-	// enforcement is unaffected either way.
+	// OperationAccess filters gestalt_search and gestalt_describe results
+	// using the same decision path tools/call uses. Nil means those tools
+	// are not authorization-filtered; tools/call enforcement is unaffected.
+	// tools/list does not consult this checker: it returns the static
+	// workspace front door so hosts can connect without walking catalogs.
 	OperationAccess     invocation.OperationAccessChecker
 	InvocationValidator func(ctx context.Context, provName string, prov core.Provider, op catalog.CatalogOperation, params map[string]any, explicitConnection string) error
 }

--- a/gestaltd/services/apps/mcp/front_door.go
+++ b/gestaltd/services/apps/mcp/front_door.go
@@ -36,6 +36,8 @@ const (
 	liveSearchTimeout  = 8 * time.Second
 )
 
+const catalogInstanceToolPropertyJSON = `"_instance": {"type": "string", "description": "Optional. Use when the app exposes more than one catalog instance."}`
+
 var (
 	searchToolSchema = json.RawMessage(`{
   "type": "object",
@@ -51,7 +53,8 @@ var (
     "limit": {
       "type": "integer",
       "description": "Maximum number of operations to return. Defaults to 20, max 100."
-    }
+    },
+    ` + catalogInstanceToolPropertyJSON + `
   }
 }`)
 	describeToolSchema = json.RawMessage(`{
@@ -59,7 +62,8 @@ var (
   "required": ["app", "operation"],
   "properties": {
     "app": {"type": "string", "description": "App name, for example linear."},
-    "operation": {"type": "string", "description": "Operation id, for example search_issues."}
+    "operation": {"type": "string", "description": "Operation id, for example search_issues."},
+    ` + catalogInstanceToolPropertyJSON + `
   }
 }`)
 	invokeToolSchema = json.RawMessage(`{
@@ -69,7 +73,7 @@ var (
     "app": {"type": "string", "description": "App name, for example linear."},
     "operation": {"type": "string", "description": "Operation id, for example search_issues."},
     "arguments": {"type": "object", "description": "Arguments for the operation."},
-    "_instance": {"type": "string", "description": "Optional. Use when the app exposes more than one catalog instance."}
+    ` + catalogInstanceToolPropertyJSON + `
   }
 }`)
 )
@@ -127,12 +131,16 @@ func (h *StatelessHTTPHandler) callSearch(ctx context.Context, req mcpgo.CallToo
 	args := req.GetArguments()
 	query := stringArg(args, "query")
 	appFilter := stringArg(args, "app")
+	instance := stringArg(args, "_instance")
 	limit := intArg(args, "limit", defaultSearchLimit)
 	if limit < 1 {
 		limit = defaultSearchLimit
 	}
 	if limit > maxSearchLimit {
 		limit = maxSearchLimit
+	}
+	if instance != "" && appFilter == "" {
+		return mcpgo.NewToolResultError("app is required when _instance is set"), nil
 	}
 	if query == "" && appFilter == "" {
 		return toolJSONResult(SearchResult{
@@ -154,7 +162,7 @@ func (h *StatelessHTTPHandler) callSearch(ctx context.Context, req mcpgo.CallToo
 		if !ok {
 			continue
 		}
-		cat, liveErr := h.catalogForSearch(ctx, provName, prov, appFilter != "")
+		cat, liveErr := h.catalogForSearch(ctx, provName, prov, instance, appFilter != "")
 		if liveErr != nil {
 			unavailable = append(unavailable, SearchUnavailable{App: provName, Error: liveErr.Error()})
 			continue
@@ -257,13 +265,13 @@ func (h *StatelessHTTPHandler) allowedOperations(ctx context.Context, p *princip
 	return allowed, nil
 }
 
-func (h *StatelessHTTPHandler) catalogForSearch(ctx context.Context, provName string, prov core.Provider, live bool) (*catalog.Catalog, error) {
+func (h *StatelessHTTPHandler) catalogForSearch(ctx context.Context, provName string, prov core.Provider, instance string, live bool) (*catalog.Catalog, error) {
 	if !live {
 		return projectCatalog(h.cfg, provName, prov, prov.Catalog()), nil
 	}
 	liveCtx, cancel := context.WithTimeout(ctx, liveSearchTimeout)
 	defer cancel()
-	raw, err := h.resolveCatalog(liveCtx, provName, prov, "", true)
+	raw, err := h.resolveCatalog(liveCtx, provName, prov, instance, true)
 	if err != nil {
 		return nil, err
 	}

--- a/gestaltd/services/apps/mcp/front_door.go
+++ b/gestaltd/services/apps/mcp/front_door.go
@@ -185,9 +185,9 @@ func (h *StatelessHTTPHandler) callSearch(ctx context.Context, req mcpgo.CallToo
 		}
 	}
 
-	allowed, err := h.filterSearchHits(ctx, p, candidates)
-	if err != nil {
-		return mcpgo.NewToolResultError(err.Error()), nil
+	allowed, accessErr := h.filterSearchHits(ctx, p, candidates)
+	if accessErr != nil {
+		return accessErr, nil
 	}
 	sort.Slice(allowed, func(i, j int) bool {
 		if allowed[i].App != allowed[j].App {
@@ -201,35 +201,49 @@ func (h *StatelessHTTPHandler) callSearch(ctx context.Context, req mcpgo.CallToo
 	return toolJSONResult(searchResult{Results: allowed, Unavailable: unavailable}), nil
 }
 
-func (h *StatelessHTTPHandler) filterSearchHits(ctx context.Context, p *principal.Principal, candidates []searchCandidate) ([]searchHit, error) {
-	if len(candidates) == 0 {
-		return []searchHit{}, nil
-	}
-	if h.cfg.OperationAccess == nil {
-		hits := make([]searchHit, len(candidates))
-		for i := range candidates {
-			hits[i] = candidates[i].hit
-		}
-		return hits, nil
-	}
+func (h *StatelessHTTPHandler) filterSearchHits(ctx context.Context, p *principal.Principal, candidates []searchCandidate) ([]searchHit, *mcpgo.CallToolResult) {
 	queries := make([]invocation.OperationAccessQuery, len(candidates))
 	for i := range candidates {
 		queries[i] = candidates[i].query
 	}
-	results, err := h.cfg.OperationAccess.CheckOperationAccessMany(ctx, p, queries)
-	if err != nil {
-		return nil, fmt.Errorf("operation access is unavailable: %w", err)
-	}
-	if len(results) != len(candidates) {
-		return nil, fmt.Errorf("operation access returned %d decisions for %d operations", len(results), len(candidates))
+	ok, accessErr := h.allowedOperations(ctx, p, queries)
+	if accessErr != nil {
+		return nil, accessErr
 	}
 	hits := make([]searchHit, 0, len(candidates))
 	for i := range candidates {
-		if results[i] == nil {
+		if ok[i] {
 			hits = append(hits, candidates[i].hit)
 		}
 	}
 	return hits, nil
+}
+
+// allowedOperations answers the same evaluator questions FilterCatalogForPrincipal
+// asks, then maps those answers to booleans so MCP handlers can return tool
+// errors instead of JSON-RPC errors.
+func (h *StatelessHTTPHandler) allowedOperations(ctx context.Context, p *principal.Principal, queries []invocation.OperationAccessQuery) ([]bool, *mcpgo.CallToolResult) {
+	allowed := make([]bool, len(queries))
+	if len(queries) == 0 {
+		return allowed, nil
+	}
+	if h.cfg.OperationAccess == nil {
+		for i := range allowed {
+			allowed[i] = true
+		}
+		return allowed, nil
+	}
+	results, checkErr := h.cfg.OperationAccess.CheckOperationAccessMany(ctx, p, queries)
+	if checkErr != nil {
+		return nil, mcpgo.NewToolResultError("operation access is unavailable: " + checkErr.Error())
+	}
+	if len(results) != len(queries) {
+		return nil, mcpgo.NewToolResultError(fmt.Sprintf("operation access returned %d decisions for %d operations", len(results), len(queries)))
+	}
+	for i := range results {
+		allowed[i] = results[i] == nil
+	}
+	return allowed, nil
 }
 
 func (h *StatelessHTTPHandler) catalogForSearch(ctx context.Context, provName string, prov core.Provider, live bool) (*catalog.Catalog, error) {
@@ -272,18 +286,16 @@ func (h *StatelessHTTPHandler) callDescribe(ctx context.Context, req mcpgo.CallT
 	if !found || !catalogOperationProjectedToMCP(h.cfg, app, op) {
 		return mcpgo.NewToolResultError(fmt.Sprintf("operation %q is not available on app %q", operation, app)), nil
 	}
-	if h.cfg.OperationAccess != nil {
-		results, err := h.cfg.OperationAccess.CheckOperationAccessMany(ctx, p, []invocation.OperationAccessQuery{{
-			Provider:     app,
-			Operation:    operation,
-			AllowedRoles: op.AllowedRoles,
-		}})
-		if err != nil {
-			return mcpgo.NewToolResultError("operation access is unavailable: " + err.Error()), nil
-		}
-		if len(results) != 1 || results[0] != nil {
-			return mcpgo.NewToolResultError("operation access denied"), nil
-		}
+	allowed, accessErr := h.allowedOperations(ctx, p, []invocation.OperationAccessQuery{{
+		Provider:     app,
+		Operation:    operation,
+		AllowedRoles: op.AllowedRoles,
+	}})
+	if accessErr != nil {
+		return accessErr, nil
+	}
+	if len(allowed) != 1 || !allowed[0] {
+		return mcpgo.NewToolResultError("operation access denied"), nil
 	}
 	return toolJSONResult(describeResult{
 		App:          app,

--- a/gestaltd/services/apps/mcp/front_door.go
+++ b/gestaltd/services/apps/mcp/front_door.go
@@ -26,6 +26,10 @@ const (
 	InvokeToolName   = "gestalt_invoke"
 )
 
+// workspaceFrontDoorInstructions is returned on initialize so hosts do not
+// treat the three handshake tools as an inventory of app operations.
+const workspaceFrontDoorInstructions = "tools/list is the connect handshake: gestalt_search, gestalt_describe, and gestalt_invoke. Search to find operations you may use, describe for one operation's schema, then invoke with app, operation, and arguments. App operations are not listed."
+
 const (
 	defaultSearchLimit = 20
 	maxSearchLimit     = 100
@@ -82,27 +86,27 @@ func workspaceFrontDoorTools() []mcpgo.Tool {
 	}
 }
 
-type searchHit struct {
+type SearchHit struct {
 	App         string `json:"app"`
 	Operation   string `json:"operation"`
 	Title       string `json:"title,omitempty"`
 	Description string `json:"description,omitempty"`
-	MCPName     string `json:"mcpName"`
 }
 
-type searchUnavailable struct {
+type SearchUnavailable struct {
 	App   string `json:"app"`
 	Error string `json:"error"`
 }
 
-type searchResult struct {
-	Results     []searchHit         `json:"results"`
-	Unavailable []searchUnavailable `json:"unavailable,omitempty"`
+type SearchResult struct {
+	Results     []SearchHit         `json:"results"`
+	Unavailable []SearchUnavailable `json:"unavailable,omitempty"`
 	Hint        string              `json:"hint,omitempty"`
+	Truncated   bool                `json:"truncated,omitempty"`
 }
 
 type searchCandidate struct {
-	hit   searchHit
+	hit   SearchHit
 	query invocation.OperationAccessQuery
 }
 
@@ -111,7 +115,6 @@ type describeResult struct {
 	Operation    string          `json:"operation"`
 	Title        string          `json:"title,omitempty"`
 	Description  string          `json:"description,omitempty"`
-	MCPName      string          `json:"mcpName"`
 	InputSchema  json.RawMessage `json:"inputSchema,omitempty"`
 	OutputSchema json.RawMessage `json:"outputSchema,omitempty"`
 }
@@ -132,14 +135,14 @@ func (h *StatelessHTTPHandler) callSearch(ctx context.Context, req mcpgo.CallToo
 		limit = maxSearchLimit
 	}
 	if query == "" && appFilter == "" {
-		return toolJSONResult(searchResult{
-			Results: []searchHit{},
+		return toolJSONResult(SearchResult{
+			Results: []SearchHit{},
 			Hint:    "Pass query or app to search workspace operations.",
 		}), nil
 	}
 
 	candidates := make([]searchCandidate, 0)
-	unavailable := make([]searchUnavailable, 0)
+	unavailable := make([]SearchUnavailable, 0)
 	for _, provName := range h.providerNames {
 		if appFilter != "" && provName != appFilter {
 			continue
@@ -153,7 +156,7 @@ func (h *StatelessHTTPHandler) callSearch(ctx context.Context, req mcpgo.CallToo
 		}
 		cat, liveErr := h.catalogForSearch(ctx, provName, prov, appFilter != "")
 		if liveErr != nil {
-			unavailable = append(unavailable, searchUnavailable{App: provName, Error: liveErr.Error()})
+			unavailable = append(unavailable, SearchUnavailable{App: provName, Error: liveErr.Error()})
 			continue
 		}
 		if cat == nil {
@@ -169,12 +172,11 @@ func (h *StatelessHTTPHandler) callSearch(ctx context.Context, req mcpgo.CallToo
 				continue
 			}
 			candidates = append(candidates, searchCandidate{
-				hit: searchHit{
+				hit: SearchHit{
 					App:         provName,
 					Operation:   op.ID,
 					Title:       operationTitle(op),
 					Description: op.Description,
-					MCPName:     toolName(h.cfg.ToolPrefixes, provName, op.ID),
 				},
 				query: invocation.OperationAccessQuery{
 					Provider:     provName,
@@ -185,38 +187,47 @@ func (h *StatelessHTTPHandler) callSearch(ctx context.Context, req mcpgo.CallToo
 		}
 	}
 
-	allowed, accessErr := h.filterSearchHits(ctx, p, candidates)
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].hit.App != candidates[j].hit.App {
+			return candidates[i].hit.App < candidates[j].hit.App
+		}
+		return candidates[i].hit.Operation < candidates[j].hit.Operation
+	})
+	allowed, truncated, accessErr := h.pageSearchHits(ctx, p, candidates, limit)
 	if accessErr != nil {
 		return accessErr, nil
 	}
-	sort.Slice(allowed, func(i, j int) bool {
-		if allowed[i].App != allowed[j].App {
-			return allowed[i].App < allowed[j].App
-		}
-		return allowed[i].Operation < allowed[j].Operation
-	})
-	if len(allowed) > limit {
-		allowed = allowed[:limit]
-	}
-	return toolJSONResult(searchResult{Results: allowed, Unavailable: unavailable}), nil
+	return toolJSONResult(SearchResult{Results: allowed, Unavailable: unavailable, Truncated: truncated}), nil
 }
 
-func (h *StatelessHTTPHandler) filterSearchHits(ctx context.Context, p *principal.Principal, candidates []searchCandidate) ([]searchHit, *mcpgo.CallToolResult) {
-	queries := make([]invocation.OperationAccessQuery, len(candidates))
-	for i := range candidates {
-		queries[i] = candidates[i].query
-	}
-	ok, accessErr := h.allowedOperations(ctx, p, queries)
-	if accessErr != nil {
-		return nil, accessErr
-	}
-	hits := make([]searchHit, 0, len(candidates))
-	for i := range candidates {
-		if ok[i] {
-			hits = append(hits, candidates[i].hit)
+func (h *StatelessHTTPHandler) pageSearchHits(ctx context.Context, p *principal.Principal, candidates []searchCandidate, limit int) ([]SearchHit, bool, *mcpgo.CallToolResult) {
+	hits := make([]SearchHit, 0, min(limit, len(candidates)))
+	offset := 0
+	for offset < len(candidates) && len(hits) < limit {
+		need := limit - len(hits)
+		take := min(len(candidates)-offset, invocation.MaxBatchedAccessChecks, max(need, defaultSearchLimit))
+		window := candidates[offset : offset+take]
+		queries := make([]invocation.OperationAccessQuery, len(window))
+		for i := range window {
+			queries[i] = window[i].query
 		}
+		ok, accessErr := h.allowedOperations(ctx, p, queries)
+		if accessErr != nil {
+			return nil, false, accessErr
+		}
+		consumed := 0
+		for i := range window {
+			consumed++
+			if ok[i] {
+				hits = append(hits, window[i].hit)
+				if len(hits) == limit {
+					break
+				}
+			}
+		}
+		offset += consumed
 	}
-	return hits, nil
+	return hits, offset < len(candidates), nil
 }
 
 // allowedOperations answers the same evaluator questions FilterCatalogForPrincipal
@@ -302,7 +313,6 @@ func (h *StatelessHTTPHandler) callDescribe(ctx context.Context, req mcpgo.CallT
 		Operation:    operation,
 		Title:        operationTitle(op),
 		Description:  op.Description,
-		MCPName:      toolName(h.cfg.ToolPrefixes, app, operation),
 		InputSchema:  op.InputSchema,
 		OutputSchema: op.OutputSchema,
 	}), nil
@@ -402,4 +412,36 @@ func toolJSONResult(v any) *mcpgo.CallToolResult {
 		return mcpgo.NewToolResultError(err.Error())
 	}
 	return mcpgo.NewToolResultText(string(raw))
+}
+
+// DecodeSearchToolResult reads gestalt_search's JSON body from a tools/call
+// envelope. Tests and clients use this so they do not each invent a decoder.
+func DecodeSearchToolResult(envelope map[string]any) (SearchResult, error) {
+	if envelope == nil {
+		return SearchResult{}, fmt.Errorf("missing MCP envelope")
+	}
+	if rpcErr, ok := envelope["error"]; ok {
+		return SearchResult{}, fmt.Errorf("gestalt_search rpc error: %v", rpcErr)
+	}
+	result, _ := envelope["result"].(map[string]any)
+	if result == nil {
+		return SearchResult{}, fmt.Errorf("gestalt_search missing result")
+	}
+	if isError, _ := result["isError"].(bool); isError {
+		return SearchResult{}, fmt.Errorf("gestalt_search tool error: %v", result)
+	}
+	content, _ := result["content"].([]any)
+	if len(content) == 0 {
+		return SearchResult{Results: []SearchHit{}}, nil
+	}
+	block, _ := content[0].(map[string]any)
+	text, _ := block["text"].(string)
+	var body SearchResult
+	if err := json.Unmarshal([]byte(text), &body); err != nil {
+		return SearchResult{}, fmt.Errorf("decode gestalt_search: %w", err)
+	}
+	if body.Results == nil {
+		body.Results = []SearchHit{}
+	}
+	return body, nil
 }

--- a/gestaltd/services/apps/mcp/front_door.go
+++ b/gestaltd/services/apps/mcp/front_door.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 	"strconv"
@@ -349,7 +350,11 @@ func (h *StatelessHTTPHandler) callInvoke(ctx context.Context, req mcpgo.CallToo
 	}
 	inner := req
 	inner.Params.Arguments = nested
-	return h.callResolvedAppTool(ctx, inner, statelessToolRef{provider: app, operation: operation})
+	result, err := h.callResolvedAppTool(ctx, inner, statelessToolRef{provider: app, operation: operation})
+	if errors.Is(err, core.ErrNotFound) || errors.Is(err, invocation.ErrOperationNotFound) {
+		return mcpgo.NewToolResultError(err.Error()), nil
+	}
+	return result, err
 }
 
 func operationTitle(op catalog.CatalogOperation) string {

--- a/gestaltd/services/apps/mcp/front_door.go
+++ b/gestaltd/services/apps/mcp/front_door.go
@@ -1,0 +1,407 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/catalog"
+	"github.com/valon-technologies/gestalt/server/services/identity/principal"
+	"github.com/valon-technologies/gestalt/server/services/invocation"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+)
+
+// Workspace MCP handshake tools. Hosts such as Muxy and Cursor require
+// tools/list to finish before they mark the server connected, so this set is
+// static and does not walk app catalogs.
+const (
+	SearchToolName   = "gestalt_search"
+	DescribeToolName = "gestalt_describe"
+	InvokeToolName   = "gestalt_invoke"
+)
+
+const (
+	defaultSearchLimit  = 20
+	maxSearchLimit      = 100
+	maxSearchCandidates = 1000
+	liveSearchTimeout   = 8 * time.Second
+)
+
+var (
+	searchToolSchema = json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "query": {
+      "type": "string",
+      "description": "Text to match against app and operation names, titles, and descriptions."
+    },
+    "app": {
+      "type": "string",
+      "description": "If set, search only this app and include its live catalog."
+    },
+    "limit": {
+      "type": "integer",
+      "description": "Maximum number of operations to return. Defaults to 20, max 100."
+    }
+  }
+}`)
+	describeToolSchema = json.RawMessage(`{
+  "type": "object",
+  "required": ["app", "operation"],
+  "properties": {
+    "app": {"type": "string", "description": "App name, for example linear."},
+    "operation": {"type": "string", "description": "Operation id, for example search_issues."}
+  }
+}`)
+	invokeToolSchema = json.RawMessage(`{
+  "type": "object",
+  "required": ["app", "operation"],
+  "properties": {
+    "app": {"type": "string", "description": "App name, for example linear."},
+    "operation": {"type": "string", "description": "Operation id, for example search_issues."},
+    "arguments": {"type": "object", "description": "Arguments for the operation."},
+    "_instance": {"type": "string", "description": "Optional catalog instance."}
+  }
+}`)
+)
+
+func workspaceFrontDoorTools() []mcpgo.Tool {
+	return []mcpgo.Tool{
+		mcpgo.NewToolWithRawSchema(DescribeToolName, "Return one workspace operation's schema. Use this before gestalt_invoke when you need argument names.", describeToolSchema),
+		mcpgo.NewToolWithRawSchema(InvokeToolName, "Invoke a workspace app operation. Pass app, operation, and arguments. Authorization is enforced on this call.", invokeToolSchema),
+		mcpgo.NewToolWithRawSchema(SearchToolName, "Search workspace apps and operations the caller may use. Pass query and optionally app. Then call gestalt_describe or gestalt_invoke.", searchToolSchema),
+	}
+}
+
+type searchHit struct {
+	App         string `json:"app"`
+	Operation   string `json:"operation"`
+	Title       string `json:"title,omitempty"`
+	Description string `json:"description,omitempty"`
+	MCPName     string `json:"mcpName"`
+}
+
+type searchUnavailable struct {
+	App   string `json:"app"`
+	Error string `json:"error"`
+}
+
+type searchResult struct {
+	Results     []searchHit         `json:"results"`
+	Unavailable []searchUnavailable `json:"unavailable,omitempty"`
+}
+
+type searchCandidate struct {
+	hit   searchHit
+	query invocation.OperationAccessQuery
+}
+
+type describeResult struct {
+	App          string          `json:"app"`
+	Operation    string          `json:"operation"`
+	Title        string          `json:"title,omitempty"`
+	Description  string          `json:"description,omitempty"`
+	MCPName      string          `json:"mcpName"`
+	InputSchema  json.RawMessage `json:"inputSchema,omitempty"`
+	OutputSchema json.RawMessage `json:"outputSchema,omitempty"`
+}
+
+func (h *StatelessHTTPHandler) callSearch(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+	p := principal.FromContext(ctx)
+	if p == nil {
+		return mcpgo.NewToolResultError("not authenticated"), nil
+	}
+	args := req.GetArguments()
+	query := stringArg(args, "query")
+	appFilter := stringArg(args, "app")
+	limit := intArg(args, "limit", defaultSearchLimit)
+	if limit < 1 {
+		limit = defaultSearchLimit
+	}
+	if limit > maxSearchLimit {
+		limit = maxSearchLimit
+	}
+	if query == "" && appFilter == "" {
+		return toolJSONResult(searchResult{Results: []searchHit{}}), nil
+	}
+
+	candidates := make([]searchCandidate, 0)
+	unavailable := make([]searchUnavailable, 0)
+	for _, provName := range h.providerNames {
+		if appFilter != "" && provName != appFilter {
+			continue
+		}
+		if !principal.AllowsProviderPermission(p, provName) {
+			continue
+		}
+		prov, ok := h.provider(ctx, provName)
+		if !ok {
+			continue
+		}
+		live := appFilter != "" || queryMentionsProvider(query, provName, prov)
+		cat, liveErr := h.catalogForSearch(ctx, provName, prov, live)
+		if liveErr != nil {
+			unavailable = append(unavailable, searchUnavailable{App: provName, Error: liveErr.Error()})
+			continue
+		}
+		if cat == nil {
+			continue
+		}
+		appMatched := query == "" || searchTextMatches(query, provName, prov.DisplayName(), prov.Description(), cat.DisplayName, cat.Description)
+		for i := range cat.Operations {
+			op := cat.Operations[i]
+			if !catalog.OperationVisibleByDefault(op) || !catalogOperationProjectedToMCP(h.cfg, provName, op) {
+				continue
+			}
+			if !appMatched && !searchTextMatches(query, op.ID, op.Title, op.Description) {
+				continue
+			}
+			candidates = append(candidates, searchCandidate{
+				hit: searchHit{
+					App:         provName,
+					Operation:   op.ID,
+					Title:       operationTitle(op),
+					Description: op.Description,
+					MCPName:     toolName(h.cfg.ToolPrefixes, provName, op.ID),
+				},
+				query: invocation.OperationAccessQuery{
+					Provider:     provName,
+					Operation:    op.ID,
+					AllowedRoles: op.AllowedRoles,
+				},
+			})
+			if len(candidates) >= maxSearchCandidates {
+				break
+			}
+		}
+		if len(candidates) >= maxSearchCandidates {
+			break
+		}
+	}
+
+	allowed, err := h.filterSearchHits(ctx, p, candidates)
+	if err != nil {
+		return mcpgo.NewToolResultError(err.Error()), nil
+	}
+	if len(allowed) > limit {
+		allowed = allowed[:limit]
+	}
+	return toolJSONResult(searchResult{Results: allowed, Unavailable: unavailable}), nil
+}
+
+func (h *StatelessHTTPHandler) filterSearchHits(ctx context.Context, p *principal.Principal, candidates []searchCandidate) ([]searchHit, error) {
+	if len(candidates) == 0 {
+		return []searchHit{}, nil
+	}
+	if h.cfg.OperationAccess == nil {
+		hits := make([]searchHit, len(candidates))
+		for i := range candidates {
+			hits[i] = candidates[i].hit
+		}
+		return hits, nil
+	}
+	queries := make([]invocation.OperationAccessQuery, len(candidates))
+	for i := range candidates {
+		queries[i] = candidates[i].query
+	}
+	results, err := h.cfg.OperationAccess.CheckOperationAccessMany(ctx, p, queries)
+	if err != nil {
+		return nil, fmt.Errorf("search authorization is unavailable: %w", err)
+	}
+	if len(results) != len(candidates) {
+		return nil, fmt.Errorf("search authorization returned %d decisions for %d operations", len(results), len(candidates))
+	}
+	hits := make([]searchHit, 0, len(candidates))
+	for i := range candidates {
+		if results[i] == nil {
+			hits = append(hits, candidates[i].hit)
+		}
+	}
+	return hits, nil
+}
+
+func (h *StatelessHTTPHandler) catalogForSearch(ctx context.Context, provName string, prov core.Provider, live bool) (*catalog.Catalog, error) {
+	if live {
+		liveCtx, cancel := context.WithTimeout(ctx, liveSearchTimeout)
+		defer cancel()
+		raw, err := h.resolveCatalog(liveCtx, provName, prov, "", false)
+		if err == nil {
+			return projectCatalog(h.cfg, provName, prov, raw), nil
+		}
+		if static := projectCatalog(h.cfg, provName, prov, prov.Catalog()); static != nil {
+			return static, nil
+		}
+		return nil, err
+	}
+	return projectCatalog(h.cfg, provName, prov, prov.Catalog()), nil
+}
+
+func (h *StatelessHTTPHandler) callDescribe(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+	p := principal.FromContext(ctx)
+	if p == nil {
+		return mcpgo.NewToolResultError("not authenticated"), nil
+	}
+	args := req.GetArguments()
+	app := stringArg(args, "app")
+	operation := stringArg(args, "operation")
+	if app == "" || operation == "" {
+		return mcpgo.NewToolResultError("app and operation are required"), nil
+	}
+	if !principal.AllowsProviderPermission(p, app) {
+		return mcpgo.NewToolResultError("operation access denied"), nil
+	}
+	prov, ok := h.provider(ctx, app)
+	if !ok {
+		return mcpgo.NewToolResultError(fmt.Sprintf("app %q is not available", app)), nil
+	}
+	rawCat, err := h.resolveCatalog(ctx, app, prov, normalizedSessionCatalogInstance(args["_instance"]), true)
+	if err != nil {
+		return mcpgo.NewToolResultError(err.Error()), nil
+	}
+	cat := projectCatalog(h.cfg, app, prov, rawCat)
+	op, found := invocation.CatalogOperation(cat, operation)
+	if !found || !catalogOperationProjectedToMCP(h.cfg, app, op) {
+		return mcpgo.NewToolResultError(fmt.Sprintf("operation %q is not available on app %q", operation, app)), nil
+	}
+	if h.cfg.OperationAccess != nil {
+		results, err := h.cfg.OperationAccess.CheckOperationAccessMany(ctx, p, []invocation.OperationAccessQuery{{
+			Provider:     app,
+			Operation:    operation,
+			AllowedRoles: op.AllowedRoles,
+		}})
+		if err != nil {
+			return mcpgo.NewToolResultError("operation access is unavailable: " + err.Error()), nil
+		}
+		if len(results) != 1 || results[0] != nil {
+			return mcpgo.NewToolResultError("operation access denied"), nil
+		}
+	}
+	return toolJSONResult(describeResult{
+		App:          app,
+		Operation:    operation,
+		Title:        operationTitle(op),
+		Description:  op.Description,
+		MCPName:      toolName(h.cfg.ToolPrefixes, app, operation),
+		InputSchema:  op.InputSchema,
+		OutputSchema: op.OutputSchema,
+	}), nil
+}
+
+func (h *StatelessHTTPHandler) callInvoke(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+	args := req.GetArguments()
+	app := stringArg(args, "app")
+	operation := stringArg(args, "operation")
+	if app == "" || operation == "" {
+		return mcpgo.NewToolResultError("app and operation are required"), nil
+	}
+	nested := map[string]any{}
+	if raw, ok := args["arguments"].(map[string]any); ok {
+		for key, value := range raw {
+			nested[key] = value
+		}
+	}
+	if inst, ok := args["_instance"]; ok {
+		nested["_instance"] = inst
+	}
+	inner := req
+	inner.Params.Name = toolName(h.cfg.ToolPrefixes, app, operation)
+	inner.Params.Arguments = nested
+	return h.callAppTool(ctx, inner)
+}
+
+func operationTitle(op catalog.CatalogOperation) string {
+	if strings.TrimSpace(op.Title) != "" {
+		return op.Title
+	}
+	return op.ID
+}
+
+func queryMentionsProvider(query, provName string, prov core.Provider) bool {
+	q := strings.ToLower(strings.TrimSpace(query))
+	if q == "" {
+		return false
+	}
+	names := []string{provName}
+	if prov != nil {
+		names = append(names, prov.DisplayName(), prov.Name())
+	}
+	for _, name := range names {
+		name = strings.ToLower(strings.TrimSpace(name))
+		if name != "" && strings.Contains(q, name) {
+			return true
+		}
+	}
+	return false
+}
+
+func searchTextMatches(query string, parts ...string) bool {
+	q := strings.ToLower(strings.TrimSpace(query))
+	if q == "" {
+		return true
+	}
+	for _, part := range parts {
+		if strings.Contains(strings.ToLower(part), q) {
+			return true
+		}
+	}
+	return false
+}
+
+func stringArg(args map[string]any, key string) string {
+	if args == nil {
+		return ""
+	}
+	raw, ok := args[key]
+	if !ok || raw == nil {
+		return ""
+	}
+	if value, ok := raw.(string); ok {
+		return strings.TrimSpace(value)
+	}
+	return strings.TrimSpace(fmt.Sprint(raw))
+}
+
+func intArg(args map[string]any, key string, fallback int) int {
+	if args == nil {
+		return fallback
+	}
+	switch value := args[key].(type) {
+	case nil:
+		return fallback
+	case int:
+		return value
+	case int32:
+		return int(value)
+	case int64:
+		return int(value)
+	case float64:
+		return int(value)
+	case json.Number:
+		n, err := value.Int64()
+		if err != nil {
+			return fallback
+		}
+		return int(n)
+	case string:
+		n, err := strconv.Atoi(strings.TrimSpace(value))
+		if err != nil {
+			return fallback
+		}
+		return n
+	default:
+		return fallback
+	}
+}
+
+func toolJSONResult(v any) *mcpgo.CallToolResult {
+	raw, err := json.Marshal(v)
+	if err != nil {
+		return mcpgo.NewToolResultError(err.Error())
+	}
+	return mcpgo.NewToolResultText(string(raw))
+}

--- a/gestaltd/services/apps/mcp/front_door.go
+++ b/gestaltd/services/apps/mcp/front_door.go
@@ -91,10 +91,11 @@ func workspaceFrontDoorTools() []mcpgo.Tool {
 }
 
 type SearchHit struct {
-	App         string `json:"app"`
-	Operation   string `json:"operation"`
-	Title       string `json:"title,omitempty"`
-	Description string `json:"description,omitempty"`
+	App             string `json:"app"`
+	Operation       string `json:"operation"`
+	CatalogInstance string `json:"_instance,omitempty"`
+	Title           string `json:"title,omitempty"`
+	Description     string `json:"description,omitempty"`
 }
 
 type SearchUnavailable struct {
@@ -115,12 +116,13 @@ type searchCandidate struct {
 }
 
 type describeResult struct {
-	App          string          `json:"app"`
-	Operation    string          `json:"operation"`
-	Title        string          `json:"title,omitempty"`
-	Description  string          `json:"description,omitempty"`
-	InputSchema  json.RawMessage `json:"inputSchema,omitempty"`
-	OutputSchema json.RawMessage `json:"outputSchema,omitempty"`
+	App             string          `json:"app"`
+	Operation       string          `json:"operation"`
+	CatalogInstance string          `json:"_instance,omitempty"`
+	Title           string          `json:"title,omitempty"`
+	Description     string          `json:"description,omitempty"`
+	InputSchema     json.RawMessage `json:"inputSchema,omitempty"`
+	OutputSchema    json.RawMessage `json:"outputSchema,omitempty"`
 }
 
 func (h *StatelessHTTPHandler) callSearch(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
@@ -181,10 +183,11 @@ func (h *StatelessHTTPHandler) callSearch(ctx context.Context, req mcpgo.CallToo
 			}
 			candidates = append(candidates, searchCandidate{
 				hit: SearchHit{
-					App:         provName,
-					Operation:   op.ID,
-					Title:       operationTitle(op),
-					Description: op.Description,
+					App:             provName,
+					Operation:       op.ID,
+					CatalogInstance: instance,
+					Title:           operationTitle(op),
+					Description:     op.Description,
 				},
 				query: invocation.OperationAccessQuery{
 					Provider:     provName,
@@ -296,7 +299,8 @@ func (h *StatelessHTTPHandler) callDescribe(ctx context.Context, req mcpgo.CallT
 	if !ok {
 		return mcpgo.NewToolResultError(fmt.Sprintf("app %q is not available", app)), nil
 	}
-	rawCat, err := h.resolveCatalog(ctx, app, prov, normalizedSessionCatalogInstance(args["_instance"]), true)
+	instance := normalizedSessionCatalogInstance(args["_instance"])
+	rawCat, err := h.resolveCatalog(ctx, app, prov, instance, true)
 	if err != nil {
 		return mcpgo.NewToolResultError(err.Error()), nil
 	}
@@ -317,12 +321,13 @@ func (h *StatelessHTTPHandler) callDescribe(ctx context.Context, req mcpgo.CallT
 		return mcpgo.NewToolResultError("operation access denied"), nil
 	}
 	return toolJSONResult(describeResult{
-		App:          app,
-		Operation:    operation,
-		Title:        operationTitle(op),
-		Description:  op.Description,
-		InputSchema:  op.InputSchema,
-		OutputSchema: op.OutputSchema,
+		App:             app,
+		Operation:       operation,
+		CatalogInstance: instance,
+		Title:           operationTitle(op),
+		Description:     op.Description,
+		InputSchema:     op.InputSchema,
+		OutputSchema:    op.OutputSchema,
 	}), nil
 }
 

--- a/gestaltd/services/apps/mcp/front_door.go
+++ b/gestaltd/services/apps/mcp/front_door.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -26,10 +27,9 @@ const (
 )
 
 const (
-	defaultSearchLimit  = 20
-	maxSearchLimit      = 100
-	maxSearchCandidates = 1000
-	liveSearchTimeout   = 8 * time.Second
+	defaultSearchLimit = 20
+	maxSearchLimit     = 100
+	liveSearchTimeout  = 8 * time.Second
 )
 
 var (
@@ -42,7 +42,7 @@ var (
     },
     "app": {
       "type": "string",
-      "description": "If set, search only this app and include its live catalog."
+      "description": "If set, search only this app and load its current catalog. If omitted, search uses each app's static catalog."
     },
     "limit": {
       "type": "integer",
@@ -65,16 +65,20 @@ var (
     "app": {"type": "string", "description": "App name, for example linear."},
     "operation": {"type": "string", "description": "Operation id, for example search_issues."},
     "arguments": {"type": "object", "description": "Arguments for the operation."},
-    "_instance": {"type": "string", "description": "Optional catalog instance."}
+    "_instance": {"type": "string", "description": "Optional. Use when the app exposes more than one catalog instance."}
   }
 }`)
 )
+
+func WorkspaceFrontDoorToolNames() []string {
+	return []string{DescribeToolName, InvokeToolName, SearchToolName}
+}
 
 func workspaceFrontDoorTools() []mcpgo.Tool {
 	return []mcpgo.Tool{
 		mcpgo.NewToolWithRawSchema(DescribeToolName, "Return one workspace operation's schema. Use this before gestalt_invoke when you need argument names.", describeToolSchema),
 		mcpgo.NewToolWithRawSchema(InvokeToolName, "Invoke a workspace app operation. Pass app, operation, and arguments. Authorization is enforced on this call.", invokeToolSchema),
-		mcpgo.NewToolWithRawSchema(SearchToolName, "Search workspace apps and operations the caller may use. Pass query and optionally app. Then call gestalt_describe or gestalt_invoke.", searchToolSchema),
+		mcpgo.NewToolWithRawSchema(SearchToolName, "Search workspace apps and operations the caller may use. Pass query, app, or both. Then call gestalt_describe or gestalt_invoke.", searchToolSchema),
 	}
 }
 
@@ -94,6 +98,7 @@ type searchUnavailable struct {
 type searchResult struct {
 	Results     []searchHit         `json:"results"`
 	Unavailable []searchUnavailable `json:"unavailable,omitempty"`
+	Hint        string              `json:"hint,omitempty"`
 }
 
 type searchCandidate struct {
@@ -127,7 +132,10 @@ func (h *StatelessHTTPHandler) callSearch(ctx context.Context, req mcpgo.CallToo
 		limit = maxSearchLimit
 	}
 	if query == "" && appFilter == "" {
-		return toolJSONResult(searchResult{Results: []searchHit{}}), nil
+		return toolJSONResult(searchResult{
+			Results: []searchHit{},
+			Hint:    "Pass query or app to search workspace operations.",
+		}), nil
 	}
 
 	candidates := make([]searchCandidate, 0)
@@ -143,8 +151,7 @@ func (h *StatelessHTTPHandler) callSearch(ctx context.Context, req mcpgo.CallToo
 		if !ok {
 			continue
 		}
-		live := appFilter != "" || queryMentionsProvider(query, provName, prov)
-		cat, liveErr := h.catalogForSearch(ctx, provName, prov, live)
+		cat, liveErr := h.catalogForSearch(ctx, provName, prov, appFilter != "")
 		if liveErr != nil {
 			unavailable = append(unavailable, searchUnavailable{App: provName, Error: liveErr.Error()})
 			continue
@@ -175,12 +182,6 @@ func (h *StatelessHTTPHandler) callSearch(ctx context.Context, req mcpgo.CallToo
 					AllowedRoles: op.AllowedRoles,
 				},
 			})
-			if len(candidates) >= maxSearchCandidates {
-				break
-			}
-		}
-		if len(candidates) >= maxSearchCandidates {
-			break
 		}
 	}
 
@@ -188,6 +189,12 @@ func (h *StatelessHTTPHandler) callSearch(ctx context.Context, req mcpgo.CallToo
 	if err != nil {
 		return mcpgo.NewToolResultError(err.Error()), nil
 	}
+	sort.Slice(allowed, func(i, j int) bool {
+		if allowed[i].App != allowed[j].App {
+			return allowed[i].App < allowed[j].App
+		}
+		return allowed[i].Operation < allowed[j].Operation
+	})
 	if len(allowed) > limit {
 		allowed = allowed[:limit]
 	}
@@ -211,10 +218,10 @@ func (h *StatelessHTTPHandler) filterSearchHits(ctx context.Context, p *principa
 	}
 	results, err := h.cfg.OperationAccess.CheckOperationAccessMany(ctx, p, queries)
 	if err != nil {
-		return nil, fmt.Errorf("search authorization is unavailable: %w", err)
+		return nil, fmt.Errorf("operation access is unavailable: %w", err)
 	}
 	if len(results) != len(candidates) {
-		return nil, fmt.Errorf("search authorization returned %d decisions for %d operations", len(results), len(candidates))
+		return nil, fmt.Errorf("operation access returned %d decisions for %d operations", len(results), len(candidates))
 	}
 	hits := make([]searchHit, 0, len(candidates))
 	for i := range candidates {
@@ -226,19 +233,16 @@ func (h *StatelessHTTPHandler) filterSearchHits(ctx context.Context, p *principa
 }
 
 func (h *StatelessHTTPHandler) catalogForSearch(ctx context.Context, provName string, prov core.Provider, live bool) (*catalog.Catalog, error) {
-	if live {
-		liveCtx, cancel := context.WithTimeout(ctx, liveSearchTimeout)
-		defer cancel()
-		raw, err := h.resolveCatalog(liveCtx, provName, prov, "", false)
-		if err == nil {
-			return projectCatalog(h.cfg, provName, prov, raw), nil
-		}
-		if static := projectCatalog(h.cfg, provName, prov, prov.Catalog()); static != nil {
-			return static, nil
-		}
+	if !live {
+		return projectCatalog(h.cfg, provName, prov, prov.Catalog()), nil
+	}
+	liveCtx, cancel := context.WithTimeout(ctx, liveSearchTimeout)
+	defer cancel()
+	raw, err := h.resolveCatalog(liveCtx, provName, prov, "", true)
+	if err != nil {
 		return nil, err
 	}
-	return projectCatalog(h.cfg, provName, prov, prov.Catalog()), nil
+	return projectCatalog(h.cfg, provName, prov, raw), nil
 }
 
 func (h *StatelessHTTPHandler) callDescribe(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
@@ -319,24 +323,6 @@ func operationTitle(op catalog.CatalogOperation) string {
 		return op.Title
 	}
 	return op.ID
-}
-
-func queryMentionsProvider(query, provName string, prov core.Provider) bool {
-	q := strings.ToLower(strings.TrimSpace(query))
-	if q == "" {
-		return false
-	}
-	names := []string{provName}
-	if prov != nil {
-		names = append(names, prov.DisplayName(), prov.Name())
-	}
-	for _, name := range names {
-		name = strings.ToLower(strings.TrimSpace(name))
-		if name != "" && strings.Contains(q, name) {
-			return true
-		}
-	}
-	return false
 }
 
 func searchTextMatches(query string, parts ...string) bool {

--- a/gestaltd/services/apps/mcp/front_door.go
+++ b/gestaltd/services/apps/mcp/front_door.go
@@ -348,9 +348,8 @@ func (h *StatelessHTTPHandler) callInvoke(ctx context.Context, req mcpgo.CallToo
 		nested["_instance"] = inst
 	}
 	inner := req
-	inner.Params.Name = toolName(h.cfg.ToolPrefixes, app, operation)
 	inner.Params.Arguments = nested
-	return h.callAppTool(ctx, inner)
+	return h.callResolvedAppTool(ctx, inner, statelessToolRef{provider: app, operation: operation})
 }
 
 func operationTitle(op catalog.CatalogOperation) string {

--- a/gestaltd/services/apps/mcp/front_door.go
+++ b/gestaltd/services/apps/mcp/front_door.go
@@ -28,7 +28,7 @@ const (
 
 // workspaceFrontDoorInstructions is returned on initialize so hosts do not
 // treat the three handshake tools as an inventory of app operations.
-const workspaceFrontDoorInstructions = "tools/list is the connect handshake: gestalt_search, gestalt_describe, and gestalt_invoke. Search to find operations you may use, describe for one operation's schema, then invoke with app, operation, and arguments. App operations are not listed."
+const workspaceFrontDoorInstructions = "tools/list is the connect handshake: gestalt_search, gestalt_describe, and gestalt_invoke. Search to find operations you may use, describe for one operation's schema, then invoke with app, operation, and arguments. App operations are not listed; these three names are reserved for the workspace front door."
 
 const (
 	defaultSearchLimit = 20

--- a/gestaltd/services/apps/mcp/projection.go
+++ b/gestaltd/services/apps/mcp/projection.go
@@ -44,7 +44,7 @@ func providerNameForTool(prefixes map[string]string, providers []string, tool st
 
 func toolName(prefixes map[string]string, provider, operation string) string {
 	raw := prefixes[provider] + provider + toolNameSep + operation
-	return strings.Map(func(r rune) rune {
+	name := strings.Map(func(r rune) rune {
 		switch {
 		case r >= 'a' && r <= 'z':
 			return r
@@ -58,4 +58,17 @@ func toolName(prefixes map[string]string, provider, operation string) string {
 			return '_'
 		}
 	}, raw)
+	if isWorkspaceFrontDoorToolName(name) {
+		return name + "_app"
+	}
+	return name
+}
+
+func isWorkspaceFrontDoorToolName(name string) bool {
+	switch name {
+	case SearchToolName, DescribeToolName, InvokeToolName:
+		return true
+	default:
+		return false
+	}
 }

--- a/gestaltd/services/apps/mcp/projection.go
+++ b/gestaltd/services/apps/mcp/projection.go
@@ -5,8 +5,6 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
-
-	mcpgo "github.com/mark3labs/mcp-go/mcp"
 )
 
 func projectCatalog(cfg Config, provName string, prov core.Provider, cat *catalog.Catalog) *catalog.Catalog {
@@ -60,13 +58,4 @@ func toolName(prefixes map[string]string, provider, operation string) string {
 			return '_'
 		}
 	}, raw)
-}
-
-func mapAnnotations(a catalog.CapabilityAnnotations) mcpgo.ToolAnnotation {
-	return mcpgo.ToolAnnotation{
-		ReadOnlyHint:    a.ReadOnlyHint,
-		DestructiveHint: a.DestructiveHint,
-		IdempotentHint:  a.IdempotentHint,
-		OpenWorldHint:   a.OpenWorldHint,
-	}
 }

--- a/gestaltd/services/apps/mcp/projection.go
+++ b/gestaltd/services/apps/mcp/projection.go
@@ -58,9 +58,6 @@ func toolName(prefixes map[string]string, provider, operation string) string {
 			return '_'
 		}
 	}, raw)
-	if isWorkspaceFrontDoorToolName(name) {
-		return name + "_app"
-	}
 	return name
 }
 

--- a/gestaltd/services/apps/mcp/stateless_http.go
+++ b/gestaltd/services/apps/mcp/stateless_http.go
@@ -202,6 +202,15 @@ func (h *StatelessHTTPHandler) callAppTool(ctx context.Context, req mcpgo.CallTo
 	if provName == "" {
 		return nil, fmt.Errorf("%w: %q", invocation.ErrOperationNotFound, req.Params.Name)
 	}
+	return h.callResolvedAppTool(ctx, req, statelessToolRef{provider: provName})
+}
+
+func (h *StatelessHTTPHandler) callResolvedAppTool(ctx context.Context, req mcpgo.CallToolRequest, ref statelessToolRef) (*mcpgo.CallToolResult, error) {
+	p := principal.FromContext(ctx)
+	if p == nil {
+		return mcpgo.NewToolResultError("not authenticated"), nil
+	}
+	provName := ref.provider
 	prov, ok := h.provider(ctx, provName)
 	if !ok {
 		return nil, fmt.Errorf("%w: %q", core.ErrNotFound, provName)
@@ -222,9 +231,12 @@ func (h *StatelessHTTPHandler) callAppTool(ctx context.Context, req mcpgo.CallTo
 		return mcpgo.NewToolResultError(err.Error()), nil
 	}
 	projectedCat := projectCatalog(h.cfg, provName, prov, rawCat)
-	ref, ok := statelessToolRefs(h.cfg, provName, projectedCat)[req.Params.Name]
-	if !ok || ref.provider != provName {
-		return nil, fmt.Errorf("%w: %q", invocation.ErrOperationNotFound, req.Params.Name)
+	if ref.operation == "" {
+		var found bool
+		ref, found = statelessToolRefs(h.cfg, provName, projectedCat)[req.Params.Name]
+		if !found || ref.provider != provName {
+			return nil, fmt.Errorf("%w: %q", invocation.ErrOperationNotFound, req.Params.Name)
+		}
 	}
 	rawOp, ok := invocation.CatalogOperation(rawCat, ref.operation)
 	if !ok {

--- a/gestaltd/services/apps/mcp/stateless_http.go
+++ b/gestaltd/services/apps/mcp/stateless_http.go
@@ -168,97 +168,31 @@ func (h *StatelessHTTPHandler) handleMessage(ctx context.Context, headers http.H
 	}
 }
 
-// listedTool is one tools/list candidate and the operation it maps to, so the
-// authorization question asked about it is the same question tools/call asks.
-type listedTool struct {
-	tool  mcpgo.Tool
-	query invocation.OperationAccessQuery
-}
-
-// listTools answers tools/list. A tool is listed only when the caller's token
-// scope permits the app AND the authorization evaluator allows the underlying
-// operation - scope and authorization, not scope or authorization.
-//
-// The authorization answers come from one batched call through the same
-// decision path tools/call uses, so a listed tool is a callable tool. When the
-// evaluator cannot be reached the request fails with an error rather than
-// returning a short or empty tool list, because an empty tools/list is
-// indistinguishable from "you have no tools". tools/call enforcement is
-// unchanged and remains the authority.
-func (h *StatelessHTTPHandler) listTools(ctx context.Context, req mcpgo.ListToolsRequest) (mcpgo.ListToolsResult, error) {
+// listTools answers the MCP handshake. Hosts mark the server connected only
+// after this returns, so it never walks app catalogs or asks the evaluator.
+// Workspace operations are found through gestalt_search / gestalt_describe
+// and authorized on gestalt_invoke (and on leftover flattened tool names).
+func (h *StatelessHTTPHandler) listTools(_ context.Context, req mcpgo.ListToolsRequest) (mcpgo.ListToolsResult, error) {
 	if strings.TrimSpace(string(req.Params.Cursor)) != "" {
 		return mcpgo.ListToolsResult{}, fmt.Errorf("tools/list cursor is not supported")
 	}
-	p := principal.FromContext(ctx)
-	candidates := make([]listedTool, 0)
-	for _, provName := range h.providerNames {
-		if p != nil && !principal.AllowsProviderPermission(p, provName) {
-			continue
-		}
-		prov, ok := h.provider(ctx, provName)
-		if !ok {
-			continue
-		}
-		rawCat, err := h.resolveCatalog(ctx, provName, prov, "", true)
-		if err != nil {
-			continue
-		}
-		cat := projectCatalog(h.cfg, provName, prov, rawCat)
-		if cat == nil {
-			continue
-		}
-		toolMap, refs := statelessToolMap(h.cfg, provName, cat)
-		names := make([]string, 0, len(toolMap))
-		for name := range toolMap {
-			names = append(names, name)
-		}
-		sort.Strings(names)
-		for _, name := range names {
-			operation := refs[name].operation
-			var allowedRoles []string
-			if op, found := invocation.CatalogOperation(cat, operation); found {
-				allowedRoles = op.AllowedRoles
-			}
-			candidates = append(candidates, listedTool{
-				tool: toolMap[name],
-				query: invocation.OperationAccessQuery{
-					Provider:     provName,
-					Operation:    operation,
-					AllowedRoles: allowedRoles,
-				},
-			})
-		}
-	}
-
-	if h.cfg.OperationAccess == nil || len(candidates) == 0 {
-		tools := make([]mcpgo.Tool, 0, len(candidates))
-		for i := range candidates {
-			tools = append(tools, candidates[i].tool)
-		}
-		return mcpgo.ListToolsResult{Tools: tools}, nil
-	}
-
-	queries := make([]invocation.OperationAccessQuery, len(candidates))
-	for i := range candidates {
-		queries[i] = candidates[i].query
-	}
-	results, err := h.cfg.OperationAccess.CheckOperationAccessMany(ctx, p, queries)
-	if err != nil {
-		return mcpgo.ListToolsResult{}, fmt.Errorf("tools/list authorization is unavailable: %w", err)
-	}
-	if len(results) != len(candidates) {
-		return mcpgo.ListToolsResult{}, fmt.Errorf("tools/list authorization returned %d decisions for %d tools", len(results), len(candidates))
-	}
-	tools := make([]mcpgo.Tool, 0, len(candidates))
-	for i := range candidates {
-		if results[i] == nil {
-			tools = append(tools, candidates[i].tool)
-		}
-	}
-	return mcpgo.ListToolsResult{Tools: tools}, nil
+	return mcpgo.ListToolsResult{Tools: workspaceFrontDoorTools()}, nil
 }
 
 func (h *StatelessHTTPHandler) callTool(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+	switch strings.TrimSpace(req.Params.Name) {
+	case SearchToolName:
+		return h.callSearch(ctx, req)
+	case DescribeToolName:
+		return h.callDescribe(ctx, req)
+	case InvokeToolName:
+		return h.callInvoke(ctx, req)
+	default:
+		return h.callAppTool(ctx, req)
+	}
+}
+
+func (h *StatelessHTTPHandler) callAppTool(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 	p := principal.FromContext(ctx)
 	if p == nil {
 		return mcpgo.NewToolResultError("not authenticated"), nil

--- a/gestaltd/services/apps/mcp/stateless_http.go
+++ b/gestaltd/services/apps/mcp/stateless_http.go
@@ -135,6 +135,7 @@ func (h *StatelessHTTPHandler) handleMessage(ctx context.Context, headers http.H
 					ListChanged bool `json:"listChanged,omitempty"`
 				}{},
 			},
+			Instructions: workspaceFrontDoorInstructions,
 		}), false, nil
 	case string(mcpgo.MethodPing):
 		return rpcResponse(base.id(), mcpgo.EmptyResult{}), false, nil

--- a/gestaltd/services/apps/mcp/stateless_http.go
+++ b/gestaltd/services/apps/mcp/stateless_http.go
@@ -221,11 +221,7 @@ func (h *StatelessHTTPHandler) callAppTool(ctx context.Context, req mcpgo.CallTo
 		return mcpgo.NewToolResultError(err.Error()), nil
 	}
 	projectedCat := projectCatalog(h.cfg, provName, prov, rawCat)
-	projectedTools, projectedRefs := statelessToolMap(h.cfg, provName, projectedCat)
-	if _, ok := projectedTools[req.Params.Name]; !ok {
-		return nil, fmt.Errorf("%w: %q", invocation.ErrOperationNotFound, req.Params.Name)
-	}
-	ref, ok := projectedRefs[req.Params.Name]
+	ref, ok := statelessToolRefs(h.cfg, provName, projectedCat)[req.Params.Name]
 	if !ok || ref.provider != provName {
 		return nil, fmt.Errorf("%w: %q", invocation.ErrOperationNotFound, req.Params.Name)
 	}
@@ -269,41 +265,20 @@ func (h *StatelessHTTPHandler) callAppTool(ctx context.Context, req mcpgo.CallTo
 	return operationResultToMCP(result), nil
 }
 
-func statelessToolMap(cfg Config, provName string, cat *catalog.Catalog) (map[string]mcpgo.Tool, map[string]statelessToolRef) {
+func statelessToolRefs(cfg Config, provName string, cat *catalog.Catalog) map[string]statelessToolRef {
 	if cat == nil {
-		return map[string]mcpgo.Tool{}, map[string]statelessToolRef{}
+		return map[string]statelessToolRef{}
 	}
-	tools := make(map[string]mcpgo.Tool, len(cat.Operations))
 	refs := make(map[string]statelessToolRef, len(cat.Operations))
 	for i := range cat.Operations {
-		op := &cat.Operations[i]
-		if !catalogOperationProjectedToMCP(cfg, provName, *op) {
+		op := cat.Operations[i]
+		if !catalogOperationProjectedToMCP(cfg, provName, op) {
 			continue
 		}
-
 		name := toolName(cfg.ToolPrefixes, provName, op.ID)
-		var tool mcpgo.Tool
-		if len(op.InputSchema) > 0 {
-			tool = mcpgo.NewToolWithRawSchema(name, op.Description, op.InputSchema)
-		} else {
-			tool = mcpgo.NewTool(name, mcpgo.WithDescription(op.Description))
-		}
-
-		tool.Annotations = mapAnnotations(op.Annotations)
-		if op.Title != "" {
-			tool.Annotations.Title = op.Title
-		} else {
-			tool.Annotations.Title = op.ID
-		}
-
-		if len(op.OutputSchema) > 0 {
-			tool.RawOutputSchema = op.OutputSchema
-		}
-
-		tools[name] = tool
 		refs[name] = statelessToolRef{provider: provName, operation: op.ID}
 	}
-	return tools, refs
+	return refs
 }
 
 func (h *StatelessHTTPHandler) provider(ctx context.Context, provName string) (core.Provider, bool) {

--- a/gestaltd/services/apps/mcp/stateless_http.go
+++ b/gestaltd/services/apps/mcp/stateless_http.go
@@ -211,6 +211,9 @@ func (h *StatelessHTTPHandler) callResolvedAppTool(ctx context.Context, req mcpg
 		return mcpgo.NewToolResultError("not authenticated"), nil
 	}
 	provName := ref.provider
+	if !principal.AllowsProviderPermission(p, provName) {
+		return mcpgo.NewToolResultError("operation access denied"), nil
+	}
 	prov, ok := h.provider(ctx, provName)
 	if !ok {
 		return nil, fmt.Errorf("%w: %q", core.ErrNotFound, provName)

--- a/gestaltd/services/apps/mcp/stateless_http.go
+++ b/gestaltd/services/apps/mcp/stateless_http.go
@@ -292,6 +292,9 @@ func statelessToolRefs(cfg Config, provName string, cat *catalog.Catalog) map[st
 			continue
 		}
 		name := toolName(cfg.ToolPrefixes, provName, op.ID)
+		if isWorkspaceFrontDoorToolName(name) {
+			continue
+		}
 		refs[name] = statelessToolRef{provider: provName, operation: op.ID}
 	}
 	return refs

--- a/gestaltd/services/apps/mcp/stateless_http_listing_test.go
+++ b/gestaltd/services/apps/mcp/stateless_http_listing_test.go
@@ -93,6 +93,17 @@ func (i *listingInvoker) Invoke(ctx context.Context, _ *principal.Principal, _, 
 	return i.stub.Execute(ctx, operation, params, "")
 }
 
+type recordingProviderInvoker struct {
+	provider  string
+	operation string
+}
+
+func (i *recordingProviderInvoker) Invoke(_ context.Context, _ *principal.Principal, provider, _, operation string, _ map[string]any) (*core.OperationResult, error) {
+	i.provider = provider
+	i.operation = operation
+	return &core.OperationResult{Status: http.StatusOK, Body: []byte(`{}`)}, nil
+}
+
 func listingTestPrincipal() *principal.Principal {
 	return &principal.Principal{SubjectID: "user:u-1", UserID: "u-1", Kind: principal.KindUser}
 }
@@ -464,6 +475,40 @@ func TestInvokeFrontDoorRunsGrantedOperation(t *testing.T) {
 	})
 	if body["op"] != "items.list" {
 		t.Fatalf("invoke result = %v", body)
+	}
+}
+
+func TestInvokeFrontDoorUsesExplicitAppIdentity(t *testing.T) {
+	t.Parallel()
+
+	foo := &coretesting.StubIntegration{
+		N:        "foo",
+		ConnMode: core.ConnectionModeNone,
+		CatalogVal: &catalog.Catalog{Operations: []catalog.CatalogOperation{{
+			ID: "bar.items", Method: "GET", Path: "/bar-items",
+		}}},
+	}
+	fooBar := &coretesting.StubIntegration{
+		N:        "foo_bar",
+		ConnMode: core.ConnectionModeNone,
+		CatalogVal: &catalog.Catalog{Operations: []catalog.CatalogOperation{{
+			ID: "items", Method: "GET", Path: "/items",
+		}}},
+	}
+	invoker := &recordingProviderInvoker{}
+	cfg := Config{
+		Invoker:          invoker,
+		Providers:        testutil.NewProviderRegistry(t, foo, fooBar),
+		AllowedProviders: []string{"foo", "foo_bar"},
+		IncludeREST:      map[string]bool{"foo": true, "foo_bar": true},
+	}
+
+	callToolJSON(t, cfg, listingTestPrincipal(), InvokeToolName, map[string]any{
+		"app":       "foo",
+		"operation": "bar.items",
+	})
+	if invoker.provider != "foo" || invoker.operation != "bar.items" {
+		t.Fatalf("invoke target = %s.%s, want foo.bar.items", invoker.provider, invoker.operation)
 	}
 }
 

--- a/gestaltd/services/apps/mcp/stateless_http_listing_test.go
+++ b/gestaltd/services/apps/mcp/stateless_http_listing_test.go
@@ -17,9 +17,6 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 )
 
-// recordingOperationAccess allows a named set of operations and counts the
-// batched calls, so a test can prove tools/list asks once for every tool rather
-// than once per tool.
 type recordingOperationAccess struct {
 	allowed map[string]bool
 	err     error
@@ -37,27 +34,40 @@ func (r *recordingOperationAccess) CheckOperationAccessMany(
 	}
 	results := make([]error, len(queries))
 	for i, query := range queries {
-		if !r.allowed[query.Operation] {
+		if !r.allowed[query.Provider+"."+query.Operation] && !r.allowed[query.Operation] {
 			results[i] = errors.New("denied")
 		}
 	}
 	return results, nil
 }
 
+type panicCatalogProvider struct {
+	coretesting.StubIntegration
+}
+
+func (p *panicCatalogProvider) Catalog() *catalog.Catalog {
+	panic("catalog must not be read during tools/list")
+}
+
 func listingTestConfig(t *testing.T, access invocation.OperationAccessChecker) Config {
 	t.Helper()
 	stub := &coretesting.StubIntegration{
 		N:        "sampleApp",
+		DN:       "Sample App",
 		ConnMode: core.ConnectionModeNone,
 		CatalogVal: &catalog.Catalog{
 			Name: "sampleApp",
 			Operations: []catalog.CatalogOperation{
-				{ID: "items.list", Method: "GET", Path: "/items"},
-				{ID: "items.create", Method: "POST", Path: "/items"},
+				{ID: "items.list", Title: "List items", Description: "List items", Method: "GET", Path: "/items"},
+				{ID: "items.create", Title: "Create item", Description: "Create an item", Method: "POST", Path: "/items"},
 			},
+		},
+		ExecuteFn: func(_ context.Context, op string, _ map[string]any, _ string) (*core.OperationResult, error) {
+			return &core.OperationResult{Status: http.StatusOK, Body: []byte(`{"op":"` + op + `"}`)}, nil
 		},
 	}
 	return Config{
+		Invoker:          &listingInvoker{stub: stub},
 		Providers:        testutil.NewProviderRegistry(t, stub),
 		AllowedProviders: []string{"sampleApp"},
 		IncludeREST:      map[string]bool{"sampleApp": true},
@@ -65,82 +75,102 @@ func listingTestConfig(t *testing.T, access invocation.OperationAccessChecker) C
 	}
 }
 
-func listToolNames(t *testing.T, cfg Config, p *principal.Principal) ([]string, map[string]any) {
-	t.Helper()
-	handler := NewStatelessHTTPHandler(cfg)
-	body := `{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}`
-	req := httptest.NewRequest(http.MethodPost, "/mcp", bytes.NewReader([]byte(body)))
-	req.Header.Set("Content-Type", "application/json")
-	if p != nil {
-		req = req.WithContext(principal.WithPrincipal(req.Context(), p))
-	}
-	rec := httptest.NewRecorder()
-	handler.ServeHTTP(rec, req)
-	if rec.Code != http.StatusOK {
-		t.Fatalf("tools/list status = %d: %s", rec.Code, rec.Body.String())
-	}
+type listingInvoker struct {
+	stub *coretesting.StubIntegration
+}
 
-	var envelope struct {
-		Result struct {
-			Tools []struct {
-				Name string `json:"name"`
-			} `json:"tools"`
-		} `json:"result"`
-		Error map[string]any `json:"error"`
-	}
-	if err := json.Unmarshal(rec.Body.Bytes(), &envelope); err != nil {
-		t.Fatalf("decode tools/list: %v", err)
-	}
-	names := make([]string, 0, len(envelope.Result.Tools))
-	for _, tool := range envelope.Result.Tools {
-		names = append(names, tool.Name)
-	}
-	return names, envelope.Error
+func (i *listingInvoker) Invoke(ctx context.Context, _ *principal.Principal, _, _, operation string, params map[string]any) (*core.OperationResult, error) {
+	return i.stub.Execute(ctx, operation, params, "")
 }
 
 func listingTestPrincipal() *principal.Principal {
 	return &principal.Principal{SubjectID: "user:u-1", UserID: "u-1", Kind: principal.KindUser}
 }
 
-// TestListToolsFiltersOnAuthorizationWithOneBatchedCall proves tools/list now
-// consults the evaluator - a tool the caller cannot call is not listed - and
-// that it does so in one batched question for the whole tool set.
-func TestListToolsFiltersOnAuthorizationWithOneBatchedCall(t *testing.T) {
-	t.Parallel()
-
-	access := &recordingOperationAccess{allowed: map[string]bool{"items.list": true}}
-	names, rpcErr := listToolNames(t, listingTestConfig(t, access), listingTestPrincipal())
-	if rpcErr != nil {
-		t.Fatalf("tools/list error: %v", rpcErr)
-	}
-	if len(names) != 1 {
-		t.Fatalf("tools = %v, want only the allowed tool", names)
-	}
-	if access.calls != 1 {
-		t.Fatalf("batched calls = %d, want 1", access.calls)
-	}
-	if len(access.queries) != 2 {
-		t.Fatalf("batched queries = %d, want 2 (one per tool)", len(access.queries))
-	}
+func listToolNames(t *testing.T, cfg Config, p *principal.Principal) ([]string, map[string]any) {
+	t.Helper()
+	status, envelope := callMCP(t, cfg, p, map[string]any{
+		"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": map[string]any{},
+	})
+	return mcpToolNames(t, status, envelope)
 }
 
-// TestListToolsListsGrantedToolsForGrantedSubject is the positive half: a
-// subject the evaluator allows keeps every tool.
-func TestListToolsListsGrantedToolsForGrantedSubject(t *testing.T) {
-	t.Parallel()
-
-	access := &recordingOperationAccess{allowed: map[string]bool{"items.list": true, "items.create": true}}
-	names, rpcErr := listToolNames(t, listingTestConfig(t, access), listingTestPrincipal())
-	if rpcErr != nil {
-		t.Fatalf("tools/list error: %v", rpcErr)
+func callMCP(t *testing.T, cfg Config, p *principal.Principal, payload map[string]any) (int, map[string]any) {
+	t.Helper()
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal mcp payload: %v", err)
 	}
-	if len(names) != 2 {
-		t.Fatalf("tools = %v, want both tools", names)
+	req := httptest.NewRequest(http.MethodPost, "/mcp", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	if p != nil {
+		req = req.WithContext(principal.WithPrincipal(req.Context(), p))
 	}
+	rec := httptest.NewRecorder()
+	NewStatelessHTTPHandler(cfg).ServeHTTP(rec, req)
+	var envelope map[string]any
+	if rec.Body.Len() > 0 {
+		if err := json.Unmarshal(rec.Body.Bytes(), &envelope); err != nil {
+			t.Fatalf("decode mcp response: %v body=%s", err, rec.Body.String())
+		}
+	}
+	return rec.Code, envelope
 }
 
-// TestListToolsHidesEverythingForUngrantedSubject covers the ungranted case.
-func TestListToolsHidesEverythingForUngrantedSubject(t *testing.T) {
+func mcpToolNames(t *testing.T, status int, envelope map[string]any) ([]string, map[string]any) {
+	t.Helper()
+	if status != http.StatusOK {
+		t.Fatalf("mcp status = %d: %v", status, envelope)
+	}
+	rpcErr, _ := envelope["error"].(map[string]any)
+	result, _ := envelope["result"].(map[string]any)
+	rawTools, _ := result["tools"].([]any)
+	names := make([]string, 0, len(rawTools))
+	for _, raw := range rawTools {
+		tool, _ := raw.(map[string]any)
+		if name, ok := tool["name"].(string); ok {
+			names = append(names, name)
+		}
+	}
+	return names, rpcErr
+}
+
+func callToolJSON(t *testing.T, cfg Config, p *principal.Principal, name string, args map[string]any) map[string]any {
+	t.Helper()
+	status, envelope := callMCP(t, cfg, p, map[string]any{
+		"jsonrpc": "2.0", "id": 2, "method": "tools/call",
+		"params": map[string]any{"name": name, "arguments": args},
+	})
+	if status != http.StatusOK {
+		t.Fatalf("tools/call status = %d: %v", status, envelope)
+	}
+	if rpcErr, ok := envelope["error"]; ok {
+		t.Fatalf("tools/call rpc error: %v", rpcErr)
+	}
+	result, _ := envelope["result"].(map[string]any)
+	if result["isError"] == true {
+		t.Fatalf("tools/call tool error: %v", result)
+	}
+	content, _ := result["content"].([]any)
+	if len(content) == 0 {
+		return result
+	}
+	block, _ := content[0].(map[string]any)
+	text, _ := block["text"].(string)
+	if text == "" {
+		return result
+	}
+	var parsed any
+	if err := json.Unmarshal([]byte(text), &parsed); err != nil {
+		return result
+	}
+	if object, ok := parsed.(map[string]any); ok {
+		return object
+	}
+	return result
+}
+
+func TestListToolsReturnsWorkspaceFrontDoor(t *testing.T) {
 	t.Parallel()
 
 	access := &recordingOperationAccess{allowed: map[string]bool{}}
@@ -148,56 +178,170 @@ func TestListToolsHidesEverythingForUngrantedSubject(t *testing.T) {
 	if rpcErr != nil {
 		t.Fatalf("tools/list error: %v", rpcErr)
 	}
-	if len(names) != 0 {
-		t.Fatalf("ungranted subject sees tools %v", names)
+	if got, want := names, []string{DescribeToolName, InvokeToolName, SearchToolName}; !equalStrings(got, want) {
+		t.Fatalf("tools = %v, want front door %v", got, want)
+	}
+	if access.calls != 0 {
+		t.Fatalf("tools/list consulted the evaluator %d times", access.calls)
 	}
 }
 
-// TestListToolsKeepsScopeAsAnAdditionalFilter proves scope AND authorization:
-// an authorization allow does not override a token scope that excludes the app.
-func TestListToolsKeepsScopeAsAnAdditionalFilter(t *testing.T) {
+func TestListToolsDoesNotReadAppCatalogs(t *testing.T) {
+	t.Parallel()
+
+	stub := &panicCatalogProvider{StubIntegration: coretesting.StubIntegration{N: "sampleApp"}}
+	cfg := Config{
+		Providers:        testutil.NewProviderRegistry(t, stub),
+		AllowedProviders: []string{"sampleApp"},
+		IncludeREST:      map[string]bool{"sampleApp": true},
+		OperationAccess:  &recordingOperationAccess{allowed: map[string]bool{}},
+	}
+	names, rpcErr := listToolNames(t, cfg, listingTestPrincipal())
+	if rpcErr != nil {
+		t.Fatalf("tools/list error: %v", rpcErr)
+	}
+	if len(names) != 3 {
+		t.Fatalf("tools = %v, want 3 front-door tools", names)
+	}
+}
+
+func TestListToolsHidesNothingFromUngrantedSubject(t *testing.T) {
+	t.Parallel()
+
+	access := &recordingOperationAccess{allowed: map[string]bool{}}
+	names, rpcErr := listToolNames(t, listingTestConfig(t, access), listingTestPrincipal())
+	if rpcErr != nil {
+		t.Fatalf("tools/list error: %v", rpcErr)
+	}
+	if len(names) != 3 {
+		t.Fatalf("ungranted subject saw tools %v, want the front door", names)
+	}
+}
+
+func TestSearchReturnsGrantedOperations(t *testing.T) {
+	t.Parallel()
+
+	access := &recordingOperationAccess{allowed: map[string]bool{"items.list": true}}
+	body := callToolJSON(t, listingTestConfig(t, access), listingTestPrincipal(), SearchToolName, map[string]any{
+		"query": "items",
+	})
+	results, _ := body["results"].([]any)
+	if len(results) != 1 {
+		t.Fatalf("search results = %v, want the granted list operation", body)
+	}
+	hit, _ := results[0].(map[string]any)
+	if hit["app"] != "sampleApp" || hit["operation"] != "items.list" {
+		t.Fatalf("hit = %v", hit)
+	}
+	if access.calls != 1 {
+		t.Fatalf("search evaluator calls = %d, want 1", access.calls)
+	}
+}
+
+func TestSearchHidesUngrantedOperations(t *testing.T) {
+	t.Parallel()
+
+	access := &recordingOperationAccess{allowed: map[string]bool{}}
+	body := callToolJSON(t, listingTestConfig(t, access), listingTestPrincipal(), SearchToolName, map[string]any{
+		"query": "items",
+	})
+	results, _ := body["results"].([]any)
+	if len(results) != 0 {
+		t.Fatalf("ungranted search returned %v", body)
+	}
+}
+
+func TestSearchKeepsScopeAsAnAdditionalFilter(t *testing.T) {
 	t.Parallel()
 
 	access := &recordingOperationAccess{allowed: map[string]bool{"items.list": true, "items.create": true}}
 	scoped := listingTestPrincipal()
 	scoped.Scopes = []string{"otherApp"}
-	names, rpcErr := listToolNames(t, listingTestConfig(t, access), scoped)
-	if rpcErr != nil {
-		t.Fatalf("tools/list error: %v", rpcErr)
-	}
-	if len(names) != 0 {
-		t.Fatalf("out-of-scope tools listed: %v", names)
+	body := callToolJSON(t, listingTestConfig(t, access), scoped, SearchToolName, map[string]any{
+		"query": "items",
+	})
+	results, _ := body["results"].([]any)
+	if len(results) != 0 {
+		t.Fatalf("out-of-scope search returned %v", body)
 	}
 	if access.calls != 0 {
 		t.Fatalf("evaluator consulted for out-of-scope app: %d calls", access.calls)
 	}
 }
 
-// TestListToolsFailsLoudlyWhenEvaluatorUnavailable keeps an unreachable
-// evaluator from being reported to the client as "you have no tools".
-func TestListToolsFailsLoudlyWhenEvaluatorUnavailable(t *testing.T) {
+func TestSearchFailsLoudlyWhenEvaluatorUnavailable(t *testing.T) {
 	t.Parallel()
 
 	access := &recordingOperationAccess{allowed: map[string]bool{}, err: errors.New("evaluator unavailable")}
-	names, rpcErr := listToolNames(t, listingTestConfig(t, access), listingTestPrincipal())
-	if rpcErr == nil {
-		t.Fatalf("evaluator failure returned tools %v instead of an error", names)
+	status, envelope := callMCP(t, listingTestConfig(t, access), listingTestPrincipal(), map[string]any{
+		"jsonrpc": "2.0", "id": 2, "method": "tools/call",
+		"params": map[string]any{"name": SearchToolName, "arguments": map[string]any{"query": "items"}},
+	})
+	if status != http.StatusOK {
+		t.Fatalf("status = %d: %v", status, envelope)
 	}
-	if len(names) != 0 {
-		t.Fatalf("tools returned alongside error: %v", names)
+	result, _ := envelope["result"].(map[string]any)
+	if result["isError"] != true {
+		t.Fatalf("evaluator failure returned %v, want a tool error", envelope)
 	}
 }
 
-// TestListToolsWithoutCheckerKeepsCurrentBehavior keeps a deployment with no
-// authorization evaluator listing exactly what it listed before.
-func TestListToolsWithoutCheckerKeepsCurrentBehavior(t *testing.T) {
+func TestSearchWithoutCheckerReturnsMatchingOperations(t *testing.T) {
 	t.Parallel()
 
-	names, rpcErr := listToolNames(t, listingTestConfig(t, nil), listingTestPrincipal())
-	if rpcErr != nil {
-		t.Fatalf("tools/list error: %v", rpcErr)
+	body := callToolJSON(t, listingTestConfig(t, nil), listingTestPrincipal(), SearchToolName, map[string]any{
+		"query": "create",
+	})
+	results, _ := body["results"].([]any)
+	if len(results) != 1 {
+		t.Fatalf("search results = %v, want create", body)
 	}
-	if len(names) != 2 {
-		t.Fatalf("tools = %v, want both tools", names)
+}
+
+func TestInvokeFrontDoorRunsGrantedOperation(t *testing.T) {
+	t.Parallel()
+
+	access := &recordingOperationAccess{allowed: map[string]bool{"items.list": true}}
+	body := callToolJSON(t, listingTestConfig(t, access), listingTestPrincipal(), InvokeToolName, map[string]any{
+		"app":       "sampleApp",
+		"operation": "items.list",
+		"arguments": map[string]any{},
+	})
+	if body["op"] != "items.list" {
+		t.Fatalf("invoke result = %v", body)
 	}
+}
+
+func TestFlattenedToolNamesStillInvoke(t *testing.T) {
+	t.Parallel()
+
+	body := callToolJSON(t, listingTestConfig(t, nil), listingTestPrincipal(), "sampleApp_items_list", map[string]any{})
+	if body["op"] != "items.list" {
+		t.Fatalf("flattened invoke result = %v", body)
+	}
+}
+
+func TestDescribeReturnsGrantedOperationSchema(t *testing.T) {
+	t.Parallel()
+
+	access := &recordingOperationAccess{allowed: map[string]bool{"items.list": true}}
+	body := callToolJSON(t, listingTestConfig(t, access), listingTestPrincipal(), DescribeToolName, map[string]any{
+		"app":       "sampleApp",
+		"operation": "items.list",
+	})
+	if body["app"] != "sampleApp" || body["operation"] != "items.list" {
+		t.Fatalf("describe = %v", body)
+	}
+}
+
+func equalStrings(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/gestaltd/services/apps/mcp/stateless_http_listing_test.go
+++ b/gestaltd/services/apps/mcp/stateless_http_listing_test.go
@@ -557,8 +557,12 @@ func instanceListingConfig(t *testing.T, resolver invocation.TokenResolver) Conf
 		N:        "sampleApp",
 		DN:       "Sample App",
 		ConnMode: core.ConnectionModeSubject,
+		ExecuteFn: func(_ context.Context, op string, _ map[string]any, _ string) (*core.OperationResult, error) {
+			return &core.OperationResult{Status: http.StatusOK, Body: []byte(`{"op":"` + op + `"}`)}, nil
+		},
 	}}
 	return Config{
+		Invoker:          &listingInvoker{stub: &stub.StubIntegration},
 		Providers:        testutil.NewProviderRegistry(t, stub),
 		AllowedProviders: []string{"sampleApp"},
 		IncludeREST:      map[string]bool{"sampleApp": true},
@@ -582,6 +586,9 @@ func TestDescribeUsesCatalogInstance(t *testing.T) {
 	if resolver.lastInstance != "team-a" {
 		t.Fatalf("describe resolved instance %q, want team-a", resolver.lastInstance)
 	}
+	if body["_instance"] != "team-a" {
+		t.Fatalf("describe instance = %v, want team-a", body["_instance"])
+	}
 	requireToolError(t, cfg, listingTestPrincipal(), DescribeToolName, map[string]any{
 		"app":       "sampleApp",
 		"operation": "op_team-a",
@@ -602,6 +609,35 @@ func TestSearchUsesCatalogInstance(t *testing.T) {
 	}
 	if resolver.lastInstance != "team-a" {
 		t.Fatalf("search resolved instance %q, want team-a", resolver.lastInstance)
+	}
+	if body.Results[0].CatalogInstance != "team-a" {
+		t.Fatalf("search result instance = %q, want team-a", body.Results[0].CatalogInstance)
+	}
+}
+
+func TestSearchResultCarriesCatalogInstanceIntoInvoke(t *testing.T) {
+	t.Parallel()
+
+	resolver := &recordingTokenResolver{}
+	cfg := instanceListingConfig(t, resolver)
+	search := callSearch(t, cfg, listingTestPrincipal(), map[string]any{
+		"app":       "sampleApp",
+		"_instance": "team-a",
+	})
+	if len(search.Results) != 1 {
+		t.Fatalf("search = %+v, want one result", search)
+	}
+	hit := search.Results[0]
+	body := callToolJSON(t, cfg, listingTestPrincipal(), InvokeToolName, map[string]any{
+		"app":       hit.App,
+		"operation": hit.Operation,
+		"_instance": hit.CatalogInstance,
+	})
+	if body["op"] != hit.Operation {
+		t.Fatalf("invoke result = %v, want operation %q", body, hit.Operation)
+	}
+	if resolver.lastInstance != "team-a" {
+		t.Fatalf("invoke resolved instance %q, want team-a", resolver.lastInstance)
 	}
 }
 

--- a/gestaltd/services/apps/mcp/stateless_http_listing_test.go
+++ b/gestaltd/services/apps/mcp/stateless_http_listing_test.go
@@ -512,6 +512,61 @@ func TestInvokeFrontDoorUsesExplicitAppIdentity(t *testing.T) {
 	}
 }
 
+func TestInvokeRejectsOutOfScopeAppBeforeCatalogLookup(t *testing.T) {
+	t.Parallel()
+
+	stub := &panicCatalogProvider{StubIntegration: coretesting.StubIntegration{
+		N:        "sampleApp",
+		ConnMode: core.ConnectionModeNone,
+	}}
+	cfg := Config{
+		Providers:        testutil.NewProviderRegistry(t, stub),
+		AllowedProviders: []string{"sampleApp"},
+		IncludeREST:      map[string]bool{"sampleApp": true},
+	}
+	scoped := listingTestPrincipal()
+	scoped.Scopes = []string{"otherApp"}
+
+	requireToolError(t, cfg, scoped, InvokeToolName, map[string]any{
+		"app":       "sampleApp",
+		"operation": "items.list",
+	})
+}
+
+func TestFlattenedToolNamesReserveFrontDoorNames(t *testing.T) {
+	t.Parallel()
+
+	stub := &coretesting.StubIntegration{
+		N:        "gestalt",
+		ConnMode: core.ConnectionModeNone,
+		CatalogVal: &catalog.Catalog{Operations: []catalog.CatalogOperation{
+			{ID: "search", Method: "GET", Path: "/search"},
+			{ID: "describe", Method: "GET", Path: "/describe"},
+			{ID: "invoke", Method: "GET", Path: "/invoke"},
+		}},
+		ExecuteFn: func(_ context.Context, op string, _ map[string]any, _ string) (*core.OperationResult, error) {
+			return &core.OperationResult{Status: http.StatusOK, Body: []byte(`{"op":"` + op + `"}`)}, nil
+		},
+	}
+	cfg := Config{
+		Invoker:          &listingInvoker{stub: stub},
+		Providers:        testutil.NewProviderRegistry(t, stub),
+		AllowedProviders: []string{"gestalt"},
+		IncludeREST:      map[string]bool{"gestalt": true},
+	}
+
+	for _, operation := range []string{"search", "describe", "invoke"} {
+		name := toolName(nil, "gestalt", operation)
+		if name == SearchToolName || name == DescribeToolName || name == InvokeToolName {
+			t.Fatalf("flattened %s tool still collides with front door: %q", operation, name)
+		}
+		body := callToolJSON(t, cfg, listingTestPrincipal(), name, map[string]any{})
+		if body["op"] != operation {
+			t.Fatalf("flattened %s invoke = %v", operation, body)
+		}
+	}
+}
+
 func TestFlattenedToolNamesStillInvoke(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/services/apps/mcp/stateless_http_listing_test.go
+++ b/gestaltd/services/apps/mcp/stateless_http_listing_test.go
@@ -533,6 +533,24 @@ func TestInvokeRejectsOutOfScopeAppBeforeCatalogLookup(t *testing.T) {
 	})
 }
 
+func TestInvokeReturnsToolErrorForMissingApp(t *testing.T) {
+	t.Parallel()
+
+	requireToolError(t, listingTestConfig(t, nil), listingTestPrincipal(), InvokeToolName, map[string]any{
+		"app":       "missingApp",
+		"operation": "items.list",
+	})
+}
+
+func TestInvokeReturnsToolErrorForMissingOperation(t *testing.T) {
+	t.Parallel()
+
+	requireToolError(t, listingTestConfig(t, nil), listingTestPrincipal(), InvokeToolName, map[string]any{
+		"app":       "sampleApp",
+		"operation": "missing.operation",
+	})
+}
+
 func TestFlattenedToolNamesReserveFrontDoorNames(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/services/apps/mcp/stateless_http_listing_test.go
+++ b/gestaltd/services/apps/mcp/stateless_http_listing_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"slices"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/valon-technologies/gestalt/server/core"
@@ -19,15 +21,19 @@ import (
 )
 
 type recordingOperationAccess struct {
-	allowed map[string]bool
-	err     error
-	calls   int
+	allowed      map[string]bool
+	err          error
+	calls        int
+	lastBatch    int
+	totalQueries int
 }
 
 func (r *recordingOperationAccess) CheckOperationAccessMany(
 	_ context.Context, _ *principal.Principal, queries []invocation.OperationAccessQuery,
 ) ([]error, error) {
 	r.calls++
+	r.lastBatch = len(queries)
+	r.totalQueries += len(queries)
 	if r.err != nil {
 		return nil, r.err
 	}
@@ -50,16 +56,21 @@ func (p *panicCatalogProvider) Catalog() *catalog.Catalog {
 
 func listingTestConfig(t *testing.T, access invocation.OperationAccessChecker) Config {
 	t.Helper()
+	return listingConfig(t, access, []catalog.CatalogOperation{
+		{ID: "items.list", Title: "List items", Description: "List items", Method: "GET", Path: "/items", InputSchema: json.RawMessage(`{"type":"object","properties":{"limit":{"type":"integer"}}}`)},
+		{ID: "items.create", Title: "Create item", Description: "Create an item", Method: "POST", Path: "/items"},
+	})
+}
+
+func listingConfig(t *testing.T, access invocation.OperationAccessChecker, ops []catalog.CatalogOperation) Config {
+	t.Helper()
 	stub := &coretesting.StubIntegration{
 		N:        "sampleApp",
 		DN:       "Sample App",
 		ConnMode: core.ConnectionModeNone,
 		CatalogVal: &catalog.Catalog{
-			Name: "sampleApp",
-			Operations: []catalog.CatalogOperation{
-				{ID: "items.list", Title: "List items", Description: "List items", Method: "GET", Path: "/items", InputSchema: json.RawMessage(`{"type":"object","properties":{"limit":{"type":"integer"}}}`)},
-				{ID: "items.create", Title: "Create item", Description: "Create an item", Method: "POST", Path: "/items"},
-			},
+			Name:       "sampleApp",
+			Operations: ops,
 		},
 		ExecuteFn: func(_ context.Context, op string, _ map[string]any, _ string) (*core.OperationResult, error) {
 			return &core.OperationResult{Status: http.StatusOK, Body: []byte(`{"op":"` + op + `"}`)}, nil
@@ -169,6 +180,22 @@ func callToolJSON(t *testing.T, cfg Config, p *principal.Principal, name string,
 	return result
 }
 
+func callSearch(t *testing.T, cfg Config, p *principal.Principal, args map[string]any) SearchResult {
+	t.Helper()
+	status, envelope := callMCP(t, cfg, p, map[string]any{
+		"jsonrpc": "2.0", "id": 2, "method": "tools/call",
+		"params": map[string]any{"name": SearchToolName, "arguments": args},
+	})
+	if status != http.StatusOK {
+		t.Fatalf("gestalt_search status = %d: %v", status, envelope)
+	}
+	body, err := DecodeSearchToolResult(envelope)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	return body
+}
+
 func requireToolError(t *testing.T, cfg Config, p *principal.Principal, name string, args map[string]any) map[string]any {
 	t.Helper()
 	status, envelope := callMCP(t, cfg, p, map[string]any{
@@ -186,6 +213,31 @@ func requireToolError(t *testing.T, cfg Config, p *principal.Principal, name str
 		t.Fatalf("tools/call returned %v, want a tool error", envelope)
 	}
 	return result
+}
+
+func TestInitializeExplainsWorkspaceFrontDoor(t *testing.T) {
+	t.Parallel()
+
+	status, envelope := callMCP(t, listingTestConfig(t, nil), listingTestPrincipal(), map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "initialize",
+		"params": map[string]any{
+			"protocolVersion": "2025-03-26",
+			"capabilities":    map[string]any{},
+			"clientInfo":      map[string]any{"name": "test", "version": "1.0"},
+		},
+	})
+	if status != http.StatusOK {
+		t.Fatalf("initialize status = %d: %v", status, envelope)
+	}
+	result, _ := envelope["result"].(map[string]any)
+	instructions, _ := result["instructions"].(string)
+	for _, name := range []string{SearchToolName, DescribeToolName, InvokeToolName} {
+		if !strings.Contains(instructions, name) {
+			t.Fatalf("initialize instructions %q missing %s", instructions, name)
+		}
+	}
 }
 
 func TestListToolsReturnsWorkspaceFrontDoor(t *testing.T) {
@@ -240,16 +292,15 @@ func TestSearchReturnsGrantedOperations(t *testing.T) {
 	t.Parallel()
 
 	access := &recordingOperationAccess{allowed: map[string]bool{"items.list": true}}
-	body := callToolJSON(t, listingTestConfig(t, access), listingTestPrincipal(), SearchToolName, map[string]any{
+	body := callSearch(t, listingTestConfig(t, access), listingTestPrincipal(), map[string]any{
 		"query": "items",
 	})
-	results, _ := body["results"].([]any)
-	if len(results) != 1 {
-		t.Fatalf("search results = %v, want the granted list operation", body)
+	if len(body.Results) != 1 {
+		t.Fatalf("search results = %+v, want the granted list operation", body)
 	}
-	hit, _ := results[0].(map[string]any)
-	if hit["app"] != "sampleApp" || hit["operation"] != "items.list" {
-		t.Fatalf("hit = %v", hit)
+	hit := body.Results[0]
+	if hit.App != "sampleApp" || hit.Operation != "items.list" {
+		t.Fatalf("hit = %+v", hit)
 	}
 	if access.calls != 1 {
 		t.Fatalf("search evaluator calls = %d, want 1", access.calls)
@@ -260,12 +311,11 @@ func TestSearchHidesUngrantedOperations(t *testing.T) {
 	t.Parallel()
 
 	access := &recordingOperationAccess{allowed: map[string]bool{}}
-	body := callToolJSON(t, listingTestConfig(t, access), listingTestPrincipal(), SearchToolName, map[string]any{
+	body := callSearch(t, listingTestConfig(t, access), listingTestPrincipal(), map[string]any{
 		"query": "items",
 	})
-	results, _ := body["results"].([]any)
-	if len(results) != 0 {
-		t.Fatalf("ungranted search returned %v", body)
+	if len(body.Results) != 0 {
+		t.Fatalf("ungranted search returned %+v", body)
 	}
 }
 
@@ -275,12 +325,11 @@ func TestSearchKeepsScopeAsAnAdditionalFilter(t *testing.T) {
 	access := &recordingOperationAccess{allowed: map[string]bool{"items.list": true, "items.create": true}}
 	scoped := listingTestPrincipal()
 	scoped.Scopes = []string{"otherApp"}
-	body := callToolJSON(t, listingTestConfig(t, access), scoped, SearchToolName, map[string]any{
+	body := callSearch(t, listingTestConfig(t, access), scoped, map[string]any{
 		"query": "items",
 	})
-	results, _ := body["results"].([]any)
-	if len(results) != 0 {
-		t.Fatalf("out-of-scope search returned %v", body)
+	if len(body.Results) != 0 {
+		t.Fatalf("out-of-scope search returned %+v", body)
 	}
 	if access.calls != 0 {
 		t.Fatalf("evaluator consulted for out-of-scope app: %d calls", access.calls)
@@ -307,25 +356,23 @@ func TestSearchFailsLoudlyWhenEvaluatorUnavailable(t *testing.T) {
 func TestSearchWithoutCheckerReturnsMatchingOperations(t *testing.T) {
 	t.Parallel()
 
-	body := callToolJSON(t, listingTestConfig(t, nil), listingTestPrincipal(), SearchToolName, map[string]any{
+	body := callSearch(t, listingTestConfig(t, nil), listingTestPrincipal(), map[string]any{
 		"query": "create",
 	})
-	results, _ := body["results"].([]any)
-	if len(results) != 1 {
-		t.Fatalf("search results = %v, want create", body)
+	if len(body.Results) != 1 {
+		t.Fatalf("search results = %+v, want create", body)
 	}
 }
 
 func TestSearchWithoutQueryOrAppReturnsHint(t *testing.T) {
 	t.Parallel()
 
-	body := callToolJSON(t, listingTestConfig(t, nil), listingTestPrincipal(), SearchToolName, map[string]any{})
-	results, _ := body["results"].([]any)
-	if len(results) != 0 {
-		t.Fatalf("empty search returned %v", body)
+	body := callSearch(t, listingTestConfig(t, nil), listingTestPrincipal(), map[string]any{})
+	if len(body.Results) != 0 {
+		t.Fatalf("empty search returned %+v", body)
 	}
-	if body["hint"] == "" {
-		t.Fatalf("empty search missing hint: %v", body)
+	if body.Hint == "" {
+		t.Fatalf("empty search missing hint: %+v", body)
 	}
 }
 
@@ -333,17 +380,76 @@ func TestSearchOrdersAndLimitsResults(t *testing.T) {
 	t.Parallel()
 
 	access := &recordingOperationAccess{allowed: map[string]bool{"items.list": true, "items.create": true}}
-	body := callToolJSON(t, listingTestConfig(t, access), listingTestPrincipal(), SearchToolName, map[string]any{
+	body := callSearch(t, listingTestConfig(t, access), listingTestPrincipal(), map[string]any{
 		"query": "items",
 		"limit": 1,
 	})
-	results, _ := body["results"].([]any)
+	if len(body.Results) != 1 {
+		t.Fatalf("search results = %+v, want one hit", body)
+	}
+	if body.Results[0].Operation != "items.create" {
+		t.Fatalf("first limited hit = %+v, want items.create", body.Results[0])
+	}
+	if !body.Truncated {
+		t.Fatalf("limited search missing truncated: %+v", body)
+	}
+}
+
+func TestSearchAuthorizesAPageNotTheWholeMatchSet(t *testing.T) {
+	t.Parallel()
+
+	ops := make([]catalog.CatalogOperation, 0, 40)
+	allowed := map[string]bool{}
+	for i := 0; i < 40; i++ {
+		id := "item_" + strconv.Itoa(i)
+		ops = append(ops, catalog.CatalogOperation{ID: id, Title: id, Description: "item op", Method: "GET", Path: "/" + id})
+		allowed[id] = true
+	}
+	access := &recordingOperationAccess{allowed: allowed}
+	body := callSearch(t, listingConfig(t, access, ops), listingTestPrincipal(), map[string]any{
+		"query": "item",
+		"limit": 1,
+	})
+	if len(body.Results) != 1 || body.Results[0].Operation != "item_0" {
+		t.Fatalf("paged search = %+v, want item_0", body)
+	}
+	if !body.Truncated {
+		t.Fatalf("paged search missing truncated: %+v", body)
+	}
+	if access.totalQueries != defaultSearchLimit {
+		t.Fatalf("search authorized %d operations, want a page of %d", access.totalQueries, defaultSearchLimit)
+	}
+}
+
+func TestSearchWalksDeniedOperationsToFillThePage(t *testing.T) {
+	t.Parallel()
+
+	access := &recordingOperationAccess{allowed: map[string]bool{"items.list": true}}
+	body := callSearch(t, listingTestConfig(t, access), listingTestPrincipal(), map[string]any{
+		"query": "items",
+		"limit": 1,
+	})
+	if len(body.Results) != 1 || body.Results[0].Operation != "items.list" {
+		t.Fatalf("search skipped the granted operation: %+v", body)
+	}
+}
+
+func TestSearchOmitsFlattenedToolNames(t *testing.T) {
+	t.Parallel()
+
+	raw := callToolJSON(t, listingTestConfig(t, nil), listingTestPrincipal(), SearchToolName, map[string]any{
+		"query": "items.list",
+	})
+	results, _ := raw["results"].([]any)
 	if len(results) != 1 {
-		t.Fatalf("search results = %v, want one hit", body)
+		t.Fatalf("search results = %v, want items.list", raw)
 	}
 	hit, _ := results[0].(map[string]any)
-	if hit["operation"] != "items.create" {
-		t.Fatalf("first limited hit = %v, want items.create", hit)
+	if _, ok := hit["mcpName"]; ok {
+		t.Fatalf("search advertised flattened mcpName: %v", hit)
+	}
+	if hit["app"] != "sampleApp" || hit["operation"] != "items.list" {
+		t.Fatalf("hit = %v, want app and operation", hit)
 	}
 }
 
@@ -384,6 +490,9 @@ func TestDescribeReturnsGrantedOperationSchema(t *testing.T) {
 	schema, _ := body["inputSchema"].(map[string]any)
 	if schema["type"] != "object" {
 		t.Fatalf("describe schema = %v, want the list input schema", body["inputSchema"])
+	}
+	if _, ok := body["mcpName"]; ok {
+		t.Fatalf("describe advertised flattened mcpName: %v", body)
 	}
 }
 

--- a/gestaltd/services/apps/mcp/stateless_http_listing_test.go
+++ b/gestaltd/services/apps/mcp/stateless_http_listing_test.go
@@ -555,14 +555,18 @@ func TestFlattenedToolNamesReserveFrontDoorNames(t *testing.T) {
 		IncludeREST:      map[string]bool{"gestalt": true},
 	}
 
+	refs := statelessToolRefs(cfg, "gestalt", stub.Catalog())
 	for _, operation := range []string{"search", "describe", "invoke"} {
 		name := toolName(nil, "gestalt", operation)
-		if name == SearchToolName || name == DescribeToolName || name == InvokeToolName {
-			t.Fatalf("flattened %s tool still collides with front door: %q", operation, name)
+		if _, ok := refs[name]; ok {
+			t.Fatalf("flattened %s tool is mapped to reserved front-door name %q", operation, name)
 		}
-		body := callToolJSON(t, cfg, listingTestPrincipal(), name, map[string]any{})
+		body := callToolJSON(t, cfg, listingTestPrincipal(), InvokeToolName, map[string]any{
+			"app":       "gestalt",
+			"operation": operation,
+		})
 		if body["op"] != operation {
-			t.Fatalf("flattened %s invoke = %v", operation, body)
+			t.Fatalf("front-door %s invoke = %v", operation, body)
 		}
 	}
 }

--- a/gestaltd/services/apps/mcp/stateless_http_listing_test.go
+++ b/gestaltd/services/apps/mcp/stateless_http_listing_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"testing"
 
 	"github.com/valon-technologies/gestalt/server/core"
@@ -21,14 +22,12 @@ type recordingOperationAccess struct {
 	allowed map[string]bool
 	err     error
 	calls   int
-	queries []invocation.OperationAccessQuery
 }
 
 func (r *recordingOperationAccess) CheckOperationAccessMany(
 	_ context.Context, _ *principal.Principal, queries []invocation.OperationAccessQuery,
 ) ([]error, error) {
 	r.calls++
-	r.queries = append(r.queries, queries...)
 	if r.err != nil {
 		return nil, r.err
 	}
@@ -58,7 +57,7 @@ func listingTestConfig(t *testing.T, access invocation.OperationAccessChecker) C
 		CatalogVal: &catalog.Catalog{
 			Name: "sampleApp",
 			Operations: []catalog.CatalogOperation{
-				{ID: "items.list", Title: "List items", Description: "List items", Method: "GET", Path: "/items"},
+				{ID: "items.list", Title: "List items", Description: "List items", Method: "GET", Path: "/items", InputSchema: json.RawMessage(`{"type":"object","properties":{"limit":{"type":"integer"}}}`)},
 				{ID: "items.create", Title: "Create item", Description: "Create an item", Method: "POST", Path: "/items"},
 			},
 		},
@@ -170,6 +169,25 @@ func callToolJSON(t *testing.T, cfg Config, p *principal.Principal, name string,
 	return result
 }
 
+func requireToolError(t *testing.T, cfg Config, p *principal.Principal, name string, args map[string]any) map[string]any {
+	t.Helper()
+	status, envelope := callMCP(t, cfg, p, map[string]any{
+		"jsonrpc": "2.0", "id": 2, "method": "tools/call",
+		"params": map[string]any{"name": name, "arguments": args},
+	})
+	if status != http.StatusOK {
+		t.Fatalf("tools/call status = %d: %v", status, envelope)
+	}
+	if rpcErr, ok := envelope["error"]; ok {
+		t.Fatalf("tools/call rpc error: %v", rpcErr)
+	}
+	result, _ := envelope["result"].(map[string]any)
+	if result["isError"] != true {
+		t.Fatalf("tools/call returned %v, want a tool error", envelope)
+	}
+	return result
+}
+
 func TestListToolsReturnsWorkspaceFrontDoor(t *testing.T) {
 	t.Parallel()
 
@@ -178,7 +196,7 @@ func TestListToolsReturnsWorkspaceFrontDoor(t *testing.T) {
 	if rpcErr != nil {
 		t.Fatalf("tools/list error: %v", rpcErr)
 	}
-	if got, want := names, []string{DescribeToolName, InvokeToolName, SearchToolName}; !equalStrings(got, want) {
+	if got, want := names, WorkspaceFrontDoorToolNames(); !slices.Equal(got, want) {
 		t.Fatalf("tools = %v, want front door %v", got, want)
 	}
 	if access.calls != 0 {
@@ -298,6 +316,37 @@ func TestSearchWithoutCheckerReturnsMatchingOperations(t *testing.T) {
 	}
 }
 
+func TestSearchWithoutQueryOrAppReturnsHint(t *testing.T) {
+	t.Parallel()
+
+	body := callToolJSON(t, listingTestConfig(t, nil), listingTestPrincipal(), SearchToolName, map[string]any{})
+	results, _ := body["results"].([]any)
+	if len(results) != 0 {
+		t.Fatalf("empty search returned %v", body)
+	}
+	if body["hint"] == "" {
+		t.Fatalf("empty search missing hint: %v", body)
+	}
+}
+
+func TestSearchOrdersAndLimitsResults(t *testing.T) {
+	t.Parallel()
+
+	access := &recordingOperationAccess{allowed: map[string]bool{"items.list": true, "items.create": true}}
+	body := callToolJSON(t, listingTestConfig(t, access), listingTestPrincipal(), SearchToolName, map[string]any{
+		"query": "items",
+		"limit": 1,
+	})
+	results, _ := body["results"].([]any)
+	if len(results) != 1 {
+		t.Fatalf("search results = %v, want one hit", body)
+	}
+	hit, _ := results[0].(map[string]any)
+	if hit["operation"] != "items.create" {
+		t.Fatalf("first limited hit = %v, want items.create", hit)
+	}
+}
+
 func TestInvokeFrontDoorRunsGrantedOperation(t *testing.T) {
 	t.Parallel()
 
@@ -332,16 +381,28 @@ func TestDescribeReturnsGrantedOperationSchema(t *testing.T) {
 	if body["app"] != "sampleApp" || body["operation"] != "items.list" {
 		t.Fatalf("describe = %v", body)
 	}
+	schema, _ := body["inputSchema"].(map[string]any)
+	if schema["type"] != "object" {
+		t.Fatalf("describe schema = %v, want the list input schema", body["inputSchema"])
+	}
 }
 
-func equalStrings(got, want []string) bool {
-	if len(got) != len(want) {
-		return false
-	}
-	for i := range got {
-		if got[i] != want[i] {
-			return false
-		}
-	}
-	return true
+func TestDescribeDeniesUngrantedOperation(t *testing.T) {
+	t.Parallel()
+
+	access := &recordingOperationAccess{allowed: map[string]bool{}}
+	requireToolError(t, listingTestConfig(t, access), listingTestPrincipal(), DescribeToolName, map[string]any{
+		"app":       "sampleApp",
+		"operation": "items.list",
+	})
+}
+
+func TestDescribeFailsLoudlyWhenEvaluatorUnavailable(t *testing.T) {
+	t.Parallel()
+
+	access := &recordingOperationAccess{allowed: map[string]bool{}, err: errors.New("evaluator unavailable")}
+	requireToolError(t, listingTestConfig(t, access), listingTestPrincipal(), DescribeToolName, map[string]any{
+		"app":       "sampleApp",
+		"operation": "items.list",
+	})
 }

--- a/gestaltd/services/apps/mcp/stateless_http_listing_test.go
+++ b/gestaltd/services/apps/mcp/stateless_http_listing_test.go
@@ -496,6 +496,123 @@ func TestDescribeReturnsGrantedOperationSchema(t *testing.T) {
 	}
 }
 
+func TestFrontDoorToolsAdvertiseCatalogInstance(t *testing.T) {
+	t.Parallel()
+
+	status, envelope := callMCP(t, listingTestConfig(t, nil), listingTestPrincipal(), map[string]any{
+		"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": map[string]any{},
+	})
+	if status != http.StatusOK {
+		t.Fatalf("tools/list status = %d: %v", status, envelope)
+	}
+	result, _ := envelope["result"].(map[string]any)
+	tools, _ := result["tools"].([]any)
+	found := map[string]bool{}
+	for _, raw := range tools {
+		tool, _ := raw.(map[string]any)
+		name, _ := tool["name"].(string)
+		schema, _ := tool["inputSchema"].(map[string]any)
+		props, _ := schema["properties"].(map[string]any)
+		if _, ok := props["_instance"]; !ok {
+			t.Fatalf("%s schema missing _instance: %v", name, schema)
+		}
+		found[name] = true
+	}
+	for _, name := range WorkspaceFrontDoorToolNames() {
+		if !found[name] {
+			t.Fatalf("tools/list missing %s", name)
+		}
+	}
+}
+
+type recordingTokenResolver struct {
+	lastInstance string
+}
+
+func (r *recordingTokenResolver) ResolveToken(ctx context.Context, _ *principal.Principal, _, _, instance string) (context.Context, string, error) {
+	r.lastInstance = instance
+	return ctx, instance, nil
+}
+
+type instanceCatalogProvider struct {
+	coretesting.StubIntegration
+}
+
+func (p *instanceCatalogProvider) CatalogForRequest(_ context.Context, token string) (*catalog.Catalog, error) {
+	id := "op_default"
+	if token != "" {
+		id = "op_" + token
+	}
+	return &catalog.Catalog{
+		Name: p.N,
+		Operations: []catalog.CatalogOperation{{
+			ID: id, Title: id, Description: "instance op", Method: "GET", Path: "/" + id,
+		}},
+	}, nil
+}
+
+func instanceListingConfig(t *testing.T, resolver invocation.TokenResolver) Config {
+	t.Helper()
+	stub := &instanceCatalogProvider{StubIntegration: coretesting.StubIntegration{
+		N:        "sampleApp",
+		DN:       "Sample App",
+		ConnMode: core.ConnectionModeSubject,
+	}}
+	return Config{
+		Providers:        testutil.NewProviderRegistry(t, stub),
+		AllowedProviders: []string{"sampleApp"},
+		IncludeREST:      map[string]bool{"sampleApp": true},
+		TokenResolver:    resolver,
+	}
+}
+
+func TestDescribeUsesCatalogInstance(t *testing.T) {
+	t.Parallel()
+
+	resolver := &recordingTokenResolver{}
+	cfg := instanceListingConfig(t, resolver)
+	body := callToolJSON(t, cfg, listingTestPrincipal(), DescribeToolName, map[string]any{
+		"app":       "sampleApp",
+		"operation": "op_team-a",
+		"_instance": "team-a",
+	})
+	if body["operation"] != "op_team-a" {
+		t.Fatalf("describe = %v, want op_team-a from instance team-a", body)
+	}
+	if resolver.lastInstance != "team-a" {
+		t.Fatalf("describe resolved instance %q, want team-a", resolver.lastInstance)
+	}
+	requireToolError(t, cfg, listingTestPrincipal(), DescribeToolName, map[string]any{
+		"app":       "sampleApp",
+		"operation": "op_team-a",
+	})
+}
+
+func TestSearchUsesCatalogInstance(t *testing.T) {
+	t.Parallel()
+
+	resolver := &recordingTokenResolver{}
+	cfg := instanceListingConfig(t, resolver)
+	body := callSearch(t, cfg, listingTestPrincipal(), map[string]any{
+		"app":       "sampleApp",
+		"_instance": "team-a",
+	})
+	if len(body.Results) != 1 || body.Results[0].Operation != "op_team-a" {
+		t.Fatalf("search = %+v, want op_team-a", body)
+	}
+	if resolver.lastInstance != "team-a" {
+		t.Fatalf("search resolved instance %q, want team-a", resolver.lastInstance)
+	}
+}
+
+func TestSearchRequiresAppWhenInstanceIsSet(t *testing.T) {
+	t.Parallel()
+
+	requireToolError(t, listingTestConfig(t, nil), listingTestPrincipal(), SearchToolName, map[string]any{
+		"_instance": "team-a",
+	})
+}
+
 func TestDescribeDeniesUngrantedOperation(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/services/invocation/authorization_batch.go
+++ b/gestaltd/services/invocation/authorization_batch.go
@@ -9,14 +9,14 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 )
 
-// maxBatchedAccessChecks bounds one batched authorization call so a large
+// MaxBatchedAccessChecks bounds one batched authorization call so a large
 // catalog or app roster cannot turn a single listing request into an unbounded
 // provider request.
-const maxBatchedAccessChecks = 1000
+const MaxBatchedAccessChecks = 1000
 
 // ErrBatchedAccessTooLarge reports that a caller asked for more decisions in
 // one batch than the server will send to the evaluator.
-var ErrBatchedAccessTooLarge = fmt.Errorf("batched authorization check exceeds %d requests", maxBatchedAccessChecks)
+var ErrBatchedAccessTooLarge = fmt.Errorf("batched authorization check exceeds %d requests", MaxBatchedAccessChecks)
 
 // CheckResourceAccessMany answers many authorization questions with ONE
 // provider call. Listing surfaces use it so a catalog or app roster costs one
@@ -39,7 +39,7 @@ func CheckResourceAccessMany(
 	if authorization == nil {
 		return nil, ErrAuthorizationUnavailable
 	}
-	if len(reqs) > maxBatchedAccessChecks {
+	if len(reqs) > MaxBatchedAccessChecks {
 		return nil, ErrBatchedAccessTooLarge
 	}
 


### PR DESCRIPTION
## Summary

MCP clients were waiting on the tool list before they would mark Gestalt as connected. That list used to walk every app catalog and ask authorization for each operation, so the handshake could hang. Connecting now returns three fixed tools immediately. Finding and running app operations still goes through search and invoke, with the same authorization as before.

## Why / context

Hosts such as Muxy and Cursor treat `tools/list` as the end of the connect handshake. Building that list from every app catalog meant the client sat there until catalogs and the evaluator finished. An empty or delayed list also looked like "you have no tools."

The rejected alternative was to keep listing flattened app tools and try to make that path faster. Handshake latency would still grow with the number of apps.

## What changed

- `tools/list` always returns `gestalt_describe`, `gestalt_invoke`, and `gestalt_search`. It does not read app catalogs or call the evaluator.
- Connect (`initialize`) tells the host those three tools are the handshake, not an inventory of app operations.
- `gestalt_search` finds operations the caller may use. `gestalt_describe` returns one operation's schema. `gestalt_invoke` runs it.
- Search results advertise `app` and `operation` for invoke. They do not advertise old flattened names such as `sampleApp_items_list`. Those names still run if a client already knows them.
- Searching a named app loads the same current catalog that describe and invoke already use. Searching the whole workspace uses each app's static catalog so the call does not walk every live app.
- Search authorizes a page of sorted matches, then stops. If more matches remain, the response sets `truncated`. It does not ask the evaluator about every matching operation before applying `limit`.
- Authorization still uses the same evaluator path as a direct tool call. Search and describe fail closed when the evaluator is unavailable.
- Search with no query and no app stays a successful handshake probe and returns a hint instead of an error.
- Conformance and listing tests share one decoder for the search JSON body. They treat the handshake tools as public, and treat search plus invoke as the authorization surface.

## Validation

- [x] Automated: `go test ./services/apps/mcp/` (from `gestaltd`)
- [x] Automated: `go test ./internal/server/ -count=1 -timeout 180s -run 'TestMCPEndpoint_|TestConformanceMCPListingAndCallAgree|TestConformanceUngrantedExternal|TestConformanceGrantedExternal|TestConformanceRevokedExternal|TestConformanceExternalAppAdmin|TestConformanceCredentialSurfacesAgree|TestConformanceEmployeeUsesDefaultRole|TestConformanceElevatedAdmin'`
- [x] Automated: `golangci-lint run ./services/apps/mcp/ ./services/invocation/` (v2.12.1, 0 issues)
- [ ] Not run: full `go test ./...` in `gestaltd`. The merge gate covers that.

## Reviewer focus

Please check that ungranted callers can complete the handshake but still cannot discover or run app operations through search or invoke.

App-scoped search should agree with describe and invoke on which operations exist. Workspace-wide search is intentionally a static catalog index. Search should authorize about a page of operations, not the whole match set, and `truncated` should be true when more granted matches remain.

## Rollout / compatibility

No config, schema, or deploy-order change. Existing MCP clients that expected every app operation in `tools/list` will now see the three handshake tools and need to search, then invoke with `app` and `operation`. Clients that already call a known flattened name continue to work. Clients that read `mcpName` from search or describe will need to use `app` and `operation` instead.