### PR TITLE
Wake local catalog reconciler after manual app selection

### DIFF
--- a/gestaltd/internal/appregistry/poller.go
+++ b/gestaltd/internal/appregistry/poller.go
@@ -58,6 +58,7 @@ type CatalogPoller struct {
 	mu        sync.Mutex
 	inflight  map[string]struct{}
 	stoppedAt map[string]time.Time
+	notify    chan struct{}
 }
 
 type CatalogPollerConfig struct {
@@ -107,6 +108,7 @@ func NewCatalogPoller(cfg CatalogPollerConfig) *CatalogPoller {
 		HeartbeatEvaluationInterval: cfg.HeartbeatEvaluationInterval,
 		inflight:                    make(map[string]struct{}),
 		stoppedAt:                   make(map[string]time.Time),
+		notify:                      make(chan struct{}, 1),
 	}
 }
 
@@ -174,6 +176,18 @@ func (p *CatalogPoller) Stop() {
 	}
 }
 
+// Notify requests an immediate local reconciliation pass. Notifications
+// coalesce so callers never block while a pass is already running.
+func (p *CatalogPoller) Notify(_ string) {
+	if p == nil {
+		return
+	}
+	select {
+	case p.notify <- struct{}{}:
+	default:
+	}
+}
+
 func (p *CatalogPoller) loop(ctx context.Context) {
 	if p.BootstrapReady != nil {
 		select {
@@ -197,6 +211,8 @@ func (p *CatalogPoller) loop(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
+			p.runOnce(ctx)
+		case <-p.notify:
 			p.runOnce(ctx)
 		case <-heartbeatTick:
 			p.runHeartbeatEvaluations(ctx)

--- a/gestaltd/internal/appregistry/poller_test.go
+++ b/gestaltd/internal/appregistry/poller_test.go
@@ -61,6 +61,152 @@ func (r *recordingAppRestarter) RunningVersion(string) (string, bool) {
 	return r.runningVersion, r.runningVersion != ""
 }
 
+func TestCatalogPollerNotifyCoalesces(t *testing.T) {
+	t.Parallel()
+
+	poller := NewCatalogPoller(CatalogPollerConfig{})
+	poller.Notify("g-issues")
+	poller.Notify("another-app")
+	if got := len(poller.notify); got != 1 {
+		t.Fatalf("queued notifications = %d, want 1", got)
+	}
+}
+
+func TestCatalogPollerNotifyIsNonBlocking(t *testing.T) {
+	t.Parallel()
+
+	poller := NewCatalogPoller(CatalogPollerConfig{})
+	poller.notify <- struct{}{}
+	done := make(chan struct{})
+	go func() {
+		for range 1000 {
+			poller.Notify("g-issues")
+		}
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Notify blocked while notification buffer was full")
+	}
+}
+
+func TestCatalogPollerNotifyTriggersReconcile(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	services := testutil.NewStubServices(t)
+	now := time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC)
+	appendRolloutFixture(t, services, "g-issues", "v1", now)
+
+	ready := make(chan struct{})
+	restarter := &recordingAppRestarter{}
+	poller := NewCatalogPoller(CatalogPollerConfig{
+		ChangeRequests:      services.AppVersionChangeRequests,
+		Materializations:    services.AppInstanceMaterializations,
+		Rollouts:            services.AppRollouts,
+		AppRestarter:        restarter,
+		InstanceID:          "replica-a",
+		Interval:            time.Hour,
+		RestartReady:        ready,
+		BootstrapReady:      ready,
+		DisableRestartDelay: true,
+		Now:                 func() time.Time { return now },
+	})
+	poller.Start(ctx)
+	close(ready)
+
+	waitForStartCalls := func(want int) {
+		t.Helper()
+		deadline := time.Now().Add(time.Second)
+		for time.Now().Before(deadline) {
+			if len(restarter.startCalls) >= want {
+				return
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+		t.Fatalf("startCalls = %d, want >= %d", len(restarter.startCalls), want)
+	}
+	waitForStartCalls(1)
+
+	appendRolloutFixture(t, services, "g-issues", "v2", now.Add(time.Minute))
+	poller.Notify("g-issues")
+	waitForStartCalls(2)
+	if got := restarter.startVersions[len(restarter.startVersions)-1]; got != "v2" {
+		t.Fatalf("last started version = %q, want v2", got)
+	}
+
+	poller.Stop()
+}
+
+func TestCatalogPollerNotifyRetriesAfterReconcileFailure(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	services := testutil.NewStubServices(t)
+	now := time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC)
+	appendRolloutFixture(t, services, "g-issues", "v1", now)
+
+	ready := make(chan struct{})
+	restarter := &recordingAppRestarter{startErr: errors.New("start failed")}
+	poller := NewCatalogPoller(CatalogPollerConfig{
+		ChangeRequests:       services.AppVersionChangeRequests,
+		Materializations:     services.AppInstanceMaterializations,
+		Rollouts:             services.AppRollouts,
+		AppRestarter:         restarter,
+		InstanceID:           "replica-a",
+		Interval:             time.Hour,
+		RestartReady:         ready,
+		BootstrapReady:       ready,
+		DisableRestartDelay:  true,
+		MaxReconcileAttempts: 3,
+		Now:                  func() time.Time { return now },
+	})
+	poller.Start(ctx)
+	close(ready)
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		materialization, err := services.AppInstanceMaterializations.Get(
+			context.Background(), "replica-a", "g-issues", "v1",
+		)
+		if err == nil && materialization.AttemptCount > 0 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	materialization, err := services.AppInstanceMaterializations.Get(
+		context.Background(), "replica-a", "g-issues", "v1",
+	)
+	if err != nil {
+		t.Fatalf("Get materialization: %v", err)
+	}
+	if materialization.AttemptCount == 0 {
+		t.Fatal("expected a recorded reconciliation failure before retry")
+	}
+
+	restarter.startErr = nil
+	poller.Notify("g-issues")
+
+	deadline = time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		materialization, err = services.AppInstanceMaterializations.Get(
+			context.Background(), "replica-a", "g-issues", "v1",
+		)
+		if err == nil && materialization.RestartedAt == now {
+			poller.Stop()
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	poller.Stop()
+	t.Fatalf("materialization after notify = %#v, err = %v", materialization, err)
+}
+
 func TestCatalogPollerStopsRetryingAtConfiguredLimit(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/gestaltd/internal/appregistry/poller_test.go
+++ b/gestaltd/internal/appregistry/poller_test.go
@@ -197,7 +197,7 @@ func TestCatalogPollerNotifyRetriesAfterReconcileFailure(t *testing.T) {
 		materialization, err = services.AppInstanceMaterializations.Get(
 			context.Background(), "replica-a", "g-issues", "v1",
 		)
-		if err == nil && materialization.RestartedAt == now {
+		if err == nil && materialization.RestartedAt.Equal(now) {
 			poller.Stop()
 			return
 		}

--- a/gestaltd/internal/server/handlers_app_admin_registry.go
+++ b/gestaltd/internal/server/handlers_app_admin_registry.go
@@ -510,6 +510,17 @@ func (s *Server) notifyAppAutoDeploy(app string) {
 	s.appAutoDeployNotify(app)
 }
 
+func (s *Server) notifyAppRegistryReconcile(app string) {
+	if s == nil || s.appRegistryReconcileNotify == nil {
+		return
+	}
+	app = strings.TrimSpace(app)
+	if app == "" {
+		return
+	}
+	s.appRegistryReconcileNotify(app)
+}
+
 func (s *Server) getAppAdminRegistryHistory(w http.ResponseWriter, r *http.Request) {
 	app, registry, ok := s.appAdminRegistryConfig(w, r)
 	if !ok {
@@ -675,6 +686,7 @@ func (s *Server) selectAppAdminRegistryVersion(w http.ResponseWriter, r *http.Re
 		writeAppAdminRegistryInstallError(w, err)
 		return
 	}
+	s.notifyAppRegistryReconcile(app.name)
 	writeJSON(w, http.StatusOK, appAdminRegistryVersionResponse{
 		App:            app.name,
 		Registry:       app.registry,

--- a/gestaltd/internal/server/handlers_app_admin_registry_test.go
+++ b/gestaltd/internal/server/handlers_app_admin_registry_test.go
@@ -31,6 +31,7 @@ func TestAppAdminRegistrySelectAndRead(t *testing.T) {
 			testAuthorizationRelationship(subjectID, "admin", "app", "g-issues"),
 		},
 	}
+	reconciled := make(chan string, 1)
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Auth = authStubWithSessionTokenIntrospect("alice-token", subjectID, "")
 		cfg.Authorization = authz
@@ -39,6 +40,9 @@ func TestAppAdminRegistrySelectAndRead(t *testing.T) {
 		}
 		cfg.AppRegistries = map[string]config.AppRegistryConfig{"toolshed": fixture.Registry}
 		cfg.AppRegistryReader = fixture.Reader
+		cfg.AppRegistryReconcileNotify = func(app string) {
+			reconciled <- app
+		}
 	})
 	testutil.CloseOnCleanup(t, ts)
 
@@ -66,6 +70,14 @@ func TestAppAdminRegistrySelectAndRead(t *testing.T) {
 	}
 	if selected.FromVersion != "registry:first-install" || selected.DesiredVersion != fixture.Version || selected.Rollout.State != "enrolling" {
 		t.Fatalf("selection response = %#v", selected)
+	}
+	select {
+	case app := <-reconciled:
+		if app != "g-issues" {
+			t.Fatalf("reconciled app = %q, want g-issues", app)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("manual selection did not request local reconciliation")
 	}
 
 	request, _ = http.NewRequest(http.MethodGet, ts.URL+"/api/v1/apps/g-issues/admin/registry", nil)
@@ -106,6 +118,70 @@ func TestAppAdminRegistrySelectAndRead(t *testing.T) {
 	if len(state.PublishedVersions) != 1 || state.PublishedVersions[0].SourceRef == "" ||
 		state.PublishedVersions[0].SourceURL == "" || state.PublishedVersions[0].Publication.WorkflowRunURL == "" {
 		t.Fatalf("published versions = %#v", state.PublishedVersions)
+	}
+}
+
+func TestAppAdminRegistrySelectRejectedDoesNotReconcile(t *testing.T) {
+	t.Parallel()
+
+	fixture := registrytest.NewInstallFixture(t)
+	subjectID := principal.UserSubjectID(testCanonicalAdminUserID)
+	authz := &serverTestAuthorizationProvider{
+		relationships: []*proto.Relationship{
+			testAuthorizationRelationship(subjectID, "admin", "app", "g-issues"),
+		},
+	}
+	reconciled := make(chan string, 2)
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = authStubWithSessionTokenIntrospect("alice-token", subjectID, "")
+		cfg.Authorization = authz
+		cfg.AppDefs = map[string]*config.ProviderEntry{
+			"g-issues": {Source: config.ProviderSource{Registry: "toolshed"}},
+		}
+		cfg.AppRegistries = map[string]config.AppRegistryConfig{"toolshed": fixture.Registry}
+		cfg.AppRegistryReader = fixture.Reader
+		cfg.AppRegistryReconcileNotify = func(app string) {
+			reconciled <- app
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	selectVersion := func() int {
+		t.Helper()
+		request, _ := http.NewRequest(
+			http.MethodPost,
+			ts.URL+"/api/v1/apps/g-issues/admin/registry/version",
+			bytes.NewBufferString(`{"version":"`+fixture.Version+`"}`),
+		)
+		request.Header.Set("Authorization", "Bearer alice-token")
+		request.Header.Set("Content-Type", "application/json")
+		response, err := http.DefaultClient.Do(request)
+		if err != nil {
+			t.Fatalf("POST registry version: %v", err)
+		}
+		defer func() { _ = response.Body.Close() }()
+		return response.StatusCode
+	}
+
+	if status := selectVersion(); status != http.StatusOK {
+		t.Fatalf("first select status = %d, want 200", status)
+	}
+	select {
+	case app := <-reconciled:
+		if app != "g-issues" {
+			t.Fatalf("reconciled app = %q, want g-issues", app)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("successful selection did not request local reconciliation")
+	}
+
+	if status := selectVersion(); status != http.StatusConflict {
+		t.Fatalf("duplicate select status = %d, want 409", status)
+	}
+	select {
+	case app := <-reconciled:
+		t.Fatalf("rejected selection requested local reconciliation for %q", app)
+	case <-time.After(100 * time.Millisecond):
 	}
 }
 

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -185,6 +185,7 @@ func run(ctx context.Context, cfg *config.Config, result *bootstrap.Result, gest
 	catalogPoller := startAppRegistryCatalogPoller(ctx, cfg, result, restartDelay, disableRestartDelay, onRolloutTerminal)
 	if catalogPoller != nil {
 		defer catalogPoller.Stop()
+		baseConfig.AppRegistryReconcileNotify = catalogPoller.Notify
 	}
 	heartbeatWriter, err := startAppRegistryHeartbeatWriter(ctx, cfg, result)
 	if err != nil {

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -189,6 +189,7 @@ type Server struct {
 	appRolloutOutcomes            *coredata.AppVersionRolloutOutcomeService
 	recoveryObservations          *coredata.AppVersionRecoveryObservationService
 	appAutoDeployNotify           func(string)
+	appRegistryReconcileNotify    func(string)
 	artifactsDir                  string
 	sourceVersion                 string
 	appRegistryRolloutMode        config.AppRegistryRolloutMode
@@ -273,6 +274,8 @@ type Config struct {
 	TunnelResolver                TunnelResolverConfig
 	// AppAutoDeployNotify requests prompt auto-deploy reconciliation for an app.
 	AppAutoDeployNotify func(app string)
+	// AppRegistryReconcileNotify requests prompt local runtime reconciliation.
+	AppRegistryReconcileNotify func(app string)
 }
 
 func New(cfg Config) (*Server, error) {
@@ -510,6 +513,7 @@ func New(cfg Config) (*Server, error) {
 		appRolloutOutcomes:            cfg.Services.AppVersionRolloutOutcomes,
 		recoveryObservations:          cfg.Services.AppVersionRecoveryObservations,
 		appAutoDeployNotify:           cfg.AppAutoDeployNotify,
+		appRegistryReconcileNotify:    cfg.AppRegistryReconcileNotify,
 		artifactsDir:                  strings.TrimSpace(cfg.ArtifactsDir),
 		sourceVersion:                 strings.TrimSpace(cfg.SourceVersion),
 		appRegistryRolloutMode:        cfg.AppRegistryRolloutMode,


### PR DESCRIPTION
## Summary
- Add a coalescing, non-blocking `CatalogPoller.Notify` hook and invoke it after successful manual registry version selection on the request-serving replica.
- Wire runtime notification from the catalog poller through `AppRegistryReconcileNotify`, keeping the one-minute periodic poll as the fleet-wide correctness fallback.
- Add focused poller, handler, lifecycle, and failure-path tests for successful, rejected, burst, and retry notifications.

## Test plan
- [x] `go test ./gestaltd/internal/appregistry -run TestCatalogPollerNotify -count=1`
- [x] `go test ./gestaltd/internal/server -run TestAppAdminRegistrySelect -count=1`
- [ ] Deploy gestaltd and run `profile_deploy.py` (≥5 trials) to compare `firstReplicaSeconds` against the 38.449 s baseline
- [ ] Confirm no rollout errors, replica loss, or sustained background load during measurement


Made with [Cursor](https://cursor.com)