### PR TITLE
apps: let users choose app capabilities

### DIFF
--- a/gestaltd/core/app_access.go
+++ b/gestaltd/core/app_access.go
@@ -5,6 +5,10 @@ import (
 	"time"
 )
 
+// GraphQLCapabilityID is the reserved app capability for raw GraphQL
+// requests, which do not correspond to one catalog operation.
+const GraphQLCapabilityID = "graphql"
+
 // AppAccessProfile is the user-owned allow list for one app. Workspace
 // authorization remains a separate ceiling: enabling an operation here never
 // grants access the workspace has not granted.

--- a/gestaltd/core/app_access.go
+++ b/gestaltd/core/app_access.go
@@ -1,0 +1,26 @@
+package core
+
+import (
+	"context"
+	"time"
+)
+
+// AppAccessProfile is the user-owned allow list for one app. Workspace
+// authorization remains a separate ceiling: enabling an operation here never
+// grants access the workspace has not granted.
+type AppAccessProfile struct {
+	SubjectID           string
+	App                 string
+	EnabledOperations   []string
+	DefaultsInitialized bool
+	UpdatedAt           time.Time
+}
+
+// AppAccessProfileStore persists the interactive app capabilities a user has
+// selected. The store deliberately has an idempotent defaulting operation so
+// reconnecting an account cannot overwrite a user's choices.
+type AppAccessProfileStore interface {
+	GetAppAccessProfile(ctx context.Context, subjectID, app string) (*AppAccessProfile, error)
+	EnsureAppAccessDefaults(ctx context.Context, subjectID, app string, operations []string) (*AppAccessProfile, error)
+	SetAppAccessOperations(ctx context.Context, subjectID, app string, operations []string) (*AppAccessProfile, error)
+}

--- a/gestaltd/core/provider.go
+++ b/gestaltd/core/provider.go
@@ -52,6 +52,14 @@ type Provider interface {
 	Execute(ctx context.Context, operation string, params map[string]any, token string) (*OperationResult, error)
 }
 
