### PR TITLE
Fix race detector failures blocking gestaltd CD

### DIFF
--- a/gestaltd/internal/daemon/app_registry_remote_publish_test.go
+++ b/gestaltd/internal/daemon/app_registry_remote_publish_test.go
@@ -344,9 +344,12 @@ func TestRemoteRegistryPublishAlreadyPublishedAndAuth(t *testing.T) { //nolint:p
 func TestRemoteRegistryPublishInterruptedResume(t *testing.T) { //nolint:paralleltest // chdirs
 	_, distDir, _, base := setupRemotePublishFixture(t)
 	_, darwinHeaders := remotePublishArtifactFixture(t, filepath.Join(distDir, "darwin-arm64.tar.gz"))
+	var stateMu sync.Mutex
 	uploaded := map[string]bool{}
 	uploadServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		stateMu.Lock()
 		uploaded[strings.TrimPrefix(r.URL.Path, "/upload/")] = true
+		stateMu.Unlock()
 		w.WriteHeader(http.StatusOK)
 	}))
 	t.Cleanup(uploadServer.Close)
@@ -357,8 +360,15 @@ func TestRemoteRegistryPublishInterruptedResume(t *testing.T) { //nolint:paralle
 		case strings.HasSuffix(r.URL.Path, "/finalize"):
 			writeRemotePublishJSON(w, appregistry.AdminPublishResponse{PublishID: "pub_resume", App: "demo", Version: "0.3.0-dev.1", State: appregistry.PublishStatePublished})
 		case strings.HasSuffix(r.URL.Path, "/publishes"):
+			stateMu.Lock()
+			first := firstCreate
 			if firstCreate {
 				firstCreate = false
+			}
+			darwinDone := uploaded["darwin/arm64"]
+			stateMu.Unlock()
+
+			if first {
 				_, linuxHeaders := remotePublishArtifactFixture(t, filepath.Join(distDir, "linux-amd64.tar.gz"))
 				writeRemotePublishJSON(w, appregistry.AdminPublishResponse{
 					PublishID: "pub_resume", App: "demo", Version: "0.3.0-dev.1", State: appregistry.PublishStateUploading,
@@ -369,7 +379,7 @@ func TestRemoteRegistryPublishInterruptedResume(t *testing.T) { //nolint:paralle
 				})
 				return
 			}
-			if !uploaded["darwin/arm64"] {
+			if !darwinDone {
 				writeRemotePublishJSON(w, appregistry.AdminPublishResponse{
 					PublishID: "pub_resume", App: "demo", Version: "0.3.0-dev.1", State: appregistry.PublishStateUploading,
 					Uploads: []appregistry.AdminPublishUpload{{Platform: "darwin/arm64", UploadURL: uploadServer.URL + "/upload/darwin/arm64", Headers: darwinHeaders}},
@@ -381,14 +391,22 @@ func TestRemoteRegistryPublishInterruptedResume(t *testing.T) { //nolint:paralle
 	}))
 	t.Cleanup(apiServer.Close)
 
+	stateMu.Lock()
 	uploaded["linux/amd64"] = true
+	stateMu.Unlock()
 	if _, err := (&remoteRegistryPublisher{
 		Version: "0.3.0-dev.1", DistDirs: []string{distDir}, GestaltURL: apiServer.URL, GestaltToken: "token",
 		BuilderVersion: remotePublishTestBuilderVersion,
 		Client:         &remoteRegistryClient{BaseURL: apiServer.URL, Token: "token"},
 		GitRunner:      base.GitRunner, collectArchives: base.collectArchives, resolveManifest: base.resolveManifest, buildReleaseMetadata: base.buildReleaseMetadata,
-	}).publish(t.Context()); err != nil || !uploaded["darwin/arm64"] {
-		t.Fatalf("resume upload = %#v err=%v", uploaded, err)
+	}).publish(t.Context()); err != nil {
+		t.Fatalf("resume upload err=%v", err)
+	}
+	stateMu.Lock()
+	darwinDone := uploaded["darwin/arm64"]
+	stateMu.Unlock()
+	if !darwinDone {
+		t.Fatalf("resume upload = %#v, want darwin/arm64 uploaded", uploaded)
 	}
 }
 

--- a/gestaltd/internal/remote/remote_preview_test.go
+++ b/gestaltd/internal/remote/remote_preview_test.go
@@ -9,9 +9,7 @@ import (
 	"golang.org/x/oauth2"
 )
 
-func TestCloudRunDialOptionsAddsGestaltAuthorizationMetadata(t *testing.T) {
-	t.Parallel()
-
+func TestCloudRunDialOptionsAddsGestaltAuthorizationMetadata(t *testing.T) { //nolint:paralleltest // mutates package-level Cloud Run token hooks
 	remote.TestCloudRunTokenSourceHook = func(context.Context, string) (oauth2.TokenSource, error) {
 		return oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "google-id-token"}), nil
 	}
@@ -26,9 +24,7 @@ func TestCloudRunDialOptionsAddsGestaltAuthorizationMetadata(t *testing.T) {
 	}
 }
 
-func TestCloudRunDialOptionsRejectsMissingTokenSource(t *testing.T) {
-	t.Parallel()
-
+func TestCloudRunDialOptionsRejectsMissingTokenSource(t *testing.T) { //nolint:paralleltest // mutates package-level Cloud Run token hooks
 	remote.TestCloudRunTokenSourceHook = func(context.Context, string) (oauth2.TokenSource, error) {
 		return nil, context.DeadlineExceeded
 	}


### PR DESCRIPTION
## Summary
- Stop running remote preview dial-option tests in parallel; they swap package-level Cloud Run token hooks.
- Serialize shared handler state in the interrupted remote publish resume test so concurrent upload requests do not race on the uploaded map.

This unblocks **Publish gestaltd Binaries to GCS** in CD, which has been skipped since Aug 21 and broke toolshed **Auto-publish App Registry** after `GESTALTD_PINNED_SHA` was bumped to speed-optimization commits without GCS artifacts.

## Test plan
- [x] `go test -race ./internal/remote/... -run TestCloudRunDialOptions -count=3`
- [x] `go test -race -parallel=16 ./internal/daemon/...`
- [ ] Gestalt CD green on merge
- [ ] Re-pin toolshed `GESTALTD_PINNED_SHA` to `c1973f88f3737e2b6be1754a6fb7f5be99195e19` after binaries land in GCS


Made with [Cursor](https://cursor.com)