### PR TITLE
Make catalog poll interval configurable

### DIFF
--- a/gestaltd/internal/config/app_registry_heartbeat_config_test.go
+++ b/gestaltd/internal/config/app_registry_heartbeat_config_test.go
@@ -14,6 +14,7 @@ func TestAppRegistryHeartbeatConfigDefaults(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
+	assertAppRegistryDuration(t, "catalog poll interval", cfg.Server.AppRegistry.CatalogPollIntervalDuration, time.Minute)
 	assertAppRegistryDuration(t, "heartbeat interval", cfg.Server.AppRegistry.HeartbeatIntervalDuration, 15*time.Second)
 	assertAppRegistryDuration(t, "heartbeat TTL", cfg.Server.AppRegistry.HeartbeatTTLDuration, 45*time.Second)
 	assertAppRegistryDuration(t, "healthy stability window", cfg.Server.AppRegistry.HealthyStabilityWindowDuration, 60*time.Second)
@@ -29,6 +30,7 @@ func TestAppRegistryHeartbeatConfigAcceptsExplicitValues(t *testing.T) {
 	path := mustWriteConfigFile(t, `
 server:
   appRegistry:
+    catalogPollInterval: 5s
     heartbeatInterval: 10s
     heartbeatTtl: 35s
     healthyStabilityWindow: 50s
@@ -39,6 +41,7 @@ server:
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
+	assertAppRegistryDuration(t, "catalog poll interval", cfg.Server.AppRegistry.CatalogPollIntervalDuration, 5*time.Second)
 	assertAppRegistryDuration(t, "heartbeat interval", cfg.Server.AppRegistry.HeartbeatIntervalDuration, 10*time.Second)
 	assertAppRegistryDuration(t, "heartbeat TTL", cfg.Server.AppRegistry.HeartbeatTTLDuration, 35*time.Second)
 	assertAppRegistryDuration(t, "healthy stability window", cfg.Server.AppRegistry.HealthyStabilityWindowDuration, 50*time.Second)
@@ -56,6 +59,7 @@ func TestAppRegistryHeartbeatConfigValidation(t *testing.T) {
 		config  string
 		wantErr string
 	}{
+		{name: "catalog interval positive", config: "catalogPollInterval: 0s", wantErr: "catalogPollInterval"},
 		{name: "interval positive", config: "heartbeatInterval: 0s", wantErr: "heartbeatInterval"},
 		{name: "ttl positive", config: "heartbeatTtl: -1s", wantErr: "heartbeatTtl"},
 		{name: "ttl exceeds interval", config: "heartbeatInterval: 15s\n    heartbeatTtl: 15s", wantErr: "must be greater than heartbeatInterval"},

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -2001,6 +2001,7 @@ type ServerAppRegistryConfig struct {
 	// MaxReconcileAttempts bounds failed convergence attempts per app/version.
 	// Omission defaults to DefaultAppRegistryMaxReconcileAttempts.
 	MaxReconcileAttempts    int                        `yaml:"maxReconcileAttempts,omitempty"`
+	CatalogPollInterval     string                     `yaml:"catalogPollInterval,omitempty"`
 	AutoDeployPollInterval  string                     `yaml:"autoDeployPollInterval,omitempty"`
 	HeartbeatInterval       string                     `yaml:"heartbeatInterval,omitempty"`
 	HeartbeatTTL            string                     `yaml:"heartbeatTtl,omitempty"`
@@ -2073,6 +2074,7 @@ type AppRegistryPublishLimits struct {
 }
 
 const DefaultAppRegistryMaxReconcileAttempts = 3
+const DefaultAppRegistryCatalogPollInterval = time.Minute
 const DefaultAppRegistryAutoDeployPollInterval = time.Minute
 const DefaultAppRegistryHeartbeatInterval = 15 * time.Second
 const DefaultAppRegistryHeartbeatTTL = 45 * time.Second
@@ -2092,6 +2094,10 @@ func (c ServerAppRegistryConfig) AutoDeployPollIntervalDuration() (time.Duration
 		return DefaultAppRegistryAutoDeployPollInterval, nil
 	}
 	return ParseDuration(raw)
+}
+
+func (c ServerAppRegistryConfig) CatalogPollIntervalDuration() (time.Duration, error) {
+	return appRegistryDuration(c.CatalogPollInterval, DefaultAppRegistryCatalogPollInterval)
 }
 
 func (c ServerAppRegistryConfig) HeartbeatIntervalDuration() (time.Duration, error) {

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -247,6 +247,9 @@ func validateServerAppRegistry(cfg *Config) error {
 	} else if attempts <= 0 {
 		return fmt.Errorf("config validation: server.appRegistry.maxReconcileAttempts must be a positive integer")
 	}
+	if _, err := cfg.Server.AppRegistry.CatalogPollIntervalDuration(); err != nil {
+		return fmt.Errorf("config validation: server.appRegistry.catalogPollInterval: %w", err)
+	}
 	if _, err := cfg.Server.AppRegistry.AutoDeployPollIntervalDuration(); err != nil {
 		return fmt.Errorf("config validation: server.appRegistry.autoDeployPollInterval: %w", err)
 	}

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -575,6 +575,10 @@ func startAppRegistryCatalogPoller(
 			}
 		}
 	}
+	catalogPollInterval, err := cfg.Server.AppRegistry.CatalogPollIntervalDuration()
+	if err != nil {
+		catalogPollInterval = config.DefaultAppRegistryCatalogPollInterval
+	}
 	heartbeatInterval, err := cfg.Server.AppRegistry.HeartbeatIntervalDuration()
 	if err != nil {
 		heartbeatInterval = config.DefaultAppRegistryHeartbeatInterval
@@ -597,6 +601,7 @@ func startAppRegistryCatalogPoller(
 		AppRestarter:                result.AppRestarter,
 		InstanceID:                  appregistry.ResolveInstanceID(),
 		SourceVersion:               appregistry.ResolveSourceVersion(),
+		Interval:                    catalogPollInterval,
 		HeartbeatEvaluationInterval: heartbeatInterval,
 		HeartbeatTTL:                heartbeatTTL,
 		HealthyStabilityWindow:      stabilityWindow,

--- a/gestaltd/internal/server/runtime_app_registry_test.go
+++ b/gestaltd/internal/server/runtime_app_registry_test.go
@@ -77,10 +77,11 @@ func TestServerInstallerWiringPreservesConfiguredRolloutMode(t *testing.T) {
 	}
 }
 
-func TestCatalogPollerWiringPreservesCatalogCadence(t *testing.T) {
+func TestCatalogPollerWiringPreservesIndependentCadences(t *testing.T) {
 	t.Parallel()
 
 	cfg := &config.Config{}
+	cfg.Server.AppRegistry.CatalogPollInterval = "5s"
 	cfg.Server.AppRegistry.HeartbeatInterval = "7s"
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -96,8 +97,8 @@ func TestCatalogPollerWiringPreservesCatalogCadence(t *testing.T) {
 		t.Fatal("catalog poller is nil")
 	}
 	poller.Stop()
-	if poller.Interval != 0 {
-		t.Fatalf("catalog interval = %v, want default %v", poller.Interval, appregistry.DefaultCatalogPollInterval)
+	if poller.Interval != 5*time.Second {
+		t.Fatalf("catalog interval = %v, want 5s", poller.Interval)
 	}
 	if poller.HeartbeatEvaluationInterval != 7*time.Second {
 		t.Fatalf("heartbeat evaluation interval = %v, want 7s", poller.HeartbeatEvaluationInterval)

--- a/plans/app_registry/architecture/config.md
+++ b/plans/app_registry/architecture/config.md
@@ -155,6 +155,21 @@ This limit does not apply to bootstrap. Bootstrap never consults rollout-progres
 
 A newly accepted desired version uses a new materialization row and starts with zero failed attempts. Increasing the configured limit allows rows below the new limit to resume retrying.
 
+### Catalog Poll Interval
+
+```yaml
+server:
+  appRegistry:
+    catalogPollInterval: 1m
+```
+
+`server.appRegistry.catalogPollInterval` controls how often each replica checks
+shared desired-version state and reconciles registry app runtimes. It defaults
+to `1m` and must be a positive duration. Manual selection also requests an
+immediate reconciliation on the replica that serves the request; the interval
+remains the upper bound for the rest of the fleet. Shorter values improve fleet
+convergence at the cost of proportionally more shared-state reads.
+
 ### Auto-Deploy Poll Interval
 
 ```yaml


### PR DESCRIPTION
## Summary
- Add `server.appRegistry.catalogPollInterval` with a one-minute default, positive-duration validation, and runtime wiring into the catalog poller.
- Keep catalog polling independent from heartbeat evaluation cadence and rollout safety settings.
- Document the new setting in the app registry config architecture notes.

## Test plan
- [x] `go test ./gestaltd/internal/config -run TestAppRegistryHeartbeatConfig -count=1`
- [x] `go test ./gestaltd/internal/server -run TestCatalogPollerWiring -count=1`
- [ ] Merge and deploy after #3124 (immediate local reconciliation)
- [ ] Merge toolshed opt-in PR setting `catalogPollInterval: 10s`
- [ ] Run `profile_deploy.py` (≥5 trials) to compare `fleetHealthySeconds` against the 63.507 s baseline and record registry GET volume


Made with [Cursor](https://cursor.com)