+// AppAccessDefaultsProvider is implemented by manifest-backed apps that
+// publish an explicit, provider-owned recommendation for the operations a new
+// user profile should enable. The bool distinguishes an explicit empty policy
+// from an older provider with no policy metadata.
+type AppAccessDefaultsProvider interface {
+	DefaultAppAccessOperations() ([]string, bool)
+}
+
 // OperationConnectionSelector maps a caller-supplied parameter value to the
 // named connection Gestalt should use for an operation invocation.
 type OperationConnectionSelector struct {

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -1315,6 +1315,7 @@ func BootstrapWithOptions(ctx context.Context, cfg *config.Config, factories *Fa
 		invocation.WithMCPConnectionMapper(invocation.ConnectionMap(connMaps.MCPConnection)),
 		invocation.WithConnectionRuntime(connRuntime.Resolve),
 		invocation.WithConnectionInstancePreferences(prepared.Services.ConnectionInstancePreferences),
+		invocation.WithAppAccessProfiles(prepared.Services.AppAccessProfiles),
 		invocation.WithAuthorizationProvider(authorizationProvider),
 		invocation.WithProviderKinds(kinds),
 		invocation.WithAuthorizationPolicies(authorizationPolicies),

--- a/gestaltd/internal/bootstrap/validate.go
+++ b/gestaltd/internal/bootstrap/validate.go
@@ -72,6 +72,7 @@ func Validate(ctx context.Context, cfg *config.Config, factories *FactoryRegistr
 		invocation.WithMCPConnectionMapper(invocation.ConnectionMap(connMaps.MCPConnection)),
 		invocation.WithConnectionRuntime(connRuntime.Resolve),
 		invocation.WithConnectionInstancePreferences(prepared.Services.ConnectionInstancePreferences),
+		invocation.WithAppAccessProfiles(prepared.Services.AppAccessProfiles),
 	)
 	workflowTools := newWorkflowSystemTools(prepared.WorkflowManager, prepared.Deps.WorkflowRuntime)
 	prepared.WorkflowManager.SetTarget(workflowmanager.New(workflowmanager.Config{

--- a/gestaltd/internal/coredata/app_access_profiles.go
+++ b/gestaltd/internal/coredata/app_access_profiles.go
@@ -1,0 +1,188 @@
+package coredata
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	idb "github.com/valon-technologies/gestalt/sdk/go/indexeddb"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/indexeddb"
+)
+
+const appAccessProfileKeySep = "\x1f"
+
+// AppAccessProfileService is the durable store for user-selected app
+// capabilities. Profiles are keyed by the canonical credential subject and
+// app, so a user's settings follow the user across connection methods and
+// account instances.
+type AppAccessProfileService struct {
+	db    indexeddb.IndexedDB
+	store idb.ObjectStore
+}
+
+func NewAppAccessProfileService(ds indexeddb.IndexedDB) *AppAccessProfileService {
+	return &AppAccessProfileService{
+		db:    ds,
+		store: ds.ObjectStore(StoreAppAccessProfiles),
+	}
+}
+
+// EnsureStore idempotently creates the profile store for deployments that
+// started before app capabilities were introduced.
+func (s *AppAccessProfileService) EnsureStore(ctx context.Context) error {
+	if s == nil || s.db == nil {
+		return fmt.Errorf("ensure app access profiles store: service is not configured")
+	}
+	return ensureAppAccessProfilesStore(ctx, s.db)
+}
+
+func (s *AppAccessProfileService) GetAppAccessProfile(ctx context.Context, subjectID, app string) (*core.AppAccessProfile, error) {
+	if s == nil {
+		return nil, fmt.Errorf("get app access profile: service is not configured")
+	}
+	key, subjectID, app, err := validateAppAccessProfileKey(subjectID, app)
+	if err != nil {
+		return nil, err
+	}
+	rec, err := s.store.Get(ctx, key)
+	if err != nil {
+		if errors.Is(err, idb.ErrNotFound) {
+			return nil, core.ErrNotFound
+		}
+		return nil, fmt.Errorf("get app access profile: %w", err)
+	}
+	profile, err := recordToAppAccessProfile(rec)
+	if err != nil {
+		return nil, fmt.Errorf("get app access profile: %w", err)
+	}
+	profile.SubjectID = subjectID
+	profile.App = app
+	return profile, nil
+}
+
+// EnsureAppAccessDefaults creates the initial profile only when it does not
+// already exist. Existing profiles are returned unchanged, including an
+// intentionally empty allow list.
+func (s *AppAccessProfileService) EnsureAppAccessDefaults(ctx context.Context, subjectID, app string, operations []string) (*core.AppAccessProfile, error) {
+	if s == nil || s.db == nil {
+		return nil, fmt.Errorf("ensure app access defaults: service is not configured")
+	}
+	_, subjectID, app, err := validateAppAccessProfileKey(subjectID, app)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.EnsureStore(ctx); err != nil {
+		return nil, err
+	}
+	profile := &core.AppAccessProfile{
+		SubjectID:           subjectID,
+		App:                 app,
+		EnabledOperations:   normalizeAppAccessOperations(operations),
+		DefaultsInitialized: true,
+		UpdatedAt:           time.Now().UTC().Truncate(time.Millisecond),
+	}
+	if err := s.store.Add(ctx, appAccessProfileRecord(profile)); err == nil {
+		return profile, nil
+	} else if !errors.Is(err, idb.ErrAlreadyExists) {
+		return nil, fmt.Errorf("ensure app access defaults: write: %w", err)
+	}
+	// Another connection completion won the create race. Read its profile and
+	// preserve the user's existing choices rather than replacing them.
+	existing, err := s.GetAppAccessProfile(ctx, subjectID, app)
+	if err != nil {
+		return nil, fmt.Errorf("ensure app access defaults: load current: %w", err)
+	}
+	return existing, nil
+}
+
+func (s *AppAccessProfileService) SetAppAccessOperations(ctx context.Context, subjectID, app string, operations []string) (*core.AppAccessProfile, error) {
+	if s == nil || s.db == nil {
+		return nil, fmt.Errorf("set app access operations: service is not configured")
+	}
+	_, subjectID, app, err := validateAppAccessProfileKey(subjectID, app)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.EnsureStore(ctx); err != nil {
+		return nil, err
+	}
+	profile, err := s.GetAppAccessProfile(ctx, subjectID, app)
+	if err != nil && !errors.Is(err, core.ErrNotFound) {
+		return nil, err
+	}
+	if profile == nil {
+		profile = &core.AppAccessProfile{SubjectID: subjectID, App: app}
+	}
+	profile.EnabledOperations = normalizeAppAccessOperations(operations)
+	profile.DefaultsInitialized = true
+	profile.UpdatedAt = time.Now().UTC().Truncate(time.Millisecond)
+	if err := s.store.Put(ctx, appAccessProfileRecord(profile)); err != nil {
+		return nil, fmt.Errorf("set app access operations: write: %w", err)
+	}
+	return profile, nil
+}
+
+func validateAppAccessProfileKey(subjectID, app string) (string, string, string, error) {
+	subjectID = strings.TrimSpace(subjectID)
+	app = strings.TrimSpace(app)
+	if subjectID == "" || app == "" {
+		return "", "", "", fmt.Errorf("app access profile: subject_id and app are required")
+	}
+	return subjectID + appAccessProfileKeySep + app, subjectID, app, nil
+}
+
+func normalizeAppAccessOperations(operations []string) []string {
+	if len(operations) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(operations))
+	out := make([]string, 0, len(operations))
+	for _, operation := range operations {
+		operation = strings.TrimSpace(operation)
+		if operation == "" {
+			continue
+		}
+		if _, ok := seen[operation]; ok {
+			continue
+		}
+		seen[operation] = struct{}{}
+		out = append(out, operation)
+	}
+	slices.Sort(out)
+	return out
+}
+
+func appAccessProfileRecord(profile *core.AppAccessProfile) idb.Record {
+	operations, _ := json.Marshal(normalizeAppAccessOperations(profile.EnabledOperations))
+	return idb.Record{
+		"id":                   strings.TrimSpace(profile.SubjectID) + appAccessProfileKeySep + strings.TrimSpace(profile.App),
+		"subject_id":           strings.TrimSpace(profile.SubjectID),
+		"app":                  strings.TrimSpace(profile.App),
+		"enabled_operations":   string(operations),
+		"defaults_initialized": profile.DefaultsInitialized,
+		"updated_at":           profile.UpdatedAt.UTC().Truncate(time.Millisecond),
+	}
+}
+
+func recordToAppAccessProfile(rec idb.Record) (*core.AppAccessProfile, error) {
+	var operations []string
+	if raw := recString(rec, "enabled_operations"); raw != "" {
+		if err := json.Unmarshal([]byte(raw), &operations); err != nil {
+			return nil, fmt.Errorf("decode enabled operations: %w", err)
+		}
+	}
+	initialized, _ := rec["defaults_initialized"].(bool)
+	return &core.AppAccessProfile{
+		SubjectID:           recString(rec, "subject_id"),
+		App:                 recString(rec, "app"),
+		EnabledOperations:   normalizeAppAccessOperations(operations),
+		DefaultsInitialized: initialized,
+		UpdatedAt:           recTime(rec, "updated_at"),
+	}, nil
+}

--- a/gestaltd/internal/coredata/app_access_profiles_test.go
+++ b/gestaltd/internal/coredata/app_access_profiles_test.go
@@ -1,0 +1,56 @@
+package coredata_test
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
+)
+
+func TestAppAccessProfileService(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	svc := testutil.NewStubServices(t).AppAccessProfiles
+	const subject = "user:person@example.com"
+	const app = "slack"
+
+	if _, err := svc.GetAppAccessProfile(ctx, subject, app); !errors.Is(err, core.ErrNotFound) {
+		t.Fatalf("missing profile error = %v, want %v", err, core.ErrNotFound)
+	}
+
+	created, err := svc.EnsureAppAccessDefaults(ctx, subject, app, []string{"users.list", "conversations.list", "users.list"})
+	if err != nil {
+		t.Fatalf("EnsureAppAccessDefaults: %v", err)
+	}
+	if !created.DefaultsInitialized || !slices.Equal(created.EnabledOperations, []string{"conversations.list", "users.list"}) {
+		t.Fatalf("created profile = %#v", created)
+	}
+
+	unchanged, err := svc.EnsureAppAccessDefaults(ctx, subject, app, []string{"chat.postMessage"})
+	if err != nil {
+		t.Fatalf("EnsureAppAccessDefaults existing: %v", err)
+	}
+	if !slices.Equal(unchanged.EnabledOperations, created.EnabledOperations) {
+		t.Fatalf("reconnect changed profile from %#v to %#v", created.EnabledOperations, unchanged.EnabledOperations)
+	}
+
+	updated, err := svc.SetAppAccessOperations(ctx, subject, app, []string{"chat.postMessage"})
+	if err != nil {
+		t.Fatalf("SetAppAccessOperations: %v", err)
+	}
+	if !slices.Equal(updated.EnabledOperations, []string{"chat.postMessage"}) {
+		t.Fatalf("updated profile = %#v", updated)
+	}
+
+	cleared, err := svc.SetAppAccessOperations(ctx, subject, app, nil)
+	if err != nil {
+		t.Fatalf("SetAppAccessOperations empty: %v", err)
+	}
+	if len(cleared.EnabledOperations) != 0 {
+		t.Fatalf("cleared profile = %#v", cleared)
+	}
+}

--- a/gestaltd/internal/coredata/schemas.go
+++ b/gestaltd/internal/coredata/schemas.go
@@ -21,6 +21,7 @@ const (
 	StoreRemoteRegistrations            = "remote_registrations"
 	StoreRemoteProviders                = "remote_providers"
 	StoreConnectionInstancePreferences  = "connection_instance_preferences"
+	StoreAppAccessProfiles              = "app_access_profiles"
 )
 
 var AppSHAsSchema = idb.ObjectStoreOptions{
@@ -228,6 +229,22 @@ var ConnectionInstancePreferencesSchema = idb.ObjectStoreOptions{
 		{Name: "subject_id", Type: idb.TypeString, NotNull: true},
 		{Name: "connection_id", Type: idb.TypeString, NotNull: true},
 		{Name: "instance", Type: idb.TypeString, NotNull: true},
+		{Name: "updated_at", Type: idb.TypeTime, NotNull: true},
+	},
+}
+
+var AppAccessProfilesSchema = idb.ObjectStoreOptions{
+	Indexes: []idb.IndexSchema{
+		{Name: "by_subject", KeyPath: []string{"subject_id"}},
+		{Name: "by_app", KeyPath: []string{"app"}},
+		{Name: "by_subject_app", KeyPath: []string{"subject_id", "app"}, Unique: true},
+	},
+	Columns: []idb.ColumnDef{
+		{Name: "id", Type: idb.TypeString, PrimaryKey: true},
+		{Name: "subject_id", Type: idb.TypeString, NotNull: true},
+		{Name: "app", Type: idb.TypeString, NotNull: true},
+		{Name: "enabled_operations", Type: idb.TypeString},
+		{Name: "defaults_initialized", Type: idb.TypeBool, NotNull: true},
 		{Name: "updated_at", Type: idb.TypeTime, NotNull: true},
 	},
 }

--- a/gestaltd/internal/coredata/services.go
+++ b/gestaltd/internal/coredata/services.go
@@ -23,6 +23,7 @@ type Services struct {
 	AppVersionRecoveryObservations *AppVersionRecoveryObservationService
 	RemoteRegistrations            *RemoteRegistrationService
 	ConnectionInstancePreferences  *ConnectionInstancePreferenceService
+	AppAccessProfiles              *AppAccessProfileService
 	DB                             indexeddb.IndexedDB
 }
 
@@ -91,6 +92,9 @@ func NewWithOptions(ctx context.Context, ds indexeddb.IndexedDB, opts NewOptions
 		if _, err := ds.CreateObjectStore(ctx, StoreConnectionInstancePreferences, ConnectionInstancePreferencesSchema); err != nil {
 			return nil, fmt.Errorf("create connection_instance_preferences store: %w", err)
 		}
+		if _, err := ds.CreateObjectStore(ctx, StoreAppAccessProfiles, AppAccessProfilesSchema); err != nil {
+			return nil, fmt.Errorf("create app_access_profiles store: %w", err)
+		}
 	} else if err := ensureDeferredAppRegistryStores(ctx, ds); err != nil {
 		return nil, err
 	}
@@ -107,6 +111,7 @@ func NewWithOptions(ctx context.Context, ds indexeddb.IndexedDB, opts NewOptions
 	appVersionRecoveryObservations := NewAppVersionRecoveryObservationService(ds)
 	remoteRegistrations := NewRemoteRegistrationService(ds)
 	connectionInstancePreferences := NewConnectionInstancePreferenceService(ds)
+	appAccessProfiles := NewAppAccessProfileService(ds)
 	return &Services{
 		ExternalCredentials:            nil,
 		Users:                          users,
@@ -122,6 +127,7 @@ func NewWithOptions(ctx context.Context, ds indexeddb.IndexedDB, opts NewOptions
 		AppVersionRecoveryObservations: appVersionRecoveryObservations,
 		RemoteRegistrations:            remoteRegistrations,
 		ConnectionInstancePreferences:  connectionInstancePreferences,
+		AppAccessProfiles:              appAccessProfiles,
 		DB:                             ds,
 	}, nil
 }
@@ -146,6 +152,16 @@ func ensureDeferredAppRegistryStores(ctx context.Context, ds indexeddb.IndexedDB
 	}
 	if err := ensureAppVersionRecoveryObservationsStore(ctx, ds); err != nil {
 		return err
+	}
+	if err := ensureAppAccessProfilesStore(ctx, ds); err != nil {
+		return err
+	}
+	return nil
+}
+
+func ensureAppAccessProfilesStore(ctx context.Context, ds indexeddb.IndexedDB) error {
+	if _, err := ds.CreateObjectStore(ctx, StoreAppAccessProfiles, AppAccessProfilesSchema); err != nil {
+		return fmt.Errorf("ensure app_access_profiles store: %w", err)
 	}
 	return nil
 }

--- a/gestaltd/internal/coredata/services_test.go
+++ b/gestaltd/internal/coredata/services_test.go
@@ -255,6 +255,7 @@ func TestNew(t *testing.T) {
 			coredata.StoreRemoteRegistrations,
 			coredata.StoreRemoteProviders,
 			coredata.StoreConnectionInstancePreferences,
+			coredata.StoreAppAccessProfiles,
 		} {
 			if _, ok := contexts[store]; !ok {
 				t.Fatalf("NewWithContext did not create store %q", store)
@@ -275,14 +276,15 @@ func TestNew(t *testing.T) {
 			t.Fatalf("coredata.NewWithOptions: %v", err)
 		}
 		contexts := db.createdStoreContexts()
-		if len(contexts) != 4 {
-			t.Fatalf("CreateObjectStore calls = %d, want 4", len(contexts))
+		if len(contexts) != 5 {
+			t.Fatalf("CreateObjectStore calls = %d, want 5", len(contexts))
 		}
 		for _, store := range []string{
 			coredata.StoreAppAutoDeploySettings,
 			coredata.StoreAppVersionRolloutOutcomes,
 			coredata.StoreGestaltdInstanceHeartbeats,
 			coredata.StoreAppVersionRecoveryObservations,
+			coredata.StoreAppAccessProfiles,
 		} {
 			if _, ok := contexts[store]; !ok {
 				t.Fatalf("CreateObjectStore calls = %v, want %q", contexts, store)

--- a/gestaltd/internal/server/handlers_app_access.go
+++ b/gestaltd/internal/server/handlers_app_access.go
@@ -174,7 +174,7 @@ func (s *Server) appAccessResponse(r *http.Request, subjectID, app string, prov 
 }
 
 func (s *Server) appAccessCatalog(r *http.Request, app string, prov core.Provider) (*catalog.Catalog, error) {
-	staticCat := s.publicCatalog(app, prov, prov.Catalog())
+	staticCat := appAccessCapabilityCatalog(prov, s.publicCatalog(app, prov, prov.Catalog()))
 	if !core.SupportsSessionCatalog(prov) {
 		return staticCat, nil
 	}
@@ -198,7 +198,37 @@ func (s *Server) appAccessCatalog(r *http.Request, app string, prov core.Provide
 		}
 		return nil, err
 	}
-	return s.publicCatalog(app, prov, cat), nil
+	return appAccessCapabilityCatalog(prov, s.publicCatalog(app, prov, cat)), nil
+}
+
+func appAccessCapabilityCatalog(prov core.Provider, cat *catalog.Catalog) *catalog.Catalog {
+	if prov == nil {
+		return cat
+	}
+	if _, ok := prov.(core.GraphQLSurfaceInvoker); !ok {
+		return cat
+	}
+	if cat == nil {
+		cat = &catalog.Catalog{
+			Name:        prov.Name(),
+			DisplayName: prov.DisplayName(),
+			Description: prov.Description(),
+		}
+	} else {
+		cat = cat.Clone()
+	}
+	if _, ok := catalog.OperationByID(cat, core.GraphQLCapabilityID); ok {
+		return cat
+	}
+	cat.Operations = append(cat.Operations, catalog.CatalogOperation{
+		ID:          core.GraphQLCapabilityID,
+		Title:       "GraphQL",
+		Description: "Run GraphQL queries against this app",
+		Method:      "POST",
+		Tags:        []string{"graphql"},
+		Transport:   "graphql",
+	})
+	return cat
 }
 
 func defaultAppAccessOperations(cat *catalog.Catalog) []string {

--- a/gestaltd/internal/server/handlers_app_access.go
+++ b/gestaltd/internal/server/handlers_app_access.go
@@ -1,0 +1,254 @@
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"slices"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/catalog"
+	"github.com/valon-technologies/gestalt/server/services/identity/principal"
+)
+
+type appAccessOperationInfo struct {
+	ID          string   `json:"id"`
+	Title       string   `json:"title,omitempty"`
+	Description string   `json:"description,omitempty"`
+	Method      string   `json:"method,omitempty"`
+	Tags        []string `json:"tags,omitempty"`
+	ReadOnly    bool     `json:"readOnly"`
+	Enabled     bool     `json:"enabled"`
+	Default     bool     `json:"default"`
+}
+
+type appAccessResponse struct {
+	App                 string                   `json:"app"`
+	Operations          []appAccessOperationInfo `json:"operations"`
+	EnabledOperations   []string                 `json:"enabledOperations"`
+	DefaultsInitialized bool                     `json:"defaultsInitialized"`
+}
+
+type updateAppAccessRequest struct {
+	EnabledOperations []string `json:"enabledOperations"`
+}
+
+func (s *Server) getAppAccess(w http.ResponseWriter, r *http.Request) {
+	name := strings.TrimSpace(chi.URLParam(r, "name"))
+	prov, ok := s.getProvider(r.Context(), w, name)
+	if !ok {
+		return
+	}
+	subjectID, err := s.resolveAppAccessSubject(r)
+	if err != nil {
+		writeError(w, http.StatusUnauthorized, "a user session is required")
+		return
+	}
+	response, err := s.appAccessResponse(r, subjectID, name, prov)
+	if err != nil {
+		s.writeAppAccessError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, response)
+}
+
+func (s *Server) updateAppAccess(w http.ResponseWriter, r *http.Request) {
+	name := strings.TrimSpace(chi.URLParam(r, "name"))
+	prov, ok := s.getProvider(r.Context(), w, name)
+	if !ok {
+		return
+	}
+	subjectID, err := s.resolveAppAccessSubject(r)
+	if err != nil {
+		writeError(w, http.StatusUnauthorized, "a user session is required")
+		return
+	}
+	var req updateAppAccessRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	cat := s.publicCatalog(name, prov, prov.Catalog())
+	valid := make(map[string]struct{})
+	if cat != nil {
+		for _, op := range cat.Operations {
+			valid[op.ID] = struct{}{}
+		}
+	}
+	enabled, invalid := normalizeRequestedAppAccess(req.EnabledOperations, valid)
+	if len(invalid) > 0 {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("unknown app operation: %s", invalid[0]))
+		return
+	}
+	if s.appAccessProfiles == nil {
+		writeError(w, http.StatusServiceUnavailable, "app access settings are unavailable")
+		return
+	}
+	if _, err := s.appAccessProfiles.SetAppAccessOperations(r.Context(), subjectID, name, enabled); err != nil {
+		s.writeAppAccessError(w, err)
+		return
+	}
+	response, err := s.appAccessResponse(r, subjectID, name, prov)
+	if err != nil {
+		s.writeAppAccessError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, response)
+}
+
+func (s *Server) resolveAppAccessSubject(r *http.Request) (string, error) {
+	p := PrincipalFromContext(r.Context())
+	if p == nil || principal.IsNonUserPrincipal(p) {
+		return "", errors.New("user principal required")
+	}
+	return principal.ResolveCredentialSubjectID(r.Context(), s.credentialUserResolver(), p)
+}
+
+func (s *Server) appAccessResponse(r *http.Request, subjectID, app string, prov core.Provider) (*appAccessResponse, error) {
+	cat := s.publicCatalog(app, prov, prov.Catalog())
+	defaults := defaultAppAccessOperationsForProvider(prov, cat)
+	enabled := defaults
+	initialized := false
+	if s.appAccessProfiles != nil {
+		profile, err := s.appAccessProfiles.GetAppAccessProfile(r.Context(), subjectID, app)
+		if err == nil {
+			enabled = profile.EnabledOperations
+			initialized = profile.DefaultsInitialized
+		} else if !errors.Is(err, core.ErrNotFound) {
+			return nil, err
+		}
+	}
+	enabledSet := make(map[string]struct{}, len(enabled))
+	for _, operation := range enabled {
+		enabledSet[operation] = struct{}{}
+	}
+	defaultSet := make(map[string]struct{}, len(defaults))
+	for _, operation := range defaults {
+		defaultSet[operation] = struct{}{}
+	}
+	response := &appAccessResponse{
+		App:                 app,
+		Operations:          make([]appAccessOperationInfo, 0),
+		EnabledOperations:   append([]string(nil), enabled...),
+		DefaultsInitialized: initialized,
+	}
+	if cat == nil {
+		return response, nil
+	}
+	response.Operations = make([]appAccessOperationInfo, 0, len(cat.Operations))
+	for _, op := range cat.Operations {
+		readOnly := op.ReadOnly
+		if op.Annotations.ReadOnlyHint != nil {
+			readOnly = readOnly || *op.Annotations.ReadOnlyHint
+		}
+		_, isEnabled := enabledSet[op.ID]
+		_, isDefault := defaultSet[op.ID]
+		response.Operations = append(response.Operations, appAccessOperationInfo{
+			ID:          op.ID,
+			Title:       op.Title,
+			Description: op.Description,
+			Method:      op.Method,
+			Tags:        append([]string(nil), op.Tags...),
+			ReadOnly:    readOnly,
+			Enabled:     isEnabled,
+			Default:     isDefault,
+		})
+	}
+	slices.SortFunc(response.Operations, func(a, b appAccessOperationInfo) int {
+		return strings.Compare(a.ID, b.ID)
+	})
+	return response, nil
+}
+
+func defaultAppAccessOperations(cat *catalog.Catalog) []string {
+	if cat == nil {
+		return nil
+	}
+	readOnly := make([]string, 0, len(cat.Operations))
+	all := make([]string, 0, len(cat.Operations))
+	for _, op := range cat.Operations {
+		if !catalog.OperationVisibleByDefault(op) {
+			continue
+		}
+		all = append(all, op.ID)
+		isReadOnly := op.ReadOnly
+		if op.Annotations.ReadOnlyHint != nil {
+			isReadOnly = isReadOnly || *op.Annotations.ReadOnlyHint
+		}
+		if isReadOnly {
+			readOnly = append(readOnly, op.ID)
+		}
+	}
+	// Providers that declare read-only hints get a safe read-first profile.
+	// Older providers without that metadata retain their existing behavior until
+	// they publish capability annotations.
+	if len(readOnly) > 0 {
+		slices.Sort(readOnly)
+		return readOnly
+	}
+	slices.Sort(all)
+	return all
+}
+
+func defaultAppAccessOperationsForProvider(prov core.Provider, cat *catalog.Catalog) []string {
+	if provider, ok := prov.(core.AppAccessDefaultsProvider); ok {
+		operations, configured := provider.DefaultAppAccessOperations()
+		if configured {
+			valid := make(map[string]struct{}, len(catOperations(cat)))
+			for _, operation := range catOperations(cat) {
+				valid[operation] = struct{}{}
+			}
+			filtered, _ := normalizeRequestedAppAccess(operations, valid)
+			return filtered
+		}
+	}
+	return defaultAppAccessOperations(cat)
+}
+
+func catOperations(cat *catalog.Catalog) []string {
+	if cat == nil {
+		return nil
+	}
+	operations := make([]string, 0, len(cat.Operations))
+	for _, operation := range cat.Operations {
+		if catalog.OperationVisibleByDefault(operation) {
+			operations = append(operations, operation.ID)
+		}
+	}
+	return operations
+}
+
+func normalizeRequestedAppAccess(operations []string, valid map[string]struct{}) ([]string, []string) {
+	seen := make(map[string]struct{}, len(operations))
+	var normalized []string
+	var invalid []string
+	for _, operation := range operations {
+		operation = strings.TrimSpace(operation)
+		if operation == "" {
+			continue
+		}
+		if _, ok := valid[operation]; !ok {
+			invalid = append(invalid, operation)
+			continue
+		}
+		if _, ok := seen[operation]; ok {
+			continue
+		}
+		seen[operation] = struct{}{}
+		normalized = append(normalized, operation)
+	}
+	slices.Sort(normalized)
+	slices.Sort(invalid)
+	return normalized, invalid
+}
+
+func (s *Server) writeAppAccessError(w http.ResponseWriter, err error) {
+	if errors.Is(err, core.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "app access settings were not found")
+		return
+	}
+	writeError(w, http.StatusInternalServerError, "app access settings are unavailable")
+}

--- a/gestaltd/internal/server/handlers_app_access.go
+++ b/gestaltd/internal/server/handlers_app_access.go
@@ -3,10 +3,10 @@ package server
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"slices"
 	"strings"
+	"unicode"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/valon-technologies/gestalt/server/core"
@@ -74,13 +74,13 @@ func (s *Server) updateAppAccess(w http.ResponseWriter, r *http.Request) {
 	cat := s.publicCatalog(name, prov, prov.Catalog())
 	valid := make(map[string]struct{})
 	if cat != nil {
-		for _, op := range cat.Operations {
-			valid[op.ID] = struct{}{}
+		for i := range cat.Operations {
+			valid[cat.Operations[i].ID] = struct{}{}
 		}
 	}
 	enabled, invalid := normalizeRequestedAppAccess(req.EnabledOperations, valid)
 	if len(invalid) > 0 {
-		writeError(w, http.StatusBadRequest, fmt.Sprintf("unknown app operation: %s", invalid[0]))
+		writeError(w, http.StatusBadRequest, "that app operation is not available; choose an operation from the list and try again")
 		return
 	}
 	if s.appAccessProfiles == nil {
@@ -104,7 +104,7 @@ func (s *Server) resolveAppAccessSubject(r *http.Request) (string, error) {
 	if p == nil || principal.IsNonUserPrincipal(p) {
 		return "", errors.New("user principal required")
 	}
-	return principal.ResolveCredentialSubjectID(r.Context(), s.credentialUserResolver(), p)
+	return principal.ResolveAuthorizationSubjectID(r.Context(), s.credentialUserResolver(), p)
 }
 
 func (s *Server) appAccessResponse(r *http.Request, subjectID, app string, prov core.Provider) (*appAccessResponse, error) {
@@ -139,7 +139,8 @@ func (s *Server) appAccessResponse(r *http.Request, subjectID, app string, prov 
 		return response, nil
 	}
 	response.Operations = make([]appAccessOperationInfo, 0, len(cat.Operations))
-	for _, op := range cat.Operations {
+	for i := range cat.Operations {
+		op := &cat.Operations[i]
 		readOnly := op.ReadOnly
 		if op.Annotations.ReadOnlyHint != nil {
 			readOnly = readOnly || *op.Annotations.ReadOnlyHint
@@ -148,7 +149,7 @@ func (s *Server) appAccessResponse(r *http.Request, subjectID, app string, prov 
 		_, isDefault := defaultSet[op.ID]
 		response.Operations = append(response.Operations, appAccessOperationInfo{
 			ID:          op.ID,
-			Title:       op.Title,
+			Title:       appAccessOperationTitle(op.ID, op.Title),
 			Description: op.Description,
 			Method:      op.Method,
 			Tags:        append([]string(nil), op.Tags...),
@@ -169,8 +170,9 @@ func defaultAppAccessOperations(cat *catalog.Catalog) []string {
 	}
 	readOnly := make([]string, 0, len(cat.Operations))
 	all := make([]string, 0, len(cat.Operations))
-	for _, op := range cat.Operations {
-		if !catalog.OperationVisibleByDefault(op) {
+	for i := range cat.Operations {
+		op := &cat.Operations[i]
+		if !catalog.OperationVisibleByDefault(*op) {
 			continue
 		}
 		all = append(all, op.ID)
@@ -213,12 +215,45 @@ func catOperations(cat *catalog.Catalog) []string {
 		return nil
 	}
 	operations := make([]string, 0, len(cat.Operations))
-	for _, operation := range cat.Operations {
-		if catalog.OperationVisibleByDefault(operation) {
+	for i := range cat.Operations {
+		operation := &cat.Operations[i]
+		if catalog.OperationVisibleByDefault(*operation) {
 			operations = append(operations, operation.ID)
 		}
 	}
 	return operations
+}
+
+func appAccessOperationTitle(id, title string) string {
+	if title = strings.TrimSpace(title); title != "" {
+		return title
+	}
+
+	var words []string
+	var word []rune
+	flush := func() {
+		if len(word) == 0 {
+			return
+		}
+		word[0] = unicode.ToUpper(word[0])
+		words = append(words, string(word))
+		word = nil
+	}
+	var previous rune
+	for _, r := range strings.TrimSpace(id) {
+		if r == '.' || r == '_' || r == '-' {
+			flush()
+			previous = 0
+			continue
+		}
+		if len(word) > 0 && unicode.IsUpper(r) && (unicode.IsLower(previous) || unicode.IsDigit(previous)) {
+			flush()
+		}
+		word = append(word, unicode.ToLower(r))
+		previous = r
+	}
+	flush()
+	return strings.Join(words, " ")
 }
 
 func normalizeRequestedAppAccess(operations []string, valid map[string]struct{}) ([]string, []string) {

--- a/gestaltd/internal/server/handlers_app_access.go
+++ b/gestaltd/internal/server/handlers_app_access.go
@@ -12,6 +12,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
+	"github.com/valon-technologies/gestalt/server/services/invocation"
 )
 
 type appAccessOperationInfo struct {
@@ -47,7 +48,12 @@ func (s *Server) getAppAccess(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusUnauthorized, "a user session is required")
 		return
 	}
-	response, err := s.appAccessResponse(r, subjectID, name, prov)
+	cat, err := s.appAccessCatalog(r, name, prov)
+	if err != nil {
+		s.writeAppAccessError(w, err)
+		return
+	}
+	response, err := s.appAccessResponse(r, subjectID, name, prov, cat)
 	if err != nil {
 		s.writeAppAccessError(w, err)
 		return
@@ -71,7 +77,11 @@ func (s *Server) updateAppAccess(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
-	cat := s.publicCatalog(name, prov, prov.Catalog())
+	cat, err := s.appAccessCatalog(r, name, prov)
+	if err != nil {
+		s.writeAppAccessError(w, err)
+		return
+	}
 	valid := make(map[string]struct{})
 	if cat != nil {
 		for i := range cat.Operations {
@@ -91,7 +101,7 @@ func (s *Server) updateAppAccess(w http.ResponseWriter, r *http.Request) {
 		s.writeAppAccessError(w, err)
 		return
 	}
-	response, err := s.appAccessResponse(r, subjectID, name, prov)
+	response, err := s.appAccessResponse(r, subjectID, name, prov, cat)
 	if err != nil {
 		s.writeAppAccessError(w, err)
 		return
@@ -107,8 +117,7 @@ func (s *Server) resolveAppAccessSubject(r *http.Request) (string, error) {
 	return principal.ResolveAuthorizationSubjectID(r.Context(), s.credentialUserResolver(), p)
 }
 
-func (s *Server) appAccessResponse(r *http.Request, subjectID, app string, prov core.Provider) (*appAccessResponse, error) {
-	cat := s.publicCatalog(app, prov, prov.Catalog())
+func (s *Server) appAccessResponse(r *http.Request, subjectID, app string, prov core.Provider, cat *catalog.Catalog) (*appAccessResponse, error) {
 	defaults := defaultAppAccessOperationsForProvider(prov, cat)
 	enabled := defaults
 	initialized := false
@@ -162,6 +171,34 @@ func (s *Server) appAccessResponse(r *http.Request, subjectID, app string, prov 
 		return strings.Compare(a.ID, b.ID)
 	})
 	return response, nil
+}
+
+func (s *Server) appAccessCatalog(r *http.Request, app string, prov core.Provider) (*catalog.Catalog, error) {
+	staticCat := s.publicCatalog(app, prov, prov.Catalog())
+	if !core.SupportsSessionCatalog(prov) {
+		return staticCat, nil
+	}
+	p := PrincipalFromContext(r.Context())
+	resolver, _ := s.invoker.(invocation.TokenResolver)
+	if p == nil || resolver == nil {
+		return staticCat, nil
+	}
+	cat, _, err := invocation.ResolveCatalogForTargetsWithMetadata(
+		core.WithCatalogSurface(r.Context(), core.CatalogSurfaceAPI),
+		prov,
+		app,
+		resolver,
+		p,
+		s.catalogSelectorConfig().APICatalogTargets(app, "", ""),
+		true,
+	)
+	if err != nil {
+		if staticCat != nil {
+			return staticCat, nil
+		}
+		return nil, err
+	}
+	return s.publicCatalog(app, prov, cat), nil
 }
 
 func defaultAppAccessOperations(cat *catalog.Catalog) []string {

--- a/gestaltd/internal/server/handlers_app_access_test.go
+++ b/gestaltd/internal/server/handlers_app_access_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -14,6 +15,7 @@ import (
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
+	"github.com/valon-technologies/gestalt/server/services/invocation"
 )
 
 func TestAppAccessHandlers(t *testing.T) {
@@ -110,6 +112,67 @@ func TestAppAccessHandlers(t *testing.T) {
 			t.Fatalf("status = %d, want %d: %s", response.Code, http.StatusUnauthorized, response.Body.String())
 		}
 	})
+}
+
+func TestAppAccessHandlersUseSessionCatalogBeforeInitializingProfile(t *testing.T) {
+	t.Parallel()
+
+	services := testutil.NewStubServices(t)
+	provider := &stubSessionProvider{
+		stubCatalogProvider: stubCatalogProvider{
+			stubProvider: stubProvider{
+				name:     "slack",
+				connMode: core.ConnectionModeSubject,
+			},
+		},
+		sessionCat: &catalog.Catalog{Operations: []catalog.CatalogOperation{
+			{ID: "dynamic.list", Method: http.MethodGet},
+		}},
+	}
+	server := &Server{
+		providers:         testutil.NewProviderRegistry(t, provider),
+		users:             services.Users,
+		appAccessProfiles: services.AppAccessProfiles,
+		invoker: struct {
+			invocation.Invoker
+			invocation.TokenResolver
+		}{
+			TokenResolver: &stubTokenResolver{token: "session-token"},
+		},
+	}
+	user := seedAppAccessTestUser(t, services, "dynamic@example.com")
+	p := &principal.Principal{
+		SubjectID: principal.UserSubjectID(user.ID),
+		UserID:    user.ID,
+		Kind:      principal.KindUser,
+	}
+	if err := server.ensureAppAccessDefaults(context.Background(), p.SubjectID, "slack", provider); err != nil {
+		t.Fatalf("ensureAppAccessDefaults: %v", err)
+	}
+	if _, err := services.AppAccessProfiles.GetAppAccessProfile(context.Background(), p.SubjectID, "slack"); !errors.Is(err, core.ErrNotFound) {
+		t.Fatalf("profile after empty static catalog = %v, want core.ErrNotFound", err)
+	}
+
+	response := serveAppAccessTestRequest(t, server, http.MethodGet, nil, p)
+	if response.Code != http.StatusOK {
+		t.Fatalf("GET status = %d, want %d: %s", response.Code, http.StatusOK, response.Body.String())
+	}
+	var body appAccessResponse
+	decodeAppAccessTestResponse(t, response, &body)
+	if len(body.Operations) != 1 || body.Operations[0].ID != "dynamic.list" || body.DefaultsInitialized {
+		t.Fatalf("session catalog response = %#v, want dynamic operation without initialized profile", body)
+	}
+
+	response = serveAppAccessTestRequest(t, server, http.MethodPut, map[string]any{
+		"enabledOperations": []string{"dynamic.list"},
+	}, p)
+	if response.Code != http.StatusOK {
+		t.Fatalf("PUT status = %d, want %d: %s", response.Code, http.StatusOK, response.Body.String())
+	}
+	decodeAppAccessTestResponse(t, response, &body)
+	if !body.DefaultsInitialized || len(body.EnabledOperations) != 1 || body.EnabledOperations[0] != "dynamic.list" {
+		t.Fatalf("session catalog update = %#v, want persisted dynamic operation", body)
+	}
 }
 
 func newAppAccessTestFixture(t *testing.T) (*Server, *principal.Principal, *principal.Principal) {

--- a/gestaltd/internal/server/handlers_app_access_test.go
+++ b/gestaltd/internal/server/handlers_app_access_test.go
@@ -146,7 +146,10 @@ func TestAppAccessHandlersUseSessionCatalogBeforeInitializingProfile(t *testing.
 		UserID:    user.ID,
 		Kind:      principal.KindUser,
 	}
-	if err := server.ensureAppAccessDefaults(context.Background(), p.SubjectID, "slack", provider); err != nil {
+	if err := server.ensureAppAccessDefaults(context.Background(), credentialMaterial{
+		SubjectID:   p.SubjectID,
+		Integration: "slack",
+	}, provider); err != nil {
 		t.Fatalf("ensureAppAccessDefaults: %v", err)
 	}
 	if _, err := services.AppAccessProfiles.GetAppAccessProfile(context.Background(), p.SubjectID, "slack"); !errors.Is(err, core.ErrNotFound) {
@@ -172,6 +175,46 @@ func TestAppAccessHandlersUseSessionCatalogBeforeInitializingProfile(t *testing.
 	decodeAppAccessTestResponse(t, response, &body)
 	if !body.DefaultsInitialized || len(body.EnabledOperations) != 1 || body.EnabledOperations[0] != "dynamic.list" {
 		t.Fatalf("session catalog update = %#v, want persisted dynamic operation", body)
+	}
+}
+
+func TestEnsureAppAccessDefaultsCanonicalizesOpaqueCredentialSubject(t *testing.T) {
+	t.Parallel()
+
+	services := testutil.NewStubServices(t)
+	user := seedAppAccessTestUser(t, services, "canonical@example.com")
+	identityJSON, err := json.Marshal(accountIdentity{Facts: []identityFact{{Kind: "email", Value: user.Email}}})
+	if err != nil {
+		t.Fatalf("marshal account identity: %v", err)
+	}
+	metadataJSON, err := json.Marshal(map[string]string{core.AccountIdentityMetadataKey: string(identityJSON)})
+	if err != nil {
+		t.Fatalf("marshal metadata: %v", err)
+	}
+	provider := &coretesting.StubIntegration{
+		N:        "slack",
+		ConnMode: core.ConnectionModeNone,
+		CatalogVal: &catalog.Catalog{Operations: []catalog.CatalogOperation{
+			{ID: "conversations.list", Method: http.MethodGet},
+		}},
+	}
+	server := &Server{users: services.Users, appAccessProfiles: services.AppAccessProfiles}
+	if err := server.ensureAppAccessDefaults(context.Background(), credentialMaterial{
+		SubjectID:    principal.UserSubjectID("auth0|opaque-user"),
+		Integration:  "slack",
+		MetadataJSON: string(metadataJSON),
+	}, provider); err != nil {
+		t.Fatalf("ensureAppAccessDefaults: %v", err)
+	}
+	profile, err := services.AppAccessProfiles.GetAppAccessProfile(context.Background(), principal.UserSubjectID(user.ID), "slack")
+	if err != nil {
+		t.Fatalf("canonical profile: %v", err)
+	}
+	if len(profile.EnabledOperations) != 1 || profile.EnabledOperations[0] != "conversations.list" {
+		t.Fatalf("canonical profile operations = %#v, want conversations.list", profile.EnabledOperations)
+	}
+	if _, err := services.AppAccessProfiles.GetAppAccessProfile(context.Background(), principal.UserSubjectID("auth0|opaque-user"), "slack"); !errors.Is(err, core.ErrNotFound) {
+		t.Fatalf("raw opaque profile = %v, want core.ErrNotFound", err)
 	}
 }
 

--- a/gestaltd/internal/server/handlers_app_access_test.go
+++ b/gestaltd/internal/server/handlers_app_access_test.go
@@ -218,6 +218,43 @@ func TestEnsureAppAccessDefaultsCanonicalizesOpaqueCredentialSubject(t *testing.
 	}
 }
 
+func TestEnsureAppAccessDefaultsKeepsEmailSubjectOwner(t *testing.T) {
+	t.Parallel()
+
+	services := testutil.NewStubServices(t)
+	owner := seedAppAccessTestUser(t, services, "owner@example.com")
+	connectedAccount := seedAppAccessTestUser(t, services, "connected@example.com")
+	identityJSON, err := json.Marshal(accountIdentity{Facts: []identityFact{{Kind: "email", Value: connectedAccount.Email}}})
+	if err != nil {
+		t.Fatalf("marshal account identity: %v", err)
+	}
+	metadataJSON, err := json.Marshal(map[string]string{core.AccountIdentityMetadataKey: string(identityJSON)})
+	if err != nil {
+		t.Fatalf("marshal metadata: %v", err)
+	}
+	provider := &coretesting.StubIntegration{
+		N:        "slack",
+		ConnMode: core.ConnectionModeNone,
+		CatalogVal: &catalog.Catalog{Operations: []catalog.CatalogOperation{
+			{ID: "conversations.list", Method: http.MethodGet},
+		}},
+	}
+	server := &Server{users: services.Users, appAccessProfiles: services.AppAccessProfiles}
+	if err := server.ensureAppAccessDefaults(context.Background(), credentialMaterial{
+		SubjectID:    principal.UserSubjectID("owner@example.com"),
+		Integration:  "slack",
+		MetadataJSON: string(metadataJSON),
+	}, provider); err != nil {
+		t.Fatalf("ensureAppAccessDefaults: %v", err)
+	}
+	if _, err := services.AppAccessProfiles.GetAppAccessProfile(context.Background(), principal.UserSubjectID(owner.ID), "slack"); err != nil {
+		t.Fatalf("owner profile: %v", err)
+	}
+	if _, err := services.AppAccessProfiles.GetAppAccessProfile(context.Background(), principal.UserSubjectID(connectedAccount.ID), "slack"); !errors.Is(err, core.ErrNotFound) {
+		t.Fatalf("connected-account profile = %v, want core.ErrNotFound", err)
+	}
+}
+
 func newAppAccessTestFixture(t *testing.T) (*Server, *principal.Principal, *principal.Principal) {
 	t.Helper()
 	services := testutil.NewStubServices(t)

--- a/gestaltd/internal/server/handlers_app_access_test.go
+++ b/gestaltd/internal/server/handlers_app_access_test.go
@@ -1,0 +1,188 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/catalog"
+	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
+	"github.com/valon-technologies/gestalt/server/services/identity/principal"
+)
+
+func TestAppAccessHandlers(t *testing.T) {
+	t.Parallel()
+
+	t.Run("GET returns catalog defaults", func(t *testing.T) {
+		t.Parallel()
+		server, alicePrincipal, _ := newAppAccessTestFixture(t)
+		response := serveAppAccessTestRequest(t, server, http.MethodGet, nil, alicePrincipal)
+		if response.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d: %s", response.Code, http.StatusOK, response.Body.String())
+		}
+		var body appAccessResponse
+		decodeAppAccessTestResponse(t, response, &body)
+		if body.DefaultsInitialized {
+			t.Fatal("defaultsInitialized = true before a profile was persisted")
+		}
+		if len(body.EnabledOperations) != 2 {
+			t.Fatalf("enabled operations = %#v, want catalog defaults", body.EnabledOperations)
+		}
+		if got := body.Operations[0].Title; got != "Chat Post Message" {
+			t.Fatalf("fallback operation title = %q, want human-readable title", got)
+		}
+	})
+
+	t.Run("PUT updates and persists allow list", func(t *testing.T) {
+		t.Parallel()
+		server, alicePrincipal, _ := newAppAccessTestFixture(t)
+		response := serveAppAccessTestRequest(t, server, http.MethodPut, map[string]any{
+			"enabledOperations": []string{"conversations.list"},
+		}, alicePrincipal)
+		if response.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d: %s", response.Code, http.StatusOK, response.Body.String())
+		}
+		var body appAccessResponse
+		decodeAppAccessTestResponse(t, response, &body)
+		if !body.DefaultsInitialized || len(body.EnabledOperations) != 1 || body.EnabledOperations[0] != "conversations.list" {
+			t.Fatalf("updated response = %#v, want persisted read-only allow list", body)
+		}
+	})
+
+	t.Run("PUT empty list disables all operations", func(t *testing.T) {
+		t.Parallel()
+		server, alicePrincipal, _ := newAppAccessTestFixture(t)
+		response := serveAppAccessTestRequest(t, server, http.MethodPut, map[string]any{
+			"enabledOperations": []string{},
+		}, alicePrincipal)
+		if response.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d: %s", response.Code, http.StatusOK, response.Body.String())
+		}
+		var body appAccessResponse
+		decodeAppAccessTestResponse(t, response, &body)
+		if len(body.EnabledOperations) != 0 {
+			t.Fatalf("enabled operations = %#v, want empty", body.EnabledOperations)
+		}
+	})
+
+	t.Run("PUT rejects unknown operation", func(t *testing.T) {
+		t.Parallel()
+		server, alicePrincipal, _ := newAppAccessTestFixture(t)
+		response := serveAppAccessTestRequest(t, server, http.MethodPut, map[string]any{
+			"enabledOperations": []string{"missing.operation"},
+		}, alicePrincipal)
+		if response.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want %d: %s", response.Code, http.StatusBadRequest, response.Body.String())
+		}
+	})
+
+	t.Run("profile is isolated by canonical subject", func(t *testing.T) {
+		t.Parallel()
+		server, alicePrincipal, bobPrincipal := newAppAccessTestFixture(t)
+		update := serveAppAccessTestRequest(t, server, http.MethodPut, map[string]any{
+			"enabledOperations": []string{},
+		}, alicePrincipal)
+		if update.Code != http.StatusOK {
+			t.Fatalf("alice update status = %d, want %d: %s", update.Code, http.StatusOK, update.Body.String())
+		}
+		response := serveAppAccessTestRequest(t, server, http.MethodGet, nil, bobPrincipal)
+		if response.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d: %s", response.Code, http.StatusOK, response.Body.String())
+		}
+		var body appAccessResponse
+		decodeAppAccessTestResponse(t, response, &body)
+		if body.DefaultsInitialized || len(body.EnabledOperations) != 2 {
+			t.Fatalf("bob response = %#v, want independent defaults", body)
+		}
+	})
+
+	t.Run("requires authenticated user", func(t *testing.T) {
+		t.Parallel()
+		server, _, _ := newAppAccessTestFixture(t)
+		response := serveAppAccessTestRequest(t, server, http.MethodGet, nil, nil)
+		if response.Code != http.StatusUnauthorized {
+			t.Fatalf("status = %d, want %d: %s", response.Code, http.StatusUnauthorized, response.Body.String())
+		}
+	})
+}
+
+func newAppAccessTestFixture(t *testing.T) (*Server, *principal.Principal, *principal.Principal) {
+	t.Helper()
+	services := testutil.NewStubServices(t)
+	provider := &coretesting.StubIntegration{
+		N:        "slack",
+		ConnMode: core.ConnectionModeNone,
+		CatalogVal: &catalog.Catalog{Operations: []catalog.CatalogOperation{
+			{ID: "chat.postMessage", Method: http.MethodPost},
+			{ID: "conversations.list", Method: http.MethodGet},
+		}},
+	}
+	server := &Server{
+		providers:         testutil.NewProviderRegistry(t, provider),
+		users:             services.Users,
+		appAccessProfiles: services.AppAccessProfiles,
+	}
+	alice := seedAppAccessTestUser(t, services, "alice@example.com")
+	bob := seedAppAccessTestUser(t, services, "bob@example.com")
+	return server, &principal.Principal{
+			SubjectID: principal.UserSubjectID(alice.ID),
+			UserID:    alice.ID,
+			Kind:      principal.KindUser,
+		}, &principal.Principal{
+			SubjectID: principal.UserSubjectID(bob.ID),
+			UserID:    bob.ID,
+			Kind:      principal.KindUser,
+		}
+}
+
+func seedAppAccessTestUser(t *testing.T, services *testutil.Services, email string) *core.User {
+	t.Helper()
+	user, err := services.Users.FindOrCreateUser(context.Background(), email)
+	if err != nil {
+		t.Fatalf("FindOrCreateUser(%q): %v", email, err)
+	}
+	return user
+}
+
+func serveAppAccessTestRequest(t *testing.T, server *Server, method string, payload map[string]any, p *principal.Principal) *httptest.ResponseRecorder {
+	t.Helper()
+	var body *bytes.Reader
+	if payload == nil {
+		body = bytes.NewReader(nil)
+	} else {
+		encoded, err := json.Marshal(payload)
+		if err != nil {
+			t.Fatalf("json.Marshal: %v", err)
+		}
+		body = bytes.NewReader(encoded)
+	}
+	req := httptest.NewRequest(method, "/apps/slack/access", body)
+	routeCtx := chi.NewRouteContext()
+	routeCtx.URLParams.Add("name", "slack")
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, routeCtx)
+	if p != nil {
+		ctx = principal.WithPrincipal(ctx, p)
+	}
+	req = req.WithContext(ctx)
+	recorder := httptest.NewRecorder()
+	if method == http.MethodPut {
+		req.Header.Set("Content-Type", "application/json")
+		server.updateAppAccess(recorder, req)
+	} else {
+		server.getAppAccess(recorder, req)
+	}
+	return recorder
+}
+
+func decodeAppAccessTestResponse(t *testing.T, response *httptest.ResponseRecorder, dst *appAccessResponse) {
+	t.Helper()
+	if err := json.NewDecoder(response.Body).Decode(dst); err != nil {
+		t.Fatalf("decode response: %v; body=%s", err, response.Body.String())
+	}
+}

--- a/gestaltd/internal/server/handlers_connect.go
+++ b/gestaltd/internal/server/handlers_connect.go
@@ -551,6 +551,12 @@ func (s *Server) ensureAppAccessDefaults(ctx context.Context, subjectID, app str
 		return nil
 	}
 	cat := s.publicCatalog(app, prov, prov.Catalog())
+	if len(catOperations(cat)) == 0 && core.SupportsSessionCatalog(prov) {
+		// Session catalogs are resolved with the connected user's credential at
+		// request time. Do not turn an empty static catalog into a permanent
+		// empty allow list before those operations are discoverable.
+		return nil
+	}
 	_, err := s.appAccessProfiles.EnsureAppAccessDefaults(ctx, subjectID, app, defaultAppAccessOperationsForProvider(prov, cat))
 	return err
 }

--- a/gestaltd/internal/server/handlers_connect.go
+++ b/gestaltd/internal/server/handlers_connect.go
@@ -536,7 +536,7 @@ func (s *Server) runConnectionSetup(ctx context.Context, prov core.Provider, tm 
 
 func (s *Server) completeConnection(ctx context.Context, prov core.Provider, tm credentialMaterial) (*connectionSetupResult, error) {
 	enriched := s.enrichAccountIdentity(ctx, tm)
-	if err := s.ensureAppAccessDefaults(ctx, enriched.SubjectID, enriched.Integration, prov); err != nil {
+	if err := s.ensureAppAccessDefaults(ctx, enriched, prov); err != nil {
 		return nil, err
 	}
 	if _, err := s.storeCredentialFromMaterial(ctx, enriched); err != nil {
@@ -546,18 +546,47 @@ func (s *Server) completeConnection(ctx context.Context, prov core.Provider, tm 
 	return &connectionSetupResult{Status: "connected", Integration: enriched.Integration}, nil
 }
 
-func (s *Server) ensureAppAccessDefaults(ctx context.Context, subjectID, app string, prov core.Provider) error {
-	if s == nil || s.appAccessProfiles == nil || prov == nil || principal.KindFromSubjectID(strings.TrimSpace(subjectID)) != principal.KindUser {
+func (s *Server) ensureAppAccessDefaults(ctx context.Context, tm credentialMaterial, prov core.Provider) error {
+	if s == nil || s.appAccessProfiles == nil || prov == nil {
 		return nil
 	}
-	cat := s.publicCatalog(app, prov, prov.Catalog())
-	if len(catOperations(cat)) == 0 && core.SupportsSessionCatalog(prov) {
+	credentialPrincipal := principalForCredentialMaterial(nil, tm)
+	if credentialPrincipal == nil || principal.IsNonUserPrincipal(credentialPrincipal) {
+		return nil
+	}
+	if identity := identityFromMetadataJSON(tm.MetadataJSON); identity != nil {
+		for _, fact := range identity.Facts {
+			if fact.Kind == "email" {
+				clone := *credentialPrincipal
+				clone.Identity = &core.UserIdentity{Email: fact.Value}
+				credentialPrincipal = principal.Canonicalize(&clone)
+				break
+			}
+		}
+	}
+	subjectID, err := principal.ResolveAuthorizationSubjectID(ctx, s.credentialUserResolver(), credentialPrincipal)
+	if err != nil {
+		if errors.Is(err, principal.ErrOpaqueCredentialSubject) {
+			// A legacy/local subject without a canonical user identity cannot
+			// safely own a persisted profile; leave it uninitialized so the
+			// connection itself remains usable.
+			return nil
+		}
+		return fmt.Errorf("resolve app access subject: %w", err)
+	}
+	app := strings.TrimSpace(tm.Integration)
+	if app == "" {
+		return nil
+	}
+	staticCat := s.publicCatalog(app, prov, prov.Catalog())
+	if core.SupportsSessionCatalog(prov) {
 		// Session catalogs are resolved with the connected user's credential at
 		// request time. Do not turn an empty static catalog into a permanent
 		// empty allow list before those operations are discoverable.
 		return nil
 	}
-	_, err := s.appAccessProfiles.EnsureAppAccessDefaults(ctx, subjectID, app, defaultAppAccessOperationsForProvider(prov, cat))
+	cat := appAccessCapabilityCatalog(prov, staticCat)
+	_, err = s.appAccessProfiles.EnsureAppAccessDefaults(ctx, subjectID, app, defaultAppAccessOperationsForProvider(prov, cat))
 	return err
 }
 

--- a/gestaltd/internal/server/handlers_connect.go
+++ b/gestaltd/internal/server/handlers_connect.go
@@ -534,13 +534,25 @@ func (s *Server) runConnectionSetup(ctx context.Context, prov core.Provider, tm 
 	return s.completeConnection(ctx, prov, tm)
 }
 
-func (s *Server) completeConnection(ctx context.Context, _ core.Provider, tm credentialMaterial) (*connectionSetupResult, error) {
+func (s *Server) completeConnection(ctx context.Context, prov core.Provider, tm credentialMaterial) (*connectionSetupResult, error) {
 	enriched := s.enrichAccountIdentity(ctx, tm)
+	if err := s.ensureAppAccessDefaults(ctx, enriched.SubjectID, enriched.Integration, prov); err != nil {
+		return nil, err
+	}
 	if _, err := s.storeCredentialFromMaterial(ctx, enriched); err != nil {
 		return nil, err
 	}
 	s.maybeSetDefaultInstancePreference(ctx, enriched.SubjectID, enriched.Integration, enriched.Connection, enriched.Instance)
 	return &connectionSetupResult{Status: "connected", Integration: enriched.Integration}, nil
+}
+
+func (s *Server) ensureAppAccessDefaults(ctx context.Context, subjectID, app string, prov core.Provider) error {
+	if s == nil || s.appAccessProfiles == nil || prov == nil || principal.KindFromSubjectID(strings.TrimSpace(subjectID)) != principal.KindUser {
+		return nil
+	}
+	cat := s.publicCatalog(app, prov, prov.Catalog())
+	_, err := s.appAccessProfiles.EnsureAppAccessDefaults(ctx, subjectID, app, defaultAppAccessOperationsForProvider(prov, cat))
+	return err
 }
 
 func manualConnectionAllowed(conn config.ConnectionDef) bool {

--- a/gestaltd/internal/server/handlers_connect.go
+++ b/gestaltd/internal/server/handlers_connect.go
@@ -554,13 +554,19 @@ func (s *Server) ensureAppAccessDefaults(ctx context.Context, tm credentialMater
 	if credentialPrincipal == nil || principal.IsNonUserPrincipal(credentialPrincipal) {
 		return nil
 	}
-	if identity := identityFromMetadataJSON(tm.MetadataJSON); identity != nil {
-		for _, fact := range identity.Facts {
-			if fact.Kind == "email" {
-				clone := *credentialPrincipal
-				clone.Identity = &core.UserIdentity{Email: fact.Value}
-				credentialPrincipal = principal.Canonicalize(&clone)
-				break
+	if principal.ClassifyUserSubjectID(credentialPrincipal.SubjectID) == principal.UserSubjectFormOpaque {
+		// Account identity can bridge a provider-opaque subject to the
+		// persisted user, but it must not replace a meaningful user subject.
+		// The connected account may belong to someone else than the Gestalt
+		// user who owns this credential.
+		if identity := identityFromMetadataJSON(tm.MetadataJSON); identity != nil {
+			for _, fact := range identity.Facts {
+				if fact.Kind == "email" {
+					clone := *credentialPrincipal
+					clone.Identity = &core.UserIdentity{Email: fact.Value}
+					credentialPrincipal = principal.Canonicalize(&clone)
+					break
+				}
 			}
 		}
 	}

--- a/gestaltd/internal/server/routes_user.go
+++ b/gestaltd/internal/server/routes_user.go
@@ -20,6 +20,8 @@ func (s *Server) mountAuthenticatedRoutes(r chi.Router) {
 		r.Get("/apps", s.listIntegrations)
 		r.Delete("/apps/{name}", s.disconnectIntegration)
 		r.Put("/apps/{name}/preferred-instance", s.selectPreferredInstance)
+		r.Get("/apps/{name}/access", s.getAppAccess)
+		r.Put("/apps/{name}/access", s.updateAppAccess)
 
 		r.Post("/workflow/events", s.deliverWorkflowEvent)
 

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -123,6 +123,7 @@ type Server struct {
 	users                         userStore
 	externalCredentials           core.ExternalCredentialProvider
 	connectionInstancePreferences *coredata.ConnectionInstancePreferenceService
+	appAccessProfiles             *coredata.AppAccessProfileService
 	managedSubjects               *coredata.ManagedSubjectService
 	agent                         bootstrap.AgentControl
 	workflowSchedules             *workflowmanager.Manager
@@ -459,6 +460,7 @@ func New(cfg Config) (*Server, error) {
 		users:                         users,
 		externalCredentials:           externalCredentials,
 		connectionInstancePreferences: connectionInstancePreferences,
+		appAccessProfiles:             cfg.Services.AppAccessProfiles,
 		managedSubjects:               managedSubjects,
 		agent:                         cfg.Agent,
 		agentRuns:                     cfg.AgentManager,

--- a/gestaltd/sdk/providermanifest/v1/access_test.go
+++ b/gestaltd/sdk/providermanifest/v1/access_test.go
@@ -1,0 +1,75 @@
+package providermanifestv1_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	"gopkg.in/yaml.v3"
+)
+
+func TestSpecAccessRoundTripsThroughJSONAndYAML(t *testing.T) {
+	t.Parallel()
+
+	original := providermanifestv1.Spec{
+		Access: &providermanifestv1.ProviderAccess{
+			DefaultOperations: []string{"conversations.list", "chat.postMessage"},
+		},
+	}
+	for _, tc := range []struct {
+		name      string
+		marshal   func(any) ([]byte, error)
+		unmarshal func([]byte, any) error
+	}{
+		{name: "json", marshal: json.Marshal, unmarshal: json.Unmarshal},
+		{name: "yaml", marshal: yaml.Marshal, unmarshal: yaml.Unmarshal},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			encoded, err := tc.marshal(original)
+			if err != nil {
+				t.Fatalf("Marshal: %v", err)
+			}
+			var got providermanifestv1.Spec
+			if err := tc.unmarshal(encoded, &got); err != nil {
+				t.Fatalf("Unmarshal: %v\n%s", err, encoded)
+			}
+			if got.Access == nil || len(got.Access.DefaultOperations) != 2 ||
+				got.Access.DefaultOperations[0] != "conversations.list" ||
+				got.Access.DefaultOperations[1] != "chat.postMessage" {
+				t.Fatalf("access = %#v, want default operations round trip", got.Access)
+			}
+		})
+	}
+}
+
+func TestManifestJSONSchemaAcceptsSpecAccess(t *testing.T) {
+	t.Parallel()
+
+	var schemaDocument any
+	if err := json.Unmarshal(providermanifestv1.ManifestJSONSchema, &schemaDocument); err != nil {
+		t.Fatalf("decode embedded schema: %v", err)
+	}
+	compiler := jsonschema.NewCompiler()
+	if err := compiler.AddResource("manifest.schema.json", schemaDocument); err != nil {
+		t.Fatalf("add schema resource: %v", err)
+	}
+	schema, err := compiler.Compile("manifest.schema.json")
+	if err != nil {
+		t.Fatalf("compile embedded schema: %v", err)
+	}
+	manifest := map[string]any{
+		"kind":    "app",
+		"source":  "github.com/acme/apps/slack",
+		"version": "1.0.0",
+		"spec": map[string]any{
+			"access": map[string]any{
+				"defaultOperations": []any{"conversations.list"},
+			},
+		},
+	}
+	if err := schema.Validate(manifest); err != nil {
+		t.Fatalf("manifest with spec.access failed schema validation: %v", err)
+	}
+}

--- a/gestaltd/sdk/providermanifest/v1/manifest.jsonschema.json
+++ b/gestaltd/sdk/providermanifest/v1/manifest.jsonschema.json
@@ -355,6 +355,9 @@
         "pagination": {
           "$ref": "#/$defs/paginationConfig"
         },
+        "access": {
+          "$ref": "#/$defs/providerAccess"
+        },
         "allowedOperations": {
           "type": "object",
           "additionalProperties": {
@@ -1322,6 +1325,19 @@
         },
         "graphql": {
           "$ref": "#/$defs/manifestGraphQLOperation"
+        }
+      }
+    },
+    "providerAccess": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "defaultOperations": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
         }
       }
     },

--- a/gestaltd/sdk/providermanifest/v1/types.go
+++ b/gestaltd/sdk/providermanifest/v1/types.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"maps"
+	"slices"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -481,8 +482,16 @@ type Spec struct {
 	Connections       map[string]*ManifestConnectionDef     `json:"connections,omitempty" yaml:"connections,omitempty"`
 	ResponseMapping   *ManifestResponseMapping              `json:"responseMapping,omitempty" yaml:"responseMapping,omitempty"`
 	Pagination        *ManifestPaginationConfig             `json:"pagination,omitempty" yaml:"pagination,omitempty"`
+	Access            *ProviderAccess                       `json:"access,omitempty" yaml:"access,omitempty"`
 	Requires          []string                              `json:"requires,omitempty" yaml:"requires,omitempty"`
 	AssetRoot         string                                `json:"assetRoot,omitempty" yaml:"assetRoot,omitempty"`
+}
+
+// ProviderAccess declares the initial user-facing app capability profile.
+// These are app operation IDs, not upstream OAuth scopes; the connection
+// provider remains responsible for requesting the scopes it needs.
+type ProviderAccess struct {
+	DefaultOperations []string `json:"defaultOperations,omitempty" yaml:"defaultOperations,omitempty"`
 }
 
 type RouteAuthRef struct {
@@ -609,6 +618,13 @@ func (s *Spec) RESTOperations() []ProviderOperation {
 		return nil
 	}
 	return s.Surfaces.REST.Operations
+}
+
+func (s *Spec) AccessDefaultOperations() []string {
+	if s == nil || s.Access == nil {
+		return nil
+	}
+	return slices.Clone(s.Access.DefaultOperations)
 }
 
 func (s *Spec) SurfaceConnectionName(surface string) string {

--- a/gestaltd/sdk/providermanifest/v1/types.go
+++ b/gestaltd/sdk/providermanifest/v1/types.go
@@ -935,6 +935,7 @@ type specJSONWire struct {
 	Connections       map[string]*ManifestConnectionDef     `json:"connections,omitempty"`
 	ResponseMapping   *ManifestResponseMapping              `json:"responseMapping,omitempty"`
 	Pagination        *ManifestPaginationConfig             `json:"pagination,omitempty"`
+	Access            *ProviderAccess                       `json:"access,omitempty"`
 	Requires          []string                              `json:"requires,omitempty"`
 	AssetRoot         string                                `json:"assetRoot,omitempty"`
 }
@@ -953,6 +954,7 @@ type specYAMLWire struct {
 	Connections       map[string]*ManifestConnectionDef     `yaml:"connections,omitempty"`
 	ResponseMapping   *ManifestResponseMapping              `yaml:"responseMapping,omitempty"`
 	Pagination        *ManifestPaginationConfig             `yaml:"pagination,omitempty"`
+	Access            *ProviderAccess                       `yaml:"access,omitempty"`
 	Requires          []string                              `yaml:"requires,omitempty"`
 	AssetRoot         string                                `yaml:"assetRoot,omitempty"`
 }
@@ -971,6 +973,7 @@ type specWire struct {
 	Connections       map[string]*ManifestConnectionDef     `json:"connections,omitempty" yaml:"connections,omitempty"`
 	ResponseMapping   *ManifestResponseMapping              `json:"responseMapping,omitempty" yaml:"responseMapping,omitempty"`
 	Pagination        *ManifestPaginationConfig             `json:"pagination,omitempty" yaml:"pagination,omitempty"`
+	Access            *ProviderAccess                       `json:"access,omitempty" yaml:"access,omitempty"`
 	Requires          []string                              `json:"requires,omitempty" yaml:"requires,omitempty"`
 	AssetRoot         string                                `json:"assetRoot,omitempty" yaml:"assetRoot,omitempty"`
 }
@@ -999,6 +1002,7 @@ func (s *Spec) UnmarshalJSON(data []byte) error {
 		Connections:       raw.Connections,
 		ResponseMapping:   raw.ResponseMapping,
 		Pagination:        raw.Pagination,
+		Access:            cloneProviderAccess(raw.Access),
 		Requires:          raw.Requires,
 		AssetRoot:         raw.AssetRoot,
 	}
@@ -1046,6 +1050,7 @@ func (s *Spec) UnmarshalYAML(value *yaml.Node) error {
 		Connections:       raw.Connections,
 		ResponseMapping:   raw.ResponseMapping,
 		Pagination:        raw.Pagination,
+		Access:            cloneProviderAccess(raw.Access),
 		Requires:          raw.Requires,
 		AssetRoot:         raw.AssetRoot,
 	}
@@ -1076,9 +1081,19 @@ func (s Spec) canonicalWire() (specWire, error) {
 		Connections:       cloneManifestConnections(s.Connections),
 		ResponseMapping:   s.ResponseMapping,
 		Pagination:        s.Pagination,
+		Access:            cloneProviderAccess(s.Access),
 		Requires:          s.Requires,
 		AssetRoot:         s.AssetRoot,
 	}, nil
+}
+
+func cloneProviderAccess(src *ProviderAccess) *ProviderAccess {
+	if src == nil {
+		return nil
+	}
+	dst := *src
+	dst.DefaultOperations = slices.Clone(src.DefaultOperations)
+	return &dst
 }
 
 func cloneManifestConnections(src map[string]*ManifestConnectionDef) map[string]*ManifestConnectionDef {
@@ -1267,6 +1282,7 @@ var specWireFields = map[string]struct{}{
 	"connections":       {},
 	"responseMapping":   {},
 	"pagination":        {},
+	"access":            {},
 	"requires":          {},
 	"assetRoot":         {},
 }

--- a/gestaltd/services/apps/declarative_provider.go
+++ b/gestaltd/services/apps/declarative_provider.go
@@ -74,6 +74,8 @@ type DeclarativeProvider struct {
 	connectionSelectors  map[string]core.OperationConnectionSelector
 	operationLocks       map[string]bool
 	tokenParsers         map[string]egress.TokenParser
+	accessDefaults       []string
+	accessDefaultsSet    bool
 }
 
 func NewDeclarativeProvider(manifest *providermanifestv1.Manifest, httpClient *http.Client, opts ...DeclarativeProviderOption) (*DeclarativeProvider, error) {
@@ -135,11 +137,20 @@ func NewDeclarativeProvider(manifest *providermanifestv1.Manifest, httpClient *h
 		connectionSelectors:  cloneOperationConnectionSelectors(options.connectionSelectors),
 		operationLocks:       maps.Clone(options.operationLocks),
 		tokenParsers:         connectionTokenParsers(manifest.Spec.Connections),
+		accessDefaults:       slices.Clone(manifest.Spec.AccessDefaultOperations()),
+		accessDefaultsSet:    manifest.Spec.Access != nil,
 	}, nil
 }
 
 func (p *DeclarativeProvider) Catalog() *catalog.Catalog {
 	return p.Base.Catalog().Clone()
+}
+
+func (p *DeclarativeProvider) DefaultAppAccessOperations() ([]string, bool) {
+	if p == nil || !p.accessDefaultsSet {
+		return nil, false
+	}
+	return slices.Clone(p.accessDefaults), true
 }
 
 func (p *DeclarativeProvider) Execute(ctx context.Context, operation string, params map[string]any, token string) (*core.OperationResult, error) {

--- a/gestaltd/services/apps/declarative_provider.go
+++ b/gestaltd/services/apps/declarative_provider.go
@@ -105,6 +105,15 @@ func NewDeclarativeProvider(manifest *providermanifestv1.Manifest, httpClient *h
 		discovery = def.Discovery
 	}
 	cat := declarativeCatalog(manifest, options)
+	accessDefaults := manifest.Spec.AccessDefaultOperations()
+	accessDefaultsSet := manifest.Spec.Access != nil
+	if accessDefaultsSet {
+		for _, operation := range accessDefaults {
+			if !declarativeHasOperation(cat, operation) {
+				return nil, fmt.Errorf("manifest spec.access.defaultOperations contains unknown operation %q", operation)
+			}
+		}
+	}
 	authType := providermanifestv1.AuthType("")
 	authorizationURL := ""
 	base := &integration.Base{
@@ -137,8 +146,8 @@ func NewDeclarativeProvider(manifest *providermanifestv1.Manifest, httpClient *h
 		connectionSelectors:  cloneOperationConnectionSelectors(options.connectionSelectors),
 		operationLocks:       maps.Clone(options.operationLocks),
 		tokenParsers:         connectionTokenParsers(manifest.Spec.Connections),
-		accessDefaults:       slices.Clone(manifest.Spec.AccessDefaultOperations()),
-		accessDefaultsSet:    manifest.Spec.Access != nil,
+		accessDefaults:       slices.Clone(accessDefaults),
+		accessDefaultsSet:    accessDefaultsSet,
 	}, nil
 }
 

--- a/gestaltd/services/apps/declarative_provider_test.go
+++ b/gestaltd/services/apps/declarative_provider_test.go
@@ -304,3 +304,29 @@ func TestDeclarativeProvider_ExplicitAppAccessDefaults(t *testing.T) {
 		t.Fatalf("default app access operations = %#v, configured=%v", operations, configured)
 	}
 }
+
+func TestDeclarativeProvider_RejectsUnknownAppAccessDefault(t *testing.T) {
+	t.Parallel()
+
+	manifest := &providermanifestv1.Manifest{
+		Kind:    providermanifestv1.KindApp,
+		Source:  "github.com/test/access-defaults",
+		Version: "0.0.1-alpha.1",
+		Spec: &providermanifestv1.Spec{
+			Access: &providermanifestv1.ProviderAccess{
+				DefaultOperations: []string{"missing.operation"},
+			},
+			Surfaces: &providermanifestv1.ProviderSurfaces{
+				REST: &providermanifestv1.RESTSurface{
+					BaseURL: "https://example.com",
+					Operations: []providermanifestv1.ProviderOperation{
+						{Name: "users.list", Method: http.MethodGet, Path: "/users"},
+					},
+				},
+			},
+		},
+	}
+	if _, err := NewDeclarativeProvider(manifest, http.DefaultClient); err == nil {
+		t.Fatal("NewDeclarativeProvider succeeded with an unknown app access default")
+	}
+}

--- a/gestaltd/services/apps/declarative_provider_test.go
+++ b/gestaltd/services/apps/declarative_provider_test.go
@@ -273,3 +273,34 @@ func TestDeclarativeProvider_HTTPRequestMaterialization(t *testing.T) {
 		})
 	})
 }
+
+func TestDeclarativeProvider_ExplicitAppAccessDefaults(t *testing.T) {
+	t.Parallel()
+
+	manifest := &providermanifestv1.Manifest{
+		Kind:    providermanifestv1.KindApp,
+		Source:  "github.com/test/access-defaults",
+		Version: "0.0.1-alpha.1",
+		Spec: &providermanifestv1.Spec{
+			Access: &providermanifestv1.ProviderAccess{
+				DefaultOperations: []string{"users.list"},
+			},
+			Surfaces: &providermanifestv1.ProviderSurfaces{
+				REST: &providermanifestv1.RESTSurface{
+					BaseURL: "https://example.com",
+					Operations: []providermanifestv1.ProviderOperation{
+						{Name: "users.list", Method: http.MethodGet, Path: "/users"},
+					},
+				},
+			},
+		},
+	}
+	prov, err := NewDeclarativeProvider(manifest, http.DefaultClient)
+	if err != nil {
+		t.Fatalf("NewDeclarativeProvider: %v", err)
+	}
+	operations, configured := prov.DefaultAppAccessOperations()
+	if !configured || len(operations) != 1 || operations[0] != "users.list" {
+		t.Fatalf("default app access operations = %#v, configured=%v", operations, configured)
+	}
+}

--- a/gestaltd/services/identity/principal/principal.go
+++ b/gestaltd/services/identity/principal/principal.go
@@ -250,11 +250,12 @@ func AllowsProviderPermission(p *Principal, provider string) bool {
 	if p == nil || provider == "" {
 		return false
 	}
-	if len(p.Scopes) == 0 {
+	scopes := appPermissionScopes(p.Scopes)
+	if len(scopes) == 0 {
 		return true
 	}
 	prefix := provider + ":"
-	for _, scope := range p.Scopes {
+	for _, scope := range scopes {
 		if scope == provider || strings.HasPrefix(scope, prefix) {
 			return true
 		}
@@ -266,16 +267,37 @@ func AllowsOperationPermission(p *Principal, provider, operation string) bool {
 	if p == nil || provider == "" || operation == "" {
 		return false
 	}
-	if len(p.Scopes) == 0 {
+	scopes := appPermissionScopes(p.Scopes)
+	if len(scopes) == 0 {
 		return true
 	}
 	opScope := provider + ":" + operation
-	for _, scope := range p.Scopes {
+	for _, scope := range scopes {
 		if scope == provider || scope == opScope {
 			return true
 		}
 	}
 	return false
+}
+
+// appPermissionScopes separates OIDC identity scopes from Gestalt app
+// permissions. A browser/MCP token commonly carries openid, email, and
+// profile; those scopes describe who the caller is and must not accidentally
+// turn into a deny-all app permission set.
+func appPermissionScopes(scopes []string) []string {
+	if len(scopes) == 0 {
+		return nil
+	}
+	filtered := make([]string, 0, len(scopes))
+	for _, scope := range scopes {
+		switch strings.ToLower(strings.TrimSpace(scope)) {
+		case "", "openid", "email", "profile", "offline_access":
+			continue
+		default:
+			filtered = append(filtered, scope)
+		}
+	}
+	return filtered
 }
 
 func clonePermissionOps(src map[string]struct{}) map[string]struct{} {
@@ -298,7 +320,7 @@ func PermissionSetFromScopes(scopes []string) PermissionSet {
 	set := make(PermissionSet)
 	for _, scope := range scopes {
 		scope = strings.TrimSpace(scope)
-		if scope == "" {
+		if scope == "" || isIdentityScope(scope) {
 			continue
 		}
 		app, op, hasOp := strings.Cut(scope, ":")
@@ -320,6 +342,15 @@ func PermissionSetFromScopes(scopes []string) PermissionSet {
 		return PermissionSet{}
 	}
 	return set
+}
+
+func isIdentityScope(scope string) bool {
+	switch strings.ToLower(strings.TrimSpace(scope)) {
+	case "openid", "email", "profile", "offline_access":
+		return true
+	default:
+		return false
+	}
 }
 
 // ScopeStringsFromPermissionSet flattens a permission set into OAuth scope strings.

--- a/gestaltd/services/identity/principal/resolver_test.go
+++ b/gestaltd/services/identity/principal/resolver_test.go
@@ -21,6 +21,24 @@ func TestPermissionSetFromScopesExplicitEmptyDeniesAll(t *testing.T) {
 	}
 }
 
+func TestOIDCIdentityScopesDoNotRestrictAppPermissions(t *testing.T) {
+	t.Parallel()
+
+	p := &Principal{
+		SubjectID: "user:user-1",
+		Scopes:    []string{"openid", "email", "profile"},
+	}
+	if !AllowsProviderPermission(p, "slack") {
+		t.Fatal("OIDC identity scopes denied provider access")
+	}
+	if !AllowsOperationPermission(p, "slack", "conversations.list") {
+		t.Fatal("OIDC identity scopes denied operation access")
+	}
+	if got := p.EffectivePermissions(); got == nil || len(got) != 0 {
+		t.Fatalf("effective permissions = %#v, want explicit empty app permission set", got)
+	}
+}
+
 func TestResolveTokenPropagatesIntrospectError(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/services/invocation/app_access_test.go
+++ b/gestaltd/services/invocation/app_access_test.go
@@ -36,7 +36,7 @@ func TestBrokerAppAccessProfileIsSharedByInvocationAndListing(t *testing.T) {
 		nil,
 		WithAppAccessProfiles(svc.AppAccessProfiles),
 	)
-	const userID = "user-app-access"
+	const userID = "4f1d2e3c-5b6a-47c8-9d0e-1f2a3b4c5d6e"
 	if _, err := svc.AppAccessProfiles.EnsureAppAccessDefaults(
 		context.Background(),
 		principal.UserSubjectID(userID),
@@ -60,5 +60,124 @@ func TestBrokerAppAccessProfileIsSharedByInvocationAndListing(t *testing.T) {
 	}
 	if _, err := broker.Invoke(context.Background(), p, "slack", "", "chat.postMessage", nil); !errors.Is(err, ErrAuthorizationDenied) {
 		t.Fatalf("write invoke = %v, want ErrAuthorizationDenied", err)
+	}
+}
+
+func TestBrokerAppAccessProfileResolvesOpaqueSubjectToCanonicalUser(t *testing.T) {
+	t.Parallel()
+
+	svc := testutil.NewStubServices(t)
+	user, err := svc.Users.FindOrCreateUser(context.Background(), "opaque-subject@example.com")
+	if err != nil {
+		t.Fatalf("FindOrCreateUser: %v", err)
+	}
+	provider := &coretesting.StubIntegration{
+		N:        "slack",
+		ConnMode: core.ConnectionModeNone,
+		CatalogVal: &catalog.Catalog{Operations: []catalog.CatalogOperation{
+			{ID: "conversations.list", Method: "GET"},
+		}},
+	}
+	broker := NewBroker(
+		testutil.NewProviderRegistry(t, provider),
+		svc.Users,
+		nil,
+		WithAppAccessProfiles(svc.AppAccessProfiles),
+	)
+	if _, err := svc.AppAccessProfiles.EnsureAppAccessDefaults(
+		context.Background(),
+		principal.UserSubjectID(user.ID),
+		"slack",
+		[]string{"conversations.list"},
+	); err != nil {
+		t.Fatalf("EnsureAppAccessDefaults: %v", err)
+	}
+
+	p := &principal.Principal{
+		SubjectID: principal.UserSubjectID("auth0|opaque-user"),
+		Identity:  &core.UserIdentity{Email: user.Email},
+		Kind:      principal.KindUser,
+		Scopes:    []string{"openid", "email", "profile"},
+	}
+	if err := broker.CheckOperationAccess(context.Background(), p, "slack", "conversations.list"); err != nil {
+		t.Fatalf("opaque subject access = %v, want allowed after canonicalization", err)
+	}
+	withoutVerifiedIdentity := &principal.Principal{
+		SubjectID: principal.UserSubjectID("auth0|opaque-user"),
+		Kind:      principal.KindUser,
+	}
+	if err := broker.CheckOperationAccess(context.Background(), withoutVerifiedIdentity, "slack", "conversations.list"); !errors.Is(err, ErrAuthorizationDenied) {
+		t.Fatalf("opaque subject without verified identity = %v, want ErrAuthorizationDenied", err)
+	}
+}
+
+func TestBrokerAppAccessProfileCoversEveryInvocationMode(t *testing.T) {
+	t.Parallel()
+
+	svc := testutil.NewStubServices(t)
+	const userID = "4f1d2e3c-5b6a-47c8-9d0e-1f2a3b4c5d6e"
+	streamCalled := false
+	executeCalled := false
+	graphQLCalled := false
+	provider := &brokerGraphQLProvider{
+		StubIntegration: &coretesting.StubIntegration{
+			N:        "slack",
+			ConnMode: core.ConnectionModeNone,
+			CatalogVal: &catalog.Catalog{Operations: []catalog.CatalogOperation{
+				{ID: "chat.postMessage", Method: "POST"},
+				{ID: "events.watch", Method: "GET", Response: &catalog.OperationResponseSpec{
+					Stream: &catalog.StreamResponseSpec{MediaType: "application/x-ndjson"},
+				}},
+			}},
+			ExecuteFn: func(context.Context, string, map[string]any, string) (*core.OperationResult, error) {
+				executeCalled = true
+				return &core.OperationResult{Status: 200}, nil
+			},
+			StreamFn: func(context.Context, string, map[string]any, string) (core.StreamReader, error) {
+				streamCalled = true
+				return &sliceCoreStreamReader{}, nil
+			},
+		},
+		invokeGraphQL: func(context.Context, core.GraphQLRequest, string) (*core.OperationResult, error) {
+			graphQLCalled = true
+			return &core.OperationResult{Status: 200}, nil
+		},
+	}
+	broker := NewBroker(
+		testutil.NewProviderRegistry(t, provider),
+		svc.Users,
+		nil,
+		WithAppAccessProfiles(svc.AppAccessProfiles),
+	)
+	if _, err := svc.AppAccessProfiles.EnsureAppAccessDefaults(
+		context.Background(),
+		principal.UserSubjectID(userID),
+		"slack",
+		[]string{"allowed.operation"},
+	); err != nil {
+		t.Fatalf("EnsureAppAccessDefaults: %v", err)
+	}
+	p := &principal.Principal{
+		SubjectID: principal.UserSubjectID(userID),
+		UserID:    userID,
+		Kind:      principal.KindUser,
+	}
+
+	assertDenied := func(t *testing.T, mode string, err error) {
+		t.Helper()
+		if !errors.Is(err, ErrAuthorizationDenied) {
+			t.Fatalf("%s error = %v, want ErrAuthorizationDenied", mode, err)
+		}
+	}
+	_, err := broker.Invoke(context.Background(), p, "slack", "", "chat.postMessage", nil)
+	assertDenied(t, "unary", err)
+	_, err = broker.InvokeStream(context.Background(), p, "slack", "", "events.watch", nil)
+	assertDenied(t, "stream", err)
+	_, err = broker.InvokeMaybeStream(context.Background(), p, "slack", "", "events.watch", nil)
+	assertDenied(t, "maybe stream", err)
+	_, err = broker.InvokeGraphQL(context.Background(), p, "slack", "", core.GraphQLRequest{Document: "query { viewer { id } }"})
+	assertDenied(t, "graphql", err)
+	if executeCalled || streamCalled || graphQLCalled {
+		t.Fatal("a disabled operation reached the provider")
 	}
 }

--- a/gestaltd/services/invocation/app_access_test.go
+++ b/gestaltd/services/invocation/app_access_test.go
@@ -1,0 +1,64 @@
+package invocation
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/catalog"
+	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
+	"github.com/valon-technologies/gestalt/server/services/identity/principal"
+)
+
+func TestBrokerAppAccessProfileIsSharedByInvocationAndListing(t *testing.T) {
+	t.Parallel()
+
+	svc := testutil.NewStubServices(t)
+	provider := &coretesting.StubIntegration{
+		N:        "slack",
+		ConnMode: core.ConnectionModeNone,
+		CatalogVal: &catalog.Catalog{
+			Name: "slack",
+			Operations: []catalog.CatalogOperation{
+				{ID: "conversations.list", Method: "GET"},
+				{ID: "chat.postMessage", Method: "POST"},
+			},
+		},
+		ExecuteFn: func(_ context.Context, _ string, _ map[string]any, _ string) (*core.OperationResult, error) {
+			return &core.OperationResult{Status: 200}, nil
+		},
+	}
+	broker := NewBroker(
+		testutil.NewProviderRegistry(t, provider),
+		svc.Users,
+		nil,
+		WithAppAccessProfiles(svc.AppAccessProfiles),
+	)
+	const userID = "user-app-access"
+	if _, err := svc.AppAccessProfiles.EnsureAppAccessDefaults(
+		context.Background(),
+		principal.UserSubjectID(userID),
+		"slack",
+		[]string{"conversations.list"},
+	); err != nil {
+		t.Fatalf("EnsureAppAccessDefaults: %v", err)
+	}
+	p := &principal.Principal{
+		SubjectID: principal.UserSubjectID(userID),
+		UserID:    userID,
+		Kind:      principal.KindUser,
+		Scopes:    []string{"openid", "email", "profile"},
+	}
+
+	if err := broker.CheckOperationAccess(context.Background(), p, "slack", "conversations.list"); err != nil {
+		t.Fatalf("read operation access = %v, want allowed", err)
+	}
+	if err := broker.CheckOperationAccess(context.Background(), p, "slack", "chat.postMessage"); !errors.Is(err, ErrAuthorizationDenied) {
+		t.Fatalf("write operation access = %v, want ErrAuthorizationDenied", err)
+	}
+	if _, err := broker.Invoke(context.Background(), p, "slack", "", "chat.postMessage", nil); !errors.Is(err, ErrAuthorizationDenied) {
+		t.Fatalf("write invoke = %v, want ErrAuthorizationDenied", err)
+	}
+}

--- a/gestaltd/services/invocation/app_access_test.go
+++ b/gestaltd/services/invocation/app_access_test.go
@@ -181,3 +181,49 @@ func TestBrokerAppAccessProfileCoversEveryInvocationMode(t *testing.T) {
 		t.Fatal("a disabled operation reached the provider")
 	}
 }
+
+func TestBrokerAppAccessProfileAllowsGraphQLCapability(t *testing.T) {
+	t.Parallel()
+
+	svc := testutil.NewStubServices(t)
+	called := false
+	provider := &brokerGraphQLProvider{
+		StubIntegration: &coretesting.StubIntegration{
+			N:        "slack",
+			ConnMode: core.ConnectionModeNone,
+			CatalogVal: &catalog.Catalog{Operations: []catalog.CatalogOperation{
+				{ID: "conversations.list", Method: "GET"},
+			}},
+		},
+		invokeGraphQL: func(context.Context, core.GraphQLRequest, string) (*core.OperationResult, error) {
+			called = true
+			return &core.OperationResult{Status: 200}, nil
+		},
+	}
+	broker := NewBroker(
+		testutil.NewProviderRegistry(t, provider),
+		svc.Users,
+		nil,
+		WithAppAccessProfiles(svc.AppAccessProfiles),
+	)
+	const userID = "4f1d2e3c-5b6a-47c8-9d0e-1f2a3b4c5d6e"
+	if _, err := svc.AppAccessProfiles.EnsureAppAccessDefaults(
+		context.Background(),
+		principal.UserSubjectID(userID),
+		"slack",
+		[]string{core.GraphQLCapabilityID},
+	); err != nil {
+		t.Fatalf("EnsureAppAccessDefaults: %v", err)
+	}
+	p := &principal.Principal{
+		SubjectID: principal.UserSubjectID(userID),
+		UserID:    userID,
+		Kind:      principal.KindUser,
+	}
+	if _, err := broker.InvokeGraphQL(context.Background(), p, "slack", "", core.GraphQLRequest{Document: "query { viewer { id } }"}); err != nil {
+		t.Fatalf("InvokeGraphQL = %v, want allowed", err)
+	}
+	if !called {
+		t.Fatal("GraphQL provider was not called")
+	}
+}

--- a/gestaltd/services/invocation/authorization_batch.go
+++ b/gestaltd/services/invocation/authorization_batch.go
@@ -123,6 +123,8 @@ func (b *Broker) CheckOperationAccessMany(
 		switch {
 		case !principal.AllowsOperationPermission(p, query.Provider, query.Operation):
 			results[i] = operationAccessDenied(query)
+		case b.checkAppAccess(ctx, p, query.Provider, query.Operation) != nil:
+			results[i] = operationAccessDenied(query)
 		case b.providerDelegatesRemoteAuthorization(ctx, query.Provider):
 			// The remote app owns this decision, exactly as at invoke time.
 		default:

--- a/gestaltd/services/invocation/broker.go
+++ b/gestaltd/services/invocation/broker.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	tracerName         = "gestaltd"
-	graphQLOperationID = "graphql"
+	graphQLOperationID = core.GraphQLCapabilityID
 	resultBodyLogLimit = 4096
 
 	attrProvider       = metricutil.AttrProvider

--- a/gestaltd/services/invocation/broker.go
+++ b/gestaltd/services/invocation/broker.go
@@ -131,6 +131,7 @@ type Broker struct {
 	connMapper                    ConnectionMapper
 	mcpMapper                     ConnectionMapper
 	connectionRuntime             ConnectionRuntimeResolver
+	appAccessProfiles             core.AppAccessProfileStore
 	authorization                 core.AuthorizationProvider
 	providerKinds                 map[string]ProviderKind
 	authorizationPolicies         map[string]string
@@ -163,6 +164,12 @@ func WithConnectionRuntime(r ConnectionRuntimeResolver) BrokerOption {
 
 func WithAuthorizationProvider(provider core.AuthorizationProvider) BrokerOption {
 	return func(b *Broker) { b.authorization = provider }
+}
+
+// WithAppAccessProfiles installs the user-owned app capability policy. It is
+// checked in the broker so every invocation surface shares the same decision.
+func WithAppAccessProfiles(store core.AppAccessProfileStore) BrokerOption {
+	return func(b *Broker) { b.appAccessProfiles = store }
 }
 
 func WithProviderKinds(kinds map[string]ProviderKind) BrokerOption {
@@ -300,6 +307,9 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 	}
 	if !principal.AllowsOperationPermission(p, providerName, opMeta.ID) {
 		return fail(fmt.Errorf("%w: %s.%s", ErrScopeDenied, providerName, opMeta.ID))
+	}
+	if err := b.checkAppAccess(ctx, p, providerName, opMeta.ID); err != nil {
+		return fail(err)
 	}
 	if !providerDelegatesRemoteAuthorization(prov) {
 		ctx, err = b.authorizeOperation(ctx, p, providerName, opMeta)
@@ -1095,10 +1105,36 @@ func (b *Broker) CheckOperationAccess(ctx context.Context, p *principal.Principa
 	if !principal.AllowsOperationPermission(p, providerName, operationID) {
 		return fmt.Errorf("%w: %s.%s", ErrAuthorizationDenied, providerName, operationID)
 	}
+	if err := b.checkAppAccess(ctx, p, providerName, operationID); err != nil {
+		return err
+	}
 	if b.providerDelegatesRemoteAuthorization(ctx, providerName) {
 		return nil
 	}
 	return b.checkAuthorizationAccess(ctx, p, providerName, operationID)
+}
+
+func (b *Broker) checkAppAccess(ctx context.Context, p *principal.Principal, providerName, operationID string) error {
+	if b == nil || b.appAccessProfiles == nil || p == nil || principal.IsNonUserPrincipal(p) {
+		return nil
+	}
+	subjectID, err := principal.ResolveCredentialSubjectID(ctx, b.users, p)
+	if err != nil {
+		return fmt.Errorf("%w: %s.%s: %v", ErrAuthorizationDenied, providerName, operationID, err)
+	}
+	profile, err := b.appAccessProfiles.GetAppAccessProfile(ctx, subjectID, providerName)
+	if err != nil {
+		if errors.Is(err, core.ErrNotFound) {
+			return nil
+		}
+		return fmt.Errorf("%w: %s.%s: %v", ErrAuthorizationDenied, providerName, operationID, err)
+	}
+	for _, enabled := range profile.EnabledOperations {
+		if strings.TrimSpace(enabled) == strings.TrimSpace(operationID) {
+			return nil
+		}
+	}
+	return fmt.Errorf("%w: %s.%s", ErrAuthorizationDenied, providerName, operationID)
 }
 
 func (b *Broker) CheckProviderAccess(ctx context.Context, p *principal.Principal, providerName string) error {

--- a/gestaltd/services/invocation/broker.go
+++ b/gestaltd/services/invocation/broker.go
@@ -305,10 +305,7 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 	if err != nil {
 		return fail(err)
 	}
-	if !principal.AllowsOperationPermission(p, providerName, opMeta.ID) {
-		return fail(fmt.Errorf("%w: %s.%s", ErrScopeDenied, providerName, opMeta.ID))
-	}
-	if err := b.checkAppAccess(ctx, p, providerName, opMeta.ID); err != nil {
+	if err := b.checkInvocationOperationAccess(ctx, p, providerName, opMeta.ID); err != nil {
 		return fail(err)
 	}
 	if !providerDelegatesRemoteAuthorization(prov) {
@@ -467,8 +464,8 @@ func (b *Broker) InvokeStream(ctx context.Context, p *principal.Principal, provi
 	if err != nil {
 		return fail(err)
 	}
-	if !principal.AllowsOperationPermission(p, providerName, opMeta.ID) {
-		return fail(fmt.Errorf("%w: %s.%s", ErrScopeDenied, providerName, opMeta.ID))
+	if err := b.checkInvocationOperationAccess(ctx, p, providerName, opMeta.ID); err != nil {
+		return fail(err)
 	}
 	if !providerDelegatesRemoteAuthorization(prov) {
 		ctx, err = b.authorizeOperation(ctx, p, providerName, opMeta)
@@ -652,8 +649,8 @@ func (b *Broker) InvokeMaybeStream(ctx context.Context, p *principal.Principal, 
 	if err != nil {
 		return fail(err)
 	}
-	if !principal.AllowsOperationPermission(p, providerName, opMeta.ID) {
-		return fail(fmt.Errorf("%w: %s.%s", ErrScopeDenied, providerName, opMeta.ID))
+	if err := b.checkInvocationOperationAccess(ctx, p, providerName, opMeta.ID); err != nil {
+		return fail(err)
 	}
 	if !providerDelegatesRemoteAuthorization(prov) {
 		ctx, err = b.authorizeOperation(ctx, p, providerName, opMeta)
@@ -915,8 +912,8 @@ func (b *Broker) InvokeGraphQL(ctx context.Context, p *principal.Principal, prov
 	if !principal.AllowsProviderPermission(p, providerName) {
 		return fail(fmt.Errorf("%w: %s", ErrScopeDenied, providerName))
 	}
-	if !principal.AllowsOperationPermission(p, providerName, graphQLOperationID) {
-		return fail(fmt.Errorf("%w: %s.%s", ErrScopeDenied, providerName, graphQLOperationID))
+	if err := b.checkInvocationOperationAccess(ctx, p, providerName, graphQLOperationID); err != nil {
+		return fail(err)
 	}
 	setSubjectAttribute(p)
 	ctx = withResolvedPrincipal(ctx, p)
@@ -1114,13 +1111,34 @@ func (b *Broker) CheckOperationAccess(ctx context.Context, p *principal.Principa
 	return b.checkAuthorizationAccess(ctx, p, providerName, operationID)
 }
 
+// checkInvocationOperationAccess is the shared caller-side operation gate for
+// every invocation mode. Workspace authorization is applied separately because
+// remote-delegated providers own that decision, but user app capabilities and
+// token operation scopes must be enforced before any provider dispatch.
+func (b *Broker) checkInvocationOperationAccess(ctx context.Context, p *principal.Principal, providerName, operationID string) error {
+	if !principal.AllowsOperationPermission(p, providerName, operationID) {
+		return fmt.Errorf("%w: %s.%s", ErrScopeDenied, providerName, operationID)
+	}
+	return b.checkAppAccess(ctx, p, providerName, operationID)
+}
+
 func (b *Broker) checkAppAccess(ctx context.Context, p *principal.Principal, providerName, operationID string) error {
 	if b == nil || b.appAccessProfiles == nil || p == nil || principal.IsNonUserPrincipal(p) {
 		return nil
 	}
-	subjectID, err := principal.ResolveCredentialSubjectID(ctx, b.users, p)
+	subjectID, err := principal.ResolveAuthorizationSubjectID(ctx, b.users, p)
 	if err != nil {
-		return fmt.Errorf("%w: %s.%s: %v", ErrAuthorizationDenied, providerName, operationID, err)
+		if !errors.Is(err, principal.ErrOpaqueCredentialSubject) {
+			return fmt.Errorf("%w: %s.%s: %v", ErrAuthorizationDenied, providerName, operationID, err)
+		}
+		subjectID = legacyAppAccessSubjectID(p)
+		if subjectID == "" {
+			return fmt.Errorf("%w: %s.%s: %v", ErrAuthorizationDenied, providerName, operationID, err)
+		}
+		// Older local callers can carry a non-UUID user ID. Preserve their
+		// existing no-profile allow behavior, but honor a legacy raw profile
+		// if one exists. Provider-namespaced opaque subjects are rejected above
+		// instead of being allowed to bypass a canonical profile.
 	}
 	profile, err := b.appAccessProfiles.GetAppAccessProfile(ctx, subjectID, providerName)
 	if err != nil {
@@ -1135,6 +1153,19 @@ func (b *Broker) checkAppAccess(ctx context.Context, p *principal.Principal, pro
 		}
 	}
 	return fmt.Errorf("%w: %s.%s", ErrAuthorizationDenied, providerName, operationID)
+}
+
+func legacyAppAccessSubjectID(p *principal.Principal) string {
+	p = principal.Canonicalized(p)
+	if p == nil || p.Kind != principal.KindUser {
+		return ""
+	}
+	subjectID := strings.TrimSpace(p.SubjectID)
+	userID := strings.TrimSpace(principal.UserIDFromSubjectID(subjectID))
+	if userID == "" || strings.ContainsAny(userID, "|:/\\") {
+		return ""
+	}
+	return subjectID
 }
 
 func (b *Broker) CheckProviderAccess(ctx context.Context, p *principal.Principal, providerName string) error {


### PR DESCRIPTION
## Summary

Users can now choose which operations a connected app may use. The same setting is enforced for API, CLI, MCP, and operation discovery, while workspace authorization remains the upper limit.

## Why / context

Connection credentials and app capabilities are separate concerns. Previously, there was no durable user-owned capability profile, so a UI setting could not consistently govern every access path.

## What changed

- Added a durable per-user, per-app capability profile with idempotent default initialization.
- Added authenticated endpoints for reading and updating enabled operations.
- Applied the profile in invocation and batched operation-access checks.
- Added provider manifest support for explicit recommended defaults.
- Kept standard OIDC identity scopes from being treated as app permissions.
- Added deferred store creation so existing databases can upgrade safely.

## Validation

- [x] Automated: `go test ./core ./sdk/providermanifest/v1 ./internal/coredata ./services/apps/declarative ./services/apps/mcp ./services/identity/principal ./services/invocation ./internal/server ./internal/bootstrap`
- [x] `gofmt` and `git diff --check`
- [ ] Full suite: two unrelated environment failures remain, one Python 3.9.6 SDK compatibility failure and one provider restart-probe timeout.

## Reviewer focus

Please review the canonical user subject used for profile lookup, the create-once behavior during reconnect races, and the ordering between user capabilities and workspace authorization.

## Rollout / compatibility

Deploy this backend before the frontend. Existing users without a profile retain the previous allow behavior; newly completed user connections receive the provider's defaults once and reconnects do not overwrite changes.
