### PR TITLE
Speed up provider packaging and remote publish

### DIFF
--- a/gestaltd/internal/daemon/app_registry_remote_publish.go
+++ b/gestaltd/internal/daemon/app_registry_remote_publish.go
@@ -7,11 +7,14 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/valon-technologies/gestalt/server/internal/appregistry"
 	"github.com/valon-technologies/gestalt/server/internal/providerrelease"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 )
+
+const remoteRegistryUploadParallelism = 4
 
 type remoteGitRunner interface {
 	Run(name string, args ...string) (string, error)
@@ -103,18 +106,19 @@ func (p *remoteRegistryPublisher) publish(ctx context.Context) (remoteRegistryPu
 	for _, archive := range prepared.Archives {
 		archiveByPlatform[strings.TrimSpace(archive.Target)] = archive
 	}
+	uploadInputs := make([]remoteRegistryUploadInput, 0, len(created.Uploads))
 	for _, upload := range created.Uploads {
 		platform := strings.TrimSpace(upload.Platform)
 		archive, ok := archiveByPlatform[platform]
 		if !ok {
 			return zero, fmt.Errorf("local archive for platform %q is missing from --dist-dir", platform)
 		}
-		logf("Uploading %s (%s)", filepath.Base(archive.Path), platform)
-		if err := uploader.upload(ctx, remoteRegistryUploadInput{
+		uploadInputs = append(uploadInputs, remoteRegistryUploadInput{
 			Platform: platform, LocalPath: archive.Path, SHA256: archive.SHA256, UploadURL: upload.UploadURL, Headers: upload.Headers,
-		}); err != nil {
-			return zero, err
-		}
+		})
+	}
+	if err := uploadRemoteRegistryArtifacts(ctx, uploader, uploadInputs, logf); err != nil {
+		return zero, err
 	}
 	finalized, err := client.finalize(ctx, appName, created.PublishID, declaration)
 	if err != nil {
@@ -129,6 +133,67 @@ func (p *remoteRegistryPublisher) publish(ctx context.Context) (remoteRegistryPu
 	}
 	printRemoteRegistryPublishResult(p.Output, result)
 	return result, nil
+}
+
+func uploadRemoteRegistryArtifacts(ctx context.Context, uploader *remoteRegistryUploader, inputs []remoteRegistryUploadInput, logf func(string, ...any)) error {
+	if len(inputs) == 0 {
+		return nil
+	}
+	if logf == nil {
+		logf = func(string, ...any) {}
+	}
+	workerCount := min(remoteRegistryUploadParallelism, len(inputs))
+	uploadCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	jobs := make(chan remoteRegistryUploadInput, len(inputs))
+	for _, input := range inputs {
+		jobs <- input
+	}
+	close(jobs)
+
+	var (
+		firstErr     error
+		firstErrOnce sync.Once
+		logMu        sync.Mutex
+		workers      sync.WaitGroup
+	)
+	workers.Add(workerCount)
+	for range workerCount {
+		go func() {
+			defer workers.Done()
+			for {
+				select {
+				case <-uploadCtx.Done():
+					return
+				case input, ok := <-jobs:
+					if !ok {
+						return
+					}
+					// Both cases can be ready after cancellation, so check again
+					// before opening a file or starting another request.
+					if uploadCtx.Err() != nil {
+						return
+					}
+					logMu.Lock()
+					logf("Uploading %s (%s)", filepath.Base(input.LocalPath), input.Platform)
+					logMu.Unlock()
+					if err := uploader.upload(uploadCtx, input); err != nil {
+						firstErrOnce.Do(func() {
+							firstErr = err
+							cancel()
+						})
+						return
+					}
+				}
+			}
+		}()
+	}
+	workers.Wait()
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return firstErr
 }
 
 func resolveRemotePublishManifest(appName string) (string, string, error) {

--- a/gestaltd/internal/daemon/app_registry_remote_publish_test.go
+++ b/gestaltd/internal/daemon/app_registry_remote_publish_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -16,6 +17,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	"github.com/valon-technologies/gestalt/server/internal/appregistry"
@@ -110,6 +112,188 @@ func TestRemoteRegistryPublishFlowAndResume(t *testing.T) { //nolint:paralleltes
 	if _, err := pub.publish(t.Context()); err != nil || uploaded["linux/amd64"] != 1 || uploaded["darwin/arm64"] != 1 {
 		t.Fatalf("resume changed uploads: %#v err=%v", uploaded, err)
 	}
+}
+
+func TestRemoteRegistryPublishUploadsOverlapAndFinalizeAfterCompletion(t *testing.T) { //nolint:paralleltest // chdirs
+	_, distDir, _, base := setupRemotePublishFixture(t)
+	_, linuxHeaders := remotePublishArtifactFixture(t, filepath.Join(distDir, "linux-amd64.tar.gz"))
+	_, darwinHeaders := remotePublishArtifactFixture(t, filepath.Join(distDir, "darwin-arm64.tar.gz"))
+
+	var active, maxActive, completed, finalized atomic.Int32
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	uploadServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nowActive := active.Add(1)
+		defer active.Add(-1)
+		for {
+			previous := maxActive.Load()
+			if nowActive <= previous || maxActive.CompareAndSwap(previous, nowActive) {
+				break
+			}
+		}
+		if nowActive == 2 {
+			releaseOnce.Do(func() { close(release) })
+		}
+		select {
+		case <-release:
+		case <-r.Context().Done():
+			return
+		}
+		completed.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(uploadServer.Close)
+
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/finalize") {
+			finalized.Store(completed.Load())
+			writeRemotePublishJSON(w, appregistry.AdminPublishResponse{
+				PublishID: "pub_concurrent", App: "demo", Version: "0.3.0-dev.1", State: appregistry.PublishStatePublished,
+			})
+			return
+		}
+		writeRemotePublishJSON(w, appregistry.AdminPublishResponse{
+			PublishID: "pub_concurrent", App: "demo", Version: "0.3.0-dev.1", State: appregistry.PublishStateUploading,
+			Uploads: []appregistry.AdminPublishUpload{
+				{Platform: "linux/amd64", UploadURL: uploadServer.URL + "/linux", Headers: linuxHeaders},
+				{Platform: "darwin/arm64", UploadURL: uploadServer.URL + "/darwin", Headers: darwinHeaders},
+			},
+		})
+	}))
+	t.Cleanup(apiServer.Close)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
+	defer cancel()
+	_, err := (&remoteRegistryPublisher{
+		Version: "0.3.0-dev.1", DistDirs: []string{distDir}, GestaltURL: apiServer.URL, GestaltToken: "token",
+		BuilderVersion: remotePublishTestBuilderVersion,
+		Client:         &remoteRegistryClient{BaseURL: apiServer.URL, Token: "token"},
+		GitRunner:      base.GitRunner, collectArchives: base.collectArchives, resolveManifest: base.resolveManifest, buildReleaseMetadata: base.buildReleaseMetadata,
+	}).publish(ctx)
+	if err != nil {
+		t.Fatalf("publish() err=%v", err)
+	}
+	if maxActive.Load() < 2 {
+		t.Fatalf("maximum concurrent uploads = %d, want at least 2", maxActive.Load())
+	}
+	if finalized.Load() != 2 {
+		t.Fatalf("finalize observed %d completed uploads, want 2", finalized.Load())
+	}
+}
+
+func TestRemoteRegistryPublishFailureCancelsSiblingAndSkipsFinalize(t *testing.T) { //nolint:paralleltest // chdirs
+	_, distDir, _, base := setupRemotePublishFixture(t)
+	_, linuxHeaders := remotePublishArtifactFixture(t, filepath.Join(distDir, "linux-amd64.tar.gz"))
+	_, darwinHeaders := remotePublishArtifactFixture(t, filepath.Join(distDir, "darwin-arm64.tar.gz"))
+
+	siblingStarted := make(chan struct{})
+	siblingCanceled := make(chan struct{})
+	var startedOnce, canceledOnce sync.Once
+	uploadClient := &http.Client{Transport: roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		switch r.URL.Path {
+		case "/darwin":
+			startedOnce.Do(func() { close(siblingStarted) })
+			<-r.Context().Done()
+			canceledOnce.Do(func() { close(siblingCanceled) })
+			return nil, r.Context().Err()
+		case "/linux":
+			select {
+			case <-siblingStarted:
+			case <-r.Context().Done():
+				return nil, r.Context().Err()
+			}
+			return &http.Response{
+				StatusCode: http.StatusServiceUnavailable,
+				Body:       io.NopCloser(strings.NewReader("controlled failure")),
+			}, nil
+		default:
+			return nil, fmt.Errorf("unexpected upload path %q", r.URL.Path)
+		}
+	})}
+
+	var finalizeCalls atomic.Int32
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/finalize") {
+			finalizeCalls.Add(1)
+			writeRemotePublishJSON(w, appregistry.AdminPublishResponse{
+				PublishID: "pub_failed", App: "demo", Version: "0.3.0-dev.1", State: appregistry.PublishStatePublished,
+			})
+			return
+		}
+		writeRemotePublishJSON(w, appregistry.AdminPublishResponse{
+			PublishID: "pub_failed", App: "demo", Version: "0.3.0-dev.1", State: appregistry.PublishStateUploading,
+			Uploads: []appregistry.AdminPublishUpload{
+				{Platform: "linux/amd64", UploadURL: "http://upload.test/linux", Headers: linuxHeaders},
+				{Platform: "darwin/arm64", UploadURL: "http://upload.test/darwin", Headers: darwinHeaders},
+			},
+		})
+	}))
+	t.Cleanup(apiServer.Close)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
+	defer cancel()
+	_, err := (&remoteRegistryPublisher{
+		Version: "0.3.0-dev.1", DistDirs: []string{distDir}, GestaltURL: apiServer.URL, GestaltToken: "token",
+		BuilderVersion: remotePublishTestBuilderVersion,
+		Client:         &remoteRegistryClient{BaseURL: apiServer.URL, Token: "token"},
+		Uploader:       &remoteRegistryUploader{HTTPClient: uploadClient},
+		GitRunner:      base.GitRunner, collectArchives: base.collectArchives, resolveManifest: base.resolveManifest, buildReleaseMetadata: base.buildReleaseMetadata,
+	}).publish(ctx)
+	if err == nil || !strings.Contains(err.Error(), `upload platform "linux/amd64" returned 503`) {
+		t.Fatalf("publish() err=%v, want controlled linux upload failure", err)
+	}
+	select {
+	case <-siblingCanceled:
+	default:
+		t.Fatal("publish returned before the sibling upload observed cancellation")
+	}
+	if finalizeCalls.Load() != 0 {
+		t.Fatalf("finalize calls = %d, want 0", finalizeCalls.Load())
+	}
+}
+
+func BenchmarkRemoteRegistryArtifactUploads(b *testing.B) {
+	payload := bytes.Repeat([]byte("benchmark"), 128)
+	path := filepath.Join(b.TempDir(), "artifact.tar.gz")
+	if err := os.WriteFile(path, payload, 0o644); err != nil {
+		b.Fatal(err)
+	}
+	sum := sha256.Sum256(payload)
+	digest := hex.EncodeToString(sum[:])
+	headers, err := appregistry.BuildSignedUploadHeaders(int64(len(payload)), digest)
+	if err != nil {
+		b.Fatal(err)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(15 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	b.Cleanup(server.Close)
+
+	inputs := make([]remoteRegistryUploadInput, remoteRegistryUploadParallelism)
+	for i := range inputs {
+		inputs[i] = remoteRegistryUploadInput{
+			Platform: fmt.Sprintf("benchmark/%d", i), LocalPath: path, SHA256: digest,
+			UploadURL: fmt.Sprintf("%s/%d", server.URL, i), Headers: headers,
+		}
+	}
+	uploader := &remoteRegistryUploader{}
+	b.Run("serial", func(b *testing.B) {
+		for range b.N {
+			for _, input := range inputs {
+				if err := uploader.upload(context.Background(), input); err != nil {
+					b.Fatal(err)
+				}
+			}
+		}
+	})
+	b.Run("bounded-concurrent", func(b *testing.B) {
+		for range b.N {
+			if err := uploadRemoteRegistryArtifacts(context.Background(), uploader, inputs, nil); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
 }
 
 func TestRemoteRegistryPublishProvenanceWarningsUseStderr(t *testing.T) { //nolint:paralleltest // chdirs

--- a/gestaltd/internal/daemon/provider_package.go
+++ b/gestaltd/internal/daemon/provider_package.go
@@ -103,18 +103,28 @@ func runProviderPackage(args []string) (err error) {
 	}
 	validationProgress.done("Validated provider source manifest for %s", appName)
 
+	preparation, err := providerpkg.PrepareSourcePackaging(manifestPath, providerpkg.CommandOutput{})
+	if err != nil {
+		return fmt.Errorf("prepare provider packaging: %w", err)
+	}
+	defer func() {
+		if closeErr := preparation.Close(); closeErr != nil && err == nil {
+			err = fmt.Errorf("clean up provider packaging preparation: %w", closeErr)
+		}
+	}()
+
 	archiveCount := 0
 	if len(buildPlatforms) > 0 {
 		for _, platform := range buildPlatforms {
 			platformName := providerpkg.PlatformString(platform.GOOS, platform.GOARCH)
-			_, err := buildPlatformArchive(manifestPath, appName, *version, platform, *outputDir)
+			_, err := buildPlatformArchive(manifestPath, appName, *version, platform, *outputDir, preparation)
 			if err != nil {
 				return fmt.Errorf("build %s: %w", platformName, err)
 			}
 			archiveCount++
 		}
 	} else {
-		_, err := buildSourceArchive(manifestPath, appName, *version, *outputDir)
+		_, err := buildSourceArchive(manifestPath, appName, *version, *outputDir, preparation)
 		if err != nil {
 			return err
 		}
@@ -303,7 +313,7 @@ func expandReleasePlatformValue(value string) (string, error) {
 	}
 }
 
-func buildPlatformArchive(manifestPath, appName, version string, platform releasePlatform, outputDir string) (string, error) {
+func buildPlatformArchive(manifestPath, appName, version string, platform releasePlatform, outputDir string, preparation *providerpkg.SourcePackagingPreparation) (string, error) {
 	archiveName := platformArchiveName(appName, version, platform)
 	platformName := providerpkg.PlatformString(platform.GOOS, platform.GOARCH)
 	return createReleaseArchive(outputDir, archiveName, "platform "+platformName, func(stagingDir string) (*providerpkg.StagedPreparedInstall, error) {
@@ -312,6 +322,7 @@ func buildPlatformArchive(manifestPath, appName, version string, platform releas
 			AppName:         appName,
 			GOOS:            platform.GOOS,
 			GOARCH:          platform.GOARCH,
+			Preparation:     preparation,
 		})
 	})
 }
@@ -364,11 +375,12 @@ func currentReleasePlatform() string {
 	return runtime.GOOS + "/" + runtime.GOARCH
 }
 
-func buildSourceArchive(manifestPath, appName, version, outputDir string) (string, error) {
+func buildSourceArchive(manifestPath, appName, version, outputDir string, preparation *providerpkg.SourcePackagingPreparation) (string, error) {
 	archiveName := fmt.Sprintf("gestalt-app-%s_v%s.tar.gz", appName, version)
 	return createReleaseArchive(outputDir, archiveName, "generic archive", func(stagingDir string) (*providerpkg.StagedPreparedInstall, error) {
 		return providerpkg.StageSourcePreparedInstallDir(manifestPath, stagingDir, providerpkg.StageSourcePreparedInstallOptions{
 			VersionOverride: version,
+			Preparation:     preparation,
 		})
 	})
 }

--- a/gestaltd/services/apps/providerpkg/prepared_stage.go
+++ b/gestaltd/services/apps/providerpkg/prepared_stage.go
@@ -33,6 +33,7 @@ type StageSourcePreparedInstallOptions struct {
 	GOOS            string
 	GOARCH          string
 	BuildOutput     CommandOutput
+	Preparation     *SourcePackagingPreparation
 }
 
 type StagedPreparedInstall struct {
@@ -40,6 +41,170 @@ type StagedPreparedInstall struct {
 	ManifestPath   string
 	ManifestFile   string
 	ManifestFormat string
+}
+
+// SourcePackagingPreparation owns work and artifacts that are shared by every
+// target in one packaging invocation. It is intentionally opt-in so callers
+// that stage a single source tree retain the existing self-contained behavior.
+type SourcePackagingPreparation struct {
+	manifestPath       string
+	manifest           *providermanifestv1.Manifest
+	hostBuilt          bool
+	hostExecutablePath string
+	staticDir          string
+	staticReady        bool
+	buildPlan          *sourcePackagingBuildPlan
+}
+
+// PrepareSourcePackaging runs platform-independent source preparation once.
+// The returned preparation is not safe for concurrent use.
+func PrepareSourcePackaging(manifestPath string, output CommandOutput) (*SourcePackagingPreparation, error) {
+	if strings.TrimSpace(manifestPath) == "" {
+		return nil, fmt.Errorf("manifest path is required")
+	}
+	absoluteManifestPath, err := filepath.Abs(manifestPath)
+	if err != nil {
+		return nil, fmt.Errorf("resolve manifest path: %w", err)
+	}
+	manifestPath = absoluteManifestPath
+
+	_, manifest, err := ReadSourceManifestFile(manifestPath)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", manifestPath, err)
+	}
+	if _, err := ManifestKind(manifest); err != nil {
+		return nil, err
+	}
+	if err := ValidateExplicitRunPackaging(filepath.Dir(manifestPath), manifest); err != nil {
+		return nil, err
+	}
+
+	hostOpts := SourceBuildOptions{Output: output, LibC: HostLibC()}
+	if err := RunSourceInstall(manifestPath, manifest, hostOpts); err != nil {
+		return nil, err
+	}
+
+	preparation := &SourcePackagingPreparation{
+		manifestPath: manifestPath,
+		manifest:     manifest,
+	}
+	shouldBuildHost, err := sourceStaticCatalogShouldBePreparedForPackaging(manifestPath, manifest)
+	if err != nil {
+		return nil, err
+	}
+	if SourceBuildProducesOutput(manifest) && shouldBuildHost {
+		buildPlan, err := runSourceBuildForPackaging(manifestPath, manifest, hostOpts)
+		if err != nil {
+			return nil, err
+		}
+		preparation.hostBuilt = true
+		preparation.buildPlan = buildPlan
+		if err := preparation.cacheHostExecutable(); err != nil {
+			_ = preparation.Close()
+			return nil, err
+		}
+	}
+
+	_, preparedManifest, err := prepareSourceManifestForPreparedInstallWithOptions(manifestPath, SourceBuildOptions{Output: output})
+	if err != nil {
+		_ = preparation.Close()
+		return nil, fmt.Errorf("prepare %s: %w", manifestPath, err)
+	}
+	preparation.manifest = preparedManifest
+	if preparation.hostBuilt {
+		if err := preparation.captureOrRestoreStatic(); err != nil {
+			_ = preparation.Close()
+			return nil, err
+		}
+	}
+	return preparation, nil
+}
+
+func (p *SourcePackagingPreparation) cacheHostExecutable() error {
+	outputRel, err := SourceBuildOutputPath(p.manifest, runtime.GOOS)
+	if err != nil {
+		return err
+	}
+	sourcePath := filepath.Join(filepath.Dir(p.manifestPath), filepath.FromSlash(outputRel))
+	if _, err := os.Stat(sourcePath); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("stat host build output %q: %w", outputRel, err)
+	}
+	cacheDir, err := os.MkdirTemp("", "gestalt-package-host-*")
+	if err != nil {
+		return fmt.Errorf("create host build cache: %w", err)
+	}
+	cachePath := filepath.Join(cacheDir, filepath.Base(sourcePath))
+	if err := copyPreparedInstallFile(sourcePath, cachePath); err != nil {
+		_ = os.RemoveAll(cacheDir)
+		return fmt.Errorf("cache host build output %q: %w", outputRel, err)
+	}
+	p.hostExecutablePath = cachePath
+	return nil
+}
+
+func (p *SourcePackagingPreparation) restoreHostExecutable() error {
+	if p.hostExecutablePath == "" {
+		return nil
+	}
+	outputRel, err := SourceBuildOutputPath(p.manifest, runtime.GOOS)
+	if err != nil {
+		return err
+	}
+	destination := filepath.Join(filepath.Dir(p.manifestPath), filepath.FromSlash(outputRel))
+	if err := copyPreparedInstallFile(p.hostExecutablePath, destination); err != nil {
+		return fmt.Errorf("restore host build output %q: %w", outputRel, err)
+	}
+	return nil
+}
+
+func (p *SourcePackagingPreparation) captureOrRestoreStatic() error {
+	sourceDir := SourceStaticBuildDir(p.manifestPath)
+	if !p.staticReady {
+		ok, err := sourceStaticQualifies(sourceDir)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return nil
+		}
+		cacheDir, err := os.MkdirTemp("", "gestalt-package-static-*")
+		if err != nil {
+			return fmt.Errorf("create static build cache: %w", err)
+		}
+		if err := copyPreparedInstallDir(sourceDir, cacheDir); err != nil {
+			_ = os.RemoveAll(cacheDir)
+			return fmt.Errorf("cache static build output: %w", err)
+		}
+		p.staticDir = cacheDir
+		p.staticReady = true
+		return nil
+	}
+	if err := os.RemoveAll(sourceDir); err != nil {
+		return fmt.Errorf("remove target static build output: %w", err)
+	}
+	if err := copyPreparedInstallDir(p.staticDir, sourceDir); err != nil {
+		return fmt.Errorf("restore shared static build output: %w", err)
+	}
+	return nil
+}
+
+func (p *SourcePackagingPreparation) Close() error {
+	if p == nil {
+		return nil
+	}
+	var firstErr error
+	for _, dir := range []string{filepath.Dir(p.hostExecutablePath), p.staticDir} {
+		if dir == "" || dir == "." {
+			continue
+		}
+		if err := os.RemoveAll(dir); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
 }
 
 // StageSourcePreparedInstallDir stages a source tree into its prepared-install layout.
@@ -54,6 +219,10 @@ func StageSourcePreparedInstallDir(manifestPath, stagingDir string, opts StageSo
 		return nil, fmt.Errorf("resolve manifest path: %w", err)
 	}
 	manifestPath = absoluteManifestPath
+
+	if opts.Preparation != nil {
+		return opts.Preparation.stage(manifestPath, stagingDir, opts)
+	}
 
 	_, manifest, err := ReadSourceManifestFile(manifestPath)
 	if err != nil {
@@ -95,6 +264,50 @@ func StageSourcePreparedInstallDir(manifestPath, stagingDir string, opts StageSo
 		}
 	}
 	return stagePreparedInstallDir(manifestPath, stagingDir, srcManifest, StagePreparedInstallOptions{
+		VersionOverride: opts.VersionOverride,
+		AppName:         opts.AppName,
+		GOOS:            opts.GOOS,
+		GOARCH:          opts.GOARCH,
+		BuildOutput:     opts.BuildOutput,
+	})
+}
+
+func (p *SourcePackagingPreparation) stage(manifestPath, stagingDir string, opts StageSourcePreparedInstallOptions) (*StagedPreparedInstall, error) {
+	if p == nil || p.manifest == nil {
+		return nil, fmt.Errorf("source packaging preparation is required")
+	}
+	if manifestPath != p.manifestPath {
+		return nil, fmt.Errorf("source packaging preparation is for %s, not %s", p.manifestPath, manifestPath)
+	}
+	targetOpts := SourceBuildOptions{GOOS: opts.GOOS, GOARCH: opts.GOARCH, Output: opts.BuildOutput}
+	producesOutput, err := SourceReleaseBuildProducesOutput(filepath.Dir(manifestPath), p.manifest)
+	if err != nil {
+		return nil, err
+	}
+	reuseHostBuild := p.hostBuilt &&
+		sourceBuildTargetsHost(targetOpts) &&
+		HostLibC() == effectiveTargetLibC(targetOpts)
+	if producesOutput {
+		if reuseHostBuild {
+			if err := p.restoreHostExecutable(); err != nil {
+				return nil, err
+			}
+		} else if p.buildPlan == nil {
+			buildPlan, err := runSourceBuildForPackaging(manifestPath, p.manifest, targetOpts)
+			if err != nil {
+				return nil, err
+			}
+			p.buildPlan = buildPlan
+		} else {
+			if err := runSourceBuildWithPackagingPlan(manifestPath, p.manifest, targetOpts, p.buildPlan); err != nil {
+				return nil, err
+			}
+		}
+		if err := p.captureOrRestoreStatic(); err != nil {
+			return nil, err
+		}
+	}
+	return stagePreparedInstallDir(manifestPath, stagingDir, p.manifest, StagePreparedInstallOptions{
 		VersionOverride: opts.VersionOverride,
 		AppName:         opts.AppName,
 		GOOS:            opts.GOOS,

--- a/gestaltd/services/apps/providerpkg/prepared_stage.go
+++ b/gestaltd/services/apps/providerpkg/prepared_stage.go
@@ -288,17 +288,18 @@ func (p *SourcePackagingPreparation) stage(manifestPath, stagingDir string, opts
 		sourceBuildTargetsHost(targetOpts) &&
 		HostLibC() == effectiveTargetLibC(targetOpts)
 	if producesOutput {
-		if reuseHostBuild {
+		switch {
+		case reuseHostBuild:
 			if err := p.restoreHostExecutable(); err != nil {
 				return nil, err
 			}
-		} else if p.buildPlan == nil {
+		case p.buildPlan == nil:
 			buildPlan, err := runSourceBuildForPackaging(manifestPath, p.manifest, targetOpts)
 			if err != nil {
 				return nil, err
 			}
 			p.buildPlan = buildPlan
-		} else {
+		default:
 			if err := runSourceBuildWithPackagingPlan(manifestPath, p.manifest, targetOpts, p.buildPlan); err != nil {
 				return nil, err
 			}

--- a/gestaltd/services/apps/providerpkg/prepared_stage_test.go
+++ b/gestaltd/services/apps/providerpkg/prepared_stage_test.go
@@ -511,6 +511,74 @@ fi
 	}
 }
 
+func TestSourceBuildOutputUsesTargetOS(t *testing.T) {
+	t.Parallel()
+
+	const source = "github.com/test/apps/provider"
+	manifest := &providermanifestv1.Manifest{
+		Kind:    providermanifestv1.KindApp,
+		Source:  source,
+		Version: "0.0.1-alpha.1",
+		Build: &providermanifestv1.SourceBuild{
+			Commands: []providermanifestv1.SourcePhaseCommand{{Command: []string{"build"}}},
+		},
+	}
+
+	got, kind, err := sourceBuildOutput(manifest, SourceBuildOptions{GOOS: windowsOS, GOARCH: "amd64"})
+	if err != nil {
+		t.Fatalf("sourceBuildOutput: %v", err)
+	}
+	want := sourceBuildOutputRel(t, source, windowsOS)
+	if got != want {
+		t.Fatalf("sourceBuildOutput path = %q, want %q", got, want)
+	}
+	if kind != "executable" {
+		t.Fatalf("sourceBuildOutput kind = %q, want executable", kind)
+	}
+}
+
+func TestRunSourceBuildForPackagingDoesNotSkipStaticOnlyCommands(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	script := `#!/bin/sh
+set -eu
+mkdir -p "$GESTALT_BUILD_STATIC"
+printf '<html>%s</html>\n' "$GESTALT_TARGET_PLATFORM" > "$GESTALT_BUILD_STATIC/index.html"
+`
+	mustWriteFile(t, filepath.Join(root, "build-static.sh"), []byte(script), 0o755)
+	manifest := &providermanifestv1.Manifest{
+		Kind:    providermanifestv1.KindApp,
+		Source:  "github.com/test/apps/static-only",
+		Version: "0.0.1-alpha.1",
+		Spec:    &providermanifestv1.Spec{},
+		Build: &providermanifestv1.SourceBuild{
+			Commands: []providermanifestv1.SourcePhaseCommand{{Command: []string{"sh", "./build-static.sh"}}},
+		},
+		Run: sourceRunCommand("./run.sh"),
+	}
+	manifestPath := mustWriteManifestData(t, root, "manifest.yaml", mustManifestYAML(t, manifest))
+
+	plan, err := runSourceBuildForPackaging(manifestPath, manifest, SourceBuildOptions{
+		GOOS: "linux", GOARCH: "amd64",
+	})
+	if err != nil {
+		t.Fatalf("runSourceBuildForPackaging: %v", err)
+	}
+	if len(plan.skipTargetCommands) != 0 {
+		t.Fatalf("skipTargetCommands = %v, want none for a static-only build", plan.skipTargetCommands)
+	}
+	if err := runSourceBuildWithPackagingPlan(manifestPath, manifest, SourceBuildOptions{
+		GOOS: "darwin", GOARCH: "arm64",
+	}, plan); err != nil {
+		t.Fatalf("runSourceBuildWithPackagingPlan: %v", err)
+	}
+	staticIndex := mustReadFile(t, filepath.Join(SourceStaticBuildDir(manifestPath), "index.html"))
+	if !strings.Contains(string(staticIndex), "darwin/arm64") {
+		t.Fatalf("static index = %q, want rebuilt target assets", staticIndex)
+	}
+}
+
 func TestSourcePackagingPreparation_ReusesHostWorkAndStaticAssetsAcrossTargets(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/services/apps/providerpkg/prepared_stage_test.go
+++ b/gestaltd/services/apps/providerpkg/prepared_stage_test.go
@@ -607,11 +607,18 @@ fi
 	if strings.Count(logText, "install\n") != 1 {
 		t.Fatalf("phase log = %q, want one install", logText)
 	}
-	if strings.Count(logText, "build:") != 2 {
-		t.Fatalf("phase log = %q, want one host build and one target build", logText)
+	expectedHostBuilds := 1
+	hostTargetOpts := SourceBuildOptions{GOOS: runtime.GOOS, GOARCH: runtime.GOARCH}
+	if HostLibC() != effectiveTargetLibC(hostTargetOpts) {
+		// Linux catalog generation uses a host-libc executable, while the
+		// packaged host target defaults to musl and needs its own build.
+		expectedHostBuilds = 2
 	}
-	if strings.Count(logText, "build:"+runtime.GOOS+"/"+runtime.GOARCH+"\n") != 1 {
-		t.Fatalf("phase log = %q, want exactly one host build", logText)
+	if got, want := strings.Count(logText, "build:"), expectedHostBuilds+1; got != want {
+		t.Fatalf("phase log = %q, build count = %d, want %d", logText, got, want)
+	}
+	if got := strings.Count(logText, "build:"+runtime.GOOS+"/"+runtime.GOARCH+"\n"); got != expectedHostBuilds {
+		t.Fatalf("phase log = %q, host build count = %d, want %d", logText, got, expectedHostBuilds)
 	}
 	if strings.Count(logText, "build:"+targetGOOS+"/"+targetGOARCH+"\n") != 1 {
 		t.Fatalf("phase log = %q, want exactly one target build", logText)

--- a/gestaltd/services/apps/providerpkg/prepared_stage_test.go
+++ b/gestaltd/services/apps/providerpkg/prepared_stage_test.go
@@ -511,6 +511,136 @@ fi
 	}
 }
 
+func TestSourcePackagingPreparation_ReusesHostWorkAndStaticAssetsAcrossTargets(t *testing.T) {
+	t.Parallel()
+
+	targetGOOS, targetGOARCH := "linux", "amd64"
+	if runtime.GOOS == targetGOOS && runtime.GOARCH == targetGOARCH {
+		targetGOOS, targetGOARCH = "darwin", "arm64"
+	}
+
+	root := t.TempDir()
+	const source = "github.com/test/apps/provider"
+	hostOutputRel := sourceBuildOutputRel(t, source, runtime.GOOS)
+	targetOutputRel := sourceBuildOutputRel(t, source, targetGOOS)
+	logPath := filepath.Join(root, "phases.log")
+	buildScript := `#!/bin/sh
+set -eu
+printf 'build:%s\n' "$GESTALT_TARGET_PLATFORM" >> ` + shellQuote(logPath) + `
+mkdir -p .gestaltd/bin
+if [ "$GESTALT_TARGET_OS" = "` + targetGOOS + `" ]; then
+  output=` + shellQuote(targetOutputRel) + `
+else
+  output=` + shellQuote(hostOutputRel) + `
+fi
+cat > "$output" <<'SH'
+#!/bin/sh
+if [ -n "${GESTALT_APP_WRITE_CATALOG:-}" ]; then
+  printf 'name: provider\noperations:\n  - id: packaged_catalog\n    method: POST\n' > "$GESTALT_APP_WRITE_CATALOG"
+fi
+SH
+printf '# target:%s\n' "$GESTALT_TARGET_PLATFORM" >> "$output"
+chmod +x "$output"
+`
+	uiScript := `#!/bin/sh
+set -eu
+printf 'ui:%s\n' "$GESTALT_TARGET_PLATFORM" >> ` + shellQuote(logPath) + `
+mkdir -p "$GESTALT_BUILD_STATIC"
+printf '<html>%s</html>\n' "$GESTALT_TARGET_PLATFORM" > "$GESTALT_BUILD_STATIC/index.html"
+`
+	mustWriteFile(t, filepath.Join(root, "install.sh"), []byte("#!/bin/sh\nprintf 'install\\n' >> "+shellQuote(logPath)+"\n"), 0o755)
+	mustWriteFile(t, filepath.Join(root, "build.sh"), []byte(buildScript), 0o755)
+	mustWriteFile(t, filepath.Join(root, "ui.sh"), []byte(uiScript), 0o755)
+	mustWriteFile(t, filepath.Join(root, "run.sh"), []byte(`#!/bin/sh
+if [ -n "${GESTALT_APP_WRITE_CATALOG:-}" ]; then
+  printf 'name: provider\noperations:\n  - id: run_catalog\n    method: POST\n' > "$GESTALT_APP_WRITE_CATALOG"
+fi
+`), 0o755)
+	mustWriteFile(t, filepath.Join(root, StaticCatalogFile), []byte("name: provider\noperations:\n  - id: stale_catalog\n    method: POST\n"), 0o644)
+	manifestPath := mustWriteManifestData(t, root, "manifest.yaml", mustManifestYAML(t, &providermanifestv1.Manifest{
+		Kind:    providermanifestv1.KindApp,
+		Source:  source,
+		Version: "0.0.1-alpha.1",
+		Spec:    &providermanifestv1.Spec{},
+		Install: &providermanifestv1.SourceInstall{
+			Command: []string{"sh", "./install.sh"},
+		},
+		Build: &providermanifestv1.SourceBuild{
+			Commands: []providermanifestv1.SourcePhaseCommand{
+				{Command: []string{"sh", "./build.sh"}},
+				{Command: []string{"sh", "./ui.sh"}, Workdir: "."},
+			},
+		},
+		Run: sourceRunCommand("./run.sh"),
+	}))
+
+	preparation, err := PrepareSourcePackaging(manifestPath, CommandOutput{})
+	if err != nil {
+		t.Fatalf("PrepareSourcePackaging: %v", err)
+	}
+	defer func() {
+		if err := preparation.Close(); err != nil {
+			t.Errorf("Close: %v", err)
+		}
+	}()
+
+	targetStage := filepath.Join(t.TempDir(), "target")
+	if _, err := StageSourcePreparedInstallDir(manifestPath, targetStage, StageSourcePreparedInstallOptions{
+		AppName:     "prepared-stage-test",
+		GOOS:        targetGOOS,
+		GOARCH:      targetGOARCH,
+		Preparation: preparation,
+	}); err != nil {
+		t.Fatalf("stage target: %v", err)
+	}
+	hostStage := filepath.Join(t.TempDir(), "host")
+	if _, err := StageSourcePreparedInstallDir(manifestPath, hostStage, StageSourcePreparedInstallOptions{
+		AppName:     "prepared-stage-test",
+		GOOS:        runtime.GOOS,
+		GOARCH:      runtime.GOARCH,
+		Preparation: preparation,
+	}); err != nil {
+		t.Fatalf("stage host: %v", err)
+	}
+
+	logText := readLog(t, logPath)
+	if strings.Count(logText, "install\n") != 1 {
+		t.Fatalf("phase log = %q, want one install", logText)
+	}
+	if strings.Count(logText, "build:") != 2 {
+		t.Fatalf("phase log = %q, want one host build and one target build", logText)
+	}
+	if strings.Count(logText, "build:"+runtime.GOOS+"/"+runtime.GOARCH+"\n") != 1 {
+		t.Fatalf("phase log = %q, want exactly one host build", logText)
+	}
+	if strings.Count(logText, "build:"+targetGOOS+"/"+targetGOARCH+"\n") != 1 {
+		t.Fatalf("phase log = %q, want exactly one target build", logText)
+	}
+	if strings.Count(logText, "ui:") != 1 {
+		t.Fatalf("phase log = %q, want one shared UI build", logText)
+	}
+
+	targetBinary := mustReadFile(t, filepath.Join(targetStage, filepath.FromSlash(stagedExecutableRel("prepared-stage-test", targetGOOS))))
+	if !strings.Contains(string(targetBinary), "# target:"+targetGOOS+"/"+targetGOARCH) {
+		t.Fatalf("target executable = %q, want target platform marker", targetBinary)
+	}
+	hostBinary := mustReadFile(t, filepath.Join(hostStage, filepath.FromSlash(stagedExecutableRel("prepared-stage-test", runtime.GOOS))))
+	if !strings.Contains(string(hostBinary), "# target:"+runtime.GOOS+"/"+runtime.GOARCH) {
+		t.Fatalf("host executable = %q, want host platform marker", hostBinary)
+	}
+
+	targetCatalog := mustReadFile(t, filepath.Join(targetStage, StaticCatalogFile))
+	hostCatalog := mustReadFile(t, filepath.Join(hostStage, StaticCatalogFile))
+	if !slices.Equal(targetCatalog, hostCatalog) || !strings.Contains(string(targetCatalog), "packaged_catalog") {
+		t.Fatalf("staged catalogs differ or are stale: target=%q host=%q", targetCatalog, hostCatalog)
+	}
+	targetStatic := mustReadFile(t, filepath.Join(targetStage, "static", "index.html"))
+	hostStatic := mustReadFile(t, filepath.Join(hostStage, "static", "index.html"))
+	if !slices.Equal(targetStatic, hostStatic) || !strings.Contains(string(targetStatic), runtime.GOOS+"/"+runtime.GOARCH) {
+		t.Fatalf("staged static assets differ or are not host-prepared: target=%q host=%q", targetStatic, hostStatic)
+	}
+}
+
 func TestStageSourcePreparedInstallDir_RunOnlyFailsReleasePackaging(t *testing.T) {
 	t.Parallel()
 
@@ -575,11 +705,18 @@ func assertLogContains(t *testing.T, logPath, want string) {
 func readLog(t *testing.T, logPath string) string {
 	t.Helper()
 
-	logData, err := os.ReadFile(logPath)
-	if err != nil {
-		t.Fatalf("ReadFile(%s): %v", logPath, err)
-	}
+	logData := mustReadFile(t, logPath)
 	return string(logData)
+}
+
+func mustReadFile(t *testing.T, path string) []byte {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", path, err)
+	}
+	return data
 }
 
 func shellQuote(value string) string {

--- a/gestaltd/services/apps/providerpkg/source_build.go
+++ b/gestaltd/services/apps/providerpkg/source_build.go
@@ -221,6 +221,9 @@ func runSourceBuildForPackaging(manifestPath string, manifest *providermanifestv
 		}
 	}
 	plan := &sourcePackagingBuildPlan{skipTargetCommands: make(map[int]struct{})}
+	if lastExecutableCommand < 0 {
+		return plan, nil
+	}
 	for i, observation := range observations {
 		if i > lastExecutableCommand && observation.staticChanged && !observation.supportChanged {
 			plan.skipTargetCommands[i] = struct{}{}
@@ -252,7 +255,7 @@ func runSourceBuild(manifestPath string, manifest *providermanifestv1.Manifest, 
 	var staticBuildEnv string
 	if !build.PrepareOnly {
 		var err error
-		outputRel, outputKind, err = SourceBuildOutput(manifest)
+		outputRel, outputKind, err = sourceBuildOutput(manifest, opts)
 		if err != nil {
 			return nil, err
 		}
@@ -475,13 +478,17 @@ func lookupEnv(env []string, key string) (string, bool) {
 }
 
 func SourceBuildOutput(manifest *providermanifestv1.Manifest) (rel string, kind string, err error) {
+	return sourceBuildOutput(manifest, SourceBuildOptions{})
+}
+
+func sourceBuildOutput(manifest *providermanifestv1.Manifest, opts SourceBuildOptions) (rel string, kind string, err error) {
 	if build := EffectiveSourceBuild(manifest); build != nil && build.PrepareOnly {
 		return "", "", nil
 	}
 	if _, err := ManifestKind(manifest); err != nil {
 		return "", "", err
 	}
-	goos, _ := SourceBuildTarget(SourceBuildOptions{})
+	goos, _ := SourceBuildTarget(opts)
 	outputRel, err := SourceBuildOutputPath(manifest, goos)
 	if err != nil {
 		return "", "", err
@@ -580,7 +587,7 @@ func EnsureSourceBuildOutput(manifestPath string, manifest *providermanifestv1.M
 	if !SourceBuildProducesOutput(manifest) {
 		return nil
 	}
-	outputRel, outputKind, err := SourceBuildOutput(manifest)
+	outputRel, outputKind, err := sourceBuildOutput(manifest, opts)
 	if err != nil {
 		if EffectiveSourceBuild(manifest) == nil {
 			return nil

--- a/gestaltd/services/apps/providerpkg/source_build.go
+++ b/gestaltd/services/apps/providerpkg/source_build.go
@@ -1,12 +1,15 @@
 package providerpkg
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"maps"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 	"time"
 
@@ -39,6 +42,16 @@ type SourceBuildOptions struct {
 	GOARCH string
 	LibC   string
 	Output CommandOutput
+}
+
+type sourcePackagingBuildPlan struct {
+	skipTargetCommands map[int]struct{}
+}
+
+type sourceBuildCommandObservation struct {
+	executableChanged bool
+	staticChanged     bool
+	supportChanged    bool
 }
 
 type SourceExecutionIntent int
@@ -192,12 +205,46 @@ func envMapToSlice(env map[string]string) []string {
 
 // RunSourceBuild execs declared build commands serially (no shell) and verifies output.
 func RunSourceBuild(manifestPath string, manifest *providermanifestv1.Manifest, opts SourceBuildOptions) error {
+	_, err := runSourceBuild(manifestPath, manifest, opts, nil, false)
+	return err
+}
+
+func runSourceBuildForPackaging(manifestPath string, manifest *providermanifestv1.Manifest, opts SourceBuildOptions) (*sourcePackagingBuildPlan, error) {
+	observations, err := runSourceBuild(manifestPath, manifest, opts, nil, true)
+	if err != nil {
+		return nil, err
+	}
+	lastExecutableCommand := -1
+	for i, observation := range observations {
+		if observation.executableChanged {
+			lastExecutableCommand = i
+		}
+	}
+	plan := &sourcePackagingBuildPlan{skipTargetCommands: make(map[int]struct{})}
+	for i, observation := range observations {
+		if i > lastExecutableCommand && observation.staticChanged && !observation.supportChanged {
+			plan.skipTargetCommands[i] = struct{}{}
+		}
+	}
+	return plan, nil
+}
+
+func runSourceBuildWithPackagingPlan(manifestPath string, manifest *providermanifestv1.Manifest, opts SourceBuildOptions, plan *sourcePackagingBuildPlan) error {
+	var skip map[int]struct{}
+	if plan != nil {
+		skip = plan.skipTargetCommands
+	}
+	_, err := runSourceBuild(manifestPath, manifest, opts, skip, false)
+	return err
+}
+
+func runSourceBuild(manifestPath string, manifest *providermanifestv1.Manifest, opts SourceBuildOptions, skip map[int]struct{}, observe bool) ([]sourceBuildCommandObservation, error) {
 	build := EffectiveSourceBuild(manifest)
 	if build == nil {
-		return nil
+		return nil, nil
 	}
 	if len(build.Commands) == 0 {
-		return fmt.Errorf("build.command is required")
+		return nil, fmt.Errorf("build.command is required")
 	}
 
 	rootDir := filepath.Dir(manifestPath)
@@ -207,21 +254,41 @@ func RunSourceBuild(manifestPath string, manifest *providermanifestv1.Manifest, 
 		var err error
 		outputRel, outputKind, err = SourceBuildOutput(manifest)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		if outputRel != "" {
 			outputPath = filepath.Join(rootDir, filepath.FromSlash(outputRel))
 			if err := os.RemoveAll(outputPath); err != nil {
-				return fmt.Errorf("remove build output %q: %w", outputRel, err)
+				return nil, fmt.Errorf("remove build output %q: %w", outputRel, err)
 			}
 		}
 		staticBuildEnv, err = prepareSourceStaticBuildDir(manifestPath)
 		if err != nil {
-			return err
+			return nil, err
 		}
 	}
 
+	observations := make([]sourceBuildCommandObservation, len(build.Commands))
 	for i, command := range build.Commands {
+		if _, ok := skip[i]; ok {
+			continue
+		}
+		var beforeExecutable, beforeStatic, beforeSupport string
+		if observe {
+			var err error
+			beforeExecutable, err = digestBuildPath(outputPath)
+			if err != nil {
+				return nil, err
+			}
+			beforeStatic, err = digestBuildPath(SourceStaticBuildDir(manifestPath))
+			if err != nil {
+				return nil, err
+			}
+			beforeSupport, err = digestPackagedSupport(rootDir, manifest)
+			if err != nil {
+				return nil, err
+			}
+		}
 		label := "build"
 		if len(build.Commands) > 1 {
 			label = fmt.Sprintf("build[%d]", i)
@@ -231,13 +298,103 @@ func RunSourceBuild(manifestPath string, manifest *providermanifestv1.Manifest, 
 			envOverrides = append(envOverrides, envGestaltBuildStatic+"="+staticBuildEnv)
 		}
 		if err := runSourcePhase(manifestPath, label, command.Workdir, command.Command, envOverrides, opts); err != nil {
-			return err
+			return nil, err
+		}
+		if observe {
+			afterExecutable, err := digestBuildPath(outputPath)
+			if err != nil {
+				return nil, err
+			}
+			afterStatic, err := digestBuildPath(SourceStaticBuildDir(manifestPath))
+			if err != nil {
+				return nil, err
+			}
+			afterSupport, err := digestPackagedSupport(rootDir, manifest)
+			if err != nil {
+				return nil, err
+			}
+			observations[i] = sourceBuildCommandObservation{
+				executableChanged: beforeExecutable != afterExecutable,
+				staticChanged:     beforeStatic != afterStatic,
+				supportChanged:    beforeSupport != afterSupport,
+			}
 		}
 	}
 	if build.PrepareOnly {
-		return nil
+		return observations, nil
 	}
-	return verifyAppBuildOutputs(manifestPath, manifest, outputPath, outputRel, outputKind, opts)
+	return observations, verifyAppBuildOutputs(manifestPath, manifest, outputPath, outputRel, outputKind, opts)
+}
+
+func digestPackagedSupport(root string, manifest *providermanifestv1.Manifest) (string, error) {
+	if manifest == nil {
+		return "", nil
+	}
+	paths := []string{manifest.IconFile}
+	for _, ref := range LocalPackageReferences(manifest) {
+		paths = append(paths, ref.Path)
+	}
+	if manifest.Spec != nil {
+		paths = append(paths, manifest.Spec.ConfigSchemaPath, manifest.Spec.AssetRoot)
+	}
+	for _, artifact := range manifest.Artifacts {
+		paths = append(paths, artifact.Path)
+	}
+	sort.Strings(paths)
+	hash := sha256.New()
+	for _, rel := range paths {
+		if strings.TrimSpace(rel) == "" {
+			continue
+		}
+		digest, err := digestBuildPath(filepath.Join(root, filepath.FromSlash(rel)))
+		if err != nil {
+			return "", err
+		}
+		_, _ = fmt.Fprintf(hash, "%s\x00%s\x00", rel, digest)
+	}
+	return hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+func digestBuildPath(root string) (string, error) {
+	if strings.TrimSpace(root) == "" {
+		return "", nil
+	}
+	info, err := os.Stat(root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	if !info.IsDir() {
+		return FileSHA256(root)
+	}
+	var files []string
+	if err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !entry.IsDir() {
+			files = append(files, path)
+		}
+		return nil
+	}); err != nil {
+		return "", err
+	}
+	sort.Strings(files)
+	hash := sha256.New()
+	for _, path := range files {
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return "", err
+		}
+		digest, err := FileSHA256(path)
+		if err != nil {
+			return "", err
+		}
+		_, _ = fmt.Fprintf(hash, "%s\x00%s\x00", filepath.ToSlash(rel), digest)
+	}
+	return hex.EncodeToString(hash.Sum(nil)), nil
 }
 
 func runSourcePhase(manifestPath, label, workdir string, command, envOverrides []string, opts SourceBuildOptions) error {


### PR DESCRIPTION
## Summary
- reuse install, catalog, host executable, and static build outputs within a packaging invocation while preserving platform-specific executables
- upload independent platform archives concurrently with bounded workers and cancellation on failure
- reduce two-platform g-issues packaging time by 31% in local benchmarks

## Test plan
- [x] `go test ./services/apps/providerpkg ./internal/daemon`
- [x] `go test ./internal/daemon/e2e ./services/apps/...`
- [x] `go build ./cmd/gestaltd`
- [x] benchmark baseline and optimized g-issues packaging across five alternating trials
- [x] validate catalog/static hashes and target executable formats across Linux and Darwin archives

Made with [Cursor](https://cursor.com)