### PR TITLE
Implement lean Gestalt SCIM user provisioning

### DIFF
--- a/gestaltd/core/testing/indexeddb_stub_cursor.go
+++ b/gestaltd/core/testing/indexeddb_stub_cursor.go
@@ -32,19 +32,26 @@ func (c *stubCursor) buildIndexKeys() {
 	if kp == nil {
 		return
 	}
-	c.indexKeys = make([]any, len(c.keys))
-	for i, k := range c.keys {
+	keys := make([]string, 0, len(c.keys))
+	indexKeys := make([]any, 0, len(c.keys))
+	for _, k := range c.keys {
 		rec := c.snapshot[k]
+		if !recordHasIndexKey(rec, kp) {
+			continue
+		}
+		keys = append(keys, k)
 		if len(kp) == 1 {
-			c.indexKeys[i] = rec[kp[0]]
+			indexKeys = append(indexKeys, rec[kp[0]])
 		} else {
 			vals := make([]any, len(kp))
 			for j, field := range kp {
 				vals[j] = rec[field]
 			}
-			c.indexKeys[i] = vals
+			indexKeys = append(indexKeys, vals)
 		}
 	}
+	c.keys = keys
+	c.indexKeys = indexKeys
 	sort.Sort(&indexKeySorter{keys: c.keys, indexKeys: c.indexKeys, reverse: c.reverse})
 }
 

--- a/gestaltd/core/testing/indexeddb_stub_store.go
+++ b/gestaltd/core/testing/indexeddb_stub_store.go
@@ -115,8 +115,14 @@ func (o *stubObjectStore) hasUniqueConflict(record idb.Record, ignoreID *string)
 		if !idx.Unique {
 			continue
 		}
+		if !recordHasIndexKey(record, idx.KeyPath) {
+			continue
+		}
 		for id, existing := range o.records {
 			if ignoreID != nil && id == *ignoreID {
+				continue
+			}
+			if !recordHasIndexKey(existing, idx.KeyPath) {
 				continue
 			}
 			match := true
@@ -132,6 +138,16 @@ func (o *stubObjectStore) hasUniqueConflict(record idb.Record, ignoreID *string)
 		}
 	}
 	return false
+}
+
+func recordHasIndexKey(record idb.Record, keyPath []string) bool {
+	for _, field := range keyPath {
+		value, ok := record[field]
+		if !ok || value == nil {
+			return false
+		}
+	}
+	return true
 }
 
 func (o *stubObjectStore) Delete(_ context.Context, id string) error {
@@ -228,7 +244,12 @@ func (o *stubObjectStore) DeleteRange(_ context.Context, query any) (int64, erro
 }
 
 func (o *stubObjectStore) Index(name string) idb.Index {
-	return &stubIndex{store: o, name: name, schema: o.schema}
+	done := o.readSchedule()
+	defer done()
+	o.mu.RLock()
+	schema := o.schema
+	o.mu.RUnlock()
+	return &stubIndex{store: o, name: name, schema: schema}
 }
 
 func (o *stubObjectStore) OpenCursor(_ context.Context, query any, dir idb.CursorDirection) (idb.Cursor, error) {

--- a/gestaltd/core/testing/indexeddb_stub_test.go
+++ b/gestaltd/core/testing/indexeddb_stub_test.go
@@ -184,3 +184,37 @@ func TestStubTransactionAbortsOnOperationError(t *testing.T) {
 		t.Fatalf("user-3 after aborted transaction error = %v, want idb.ErrNotFound", err)
 	}
 }
+
+func TestStubUniqueIndexOmitsMissingAndNullKeys(t *testing.T) {
+	t.Parallel()
+
+	db := &StubIndexedDB{}
+	ctx := context.Background()
+	if _, err := db.CreateObjectStore(ctx, "items", idb.ObjectStoreOptions{
+		Indexes: []idb.IndexSchema{{Name: "by_external_id", KeyPath: []string{"external_id"}, Unique: true}},
+	}); err != nil {
+		t.Fatalf("CreateObjectStore: %v", err)
+	}
+	store := db.ObjectStore("items")
+	for _, record := range []idb.Record{
+		{"id": "missing-1"},
+		{"id": "missing-2"},
+		{"id": "null-1", "external_id": nil},
+		{"id": "null-2", "external_id": nil},
+		{"id": "present", "external_id": "employee-1"},
+	} {
+		if err := store.Add(ctx, record); err != nil {
+			t.Fatalf("Add(%q): %v", record["id"], err)
+		}
+	}
+	if err := store.Add(ctx, idb.Record{"id": "duplicate", "external_id": "employee-1"}); !errors.Is(err, idb.ErrAlreadyExists) {
+		t.Fatalf("duplicate present key error = %v, want idb.ErrAlreadyExists", err)
+	}
+	records, err := store.Index("by_external_id").GetAll(ctx, nil)
+	if err != nil {
+		t.Fatalf("index GetAll: %v", err)
+	}
+	if len(records) != 1 || records[0]["id"] != "present" {
+		t.Fatalf("indexed records = %#v, want only present key", records)
+	}
+}

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
+	"net/http"
 	"os"
 	"slices"
 	"strings"
@@ -25,6 +26,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/featureflags"
 	"github.com/valon-technologies/gestalt/server/internal/publicrpc"
 	"github.com/valon-technologies/gestalt/server/internal/remote"
+	"github.com/valon-technologies/gestalt/server/internal/scim"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	agentservice "github.com/valon-technologies/gestalt/server/services/agents"
@@ -270,6 +272,7 @@ type Result struct {
 	Runtimes                RuntimeInspector
 	PublicHostServices      *runtimehost.PublicHostServiceRegistry
 	PublicGatewayTransport  *providergateway.ProviderGatewayTransport
+	SCIMHandler             http.Handler
 	DevSupervisor           *providerdev.Supervisor
 	AppRestarter            interface {
 		Restartable(string) (bool, error)
@@ -299,6 +302,8 @@ type Result struct {
 	deferred                            *deferredProviders
 	mu                                  sync.Mutex
 	closed                              bool
+	scimService                         *scim.Service
+	scimStart                           sync.Once
 }
 
 // StartAppProviders starts app providers that are required during normal
@@ -376,6 +381,11 @@ func (r *Result) Start(ctx context.Context) error {
 	if r.closed {
 		return fmt.Errorf("bootstrap result already closed")
 	}
+	r.scimStart.Do(func() {
+		if r.scimService != nil {
+			r.scimService.Start(ctx)
+		}
+	})
 	return nil
 }
 
@@ -784,6 +794,7 @@ type preparedCore struct {
 	WorkflowManager      *lazyWorkflowManager
 	AgentManager         *lazyAgentManager
 	PublicHostServices   *runtimehost.PublicHostServiceRegistry
+	SCIM                 *scim.Service
 
 	runtimeRegistry *runtimeRegistry
 }
@@ -1138,13 +1149,20 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 		_ = closeAuthProviders(authProviders)
 		return nil, err
 	}
-	_, authorizationProvider, err := selectedAuthorizationProviderInstance(cfg, authorizationProviders)
+	authorizationProviderName, authorizationProvider, err := selectedAuthorizationProviderInstance(cfg, authorizationProviders)
 	if err != nil {
 		_ = closeAuthProviders(authProviders)
 		return nil, err
 	}
+	scimService, err := scim.NewService(svc.DB, authorizationProvider, cfg.Server.BaseURL, cfg.Server.SCIM)
+	if err != nil {
+		_ = closeAuthProviders(authProviders)
+		return nil, fmt.Errorf("bootstrap: scim: %w", err)
+	}
 	if authorizationProvider != nil {
-		deps.Authorization = authorizationProvider
+		wrapped := scim.WrapAuthorization(authorizationProvider, svc.Users, scimService)
+		authorizationProviders[authorizationProviderName] = wrapped
+		deps.Authorization = wrapped
 	}
 	closeExternalCredentialsOnError := true
 	defer func() {
@@ -1187,6 +1205,7 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 		WorkflowManager:      workflowManager,
 		AgentManager:         agentManager,
 		PublicHostServices:   deps.PublicHostServices,
+		SCIM:                 scimService,
 		runtimeRegistry:      runtimeRegistry,
 	}, nil
 }
@@ -1540,6 +1559,10 @@ func BootstrapWithOptions(ctx context.Context, cfg *config.Config, factories *Fa
 		},
 	})
 	appProvidersInitialized := make(chan struct{})
+	var scimHandler http.Handler
+	if prepared.SCIM != nil && prepared.SCIM.Enabled() {
+		scimHandler = scim.NewHandler(prepared.SCIM)
+	}
 	result := &Result{
 		Auth:                           prepared.Auth,
 		SelectedAuthProvider:           prepared.SelectedAuthProvider,
@@ -1572,6 +1595,8 @@ func BootstrapWithOptions(ctx context.Context, cfg *config.Config, factories *Fa
 		Runtimes:                       prepared.runtimeRegistry,
 		PublicHostServices:             publicHostServices,
 		PublicGatewayTransport:         publicGatewayTransport,
+		SCIMHandler:                    scimHandler,
+		scimService:                    prepared.SCIM,
 		DevSupervisor:                  prepared.Deps.DevSupervisor,
 		AppRestarter:                   appRestarter,
 		AppRuntimeSnapshotter:          appRestarter,

--- a/gestaltd/internal/bootstrap/scim_bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/scim_bootstrap_test.go
@@ -1,0 +1,92 @@
+package bootstrap_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/scim"
+	"github.com/valon-technologies/gestalt/server/internal/server"
+	"gopkg.in/yaml.v3"
+)
+
+func TestSCIMSecretResolutionBootstrapAndPublicServer(t *testing.T) {
+	t.Parallel()
+
+	const bearerToken = "resolved-rippling-scim-token"
+	cfg := validConfig()
+	cfg.Server.BaseURL = "https://gestalt.example"
+	cfg.Server.SCIM = config.ServerSCIMConfig{Clients: map[string]config.SCIMClientConfig{
+		"rippling": {
+			Credentials: []config.SCIMCredentialConfig{{
+				ID:          "current",
+				BearerToken: config.EncodeSecretRefTransport(config.SecretRef{Provider: "default", Name: "rippling-scim-token"}),
+			}},
+		},
+	}}
+	factories := validFactories()
+	factories.Secrets["test-secrets"] = func(yaml.Node) (core.SecretManager, error) {
+		return &coretesting.StubSecretManager{Secrets: map[string]string{"rippling-scim-token": bearerToken}}, nil
+	}
+	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	t.Cleanup(func() { _ = result.Close(context.Background()) })
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	if err := result.Start(ctx); err != nil {
+		t.Fatalf("Result.Start: %v", err)
+	}
+
+	publicServer, err := server.New(server.Config{
+		Services:           result.Services,
+		Providers:          result.Providers,
+		Invoker:            result.Invoker,
+		AppInvocation:      result.AppInvocation,
+		SCIMHandler:        result.SCIMHandler,
+		PublicBaseURL:      cfg.Server.BaseURL,
+		StateSecret:        []byte("0123456789abcdef0123456789abcdef"),
+		PublicHostServices: result.PublicHostServices,
+		RouteProfile:       server.RouteProfilePublic,
+	})
+	if err != nil {
+		t.Fatalf("server.New: %v", err)
+	}
+	request := func(method, path, token string, body any) *httptest.ResponseRecorder {
+		t.Helper()
+		var encoded []byte
+		if body != nil {
+			encoded, err = json.Marshal(body)
+			if err != nil {
+				t.Fatalf("marshal request: %v", err)
+			}
+		}
+		req := httptest.NewRequest(method, path, bytes.NewReader(encoded))
+		req.Header.Set("Authorization", "Bearer "+token)
+		if body != nil {
+			req.Header.Set("Content-Type", "application/scim+json")
+		}
+		response := httptest.NewRecorder()
+		publicServer.ServeHTTP(response, req)
+		return response
+	}
+
+	if response := request(http.MethodGet, "/scim/v2/Schemas", "wrong", nil); response.Code != http.StatusUnauthorized {
+		t.Fatalf("wrong token status = %d", response.Code)
+	}
+	if response := request(http.MethodGet, "/scim/v2/Schemas", bearerToken, nil); response.Code != http.StatusOK || response.Header().Get("Content-Type") != "application/scim+json" {
+		t.Fatalf("resolved token schema response = %d %q", response.Code, response.Header().Get("Content-Type"))
+	}
+	payload := map[string]any{"schemas": []string{scim.UserSchemaURN}, "userName": "alice@valon.com", "active": true}
+	if response := request(http.MethodPost, "/scim/v2/Users", bearerToken, payload); response.Code != http.StatusCreated {
+		t.Fatalf("public SCIM create status = %d", response.Code)
+	}
+}

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -1915,6 +1915,57 @@ type AuthorizationResourceDef struct {
 	Properties map[string]string `yaml:"properties,omitempty"`
 }
 
+// ServerSCIMConfig configures inbound SCIM provisioning clients. Credential
+// IDs are local audit/rotation labels; only BearerToken is sent by clients.
+type ServerSCIMConfig struct {
+	Clients       map[string]SCIMClientConfig `yaml:"clients,omitempty"`
+	RetryInterval string                      `yaml:"retryInterval,omitempty"`
+	DriftInterval string                      `yaml:"driftInterval,omitempty"`
+}
+
+const (
+	DefaultSCIMRetryInterval = time.Second
+	DefaultSCIMDriftInterval = 10 * time.Minute
+)
+
+func (c ServerSCIMConfig) RetryIntervalDuration() (time.Duration, error) {
+	return scimDuration(c.RetryInterval, DefaultSCIMRetryInterval)
+}
+
+func (c ServerSCIMConfig) DriftIntervalDuration() (time.Duration, error) {
+	return scimDuration(c.DriftInterval, DefaultSCIMDriftInterval)
+}
+
+func scimDuration(raw string, defaultValue time.Duration) (time.Duration, error) {
+	if strings.TrimSpace(raw) == "" {
+		return defaultValue, nil
+	}
+	duration, err := ParseDuration(raw)
+	if err != nil {
+		return 0, err
+	}
+	if duration <= 0 {
+		return 0, fmt.Errorf("duration must be positive")
+	}
+	return duration, nil
+}
+
+type SCIMClientConfig struct {
+	Credentials              []SCIMCredentialConfig   `yaml:"credentials,omitempty"`
+	AuthoritativeUserDomains []string                 `yaml:"authoritativeUserDomains,omitempty"`
+	ActiveUserRelationships  []SCIMRelationshipConfig `yaml:"activeUserRelationships,omitempty"`
+}
+
+type SCIMCredentialConfig struct {
+	ID          string `yaml:"id"`
+	BearerToken string `yaml:"bearerToken"`
+}
+
+type SCIMRelationshipConfig struct {
+	Relation string                   `yaml:"relation"`
+	Resource AuthorizationResourceDef `yaml:"resource"`
+}
+
 type AuthorizationRelationshipTargetDef struct {
 	Subject    *AuthorizationSubjectDef    `yaml:"subject,omitempty"`
 	Resource   *AuthorizationResourceDef   `yaml:"resource,omitempty"`
@@ -1982,6 +2033,7 @@ type ServerConfig struct {
 	Egress        EgressConfig             `yaml:"egress,omitempty"`
 	Admin         AdminConfig              `yaml:"admin,omitempty"`
 	UserLookup    UserLookupConfig         `yaml:"userLookup,omitempty"`
+	SCIM          ServerSCIMConfig         `yaml:"scim,omitempty"`
 	AppRegistry   ServerAppRegistryConfig  `yaml:"appRegistry,omitempty"`
 	AutoActivate  *bool                    `yaml:"autoActivate,omitempty"`
 	// AuthorizationStateApply gates whether server startup is allowed to

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -50,13 +50,37 @@ func CanonicalizeStructure(cfg *Config) error {
 	if err := normalizeAppStaticMounts(cfg); err != nil {
 		return err
 	}
+	normalizeSCIMConfig(cfg)
 	return canonicalizeRemotes(cfg)
+}
+
+func normalizeSCIMConfig(cfg *Config) {
+	if cfg == nil {
+		return
+	}
+	for clientID, client := range cfg.Server.SCIM.Clients {
+		for i := range client.Credentials {
+			client.Credentials[i].ID = strings.TrimSpace(client.Credentials[i].ID)
+		}
+		for i := range client.AuthoritativeUserDomains {
+			client.AuthoritativeUserDomains[i] = strings.ToLower(strings.TrimSpace(client.AuthoritativeUserDomains[i]))
+		}
+		for i := range client.ActiveUserRelationships {
+			client.ActiveUserRelationships[i].Relation = strings.TrimSpace(client.ActiveUserRelationships[i].Relation)
+			client.ActiveUserRelationships[i].Resource.Type = strings.TrimSpace(client.ActiveUserRelationships[i].Resource.Type)
+			client.ActiveUserRelationships[i].Resource.ID = strings.TrimSpace(client.ActiveUserRelationships[i].Resource.ID)
+		}
+		cfg.Server.SCIM.Clients[clientID] = client
+	}
 }
 
 // ValidateCanonicalStructure checks config shape assuming canonicalization has
 // already run on the config.
 func ValidateCanonicalStructure(cfg *Config) error {
 	if err := validateAuthorizationModelConfig(cfg); err != nil {
+		return err
+	}
+	if err := validateSCIMConfig(cfg); err != nil {
 		return err
 	}
 	if err := validateServerListeners(cfg.Server); err != nil {
@@ -136,6 +160,95 @@ func ValidateCanonicalStructure(cfg *Config) error {
 		}
 	}
 	return validateWorkflowsConfig(cfg)
+}
+
+func validateSCIMConfig(cfg *Config) error {
+	if cfg == nil || len(cfg.Server.SCIM.Clients) == 0 {
+		return nil
+	}
+	if _, err := cfg.Server.SCIM.RetryIntervalDuration(); err != nil {
+		return fmt.Errorf("config validation: server.scim.retryInterval: %w", err)
+	}
+	if _, err := cfg.Server.SCIM.DriftIntervalDuration(); err != nil {
+		return fmt.Errorf("config validation: server.scim.driftInterval: %w", err)
+	}
+	resourceTypes := make(map[string]AuthorizationResourceTypeDef)
+	for _, model := range cfg.Authorization.Models {
+		for name, resourceType := range model.ResourceTypes {
+			resourceTypes[name] = resourceType
+		}
+	}
+	domainOwners := make(map[string]string)
+	credentialIDs := make(map[string]string)
+	tokens := make(map[string]string)
+	needsAuthorization := false
+	for clientID, client := range cfg.Server.SCIM.Clients {
+		path := "server.scim.clients." + clientID
+		if strings.TrimSpace(clientID) == "" || strings.TrimSpace(clientID) != clientID {
+			return fmt.Errorf("config validation: server.scim.clients keys must be non-empty and trimmed")
+		}
+		if len(client.Credentials) == 0 || len(client.Credentials) > 2 {
+			return fmt.Errorf("config validation: %s.credentials must contain one or two credentials", path)
+		}
+		for i, credential := range client.Credentials {
+			credentialPath := fmt.Sprintf("%s.credentials[%d]", path, i)
+			id := strings.TrimSpace(credential.ID)
+			if id == "" {
+				return fmt.Errorf("config validation: %s.id is required", credentialPath)
+			}
+			if previous, ok := credentialIDs[clientID+"\x00"+id]; ok {
+				return fmt.Errorf("config validation: %s.id duplicates %s", credentialPath, previous)
+			}
+			credentialIDs[clientID+"\x00"+id] = credentialPath
+			token := strings.TrimSpace(credential.BearerToken)
+			if token == "" {
+				return fmt.Errorf("config validation: %s.bearerToken is required", credentialPath)
+			}
+			if previous, ok := tokens[token]; ok {
+				return fmt.Errorf("config validation: %s.bearerToken duplicates %s", credentialPath, previous)
+			}
+			tokens[token] = credentialPath
+		}
+		for i, rawDomain := range client.AuthoritativeUserDomains {
+			domain := strings.ToLower(strings.TrimSpace(rawDomain))
+			if domain == "" || domain != rawDomain || strings.Contains(domain, "@") {
+				return fmt.Errorf("config validation: %s.authoritativeUserDomains[%d] must be a normalized domain", path, i)
+			}
+			if previous, ok := domainOwners[domain]; ok {
+				return fmt.Errorf("config validation: %s.authoritativeUserDomains[%d] overlaps client %q", path, i, previous)
+			}
+			domainOwners[domain] = clientID
+			needsAuthorization = true
+		}
+		for i, projection := range client.ActiveUserRelationships {
+			projectionPath := fmt.Sprintf("%s.activeUserRelationships[%d]", path, i)
+			resourceTypeName := strings.TrimSpace(projection.Resource.Type)
+			resourceType, ok := resourceTypes[resourceTypeName]
+			if !ok {
+				return fmt.Errorf("config validation: %s.resource.type references unknown resource type %q", projectionPath, resourceTypeName)
+			}
+			if strings.TrimSpace(projection.Resource.ID) == "" {
+				return fmt.Errorf("config validation: %s.resource.id is required", projectionPath)
+			}
+			if _, ok := resourceType.Relations[strings.TrimSpace(projection.Relation)]; !ok {
+				return fmt.Errorf("config validation: %s.relation references unknown relation %q for resource type %q", projectionPath, projection.Relation, resourceTypeName)
+			}
+			if !resourceType.Dynamic.AllowAdditionalRelationships {
+				return fmt.Errorf("config validation: authorization resource type %q must set dynamic.allowAdditionalRelationships: true for SCIM projections", resourceTypeName)
+			}
+			needsAuthorization = true
+		}
+	}
+	if needsAuthorization {
+		_, provider, err := cfg.SelectedAuthorizationProvider()
+		if err != nil {
+			return err
+		}
+		if provider == nil {
+			return fmt.Errorf("config validation: SCIM authoritative domains and projections require providers.authorization to be configured")
+		}
+	}
+	return nil
 }
 
 func validateAPIVersion(cfg *Config) error {

--- a/gestaltd/internal/config/scim_load_test.go
+++ b/gestaltd/internal/config/scim_load_test.go
@@ -1,0 +1,147 @@
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/internal/config"
+)
+
+func TestLoadSCIMConfiguration(t *testing.T) {
+	t.Parallel()
+
+	path := writeSCIMConfig(t, `
+apiVersion: gestaltd.config/v8
+providers:
+  indexeddb:
+    sqlite:
+      source:
+        path: ./providers/indexeddb/sqlite
+  secrets:
+    secrets:
+      source:
+        path: ./providers/secrets/test
+server:
+  providers:
+    indexeddb: sqlite
+  scim:
+    retryInterval: 2s
+    driftInterval: 15m
+    clients:
+      rippling:
+        credentials:
+          - id: current
+            bearerToken:
+              secret:
+                provider: secrets
+                name: rippling-scim-token
+          - id: next
+            bearerToken: rotating-token
+`)
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got, err := cfg.Server.SCIM.RetryIntervalDuration(); err != nil || got != 2*time.Second {
+		t.Fatalf("RetryIntervalDuration = %v, %v", got, err)
+	}
+	if got, err := cfg.Server.SCIM.DriftIntervalDuration(); err != nil || got != 15*time.Minute {
+		t.Fatalf("DriftIntervalDuration = %v, %v", got, err)
+	}
+	credential := cfg.Server.SCIM.Clients["rippling"].Credentials[0]
+	ref, ok, err := config.ParseSecretRefTransport(credential.BearerToken)
+	if err != nil || !ok || ref.Provider != "secrets" || ref.Name != "rippling-scim-token" {
+		t.Fatalf("structured bearer token = %#v, %v, %v", ref, ok, err)
+	}
+}
+
+func TestLoadSCIMConfigurationValidation(t *testing.T) {
+	t.Parallel()
+
+	validAuthorization := `
+providers:
+  indexeddb:
+    sqlite:
+      source:
+        path: ./providers/indexeddb/sqlite
+  authorization:
+    authz:
+      source:
+        path: ./providers/authorization/indexeddb
+server:
+  providers:
+    indexeddb: sqlite
+    authorization: authz
+  scim:
+    clients:
+      rippling:
+        credentials:
+          - id: current
+            bearerToken: rippling-token
+        authoritativeUserDomains: [VALON.COM]
+        activeUserRelationships:
+          - relation: member
+            resource:
+              type: group
+              id: valon-employees
+authorization:
+  models:
+    default:
+      resourceTypes:
+        group:
+          relations:
+            member:
+              subjectTypes: [subject]
+          dynamic:
+            allowAdditionalRelationships: true
+`
+	cfg, err := config.Load(writeSCIMConfig(t, "apiVersion: gestaltd.config/v8\n"+validAuthorization))
+	if err != nil {
+		t.Fatalf("valid Load: %v", err)
+	}
+	if got := cfg.Server.SCIM.Clients["rippling"].AuthoritativeUserDomains[0]; got != "valon.com" {
+		t.Fatalf("normalized domain = %q", got)
+	}
+	withoutAuthorization := strings.Replace(validAuthorization, `  authorization:
+    authz:
+      source:
+        path: ./providers/authorization/indexeddb
+`, "", 1)
+	withoutAuthorization = strings.Replace(withoutAuthorization, "    authorization: authz\n", "", 1)
+	if _, err := config.Load(writeSCIMConfig(t, "apiVersion: gestaltd.config/v8\n"+withoutAuthorization)); err == nil || !strings.Contains(err.Error(), "require providers.authorization") {
+		t.Fatalf("configuration without authorization error = %v", err)
+	}
+
+	cases := []struct {
+		name    string
+		replace string
+		with    string
+		want    string
+	}{
+		{name: "limits rotation credentials", replace: "          - id: current\n            bearerToken: rippling-token\n", with: "          - id: one\n            bearerToken: token-one\n          - id: two\n            bearerToken: token-two\n          - id: three\n            bearerToken: token-three\n", want: "one or two"},
+		{name: "requires dynamic projection writes", replace: "allowAdditionalRelationships: true", with: "allowAdditionalRelationships: false", want: "allowAdditionalRelationships"},
+		{name: "validates retry interval", replace: "  scim:\n", with: "  scim:\n    retryInterval: 0s\n", want: "retryInterval"},
+	}
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			yaml := "apiVersion: gestaltd.config/v8\n" + strings.Replace(validAuthorization, test.replace, test.with, 1)
+			_, err := config.Load(writeSCIMConfig(t, yaml))
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("Load error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func writeSCIMConfig(t *testing.T, contents string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "gestalt.yaml")
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return path
+}

--- a/gestaltd/internal/coredata/schemas.go
+++ b/gestaltd/internal/coredata/schemas.go
@@ -22,7 +22,71 @@ const (
 	StoreRemoteProviders                = "remote_providers"
 	StoreConnectionInstancePreferences  = "connection_instance_preferences"
 	StoreAppAccessProfiles              = "app_access_profiles"
+	StoreSCIMUsers                      = "scim_users"
+	StoreSCIMProjectionIntents          = "scim_projection_intents"
 )
+
+var SCIMUsersSchema = idb.ObjectStoreOptions{
+	Indexes: []idb.IndexSchema{
+		{Name: "by_client", KeyPath: []string{"client_id"}},
+		{Name: "by_core_user", KeyPath: []string{"core_user_id"}},
+		{Name: "by_user_name_key", KeyPath: []string{"user_name_key"}, Unique: true},
+		{Name: "by_external_id_key", KeyPath: []string{"external_id_key"}, Unique: true},
+		{Name: "by_email_key", KeyPath: []string{"email_key"}, Unique: true},
+	},
+	Columns: []idb.ColumnDef{
+		{Name: "id", Type: idb.TypeString, PrimaryKey: true},
+		{Name: "client_id", Type: idb.TypeString, NotNull: true},
+		{Name: "core_user_id", Type: idb.TypeString, NotNull: true},
+		{Name: "authoritative_domain", Type: idb.TypeString},
+		{Name: "user_name_key", Type: idb.TypeString},
+		{Name: "external_id_key", Type: idb.TypeString},
+		{Name: "email_key", Type: idb.TypeString},
+		{Name: "active", Type: idb.TypeBool, NotNull: true},
+		{Name: "deleted", Type: idb.TypeBool, NotNull: true},
+		{Name: "version", Type: idb.TypeInt, NotNull: true},
+		{Name: "resource", Type: idb.TypeJSON, NotNull: true},
+		{Name: "applied_relationships", Type: idb.TypeJSON},
+		{Name: "last_operation_fingerprint", Type: idb.TypeString},
+		{Name: "created_at", Type: idb.TypeTime, NotNull: true},
+		{Name: "updated_at", Type: idb.TypeTime, NotNull: true},
+		{Name: "deleted_at", Type: idb.TypeTime},
+	},
+}
+
+var SCIMProjectionIntentsSchema = idb.ObjectStoreOptions{
+	Indexes: []idb.IndexSchema{
+		{Name: "by_user", KeyPath: []string{"user_id"}, Unique: true},
+		{Name: "by_core_user", KeyPath: []string{"core_user_id"}},
+		{Name: "by_client", KeyPath: []string{"client_id"}},
+		{Name: "by_next_attempt", KeyPath: []string{"next_attempt_at"}},
+		{Name: "by_user_name_key", KeyPath: []string{"user_name_key"}, Unique: true},
+		{Name: "by_external_id_key", KeyPath: []string{"external_id_key"}, Unique: true},
+		{Name: "by_email_key", KeyPath: []string{"email_key"}, Unique: true},
+	},
+	Columns: []idb.ColumnDef{
+		{Name: "id", Type: idb.TypeString, PrimaryKey: true},
+		{Name: "user_id", Type: idb.TypeString, NotNull: true},
+		{Name: "client_id", Type: idb.TypeString, NotNull: true},
+		{Name: "core_user_id", Type: idb.TypeString, NotNull: true},
+		{Name: "authoritative_domain", Type: idb.TypeString},
+		{Name: "user_name_key", Type: idb.TypeString},
+		{Name: "external_id_key", Type: idb.TypeString},
+		{Name: "email_key", Type: idb.TypeString},
+		{Name: "base_version", Type: idb.TypeInt, NotNull: true},
+		{Name: "next_version", Type: idb.TypeInt, NotNull: true},
+		{Name: "proposed", Type: idb.TypeJSON, NotNull: true},
+		{Name: "proposed_deleted", Type: idb.TypeBool, NotNull: true},
+		{Name: "from_relationships", Type: idb.TypeJSON},
+		{Name: "to_relationships", Type: idb.TypeJSON},
+		{Name: "operation_fingerprint", Type: idb.TypeString},
+		{Name: "attempt_count", Type: idb.TypeInt, NotNull: true},
+		{Name: "next_attempt_at", Type: idb.TypeTime, NotNull: true},
+		{Name: "last_error", Type: idb.TypeString},
+		{Name: "created_at", Type: idb.TypeTime, NotNull: true},
+		{Name: "updated_at", Type: idb.TypeTime, NotNull: true},
+	},
+}
 
 var AppSHAsSchema = idb.ObjectStoreOptions{
 	Columns: []idb.ColumnDef{

--- a/gestaltd/internal/coredata/services.go
+++ b/gestaltd/internal/coredata/services.go
@@ -95,7 +95,15 @@ func NewWithOptions(ctx context.Context, ds indexeddb.IndexedDB, opts NewOptions
 		if _, err := ds.CreateObjectStore(ctx, StoreAppAccessProfiles, AppAccessProfilesSchema); err != nil {
 			return nil, fmt.Errorf("create app_access_profiles store: %w", err)
 		}
+		if _, err := ds.CreateObjectStore(ctx, StoreSCIMUsers, SCIMUsersSchema); err != nil {
+			return nil, fmt.Errorf("create scim_users store: %w", err)
+		}
+		if _, err := ds.CreateObjectStore(ctx, StoreSCIMProjectionIntents, SCIMProjectionIntentsSchema); err != nil {
+			return nil, fmt.Errorf("create scim_projection_intents store: %w", err)
+		}
 	} else if err := ensureDeferredAppRegistryStores(ctx, ds); err != nil {
+		return nil, err
+	} else if err := ensureSCIMStores(ctx, ds); err != nil {
 		return nil, err
 	}
 	users := NewUserService(ds)
@@ -130,6 +138,16 @@ func NewWithOptions(ctx context.Context, ds indexeddb.IndexedDB, opts NewOptions
 		AppAccessProfiles:              appAccessProfiles,
 		DB:                             ds,
 	}, nil
+}
+
+func ensureSCIMStores(ctx context.Context, ds indexeddb.IndexedDB) error {
+	if _, err := ds.CreateObjectStore(ctx, StoreSCIMUsers, SCIMUsersSchema); err != nil {
+		return fmt.Errorf("ensure scim_users store: %w", err)
+	}
+	if _, err := ds.CreateObjectStore(ctx, StoreSCIMProjectionIntents, SCIMProjectionIntentsSchema); err != nil {
+		return fmt.Errorf("ensure scim_projection_intents store: %w", err)
+	}
+	return nil
 }
 
 func (s *Services) Ping(ctx context.Context) error {

--- a/gestaltd/internal/coredata/services_test.go
+++ b/gestaltd/internal/coredata/services_test.go
@@ -256,6 +256,8 @@ func TestNew(t *testing.T) {
 			coredata.StoreRemoteProviders,
 			coredata.StoreConnectionInstancePreferences,
 			coredata.StoreAppAccessProfiles,
+			coredata.StoreSCIMUsers,
+			coredata.StoreSCIMProjectionIntents,
 		} {
 			if _, ok := contexts[store]; !ok {
 				t.Fatalf("NewWithContext did not create store %q", store)
@@ -276,8 +278,8 @@ func TestNew(t *testing.T) {
 			t.Fatalf("coredata.NewWithOptions: %v", err)
 		}
 		contexts := db.createdStoreContexts()
-		if len(contexts) != 5 {
-			t.Fatalf("CreateObjectStore calls = %d, want 5", len(contexts))
+		if len(contexts) != 7 {
+			t.Fatalf("CreateObjectStore calls = %d, want 7", len(contexts))
 		}
 		for _, store := range []string{
 			coredata.StoreAppAutoDeploySettings,
@@ -285,6 +287,8 @@ func TestNew(t *testing.T) {
 			coredata.StoreGestaltdInstanceHeartbeats,
 			coredata.StoreAppVersionRecoveryObservations,
 			coredata.StoreAppAccessProfiles,
+			coredata.StoreSCIMUsers,
+			coredata.StoreSCIMProjectionIntents,
 		} {
 			if _, ok := contexts[store]; !ok {
 				t.Fatalf("CreateObjectStore calls = %v, want %q", contexts, store)

--- a/gestaltd/internal/coredata/users.go
+++ b/gestaltd/internal/coredata/users.go
@@ -18,6 +18,8 @@ type UserService struct {
 	store idb.ObjectStore
 }
 
+var ErrUserEmailConflict = errors.New("user email is already linked to another user")
+
 func NewUserService(ds indexeddb.IndexedDB) *UserService {
 	return &UserService{store: ds.ObjectStore(StoreUsers)}
 }
@@ -52,14 +54,7 @@ func (s *UserService) FindOrCreateUserWithName(ctx context.Context, email, name 
 	}
 
 	now := time.Now()
-	newRec := idb.Record{
-		"id":               uuid.New().String(),
-		"email":            email,
-		"normalized_email": email,
-		"display_name":     strings.TrimSpace(name),
-		"created_at":       now,
-		"updated_at":       now,
-	}
+	newRec := newUserRecord(uuid.NewString(), email, name, now)
 	if err := s.store.Add(ctx, newRec); err != nil {
 		user, retryErr := s.findUserByNormalizedEmail(ctx, email)
 		if retryErr != nil {
@@ -99,8 +94,65 @@ func (s *UserService) FindUserByEmail(ctx context.Context, email string) (*core.
 	return s.findUserByNormalizedEmail(ctx, email)
 }
 
+// LinkUserInTransaction links an externally managed identity to a Gestalt
+// user while participating in the caller's transaction. An empty userID
+// reuses the single user with the normalized email or creates one.
+func LinkUserInTransaction(ctx context.Context, tx idb.Transaction, userID, email, displayName string, now time.Time) (*core.User, error) {
+	email = normalizeEmail(email)
+	if email == "" {
+		return nil, fmt.Errorf("link user: email is required")
+	}
+	store := tx.ObjectStore(StoreUsers)
+	records, err := store.Index("by_normalized_email").GetAll(ctx, email)
+	if err != nil {
+		return nil, fmt.Errorf("link user: find normalized email: %w", err)
+	}
+	if len(records) > 1 || len(records) == 1 && userID != "" && recString(records[0], "id") != userID {
+		return nil, fmt.Errorf("%w: %s", ErrUserEmailConflict, email)
+	}
+	if userID == "" {
+		if len(records) == 1 {
+			userID = recString(records[0], "id")
+		} else {
+			rec := newUserRecord(uuid.NewString(), email, displayName, now)
+			if err := store.Add(ctx, rec); err != nil {
+				return nil, fmt.Errorf("link user: create: %w", err)
+			}
+			return recordToUser(rec), nil
+		}
+	}
+	rec, err := store.Get(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("link user: get %q: %w", userID, err)
+	}
+	rec["email"] = email
+	rec["normalized_email"] = email
+	if displayName = strings.TrimSpace(displayName); displayName != "" {
+		rec["display_name"] = displayName
+	}
+	rec["updated_at"] = now
+	if err := store.Put(ctx, rec); err != nil {
+		if errors.Is(err, idb.ErrAlreadyExists) {
+			return nil, fmt.Errorf("%w: %s", ErrUserEmailConflict, email)
+		}
+		return nil, fmt.Errorf("link user: update: %w", err)
+	}
+	return recordToUser(rec), nil
+}
+
 func normalizeEmail(email string) string {
 	return strings.ToLower(strings.TrimSpace(email))
+}
+
+func newUserRecord(id, email, displayName string, now time.Time) idb.Record {
+	return idb.Record{
+		"id":               id,
+		"email":            email,
+		"normalized_email": email,
+		"display_name":     strings.TrimSpace(displayName),
+		"created_at":       now,
+		"updated_at":       now,
+	}
 }
 
 func (s *UserService) findUserByNormalizedEmail(ctx context.Context, normalizedEmail string) (*core.User, error) {

--- a/gestaltd/internal/scim/authorization.go
+++ b/gestaltd/internal/scim/authorization.go
@@ -1,0 +1,128 @@
+package scim
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/coredata"
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"github.com/valon-technologies/gestalt/server/services/identity/principal"
+)
+
+type authorizationGate struct {
+	underlying core.AuthorizationProvider
+	users      *coredata.UserService
+	scim       *Service
+}
+
+func WrapAuthorization(underlying core.AuthorizationProvider, users *coredata.UserService, service *Service) core.AuthorizationProvider {
+	if underlying == nil || service == nil || len(service.domainOwners) == 0 && len(service.managed) == 0 {
+		return underlying
+	}
+	return &authorizationGate{underlying: underlying, users: users, scim: service}
+}
+
+func (g *authorizationGate) CheckAccess(ctx context.Context, req *proto.CheckAccessRequest) (*proto.CheckAccessResponse, error) {
+	eligible, err := g.requestEligible(ctx, req)
+	if err != nil {
+		// Eligibility datastore failures fail closed as an ordinary denial.
+		eligible = false
+	}
+	if !eligible {
+		return &proto.CheckAccessResponse{Allowed: false}, nil
+	}
+	return g.underlying.CheckAccess(ctx, req)
+}
+
+func (g *authorizationGate) CheckAccessMany(ctx context.Context, req *proto.CheckAccessManyRequest) (*proto.CheckAccessManyResponse, error) {
+	if req == nil || len(req.Requests) == 0 {
+		return g.underlying.CheckAccessMany(ctx, req)
+	}
+	decisions := make([]*proto.CheckAccessResponse, len(req.Requests))
+	forward := &proto.CheckAccessManyRequest{}
+	indexes := make([]int, 0, len(req.Requests))
+	for i, request := range req.Requests {
+		eligible, err := g.requestEligible(ctx, request)
+		if err != nil {
+			// Eligibility datastore failures fail closed as an ordinary denial.
+			eligible = false
+		}
+		if !eligible {
+			decisions[i] = &proto.CheckAccessResponse{Allowed: false}
+			continue
+		}
+		forward.Requests = append(forward.Requests, request)
+		indexes = append(indexes, i)
+	}
+	if len(forward.Requests) > 0 {
+		response, err := g.underlying.CheckAccessMany(ctx, forward)
+		if err != nil {
+			return nil, err
+		}
+		if len(response.Decisions) != len(indexes) {
+			return nil, fmt.Errorf("authorization provider returned %d decisions for %d requests", len(response.Decisions), len(indexes))
+		}
+		for i, decision := range response.Decisions {
+			decisions[indexes[i]] = decision
+		}
+	}
+	return &proto.CheckAccessManyResponse{Decisions: decisions}, nil
+}
+
+func (g *authorizationGate) requestEligible(ctx context.Context, req *proto.CheckAccessRequest) (bool, error) {
+	if req == nil || req.Subject == nil {
+		return true, nil
+	}
+	userID := principal.UserIDFromSubjectID(strings.TrimSpace(req.Subject.Id))
+	if principal.ClassifyUserSubjectValue(userID) != principal.UserSubjectFormCanonical {
+		return true, nil
+	}
+	user, err := g.users.GetUser(ctx, userID)
+	if err != nil {
+		return false, err
+	}
+	return g.scim.IsEligible(ctx, user.ID, user.Email)
+}
+
+func (g *authorizationGate) ListRelationships(ctx context.Context, req *proto.ListRelationshipsRequest) (*proto.ListRelationshipsResponse, error) {
+	return g.underlying.ListRelationships(ctx, req)
+}
+
+func (g *authorizationGate) AddRelationship(ctx context.Context, req *proto.AddRelationshipRequest) (*proto.AddRelationshipResponse, error) {
+	if req != nil && req.Relationship != nil && req.Relationship.Tuple != nil && g.managed(req.Relationship.Tuple) {
+		return nil, fmt.Errorf("relationship is managed by SCIM")
+	}
+	return g.underlying.AddRelationship(ctx, req)
+}
+
+func (g *authorizationGate) DeleteRelationship(ctx context.Context, req *proto.DeleteRelationshipRequest) (*proto.DeleteRelationshipResponse, error) {
+	if req != nil && req.RelationshipTuple != nil && g.managed(req.RelationshipTuple) {
+		return nil, fmt.Errorf("relationship is managed by SCIM")
+	}
+	return g.underlying.DeleteRelationship(ctx, req)
+}
+
+func (g *authorizationGate) managed(tuple *proto.RelationshipTuple) bool {
+	return tuple.Resource != nil && g.scim.ManagedRelationship(tuple.Resource.Type, tuple.Resource.Id, tuple.Relation)
+}
+
+func (g *authorizationGate) SetAuthorizationState(ctx context.Context, req *proto.SetAuthorizationStateRequest) (*proto.SetAuthorizationStateResponse, error) {
+	return g.underlying.SetAuthorizationState(ctx, req)
+}
+
+func (g *authorizationGate) GetActiveModelRef(ctx context.Context) (*proto.GetActiveModelRefResponse, error) {
+	return g.underlying.GetActiveModelRef(ctx)
+}
+
+func (g *authorizationGate) SetActiveModel(ctx context.Context, req *proto.SetActiveModelRequest) (*proto.SetActiveModelResponse, error) {
+	return g.underlying.SetActiveModel(ctx, req)
+}
+
+func (g *authorizationGate) ListActiveModelResourceTypes(ctx context.Context, req *proto.ListActiveModelResourceTypesRequest) (*proto.ListActiveModelResourceTypesResponse, error) {
+	return g.underlying.ListActiveModelResourceTypes(ctx, req)
+}
+
+func (g *authorizationGate) Ping(ctx context.Context) error { return g.underlying.Ping(ctx) }
+func (g *authorizationGate) Close() error                   { return g.underlying.Close() }

--- a/gestaltd/internal/scim/filter.go
+++ b/gestaltd/internal/scim/filter.go
@@ -1,0 +1,108 @@
+package scim
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+type filterClause struct {
+	attribute string
+	value     string
+}
+
+var filterClausePattern = regexp.MustCompile(`(?i)^\s*(externalId|userName|emails\.value|emails\[\s*type\s+eq\s+"work"\s*\]\.value)\s+eq\s+("(?:\\.|[^"\\])*")\s*$`)
+
+func parseFilter(raw string) ([]filterClause, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+	parts, err := splitFilterConjunctions(raw)
+	if err != nil {
+		return nil, err
+	}
+	clauses := make([]filterClause, 0, len(parts))
+	for _, part := range parts {
+		matches := filterClausePattern.FindStringSubmatch(part)
+		if matches == nil {
+			return nil, fmt.Errorf("unsupported filter clause %q", strings.TrimSpace(part))
+		}
+		var value string
+		if err := json.Unmarshal([]byte(matches[2]), &value); err != nil {
+			return nil, fmt.Errorf("invalid filter value: %w", err)
+		}
+		clauses = append(clauses, filterClause{attribute: strings.ToLower(matches[1]), value: normalize(value)})
+	}
+	return clauses, nil
+}
+
+func splitFilterConjunctions(raw string) ([]string, error) {
+	var parts []string
+	start, bracketDepth := 0, 0
+	inString, escaped := false, false
+	for i := 0; i < len(raw); i++ {
+		switch raw[i] {
+		case '\\':
+			if inString {
+				escaped = !escaped
+			}
+		case '"':
+			if !escaped {
+				inString = !inString
+			}
+			escaped = false
+		case '[':
+			if !inString {
+				bracketDepth++
+			}
+		case ']':
+			if !inString {
+				bracketDepth--
+				if bracketDepth < 0 {
+					return nil, fmt.Errorf("unbalanced filter brackets")
+				}
+			}
+		default:
+			escaped = false
+		}
+		if inString || bracketDepth != 0 || i+5 > len(raw) {
+			continue
+		}
+		if strings.EqualFold(raw[i:i+5], " and ") {
+			parts = append(parts, raw[start:i])
+			start = i + 5
+			i += 4
+		}
+	}
+	if inString || bracketDepth != 0 {
+		return nil, fmt.Errorf("unterminated filter expression")
+	}
+	parts = append(parts, raw[start:])
+	return parts, nil
+}
+
+func matchesFilter(user persistedUser, clauses []filterClause) bool {
+	for _, clause := range clauses {
+		matched := false
+		switch clause.attribute {
+		case "externalid":
+			matched = normalize(user.ExternalID) == clause.value
+		case "username":
+			matched = normalize(user.UserName) == clause.value
+		case "emails.value":
+			for _, email := range user.Emails {
+				matched = matched || normalize(email.Value) == clause.value
+			}
+		default:
+			for _, email := range user.Emails {
+				matched = matched || strings.EqualFold(strings.TrimSpace(email.Type), "work") && normalize(email.Value) == clause.value
+			}
+		}
+		if !matched {
+			return false
+		}
+	}
+	return true
+}

--- a/gestaltd/internal/scim/handler.go
+++ b/gestaltd/internal/scim/handler.go
@@ -1,0 +1,206 @@
+package scim
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+type Handler struct {
+	service *Service
+}
+
+func NewHandler(service *Service) http.Handler { return &Handler{service: service} }
+
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	clientID, ok := h.authenticate(r)
+	if !ok {
+		w.Header().Set("WWW-Authenticate", `Bearer realm="Gestalt SCIM"`)
+		writeError(w, &Error{Status: http.StatusUnauthorized, Detail: "A valid SCIM bearer token is required"})
+		return
+	}
+	path := strings.TrimSuffix(r.URL.Path, "/")
+	switch {
+	case path == "/scim/v2/Schemas" && r.Method == http.MethodGet:
+		h.schemas(w)
+	case path == "/scim/v2/Users" && r.Method == http.MethodGet:
+		h.listUsers(w, r, clientID)
+	case path == "/scim/v2/Users" && r.Method == http.MethodPost:
+		h.createUser(w, r, clientID)
+	case strings.HasPrefix(path, "/scim/v2/Users/"):
+		h.user(w, r, clientID, strings.TrimPrefix(path, "/scim/v2/Users/"))
+	default:
+		writeError(w, notFound())
+	}
+}
+
+func (h *Handler) authenticate(r *http.Request) (string, bool) {
+	header := strings.TrimSpace(r.Header.Get("Authorization"))
+	if len(header) < 7 || !strings.EqualFold(header[:7], "Bearer ") {
+		return "", false
+	}
+	return h.service.ClientForToken(strings.TrimSpace(header[7:]))
+}
+
+func (h *Handler) schemas(w http.ResponseWriter) {
+	schema := map[string]any{
+		"schemas": []string{"urn:ietf:params:scim:schemas:core:2.0:Schema"}, "id": UserSchemaURN, "name": "User", "description": "Gestalt provisioned user",
+		"attributes": []map[string]any{
+			{"name": "externalId", "type": "string", "multiValued": false, "required": false, "caseExact": false, "mutability": "readWrite", "returned": "default", "uniqueness": "server"},
+			{"name": "userName", "type": "string", "multiValued": false, "required": true, "caseExact": false, "mutability": "readWrite", "returned": "always", "uniqueness": "server"},
+			{"name": "active", "type": "boolean", "multiValued": false, "required": false, "mutability": "readWrite", "returned": "default"},
+			{"name": "displayName", "type": "string", "multiValued": false, "required": false, "mutability": "readWrite", "returned": "default"},
+			{"name": "name", "type": "complex", "multiValued": false, "required": false, "mutability": "readWrite", "returned": "default", "subAttributes": []map[string]any{{"name": "formatted", "type": "string"}, {"name": "familyName", "type": "string"}, {"name": "givenName", "type": "string"}}},
+			{"name": "emails", "type": "complex", "multiValued": true, "required": false, "mutability": "readWrite", "returned": "default", "subAttributes": []map[string]any{{"name": "value", "type": "string"}, {"name": "type", "type": "string", "canonicalValues": []string{"work"}}, {"name": "primary", "type": "boolean"}}},
+		},
+		"meta": map[string]any{"resourceType": "Schema", "location": h.service.baseURL + "/scim/v2/Schemas"},
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"schemas": []string{ListSchemaURN}, "totalResults": 1, "startIndex": 1, "itemsPerPage": 1, "Resources": []any{schema}})
+}
+
+func (h *Handler) listUsers(w http.ResponseWriter, r *http.Request, clientID string) {
+	startIndex, err := paginationQueryInt(r, "startIndex", 1, 1)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	count, err := paginationQueryInt(r, "count", 100, 0)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	if count > 200 {
+		count = 200
+	}
+	response, serviceErr := h.service.list(r.Context(), clientID, r.URL.Query().Get("filter"), startIndex, count)
+	if serviceErr != nil {
+		writeError(w, serviceErr)
+		return
+	}
+	writeJSON(w, http.StatusOK, response)
+}
+
+func paginationQueryInt(r *http.Request, name string, defaultValue, minimum int) (int, error) {
+	raw := strings.TrimSpace(r.URL.Query().Get(name))
+	if raw == "" {
+		return defaultValue, nil
+	}
+	value, parseErr := strconv.Atoi(raw)
+	if parseErr != nil {
+		return 0, invalid(name + " is invalid")
+	}
+	if value < minimum {
+		value = minimum
+	}
+	return value, nil
+}
+
+func (h *Handler) createUser(w http.ResponseWriter, r *http.Request, clientID string) {
+	var input userInput
+	if err := decodeBody(r, &input); err != nil {
+		writeError(w, err)
+		return
+	}
+	user, err := h.service.Create(r.Context(), clientID, input)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	w.Header().Set("Location", user.Meta.Location)
+	w.Header().Set("ETag", user.Meta.Version)
+	writeJSON(w, http.StatusCreated, user)
+}
+
+func (h *Handler) user(w http.ResponseWriter, r *http.Request, clientID, id string) {
+	if id == "" || strings.Contains(id, "/") {
+		writeError(w, notFound())
+		return
+	}
+	switch r.Method {
+	case http.MethodGet:
+		user, err := h.service.Get(r.Context(), clientID, id)
+		if err != nil {
+			writeError(w, err)
+			return
+		}
+		writeUser(w, http.StatusOK, user)
+	case http.MethodPut:
+		var input userInput
+		if err := decodeBody(r, &input); err != nil {
+			writeError(w, err)
+			return
+		}
+		user, err := h.service.Replace(r.Context(), clientID, id, strings.TrimSpace(r.Header.Get("If-Match")), input)
+		if err != nil {
+			writeError(w, err)
+			return
+		}
+		writeUser(w, http.StatusOK, user)
+	case http.MethodPatch:
+		var request patchRequest
+		if err := decodeBody(r, &request); err != nil {
+			writeError(w, err)
+			return
+		}
+		user, err := h.service.Patch(r.Context(), clientID, id, strings.TrimSpace(r.Header.Get("If-Match")), request)
+		if err != nil {
+			writeError(w, err)
+			return
+		}
+		writeUser(w, http.StatusOK, user)
+	case http.MethodDelete:
+		if err := h.service.Delete(r.Context(), clientID, id, strings.TrimSpace(r.Header.Get("If-Match"))); err != nil {
+			writeError(w, err)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	default:
+		writeError(w, notFound())
+	}
+}
+
+func decodeBody(r *http.Request, target any) error {
+	mediaType := strings.ToLower(strings.TrimSpace(strings.Split(r.Header.Get("Content-Type"), ";")[0]))
+	if mediaType != "application/scim+json" {
+		return invalid("Content-Type must be application/scim+json")
+	}
+	decoder := json.NewDecoder(io.LimitReader(r.Body, 1<<20))
+	if err := decoder.Decode(target); err != nil {
+		return invalid("request body is not valid JSON")
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return invalid("request body must contain one JSON value")
+	}
+	return nil
+}
+
+func writeUser(w http.ResponseWriter, status int, user *User) {
+	w.Header().Set("Location", user.Meta.Location)
+	w.Header().Set("ETag", user.Meta.Version)
+	writeJSON(w, status, user)
+}
+
+func writeError(w http.ResponseWriter, err error) {
+	scimErr := &Error{Status: http.StatusInternalServerError, Detail: "internal SCIM server error"}
+	if !errors.As(err, &scimErr) {
+		scimErr = &Error{Status: http.StatusServiceUnavailable, Detail: "SCIM service is temporarily unavailable", Retry: true}
+	}
+	if scimErr.Retry {
+		w.Header().Set("Retry-After", strconv.Itoa(retryAfterSeconds))
+	}
+	payload := map[string]any{"schemas": []string{ErrorSchemaURN}, "status": strconv.Itoa(scimErr.Status), "detail": scimErr.Detail}
+	if scimErr.SCIMType != "" {
+		payload["scimType"] = scimErr.SCIMType
+	}
+	writeJSON(w, scimErr.Status, payload)
+}
+
+func writeJSON(w http.ResponseWriter, status int, value any) {
+	w.Header().Set("Content-Type", "application/scim+json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(value)
+}

--- a/gestaltd/internal/scim/patch.go
+++ b/gestaltd/internal/scim/patch.go
@@ -1,0 +1,179 @@
+package scim
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+func applyPatch(current persistedUser, request patchRequest) (persistedUser, error) {
+	if len(request.Operations) == 0 {
+		return persistedUser{}, invalid("PATCH Operations must not be empty")
+	}
+	result := current
+	for i, operation := range request.Operations {
+		op := strings.ToLower(strings.TrimSpace(operation.Op))
+		if op != "add" && op != "replace" && op != "remove" {
+			return persistedUser{}, invalid(fmt.Sprintf("Operations[%d].op is unsupported", i))
+		}
+		path := normalizePatchPath(operation.Path)
+		if path == "" {
+			if op == "remove" {
+				return persistedUser{}, invalid("remove requires a path")
+			}
+			var input userInput
+			if err := json.Unmarshal(operation.Value, &input); err != nil {
+				return persistedUser{}, invalid("pathless PATCH value must be an object")
+			}
+			mergePatchInput(&result, input)
+			continue
+		}
+		if err := applyPathPatch(&result, op, path, operation.Value); err != nil {
+			return persistedUser{}, invalid(fmt.Sprintf("Operations[%d]: %v", i, err))
+		}
+	}
+	if strings.TrimSpace(result.UserName) == "" {
+		return persistedUser{}, invalid("userName is required")
+	}
+	return result, nil
+}
+
+func mergePatchInput(result *persistedUser, input userInput) {
+	if input.ExternalID != nil {
+		result.ExternalID = *input.ExternalID
+	}
+	if input.UserName != nil {
+		result.UserName = *input.UserName
+	}
+	if input.Active != nil {
+		result.Active = *input.Active
+	}
+	if input.DisplayName != nil {
+		result.DisplayName = *input.DisplayName
+	}
+	if input.Name != nil {
+		result.Name = *input.Name
+	}
+	if input.Emails != nil {
+		result.Emails = append([]Email(nil), (*input.Emails)...)
+	}
+}
+
+func normalizePatchPath(path string) string {
+	path = strings.ToLower(strings.TrimSpace(path))
+	path = strings.Join(strings.Fields(path), " ")
+	return path
+}
+
+func applyPathPatch(result *persistedUser, op, path string, raw json.RawMessage) error {
+	remove := op == "remove"
+	switch path {
+	case "active":
+		if remove {
+			result.Active = false
+			return nil
+		}
+		return decodePatchValue(raw, &result.Active)
+	case "externalid":
+		if remove {
+			result.ExternalID = ""
+			return nil
+		}
+		return decodePatchValue(raw, &result.ExternalID)
+	case "username":
+		if remove {
+			return fmt.Errorf("userName cannot be removed")
+		}
+		return decodePatchValue(raw, &result.UserName)
+	case "displayname":
+		if remove {
+			result.DisplayName = ""
+			return nil
+		}
+		return decodePatchValue(raw, &result.DisplayName)
+	case "name":
+		if remove {
+			result.Name = Name{}
+			return nil
+		}
+		return decodePatchValue(raw, &result.Name)
+	case "name.formatted":
+		if remove {
+			result.Name.Formatted = ""
+			return nil
+		}
+		return decodePatchValue(raw, &result.Name.Formatted)
+	case "name.givenname":
+		if remove {
+			result.Name.GivenName = ""
+			return nil
+		}
+		return decodePatchValue(raw, &result.Name.GivenName)
+	case "name.familyname":
+		if remove {
+			result.Name.FamilyName = ""
+			return nil
+		}
+		return decodePatchValue(raw, &result.Name.FamilyName)
+	case "emails":
+		if remove {
+			result.Emails = nil
+			return nil
+		}
+		var many []Email
+		if err := json.Unmarshal(raw, &many); err == nil {
+			if op == "add" {
+				result.Emails = append(result.Emails, many...)
+			} else {
+				result.Emails = many
+			}
+			return nil
+		}
+		var one Email
+		if err := json.Unmarshal(raw, &one); err != nil {
+			return fmt.Errorf("emails must be an object or array")
+		}
+		if op == "add" {
+			result.Emails = append(result.Emails, one)
+		} else {
+			result.Emails = []Email{one}
+		}
+		return nil
+	case `emails[type eq "work"].value`:
+		if remove {
+			for i := range result.Emails {
+				if strings.EqualFold(strings.TrimSpace(result.Emails[i].Type), "work") {
+					result.Emails[i].Value = ""
+				}
+			}
+			return nil
+		}
+		var value string
+		if err := json.Unmarshal(raw, &value); err != nil {
+			return fmt.Errorf("work email value must be a string")
+		}
+		matched := false
+		for i := range result.Emails {
+			if strings.EqualFold(strings.TrimSpace(result.Emails[i].Type), "work") {
+				result.Emails[i].Value = value
+				matched = true
+			}
+		}
+		if !matched {
+			result.Emails = append(result.Emails, Email{Value: value, Type: "work"})
+		}
+		return nil
+	default:
+		return fmt.Errorf("unsupported path %q", path)
+	}
+}
+
+func decodePatchValue(raw json.RawMessage, target any) error {
+	if len(raw) == 0 {
+		return fmt.Errorf("value is required")
+	}
+	if err := json.Unmarshal(raw, target); err != nil {
+		return fmt.Errorf("value has the wrong type")
+	}
+	return nil
+}

--- a/gestaltd/internal/scim/service.go
+++ b/gestaltd/internal/scim/service.go
@@ -1,0 +1,1356 @@
+package scim
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/mail"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	idb "github.com/valon-technologies/gestalt/sdk/go/indexeddb"
+	"github.com/valon-technologies/gestalt/server/core"
+	coredb "github.com/valon-technologies/gestalt/server/core/indexeddb"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/coredata"
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"github.com/valon-technologies/gestalt/server/services/observability/metricutil"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	gproto "google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+const (
+	retryAfterSeconds = 1
+	maxDueIntentBatch = 200
+)
+
+type projection struct {
+	Relation     string `json:"relation"`
+	ResourceType string `json:"resourceType"`
+	ResourceID   string `json:"resourceId"`
+	Owned        bool   `json:"owned,omitempty"`
+}
+
+func (p projection) key() string { return p.ResourceType + "\x00" + p.ResourceID + "\x00" + p.Relation }
+
+type client struct {
+	id            string
+	domains       map[string]struct{}
+	relationships []projection
+}
+
+type credential struct {
+	token  string
+	client *client
+	label  string
+}
+
+type storedRow struct {
+	id                  string
+	clientID            string
+	coreUserID          string
+	authoritativeDomain string
+	resource            persistedUser
+	active              bool
+	deleted             bool
+	version             int64
+	createdAt           time.Time
+	updatedAt           time.Time
+	deletedAt           time.Time
+	applied             []projection
+	lastFingerprint     string
+}
+
+type intentRow struct {
+	id                   string
+	userID               string
+	clientID             string
+	coreUserID           string
+	authoritativeDomain  string
+	baseVersion          int64
+	nextVersion          int64
+	proposed             persistedUser
+	proposedDeleted      bool
+	from                 []projection
+	to                   []projection
+	attemptCount         int64
+	createdAt            time.Time
+	operationFingerprint string
+}
+
+type Service struct {
+	db            coredb.IndexedDB
+	authorization core.AuthorizationProvider
+	baseURL       string
+	clients       map[string]*client
+	credentials   []credential
+	domainOwners  map[string]string
+	managed       map[string]struct{}
+	retryInterval time.Duration
+	driftInterval time.Duration
+	now           func() time.Time
+	newTicker     func(time.Duration) (<-chan time.Time, func())
+	locksMu       sync.Mutex
+	locks         map[string]*keyedMutex
+}
+
+type keyedMutex struct {
+	mu   sync.Mutex
+	refs int
+}
+
+type ServiceOptions struct {
+	Now       func() time.Time
+	NewTicker func(time.Duration) (<-chan time.Time, func())
+}
+
+type reconciliationMetrics struct {
+	runs      metric.Int64Counter
+	failures  metric.Int64Counter
+	resources metric.Int64Counter
+}
+
+var scimReconciliationMetrics metricutil.MeterCache[reconciliationMetrics]
+
+func NewService(db coredb.IndexedDB, authorization core.AuthorizationProvider, baseURL string, cfg config.ServerSCIMConfig) (*Service, error) {
+	return NewServiceWithOptions(db, authorization, baseURL, cfg, ServiceOptions{})
+}
+
+func NewServiceWithOptions(db coredb.IndexedDB, authorization core.AuthorizationProvider, baseURL string, cfg config.ServerSCIMConfig, opts ServiceOptions) (*Service, error) {
+	retryInterval, err := cfg.RetryIntervalDuration()
+	if err != nil {
+		return nil, fmt.Errorf("SCIM retry interval: %w", err)
+	}
+	driftInterval, err := cfg.DriftIntervalDuration()
+	if err != nil {
+		return nil, fmt.Errorf("SCIM drift interval: %w", err)
+	}
+	s := &Service{
+		db: db, authorization: authorization, baseURL: strings.TrimRight(baseURL, "/"),
+		clients: make(map[string]*client), domainOwners: make(map[string]string), managed: make(map[string]struct{}),
+		retryInterval: retryInterval, driftInterval: driftInterval, now: opts.Now, newTicker: opts.NewTicker, locks: make(map[string]*keyedMutex),
+	}
+	seenTokens := make(map[string]string)
+	for id, clientConfig := range cfg.Clients {
+		c := &client{id: id, domains: make(map[string]struct{})}
+		for _, rawDomain := range clientConfig.AuthoritativeUserDomains {
+			domain := normalize(rawDomain)
+			c.domains[domain] = struct{}{}
+			s.domainOwners[domain] = id
+		}
+		for _, relationship := range clientConfig.ActiveUserRelationships {
+			p := projection{Relation: strings.TrimSpace(relationship.Relation), ResourceType: strings.TrimSpace(relationship.Resource.Type), ResourceID: strings.TrimSpace(relationship.Resource.ID)}
+			c.relationships = append(c.relationships, p)
+			s.managed[p.key()] = struct{}{}
+		}
+		sort.Slice(c.relationships, func(i, j int) bool { return c.relationships[i].key() < c.relationships[j].key() })
+		for _, configured := range clientConfig.Credentials {
+			token := strings.TrimSpace(configured.BearerToken)
+			if previous, ok := seenTokens[token]; ok {
+				return nil, fmt.Errorf("SCIM bearer token for %s/%s duplicates %s", id, configured.ID, previous)
+			}
+			seenTokens[token] = id + "/" + configured.ID
+			s.credentials = append(s.credentials, credential{token: token, client: c, label: configured.ID})
+		}
+		s.clients[id] = c
+	}
+	return s, nil
+}
+
+func (s *Service) Enabled() bool { return s != nil && len(s.clients) > 0 }
+
+func (s *Service) ClientForToken(token string) (string, bool) {
+	if s == nil || token == "" {
+		return "", false
+	}
+	for _, candidate := range s.credentials {
+		if len(token) == len(candidate.token) && subtle.ConstantTimeCompare([]byte(token), []byte(candidate.token)) == 1 {
+			return candidate.client.id, true
+		}
+	}
+	return "", false
+}
+
+func (s *Service) Start(ctx context.Context) {
+	if !s.Enabled() {
+		return
+	}
+	go func() {
+		s.runReconciliation(ctx, "retry", s.reconcileDueIntents)
+		s.runReconciliation(ctx, "drift", s.reconcileDrift)
+		retryTicks, stopRetry := s.ticker(s.retryInterval)
+		defer stopRetry()
+		driftTicks, stopDrift := s.ticker(s.driftInterval)
+		defer stopDrift()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-retryTicks:
+				s.runReconciliation(ctx, "retry", s.reconcileDueIntents)
+			case <-driftTicks:
+				s.runReconciliation(ctx, "drift", s.reconcileDrift)
+			}
+		}
+	}()
+}
+
+func (s *Service) currentTime() time.Time {
+	if s.now != nil {
+		return s.now().UTC().Truncate(time.Millisecond)
+	}
+	return time.Now().UTC().Truncate(time.Millisecond)
+}
+
+func (s *Service) ticker(interval time.Duration) (<-chan time.Time, func()) {
+	if s.newTicker != nil {
+		return s.newTicker(interval)
+	}
+	ticker := time.NewTicker(interval)
+	return ticker.C, ticker.Stop
+}
+
+func (s *Service) runReconciliation(ctx context.Context, kind string, reconcile func(context.Context) (int, error)) {
+	processed, err := reconcile(ctx)
+	recordReconciliationMetrics(ctx, kind, processed, err)
+	if err != nil {
+		slog.WarnContext(ctx, "SCIM reconciliation finished with errors", "kind", kind, "processed", processed, "error", err)
+	}
+}
+
+func recordReconciliationMetrics(ctx context.Context, kind string, processed int, err error) {
+	metrics := scimReconciliationMetrics.Load(ctx, "gestaltd", func(meter metric.Meter) reconciliationMetrics {
+		return reconciliationMetrics{
+			runs:      metricutil.NewInt64Counter(meter, "gestaltd.scim.reconciliation.run_count", "Counts SCIM reconciliation runs."),
+			failures:  metricutil.NewInt64Counter(meter, "gestaltd.scim.reconciliation.error_count", "Counts failed SCIM reconciliation runs."),
+			resources: metricutil.NewInt64Counter(meter, "gestaltd.scim.reconciliation.resource_count", "Counts resources processed by SCIM reconciliation."),
+		}
+	})
+	attrs := metric.WithAttributes(attribute.String("gestalt.scim.reconciliation.kind", kind))
+	metrics.runs.Add(ctx, 1, attrs)
+	if processed > 0 {
+		metrics.resources.Add(ctx, int64(processed), attrs)
+	}
+	if err != nil {
+		metrics.failures.Add(ctx, 1, attrs)
+	}
+}
+
+func (s *Service) lock(key string) func() {
+	s.locksMu.Lock()
+	entry := s.locks[key]
+	if entry == nil {
+		entry = &keyedMutex{}
+		s.locks[key] = entry
+	}
+	entry.refs++
+	s.locksMu.Unlock()
+	entry.mu.Lock()
+	return func() {
+		entry.mu.Unlock()
+		s.locksMu.Lock()
+		entry.refs--
+		if entry.refs == 0 {
+			delete(s.locks, key)
+		}
+		s.locksMu.Unlock()
+	}
+}
+
+func createLockKey(clientID, userName string) string {
+	return "create\x00" + clientID + "\x00" + normalize(userName)
+}
+
+func userLockKey(userID string) string {
+	return "user\x00" + userID
+}
+
+func (s *Service) Create(ctx context.Context, clientID string, input userInput) (*User, error) {
+	resource, email, err := createResource(input)
+	if err != nil {
+		return nil, err
+	}
+	fingerprint := operationFingerprint("create", "", resource)
+	unlock := s.lock(createLockKey(clientID, resource.UserName))
+	defer unlock()
+
+	userID, err := s.createIntent(ctx, clientID, resource, email, fingerprint)
+	if err != nil {
+		var scimErr *Error
+		if !errors.As(err, &scimErr) || scimErr.Status != 409 && scimErr.Status != 503 {
+			return nil, err
+		}
+		pending, found, pendingErr := s.findPendingCreate(ctx, clientID, resource)
+		if pendingErr != nil {
+			return nil, pendingErr
+		}
+		if found {
+			userID = pending.userID
+		} else {
+			committed, replayed, replayErr := s.findCommittedCreate(ctx, clientID, resource.UserName, fingerprint)
+			if replayErr != nil {
+				return nil, replayErr
+			}
+			if replayed {
+				return committed, nil
+			}
+			return nil, err
+		}
+	}
+	if err := s.convergeUser(ctx, userID); err != nil && !isNoIntent(err) {
+		return nil, err
+	}
+	return s.Get(ctx, clientID, userID)
+}
+
+func (s *Service) createIntent(ctx context.Context, clientID string, resource persistedUser, email, fingerprint string) (string, error) {
+	now := s.currentTime()
+	userID := uuid.NewString()
+	tx, err := s.db.Transaction(ctx, []string{coredata.StoreUsers, coredata.StoreSCIMUsers, coredata.StoreSCIMProjectionIntents}, idb.TransactionReadwrite, idb.TransactionOptions{DurabilityHint: idb.TransactionDurabilityStrict})
+	if err != nil {
+		return "", unavailable("could not begin SCIM mutation")
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Abort(context.WithoutCancel(ctx))
+		}
+	}()
+	if err := ensureUnique(ctx, tx, clientID, userID, resource, email); err != nil {
+		return "", err
+	}
+	coreUserID, err := linkCoreUser(ctx, tx, "", email, displayName(resource), now)
+	if err != nil {
+		return "", err
+	}
+	desired := s.desiredProjections(clientID, resource.Active, false)
+	intent := newIntentRecord(uuid.NewString(), userID, clientID, coreUserID, s.authoritativeDomain(clientID, email), 0, 1, resource, false, nil, desired, fingerprint, now)
+	if err := tx.ObjectStore(coredata.StoreSCIMProjectionIntents).Add(ctx, intent); err != nil {
+		return "", mapIntentWriteError("create SCIM User", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return "", mapIntentWriteError("create SCIM User", err)
+	}
+	committed = true
+	return userID, nil
+}
+
+func (s *Service) findCommittedCreate(ctx context.Context, clientID, userName, fingerprint string) (*User, bool, error) {
+	rec, err := s.db.ObjectStore(coredata.StoreSCIMUsers).Index("by_user_name_key").Get(ctx, namespaceKey(clientID, normalize(userName)))
+	if errors.Is(err, idb.ErrNotFound) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, unavailable("could not inspect committed SCIM create")
+	}
+	row, err := decodeStoredRow(rec)
+	if err != nil {
+		return nil, false, unavailable("committed SCIM User is invalid")
+	}
+	if row.clientID != clientID || row.deleted || row.lastFingerprint != fingerprint {
+		return nil, false, nil
+	}
+	user := s.publicUser(row)
+	return &user, true, nil
+}
+
+func (s *Service) findPendingCreate(ctx context.Context, clientID string, resource persistedUser) (intentRow, bool, error) {
+	rec, err := s.db.ObjectStore(coredata.StoreSCIMProjectionIntents).Index("by_user_name_key").Get(ctx, namespaceKey(clientID, normalize(resource.UserName)))
+	if errors.Is(err, idb.ErrNotFound) {
+		return intentRow{}, false, nil
+	}
+	if err != nil {
+		return intentRow{}, false, unavailable("could not inspect pending SCIM create")
+	}
+	intent, err := decodeIntentRow(rec)
+	if err != nil {
+		return intentRow{}, false, unavailable("pending SCIM create is invalid")
+	}
+	if intent.clientID != clientID || intent.baseVersion != 0 || intent.nextVersion != 1 || intent.proposedDeleted || !equalPersistedUsers(intent.proposed, resource) {
+		return intentRow{}, false, nil
+	}
+	return intent, true, nil
+}
+
+func equalPersistedUsers(left, right persistedUser) bool {
+	leftJSON, leftErr := json.Marshal(left)
+	rightJSON, rightErr := json.Marshal(right)
+	return leftErr == nil && rightErr == nil && bytes.Equal(leftJSON, rightJSON)
+}
+
+func operationFingerprint(operation, ifMatch string, payload any) string {
+	encoded, _ := json.Marshal(struct {
+		Operation string `json:"operation"`
+		IfMatch   string `json:"ifMatch,omitempty"`
+		Payload   any    `json:"payload,omitempty"`
+	}{Operation: operation, IfMatch: ifMatch, Payload: payload})
+	digest := sha256.Sum256(encoded)
+	return hex.EncodeToString(digest[:])
+}
+
+func patchOperationFingerprint(ifMatch string, request patchRequest) string {
+	type canonicalOperation struct {
+		Op    string `json:"op"`
+		Path  string `json:"path,omitempty"`
+		Value any    `json:"value,omitempty"`
+	}
+	operations := make([]canonicalOperation, 0, len(request.Operations))
+	for _, operation := range request.Operations {
+		canonical := canonicalOperation{Op: strings.ToLower(strings.TrimSpace(operation.Op)), Path: normalizePatchPath(operation.Path)}
+		if len(operation.Value) > 0 {
+			if err := json.Unmarshal(operation.Value, &canonical.Value); err != nil {
+				canonical.Value = string(operation.Value)
+			}
+		}
+		operations = append(operations, canonical)
+	}
+	return operationFingerprint("patch", ifMatch, operations)
+}
+
+func (s *Service) Get(ctx context.Context, clientID, id string) (*User, error) {
+	rec, err := s.db.ObjectStore(coredata.StoreSCIMUsers).Get(ctx, id)
+	if errors.Is(err, idb.ErrNotFound) {
+		return nil, notFound()
+	}
+	if err != nil {
+		return nil, unavailable("could not read SCIM User")
+	}
+	row, err := decodeStoredRow(rec)
+	if err != nil {
+		return nil, unavailable("stored SCIM User is invalid")
+	}
+	if row.clientID != clientID || row.deleted {
+		return nil, notFound()
+	}
+	user := s.publicUser(row)
+	return &user, nil
+}
+
+func (s *Service) list(ctx context.Context, clientID, rawFilter string, startIndex, count int) (listResponse, error) {
+	clauses, err := parseFilter(rawFilter)
+	if err != nil {
+		return listResponse{}, invalid(err.Error())
+	}
+	records, err := s.db.ObjectStore(coredata.StoreSCIMUsers).Index("by_client").GetAll(ctx, clientID)
+	if err != nil {
+		return listResponse{}, unavailable("could not list SCIM Users")
+	}
+	rows := make([]storedRow, 0, len(records))
+	for _, rec := range records {
+		row, decodeErr := decodeStoredRow(rec)
+		if decodeErr != nil {
+			return listResponse{}, unavailable("stored SCIM User is invalid")
+		}
+		if !row.deleted && matchesFilter(row.resource, clauses) {
+			rows = append(rows, row)
+		}
+	}
+	sort.Slice(rows, func(i, j int) bool { return rows[i].id < rows[j].id })
+	total := len(rows)
+	begin := startIndex - 1
+	if begin > total {
+		begin = total
+	}
+	end := begin + count
+	if end > total {
+		end = total
+	}
+	resources := make([]User, 0, end-begin)
+	for i := begin; i < end; i++ {
+		resources = append(resources, s.publicUser(rows[i]))
+	}
+	return listResponse{Schemas: []string{ListSchemaURN}, TotalResults: total, StartIndex: startIndex, ItemsPerPage: len(resources), Resources: resources}, nil
+}
+
+func (s *Service) Replace(ctx context.Context, clientID, id, ifMatch string, input userInput) (*User, error) {
+	resource, email, err := createResource(input)
+	if err != nil {
+		return nil, err
+	}
+	return s.mutate(ctx, clientID, id, ifMatch, resource, email, false, operationFingerprint("replace", ifMatch, resource))
+}
+
+func (s *Service) Patch(ctx context.Context, clientID, id, ifMatch string, request patchRequest) (*User, error) {
+	fingerprint := patchOperationFingerprint(ifMatch, request)
+	unlock := s.lock(userLockKey(id))
+	defer unlock()
+	if err := s.convergeUserLocked(ctx, id); err != nil && !isNoIntent(err) {
+		return nil, err
+	}
+	current, err := s.loadStored(ctx, clientID, id)
+	if err != nil {
+		return nil, err
+	}
+	if current.lastFingerprint == fingerprint {
+		user := s.publicUser(current)
+		return &user, nil
+	}
+	resource, err := applyPatch(current.resource, request)
+	if err != nil {
+		return nil, err
+	}
+	email, err := loginEmail(resource)
+	if err != nil {
+		return nil, err
+	}
+	return s.commitMutationLocked(ctx, clientID, id, ifMatch, current, resource, email, false, fingerprint)
+}
+
+func (s *Service) Delete(ctx context.Context, clientID, id, ifMatch string) error {
+	fingerprint := operationFingerprint("delete", ifMatch, nil)
+	unlock := s.lock(userLockKey(id))
+	defer unlock()
+	if err := s.convergeUserLocked(ctx, id); err != nil && !isNoIntent(err) {
+		return err
+	}
+	current, err := s.loadStoredIncludingDeleted(ctx, clientID, id)
+	if err != nil {
+		return err
+	}
+	if current.deleted {
+		if current.lastFingerprint == fingerprint {
+			return nil
+		}
+		return notFound()
+	}
+	_, err = s.commitMutationLocked(ctx, clientID, id, ifMatch, current, current.resource, mustLoginEmail(current.resource), true, fingerprint)
+	return err
+}
+
+func (s *Service) mutate(ctx context.Context, clientID, id, ifMatch string, proposed persistedUser, email string, deleted bool, fingerprint string) (*User, error) {
+	unlock := s.lock(userLockKey(id))
+	defer unlock()
+	if err := s.convergeUserLocked(ctx, id); err != nil && !isNoIntent(err) {
+		return nil, err
+	}
+	current, err := s.loadStored(ctx, clientID, id)
+	if err != nil {
+		return nil, err
+	}
+	if current.lastFingerprint == fingerprint {
+		user := s.publicUser(current)
+		return &user, nil
+	}
+	return s.commitMutationLocked(ctx, clientID, id, ifMatch, current, proposed, email, deleted, fingerprint)
+}
+
+func (s *Service) commitMutationLocked(ctx context.Context, clientID, id, ifMatch string, current storedRow, proposed persistedUser, email string, deleted bool, fingerprint string) (*User, error) {
+	if ifMatch != "" && ifMatch != "*" && ifMatch != etag(current.version) {
+		return nil, &Error{Status: 412, Detail: "If-Match does not match the current SCIM User version"}
+	}
+	now := s.currentTime()
+	tx, err := s.db.Transaction(ctx, []string{coredata.StoreUsers, coredata.StoreSCIMUsers, coredata.StoreSCIMProjectionIntents}, idb.TransactionReadwrite, idb.TransactionOptions{DurabilityHint: idb.TransactionDurabilityStrict})
+	if err != nil {
+		return nil, unavailable("could not begin SCIM mutation")
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Abort(context.WithoutCancel(ctx))
+		}
+	}()
+	latestRec, err := tx.ObjectStore(coredata.StoreSCIMUsers).Get(ctx, id)
+	if errors.Is(err, idb.ErrNotFound) {
+		return nil, notFound()
+	}
+	if err != nil {
+		return nil, unavailable("could not verify current SCIM User")
+	}
+	latest, decodeErr := decodeStoredRow(latestRec)
+	if decodeErr != nil || latest.clientID != clientID || latest.deleted || latest.version != current.version {
+		return nil, &Error{Status: 412, Detail: "SCIM User changed during mutation"}
+	}
+	if !deleted {
+		if err := ensureUnique(ctx, tx, clientID, id, proposed, email); err != nil {
+			return nil, err
+		}
+		if _, err := linkCoreUser(ctx, tx, current.coreUserID, email, displayName(proposed), now); err != nil {
+			return nil, err
+		}
+	}
+	desired := s.desiredProjections(clientID, proposed.Active, deleted)
+	authoritativeDomain := current.authoritativeDomain
+	if authoritativeDomain == "" {
+		authoritativeDomain = s.authoritativeDomain(clientID, mustLoginEmail(current.resource))
+	}
+	if authoritativeDomain == "" && !deleted {
+		authoritativeDomain = s.authoritativeDomain(clientID, email)
+	}
+	intent := newIntentRecord(uuid.NewString(), id, clientID, current.coreUserID, authoritativeDomain, current.version, current.version+1, proposed, deleted, current.applied, desired, fingerprint, now)
+	if err := tx.ObjectStore(coredata.StoreSCIMProjectionIntents).Add(ctx, intent); err != nil {
+		return nil, mapIntentWriteError("update SCIM User", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, mapIntentWriteError("update SCIM User", err)
+	}
+	committed = true
+	if err := s.convergeUserLocked(ctx, id); err != nil && !isNoIntent(err) {
+		return nil, err
+	}
+	if deleted {
+		return nil, nil
+	}
+	return s.Get(ctx, clientID, id)
+}
+
+func (s *Service) loadStored(ctx context.Context, clientID, id string) (storedRow, error) {
+	row, err := s.loadStoredIncludingDeleted(ctx, clientID, id)
+	if err != nil {
+		return storedRow{}, err
+	}
+	if row.deleted {
+		return storedRow{}, notFound()
+	}
+	return row, nil
+}
+
+func (s *Service) loadStoredIncludingDeleted(ctx context.Context, clientID, id string) (storedRow, error) {
+	rec, err := s.db.ObjectStore(coredata.StoreSCIMUsers).Get(ctx, id)
+	if errors.Is(err, idb.ErrNotFound) {
+		return storedRow{}, notFound()
+	}
+	if err != nil {
+		return storedRow{}, unavailable("could not read SCIM User")
+	}
+	row, decodeErr := decodeStoredRow(rec)
+	if decodeErr != nil {
+		return storedRow{}, unavailable("stored SCIM User is invalid")
+	}
+	if row.clientID != clientID {
+		return storedRow{}, notFound()
+	}
+	return row, nil
+}
+
+func createResource(input userInput) (persistedUser, string, error) {
+	resource := persistedUser{}
+	if input.ExternalID != nil {
+		resource.ExternalID = *input.ExternalID
+	}
+	if input.UserName != nil {
+		resource.UserName = *input.UserName
+	}
+	if strings.TrimSpace(resource.UserName) == "" {
+		return persistedUser{}, "", invalid("userName is required")
+	}
+	resource.Active = input.Active != nil && *input.Active
+	if input.DisplayName != nil {
+		resource.DisplayName = *input.DisplayName
+	}
+	if input.Name != nil {
+		resource.Name = *input.Name
+	}
+	if input.Emails != nil {
+		resource.Emails = append([]Email(nil), (*input.Emails)...)
+	}
+	email, err := loginEmail(resource)
+	return resource, email, err
+}
+
+func loginEmail(resource persistedUser) (string, error) {
+	var primaryWork, primary []string
+	var work []string
+	for _, email := range resource.Emails {
+		value := normalizedEmail(email.Value)
+		if value == "" {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(email.Type), "work") {
+			work = append(work, value)
+			if email.Primary {
+				primaryWork = append(primaryWork, value)
+			}
+		}
+		if email.Primary {
+			primary = append(primary, value)
+		}
+	}
+	candidates := [][]string{primaryWork, primary}
+	for _, values := range candidates {
+		if len(values) > 0 {
+			return values[0], nil
+		}
+	}
+	if len(work) == 1 {
+		return work[0], nil
+	}
+	if value := normalizedEmail(resource.UserName); value != "" {
+		return value, nil
+	}
+	return "", invalid("User must have a primary work email, primary email, sole work email, or email-form userName")
+}
+
+func normalizedEmail(raw string) string {
+	raw = strings.TrimSpace(raw)
+	parsed, err := mail.ParseAddress(raw)
+	if err != nil || !strings.EqualFold(parsed.Address, raw) || strings.Count(parsed.Address, "@") != 1 {
+		return ""
+	}
+	return normalize(parsed.Address)
+}
+
+func displayName(resource persistedUser) string {
+	if value := strings.TrimSpace(resource.DisplayName); value != "" {
+		return value
+	}
+	if value := strings.TrimSpace(resource.Name.Formatted); value != "" {
+		return value
+	}
+	return strings.TrimSpace(resource.Name.GivenName + " " + resource.Name.FamilyName)
+}
+
+func ensureUnique(ctx context.Context, tx idb.Transaction, clientID, userID string, resource persistedUser, email string) error {
+	checks := []struct {
+		index string
+		key   string
+		name  string
+	}{
+		{"by_user_name_key", namespaceKey(clientID, normalize(resource.UserName)), "userName"},
+		{"by_email_key", namespaceKey(clientID, email), "email"},
+	}
+	if value := normalize(resource.ExternalID); value != "" {
+		checks = append(checks, struct{ index, key, name string }{"by_external_id_key", namespaceKey(clientID, value), "externalId"})
+	}
+	for _, storeName := range []string{coredata.StoreSCIMUsers, coredata.StoreSCIMProjectionIntents} {
+		store := tx.ObjectStore(storeName)
+		for _, check := range checks {
+			rec, err := store.Index(check.index).Get(ctx, check.key)
+			if errors.Is(err, idb.ErrNotFound) {
+				continue
+			}
+			if err != nil {
+				return unavailable("could not validate SCIM uniqueness")
+			}
+			if recordString(rec, "user_id") != userID && recordString(rec, "id") != userID {
+				return conflict(check.name + " is already assigned in this SCIM client namespace")
+			}
+		}
+	}
+	return nil
+}
+
+func linkCoreUser(ctx context.Context, tx idb.Transaction, coreUserID, email, name string, now time.Time) (string, error) {
+	user, err := coredata.LinkUserInTransaction(ctx, tx, coreUserID, email, name, now)
+	if errors.Is(err, coredata.ErrUserEmailConflict) {
+		return "", conflict("email is already linked to another Gestalt user")
+	}
+	if err != nil {
+		return "", unavailable("could not link Gestalt user")
+	}
+	return user.ID, nil
+}
+
+func namespaceKey(clientID, value string) string { return clientID + "\x00" + value }
+
+func mapIntentWriteError(operation string, err error) error {
+	if errors.Is(err, idb.ErrAlreadyExists) {
+		return unavailable(operation + " is contending with another SCIM worker")
+	}
+	return unavailable(operation + " could not be persisted")
+}
+
+func newIntentRecord(intentID, userID, clientID, coreUserID, authoritativeDomain string, baseVersion, nextVersion int64, proposed persistedUser, deleted bool, from, to []projection, fingerprint string, now time.Time) idb.Record {
+	rec := idb.Record{
+		"id": intentID, "user_id": userID, "client_id": clientID, "core_user_id": coreUserID,
+		"base_version": baseVersion, "next_version": nextVersion, "proposed": jsonMap(proposed), "proposed_deleted": deleted,
+		"from_relationships": jsonSlice(from), "to_relationships": jsonSlice(to), "attempt_count": int64(0), "next_attempt_at": now,
+		"created_at": now, "updated_at": now,
+	}
+	if authoritativeDomain != "" {
+		rec["authoritative_domain"] = authoritativeDomain
+	}
+	if fingerprint != "" {
+		rec["operation_fingerprint"] = fingerprint
+	}
+	if !deleted {
+		rec["user_name_key"] = namespaceKey(clientID, normalize(proposed.UserName))
+		rec["email_key"] = namespaceKey(clientID, mustLoginEmail(proposed))
+		if externalID := normalize(proposed.ExternalID); externalID != "" {
+			rec["external_id_key"] = namespaceKey(clientID, externalID)
+		}
+	}
+	return rec
+}
+
+func mustLoginEmail(resource persistedUser) string {
+	email, _ := loginEmail(resource)
+	return email
+}
+
+func (s *Service) desiredProjections(clientID string, active, deleted bool) []projection {
+	if deleted || !active {
+		return nil
+	}
+	client := s.clients[clientID]
+	if client == nil {
+		return nil
+	}
+	return append([]projection(nil), client.relationships...)
+}
+
+func (s *Service) publicUser(row storedRow) User {
+	return User{
+		Schemas: []string{UserSchemaURN}, ID: row.id, ExternalID: row.resource.ExternalID, UserName: row.resource.UserName,
+		Active: row.resource.Active, DisplayName: row.resource.DisplayName, Name: row.resource.Name, Emails: append([]Email(nil), row.resource.Emails...),
+		Meta: Meta{ResourceType: "User", Created: row.createdAt, LastModified: row.updatedAt, Location: s.baseURL + "/scim/v2/Users/" + row.id, Version: etag(row.version)},
+	}
+}
+
+func decodeStoredRow(rec idb.Record) (storedRow, error) {
+	var resource persistedUser
+	if err := decodeJSONValue(rec["resource"], &resource); err != nil {
+		return storedRow{}, err
+	}
+	var applied []projection
+	if err := decodeJSONValue(rec["applied_relationships"], &applied); err != nil {
+		return storedRow{}, err
+	}
+	return storedRow{
+		id: recordString(rec, "id"), clientID: recordString(rec, "client_id"), coreUserID: recordString(rec, "core_user_id"), authoritativeDomain: recordString(rec, "authoritative_domain"), resource: resource,
+		active: recordBool(rec, "active"), deleted: recordBool(rec, "deleted"), version: recordInt(rec, "version"), createdAt: recordTime(rec, "created_at"),
+		updatedAt: recordTime(rec, "updated_at"), deletedAt: recordTime(rec, "deleted_at"), applied: applied, lastFingerprint: recordString(rec, "last_operation_fingerprint"),
+	}, nil
+}
+
+func decodeIntentRow(rec idb.Record) (intentRow, error) {
+	var proposed persistedUser
+	var from, to []projection
+	if err := decodeJSONValue(rec["proposed"], &proposed); err != nil {
+		return intentRow{}, err
+	}
+	if err := decodeJSONValue(rec["from_relationships"], &from); err != nil {
+		return intentRow{}, err
+	}
+	if err := decodeJSONValue(rec["to_relationships"], &to); err != nil {
+		return intentRow{}, err
+	}
+	return intentRow{id: recordString(rec, "id"), userID: recordString(rec, "user_id"), clientID: recordString(rec, "client_id"), coreUserID: recordString(rec, "core_user_id"), authoritativeDomain: recordString(rec, "authoritative_domain"), baseVersion: recordInt(rec, "base_version"), nextVersion: recordInt(rec, "next_version"), proposed: proposed, proposedDeleted: recordBool(rec, "proposed_deleted"), from: from, to: to, attemptCount: recordInt(rec, "attempt_count"), createdAt: recordTime(rec, "created_at"), operationFingerprint: recordString(rec, "operation_fingerprint")}, nil
+}
+
+func jsonMap(value any) map[string]any {
+	var result map[string]any
+	data, _ := json.Marshal(value)
+	_ = json.Unmarshal(data, &result)
+	return result
+}
+
+func jsonSlice(value any) []any {
+	var result []any
+	data, _ := json.Marshal(value)
+	_ = json.Unmarshal(data, &result)
+	return result
+}
+
+func decodeJSONValue(value any, target any) error {
+	if value == nil {
+		return nil
+	}
+	data, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(data, target)
+}
+
+func recordString(rec idb.Record, key string) string {
+	value, _ := rec[key].(string)
+	return value
+}
+
+func recordBool(rec idb.Record, key string) bool {
+	value, _ := rec[key].(bool)
+	return value
+}
+
+func recordInt(rec idb.Record, key string) int64 {
+	switch value := rec[key].(type) {
+	case int:
+		return int64(value)
+	case int32:
+		return int64(value)
+	case int64:
+		return value
+	case float64:
+		return int64(value)
+	default:
+		return 0
+	}
+}
+
+func recordTime(rec idb.Record, key string) time.Time {
+	switch value := rec[key].(type) {
+	case time.Time:
+		return value
+	case string:
+		parsed, _ := time.Parse(time.RFC3339Nano, value)
+		return parsed
+	default:
+		return time.Time{}
+	}
+}
+
+func projectionSet(values []projection) map[string]projection {
+	out := make(map[string]projection, len(values))
+	for _, value := range values {
+		out[value.key()] = value
+	}
+	return out
+}
+
+func (s *Service) applyProjections(ctx context.Context, intent intentRow) ([]projection, error) {
+	if s.authorization == nil && (len(intent.from) > 0 || len(intent.to) > 0) {
+		return nil, fmt.Errorf("authorization provider is unavailable")
+	}
+	from, to := projectionSet(intent.from), projectionSet(intent.to)
+	for key, value := range from {
+		if _, keep := to[key]; keep || !value.Owned {
+			continue
+		}
+		existing, err := s.findProjection(ctx, intent.coreUserID, value)
+		if err != nil {
+			return nil, err
+		}
+		if existing == nil || !relationshipOwnedBy(existing, intent.clientID, intent.userID) {
+			continue
+		}
+		_, err = s.authorization.DeleteRelationship(ctx, &proto.DeleteRelationshipRequest{RelationshipTuple: projectionTuple(intent.coreUserID, value)})
+		if err != nil && !errors.Is(err, core.ErrNotFound) {
+			return nil, err
+		}
+	}
+	desired := make([]projection, 0, len(to))
+	for _, value := range to {
+		desired = append(desired, value)
+	}
+	sort.Slice(desired, func(i, j int) bool { return desired[i].key() < desired[j].key() })
+	applied := make([]projection, 0, len(desired))
+	for _, value := range desired {
+		value.Owned = false
+		existing, err := s.findProjection(ctx, intent.coreUserID, value)
+		if err != nil {
+			return nil, err
+		}
+		if existing != nil {
+			value.Owned = relationshipOwnedBy(existing, intent.clientID, intent.userID)
+			applied = append(applied, value)
+			continue
+		}
+		properties, _ := structpb.NewStruct(map[string]any{"managedBy": "scim", "scimClientId": intent.clientID, "scimUserId": intent.userID})
+		_, err = s.authorization.AddRelationship(ctx, &proto.AddRelationshipRequest{Relationship: &proto.Relationship{Tuple: projectionTuple(intent.coreUserID, value), Properties: properties, SourceLayer: proto.SourceLayer_SOURCE_LAYER_RUNTIME}})
+		if err != nil {
+			return nil, err
+		}
+		value.Owned = true
+		applied = append(applied, value)
+	}
+	return applied, nil
+}
+
+func (s *Service) findProjection(ctx context.Context, coreUserID string, value projection) (*proto.Relationship, error) {
+	tuple := projectionTuple(coreUserID, value)
+	response, err := s.authorization.ListRelationships(ctx, &proto.ListRelationshipsRequest{
+		Filter:   &proto.RelationshipFilter{Target: tuple.Target, Relation: tuple.Relation, Resource: tuple.Resource},
+		PageSize: 2,
+	})
+	if err != nil {
+		return nil, err
+	}
+	for _, relationship := range response.GetRelationships() {
+		if gproto.Equal(relationship.GetTuple(), tuple) {
+			return relationship, nil
+		}
+	}
+	return nil, nil
+}
+
+func relationshipOwnedBy(relationship *proto.Relationship, clientID, userID string) bool {
+	if relationship == nil || relationship.GetSourceLayer() != proto.SourceLayer_SOURCE_LAYER_RUNTIME || relationship.GetProperties() == nil {
+		return false
+	}
+	properties := relationship.GetProperties().AsMap()
+	return properties["managedBy"] == "scim" && properties["scimClientId"] == clientID && properties["scimUserId"] == userID
+}
+
+func projectionTuple(coreUserID string, value projection) *proto.RelationshipTuple {
+	return &proto.RelationshipTuple{
+		Target:   &proto.RelationshipTarget{Kind: &proto.RelationshipTarget_Subject{Subject: &proto.Subject{Type: "subject", Id: "user:" + coreUserID}}},
+		Relation: value.Relation,
+		Resource: &proto.Resource{Type: value.ResourceType, Id: value.ResourceID},
+	}
+}
+
+var errNoIntent = errors.New("SCIM projection intent not found")
+
+func isNoIntent(err error) bool { return errors.Is(err, errNoIntent) }
+
+func (s *Service) convergeUser(ctx context.Context, userID string) error {
+	unlock := s.lock(userLockKey(userID))
+	defer unlock()
+	return s.convergeUserLocked(ctx, userID)
+}
+
+func (s *Service) convergeUserLocked(ctx context.Context, userID string) error {
+	rec, err := s.db.ObjectStore(coredata.StoreSCIMProjectionIntents).Index("by_user").Get(ctx, userID)
+	if errors.Is(err, idb.ErrNotFound) {
+		return errNoIntent
+	}
+	if err != nil {
+		return unavailable("could not load pending SCIM mutation")
+	}
+	intent, err := decodeIntentRow(rec)
+	if err != nil {
+		return unavailable("pending SCIM mutation is invalid")
+	}
+	applied, err := s.applyProjections(ctx, intent)
+	if err != nil {
+		if recordErr := s.recordProjectionFailure(ctx, rec, err); recordErr != nil {
+			slog.WarnContext(ctx, "SCIM projection failure could not be recorded", "user_id", intent.userID, "client_id", intent.clientID, "error", recordErr)
+		}
+		return unavailable("authorization projection has not converged")
+	}
+	intent.to = applied
+	now := s.currentTime()
+	tx, err := s.db.Transaction(ctx, []string{coredata.StoreSCIMUsers, coredata.StoreSCIMProjectionIntents}, idb.TransactionReadwrite, idb.TransactionOptions{DurabilityHint: idb.TransactionDurabilityStrict})
+	if err != nil {
+		return unavailable("could not commit SCIM mutation")
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Abort(context.WithoutCancel(ctx))
+		}
+	}()
+	latest, err := tx.ObjectStore(coredata.StoreSCIMProjectionIntents).Get(ctx, intent.id)
+	if errors.Is(err, idb.ErrNotFound) {
+		alreadyCommitted, committedErr := intentAlreadyCommitted(ctx, tx, intent)
+		if committedErr != nil {
+			return unavailable("could not verify superseded SCIM mutation")
+		}
+		if alreadyCommitted {
+			return nil
+		}
+		return unavailable("SCIM mutation was superseded")
+	}
+	if err != nil || recordString(latest, "user_id") != intent.userID || recordInt(latest, "next_version") != intent.nextVersion {
+		return unavailable("SCIM mutation was superseded")
+	}
+	createdAt := intent.createdAt
+	lastFingerprint := intent.operationFingerprint
+	if existing, getErr := tx.ObjectStore(coredata.StoreSCIMUsers).Get(ctx, intent.userID); getErr == nil {
+		createdAt = recordTime(existing, "created_at")
+		if lastFingerprint == "" {
+			lastFingerprint = recordString(existing, "last_operation_fingerprint")
+		}
+	}
+	row := idb.Record{
+		"id": intent.userID, "client_id": intent.clientID, "core_user_id": intent.coreUserID,
+		"active": intent.proposed.Active && !intent.proposedDeleted, "deleted": intent.proposedDeleted, "version": intent.nextVersion,
+		"resource": jsonMap(intent.proposed), "applied_relationships": jsonSlice(intent.to), "created_at": createdAt, "updated_at": now,
+	}
+	if intent.authoritativeDomain != "" {
+		row["authoritative_domain"] = intent.authoritativeDomain
+	}
+	if lastFingerprint != "" {
+		row["last_operation_fingerprint"] = lastFingerprint
+	}
+	if intent.proposedDeleted {
+		row["deleted_at"] = now
+	} else {
+		row["user_name_key"] = namespaceKey(intent.clientID, normalize(intent.proposed.UserName))
+		row["email_key"] = namespaceKey(intent.clientID, mustLoginEmail(intent.proposed))
+		if value := normalize(intent.proposed.ExternalID); value != "" {
+			row["external_id_key"] = namespaceKey(intent.clientID, value)
+		}
+	}
+	if err := tx.ObjectStore(coredata.StoreSCIMUsers).Put(ctx, row); err != nil {
+		return mapIntentWriteError("commit SCIM User", err)
+	}
+	if err := tx.ObjectStore(coredata.StoreSCIMProjectionIntents).Delete(ctx, intent.id); err != nil {
+		return unavailable("could not clear committed SCIM mutation")
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return unavailable("could not commit SCIM mutation")
+	}
+	committed = true
+	return nil
+}
+
+func intentAlreadyCommitted(ctx context.Context, tx idb.Transaction, intent intentRow) (bool, error) {
+	rec, err := tx.ObjectStore(coredata.StoreSCIMUsers).Get(ctx, intent.userID)
+	if errors.Is(err, idb.ErrNotFound) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	row, err := decodeStoredRow(rec)
+	if err != nil {
+		return false, err
+	}
+	if row.clientID != intent.clientID || row.coreUserID != intent.coreUserID || row.version < intent.nextVersion {
+		return false, nil
+	}
+	return intent.operationFingerprint == "" || row.lastFingerprint == intent.operationFingerprint, nil
+}
+
+func (s *Service) recordProjectionFailure(ctx context.Context, rec idb.Record, projectionErr error) error {
+	tx, err := s.db.Transaction(ctx, []string{coredata.StoreSCIMProjectionIntents}, idb.TransactionReadwrite, idb.TransactionOptions{DurabilityHint: idb.TransactionDurabilityStrict})
+	if err != nil {
+		return fmt.Errorf("begin failure update: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Abort(context.WithoutCancel(ctx))
+		}
+	}()
+	latest, err := tx.ObjectStore(coredata.StoreSCIMProjectionIntents).Get(ctx, recordString(rec, "id"))
+	if errors.Is(err, idb.ErrNotFound) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("load pending intent: %w", err)
+	}
+	if recordString(latest, "user_id") != recordString(rec, "user_id") || recordInt(latest, "next_version") != recordInt(rec, "next_version") {
+		return nil
+	}
+	attempt := recordInt(latest, "attempt_count") + 1
+	delay := time.Second << min(attempt-1, 6)
+	if delay > time.Minute {
+		delay = time.Minute
+	}
+	now := s.currentTime()
+	latest["attempt_count"] = attempt
+	latest["next_attempt_at"] = now.Add(delay)
+	latest["updated_at"] = now
+	latest["last_error"] = projectionErr.Error()
+	if err := tx.ObjectStore(coredata.StoreSCIMProjectionIntents).Put(ctx, latest); err != nil {
+		return fmt.Errorf("store failure update: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit failure update: %w", err)
+	}
+	committed = true
+	return nil
+}
+
+func (s *Service) reconcileDueIntents(ctx context.Context) (int, error) {
+	intents, err := s.db.ObjectStore(coredata.StoreSCIMProjectionIntents).Index("by_next_attempt").GetAll(ctx, idb.UpperBound(s.currentTime(), false), maxDueIntentBatch)
+	if err != nil {
+		return 0, fmt.Errorf("list due projection intents: %w", err)
+	}
+	var errs []error
+	for _, rec := range intents {
+		userID := recordString(rec, "user_id")
+		if userID == "" {
+			errs = append(errs, fmt.Errorf("projection intent %q has no user", recordString(rec, "id")))
+			continue
+		}
+		if err := s.convergeUser(ctx, userID); err != nil && !isNoIntent(err) {
+			errs = append(errs, fmt.Errorf("converge user %q: %w", userID, err))
+		}
+	}
+	return len(intents), errors.Join(errs...)
+}
+
+func (s *Service) reconcileDrift(ctx context.Context) (int, error) {
+	records, err := s.db.ObjectStore(coredata.StoreSCIMUsers).GetAll(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("list SCIM users for drift reconciliation: %w", err)
+	}
+	var errs []error
+	processed := 0
+	for _, rec := range records {
+		row, decodeErr := decodeStoredRow(rec)
+		if decodeErr != nil {
+			errs = append(errs, fmt.Errorf("decode SCIM user %q: %w", recordString(rec, "id"), decodeErr))
+			continue
+		}
+		if row.deleted {
+			continue
+		}
+		desired := s.desiredProjections(row.clientID, row.resource.Active, false)
+		if len(desired) == 0 && len(row.applied) == 0 {
+			continue
+		}
+		processed++
+		unlock := s.lock(userLockKey(row.id))
+		_, pendingErr := s.db.ObjectStore(coredata.StoreSCIMProjectionIntents).Index("by_user").Get(ctx, row.id)
+		if errors.Is(pendingErr, idb.ErrNotFound) {
+			converged, convergenceErr := s.projectionsConverged(ctx, row, desired)
+			if convergenceErr != nil {
+				errs = append(errs, fmt.Errorf("inspect projections for user %q: %w", row.id, convergenceErr))
+				unlock()
+				continue
+			}
+			if converged {
+				unlock()
+				continue
+			}
+			now := s.currentTime()
+			authoritativeDomain := row.authoritativeDomain
+			if authoritativeDomain == "" {
+				authoritativeDomain = s.authoritativeDomain(row.clientID, mustLoginEmail(row.resource))
+			}
+			intent := newIntentRecord(uuid.NewString(), row.id, row.clientID, row.coreUserID, authoritativeDomain, row.version, row.version, row.resource, false, row.applied, desired, "", now)
+			if addErr := s.db.ObjectStore(coredata.StoreSCIMProjectionIntents).Add(ctx, intent); addErr != nil && !errors.Is(addErr, idb.ErrAlreadyExists) {
+				errs = append(errs, fmt.Errorf("record projection drift for user %q: %w", row.id, addErr))
+				unlock()
+				continue
+			}
+			if convergenceErr := s.convergeUserLocked(ctx, row.id); convergenceErr != nil && !isNoIntent(convergenceErr) {
+				errs = append(errs, fmt.Errorf("converge projection drift for user %q: %w", row.id, convergenceErr))
+			}
+		} else if pendingErr != nil {
+			errs = append(errs, fmt.Errorf("inspect pending projection for user %q: %w", row.id, pendingErr))
+		}
+		unlock()
+	}
+	return processed, errors.Join(errs...)
+}
+
+func (s *Service) projectionsConverged(ctx context.Context, row storedRow, desired []projection) (bool, error) {
+	if !equalProjections(row.applied, desired) {
+		return false, nil
+	}
+	applied := projectionSet(row.applied)
+	for _, value := range desired {
+		existing, err := s.findProjection(ctx, row.coreUserID, value)
+		if err != nil {
+			return false, err
+		}
+		if existing == nil || applied[value.key()].Owned != relationshipOwnedBy(existing, row.clientID, row.id) {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func equalProjections(left, right []projection) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	a, b := projectionSet(left), projectionSet(right)
+	if len(a) != len(b) {
+		return false
+	}
+	for key := range a {
+		if _, ok := b[key]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func (s *Service) IsEligible(ctx context.Context, coreUserID, email string) (bool, error) {
+	intents, err := s.db.ObjectStore(coredata.StoreSCIMProjectionIntents).Index("by_core_user").GetAll(ctx, coreUserID)
+	if err != nil {
+		return false, err
+	}
+	users, err := s.db.ObjectStore(coredata.StoreSCIMUsers).Index("by_core_user").GetAll(ctx, coreUserID)
+	if err != nil {
+		return false, err
+	}
+	clientID := ""
+	if parts := strings.Split(normalize(email), "@"); len(parts) == 2 {
+		clientID = s.domainOwners[parts[1]]
+	}
+	for _, rec := range users {
+		candidateClient := recordString(rec, "client_id")
+		if s.clientOwnsDomain(candidateClient, recordString(rec, "authoritative_domain")) {
+			clientID = candidateClient
+			break
+		}
+	}
+	if clientID == "" {
+		for _, rec := range intents {
+			candidateClient := recordString(rec, "client_id")
+			if s.clientOwnsDomain(candidateClient, recordString(rec, "authoritative_domain")) {
+				clientID = candidateClient
+				break
+			}
+		}
+	}
+	if clientID == "" {
+		return true, nil
+	}
+	activeUsers := make(map[string]storedRow)
+	for _, rec := range users {
+		if recordString(rec, "client_id") != clientID || !recordBool(rec, "active") || recordBool(rec, "deleted") {
+			continue
+		}
+		row, decodeErr := decodeStoredRow(rec)
+		if decodeErr != nil {
+			return false, fmt.Errorf("decode active SCIM user: %w", decodeErr)
+		}
+		activeUsers[row.id] = row
+	}
+	if len(activeUsers) == 0 {
+		return false, nil
+	}
+	for _, rec := range intents {
+		if recordString(rec, "client_id") != clientID {
+			continue
+		}
+		intent, decodeErr := decodeIntentRow(rec)
+		if decodeErr != nil {
+			return false, fmt.Errorf("decode pending SCIM mutation: %w", decodeErr)
+		}
+		committed, ok := activeUsers[intent.userID]
+		if !ok || !intentPreservesEligibility(intent, committed) {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func intentPreservesEligibility(intent intentRow, committed storedRow) bool {
+	if intent.clientID != committed.clientID || intent.coreUserID != committed.coreUserID || intent.proposedDeleted || !intent.proposed.Active {
+		return false
+	}
+	currentEmail, currentErr := loginEmail(committed.resource)
+	proposedEmail, proposedErr := loginEmail(intent.proposed)
+	if currentErr != nil || proposedErr != nil || normalize(currentEmail) != normalize(proposedEmail) {
+		return false
+	}
+	desired := projectionSet(intent.to)
+	for key := range projectionSet(intent.from) {
+		if _, retained := desired[key]; !retained {
+			return false
+		}
+	}
+	return true
+}
+
+func (s *Service) authoritativeDomain(clientID, email string) string {
+	parts := strings.Split(normalize(email), "@")
+	if len(parts) != 2 || !s.clientOwnsDomain(clientID, parts[1]) {
+		return ""
+	}
+	return parts[1]
+}
+
+func (s *Service) clientOwnsDomain(clientID, domain string) bool {
+	client := s.clients[clientID]
+	if client == nil || domain == "" {
+		return false
+	}
+	_, ok := client.domains[normalize(domain)]
+	return ok
+}
+
+func (s *Service) ManagedRelationship(resourceType, resourceID, relation string) bool {
+	_, ok := s.managed[(projection{ResourceType: resourceType, ResourceID: resourceID, Relation: relation}).key()]
+	return ok
+}

--- a/gestaltd/internal/scim/types.go
+++ b/gestaltd/internal/scim/types.go
@@ -1,0 +1,115 @@
+package scim
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	UserSchemaURN  = "urn:ietf:params:scim:schemas:core:2.0:User"
+	PatchSchemaURN = "urn:ietf:params:scim:api:messages:2.0:PatchOp"
+	ListSchemaURN  = "urn:ietf:params:scim:api:messages:2.0:ListResponse"
+	ErrorSchemaURN = "urn:ietf:params:scim:api:messages:2.0:Error"
+)
+
+type Name struct {
+	Formatted  string `json:"formatted,omitempty"`
+	FamilyName string `json:"familyName,omitempty"`
+	GivenName  string `json:"givenName,omitempty"`
+}
+
+type Email struct {
+	Value   string `json:"value"`
+	Type    string `json:"type,omitempty"`
+	Primary bool   `json:"primary,omitempty"`
+}
+
+type Meta struct {
+	ResourceType string    `json:"resourceType"`
+	Created      time.Time `json:"created"`
+	LastModified time.Time `json:"lastModified"`
+	Location     string    `json:"location"`
+	Version      string    `json:"version"`
+}
+
+type User struct {
+	Schemas     []string `json:"schemas"`
+	ID          string   `json:"id"`
+	ExternalID  string   `json:"externalId,omitempty"`
+	UserName    string   `json:"userName"`
+	Active      bool     `json:"active"`
+	DisplayName string   `json:"displayName,omitempty"`
+	Name        Name     `json:"name,omitempty"`
+	Emails      []Email  `json:"emails,omitempty"`
+	Meta        Meta     `json:"meta"`
+}
+
+type userInput struct {
+	Schemas     []string `json:"schemas"`
+	ExternalID  *string  `json:"externalId,omitempty"`
+	UserName    *string  `json:"userName,omitempty"`
+	Active      *bool    `json:"active,omitempty"`
+	DisplayName *string  `json:"displayName,omitempty"`
+	Name        *Name    `json:"name,omitempty"`
+	Emails      *[]Email `json:"emails,omitempty"`
+}
+
+type persistedUser struct {
+	ExternalID  string  `json:"externalId,omitempty"`
+	UserName    string  `json:"userName"`
+	Active      bool    `json:"active"`
+	DisplayName string  `json:"displayName,omitempty"`
+	Name        Name    `json:"name,omitempty"`
+	Emails      []Email `json:"emails,omitempty"`
+}
+
+type listResponse struct {
+	Schemas      []string `json:"schemas"`
+	TotalResults int      `json:"totalResults"`
+	StartIndex   int      `json:"startIndex"`
+	ItemsPerPage int      `json:"itemsPerPage"`
+	Resources    []User   `json:"Resources"`
+}
+
+type patchRequest struct {
+	Schemas    []string         `json:"schemas"`
+	Operations []patchOperation `json:"Operations"`
+}
+
+type patchOperation struct {
+	Op    string          `json:"op"`
+	Path  string          `json:"path,omitempty"`
+	Value json.RawMessage `json:"value,omitempty"`
+}
+
+type Error struct {
+	Status   int
+	SCIMType string
+	Detail   string
+	Retry    bool
+}
+
+func (e *Error) Error() string { return e.Detail }
+
+func invalid(detail string) *Error {
+	return &Error{Status: http.StatusBadRequest, SCIMType: "invalidValue", Detail: detail}
+}
+
+func notFound() *Error {
+	return &Error{Status: http.StatusNotFound, Detail: "SCIM User was not found"}
+}
+
+func conflict(detail string) *Error {
+	return &Error{Status: http.StatusConflict, SCIMType: "uniqueness", Detail: detail}
+}
+
+func unavailable(detail string) *Error {
+	return &Error{Status: http.StatusServiceUnavailable, Detail: detail, Retry: true}
+}
+
+func etag(version int64) string { return fmt.Sprintf("W/\"%d\"", version) }
+
+func normalize(value string) string { return strings.ToLower(strings.TrimSpace(value)) }

--- a/gestaltd/internal/scim/users_http_test.go
+++ b/gestaltd/internal/scim/users_http_test.go
@@ -1,0 +1,1114 @@
+package scim_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	idb "github.com/valon-technologies/gestalt/sdk/go/indexeddb"
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/catalog"
+	coredb "github.com/valon-technologies/gestalt/server/core/indexeddb"
+	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/coredata"
+	"github.com/valon-technologies/gestalt/server/internal/scim"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"github.com/valon-technologies/gestalt/server/services/identity/principal"
+	"github.com/valon-technologies/gestalt/server/services/invocation"
+	gproto "google.golang.org/protobuf/proto"
+)
+
+const (
+	testBaseURL      = "https://gestalt.example"
+	testCurrentToken = "rippling-current-token"
+	testNextToken    = "rippling-next-token"
+)
+
+type testListResponse struct {
+	Schemas      []string    `json:"schemas"`
+	TotalResults int         `json:"totalResults"`
+	StartIndex   int         `json:"startIndex"`
+	ItemsPerPage int         `json:"itemsPerPage"`
+	Resources    []scim.User `json:"Resources"`
+}
+
+type testErrorResponse struct {
+	Schemas  []string `json:"schemas"`
+	Status   string   `json:"status"`
+	SCIMType string   `json:"scimType"`
+	Detail   string   `json:"detail"`
+}
+
+func testSCIMConfig(clients map[string]config.SCIMClientConfig) config.ServerSCIMConfig {
+	return config.ServerSCIMConfig{
+		Clients:       clients,
+		RetryInterval: "5ms",
+		DriftInterval: "1h",
+	}
+}
+
+func ripplingClient(domains []string, relationships ...config.SCIMRelationshipConfig) config.SCIMClientConfig {
+	return config.SCIMClientConfig{
+		Credentials:              []config.SCIMCredentialConfig{{ID: "current", BearerToken: testCurrentToken}, {ID: "next", BearerToken: testNextToken}},
+		AuthoritativeUserDomains: domains,
+		ActiveUserRelationships:  relationships,
+	}
+}
+
+func employeeProjection() config.SCIMRelationshipConfig {
+	return config.SCIMRelationshipConfig{
+		Relation: "member",
+		Resource: config.AuthorizationResourceDef{Type: "group", ID: "valon-employees"},
+	}
+}
+
+func newSCIMService(t *testing.T, db coredb.IndexedDB, authorization core.AuthorizationProvider, cfg config.ServerSCIMConfig, opts ...scim.ServiceOptions) (*scim.Service, *coredata.Services, http.Handler) {
+	t.Helper()
+	if db == nil {
+		db = &coretesting.StubIndexedDB{}
+	}
+	services, err := coredata.New(db)
+	if err != nil {
+		t.Fatalf("coredata.New: %v", err)
+	}
+	var service *scim.Service
+	if len(opts) == 0 {
+		service, err = scim.NewService(services.DB, authorization, testBaseURL, cfg)
+	} else {
+		service, err = scim.NewServiceWithOptions(services.DB, authorization, testBaseURL, cfg, opts[0])
+	}
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	return service, services, scim.NewHandler(service)
+}
+
+func scimRequest(t *testing.T, handler http.Handler, method, path, token string, body any, headers ...map[string]string) *httptest.ResponseRecorder {
+	t.Helper()
+	var encoded []byte
+	if body != nil {
+		var err error
+		encoded, err = json.Marshal(body)
+		if err != nil {
+			t.Fatalf("marshal request: %v", err)
+		}
+	}
+	req := httptest.NewRequest(method, path, bytes.NewReader(encoded))
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/scim+json")
+	}
+	if len(headers) > 0 {
+		for key, value := range headers[0] {
+			req.Header.Set(key, value)
+		}
+	}
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, req)
+	return recorder
+}
+
+func decodeResponse[T any](t *testing.T, recorder *httptest.ResponseRecorder) T {
+	t.Helper()
+	var value T
+	if err := json.Unmarshal(recorder.Body.Bytes(), &value); err != nil {
+		t.Fatalf("decode response %q: %v", recorder.Body.String(), err)
+	}
+	return value
+}
+
+func createUser(t *testing.T, handler http.Handler, token, userName string, active bool, extra map[string]any) (*scim.User, *httptest.ResponseRecorder) {
+	t.Helper()
+	payload := map[string]any{
+		"schemas":  []string{scim.UserSchemaURN},
+		"userName": userName,
+		"active":   active,
+	}
+	for key, value := range extra {
+		payload[key] = value
+	}
+	recorder := scimRequest(t, handler, http.MethodPost, "/scim/v2/Users", token, payload)
+	if recorder.Code < 200 || recorder.Code >= 300 {
+		return nil, recorder
+	}
+	user := decodeResponse[scim.User](t, recorder)
+	return &user, recorder
+}
+
+func eventually(t *testing.T, condition func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if condition() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("condition did not become true")
+}
+
+func TestSCIMUsersHTTPContract(t *testing.T) {
+	t.Parallel()
+
+	_, _, handler := newSCIMService(t, nil, nil, testSCIMConfig(map[string]config.SCIMClientConfig{
+		"rippling": ripplingClient(nil),
+	}))
+
+	for _, token := range []string{"", "wrong"} {
+		response := scimRequest(t, handler, http.MethodGet, "/scim/v2/Schemas", token, nil)
+		payload := decodeResponse[testErrorResponse](t, response)
+		if response.Code != http.StatusUnauthorized || response.Header().Get("Content-Type") != "application/scim+json" || payload.Status != "401" || len(payload.Schemas) != 1 || payload.Schemas[0] != scim.ErrorSchemaURN {
+			t.Fatalf("unauthorized token %q = %d %#v", token, response.Code, payload)
+		}
+	}
+	for _, token := range []string{testCurrentToken, testNextToken} {
+		response := scimRequest(t, handler, http.MethodGet, "/scim/v2/Schemas", token, nil)
+		if response.Code != http.StatusOK || !bytes.Contains(response.Body.Bytes(), []byte(scim.UserSchemaURN)) {
+			t.Fatalf("Schemas with rotating token = %d %s", response.Code, response.Body.String())
+		}
+	}
+
+	alicePayload := map[string]any{
+		"schemas":     []string{scim.UserSchemaURN, "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"},
+		"externalId":  "employee-123",
+		"userName":    "Alice@Valon.com",
+		"active":      true,
+		"displayName": "Alice Example",
+		"name":        map[string]any{"givenName": "Alice", "familyName": "Example"},
+		"emails":      []map[string]any{{"value": "Alice@Valon.com", "type": "work", "primary": true}},
+		"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User": map[string]any{"department": "Ignored"},
+	}
+	createdRecorder := scimRequest(t, handler, http.MethodPost, "/scim/v2/Users", testCurrentToken, alicePayload)
+	created := decodeResponse[scim.User](t, createdRecorder)
+	if createdRecorder.Code != http.StatusCreated || created.ID == "" || created.UserName != "Alice@Valon.com" || !created.Active || created.Meta.Version != `W/"1"` {
+		t.Fatalf("POST = %d %#v", createdRecorder.Code, created)
+	}
+	if got := createdRecorder.Header().Get("Location"); got != testBaseURL+"/scim/v2/Users/"+created.ID {
+		t.Fatalf("Location = %q", got)
+	}
+	if got := createdRecorder.Header().Get("ETag"); got != created.Meta.Version {
+		t.Fatalf("ETag = %q", got)
+	}
+
+	for _, filter := range []string{
+		`externalId eq "employee-123"`,
+		`userName eq "alice@valon.com"`,
+		`emails.value eq "alice@valon.com"`,
+		`emails[type eq "work"].value eq "alice@valon.com"`,
+		`userName eq "alice@valon.com" and externalId eq "employee-123"`,
+	} {
+		response := scimRequest(t, handler, http.MethodGet, "/scim/v2/Users?filter="+url.QueryEscape(filter), testCurrentToken, nil)
+		list := decodeResponse[testListResponse](t, response)
+		if response.Code != http.StatusOK || list.TotalResults != 1 || list.Resources[0].ID != created.ID {
+			t.Fatalf("filter %q = %d %#v", filter, response.Code, list)
+		}
+	}
+	empty := scimRequest(t, handler, http.MethodGet, "/scim/v2/Users?filter="+url.QueryEscape(`userName eq "random-entra-probe@invalid.example"`), testCurrentToken, nil)
+	if list := decodeResponse[testListResponse](t, empty); empty.Code != http.StatusOK || list.TotalResults != 0 || list.Resources == nil {
+		t.Fatalf("empty filter = %d %s", empty.Code, empty.Body.String())
+	}
+	unsupportedFilter := scimRequest(t, handler, http.MethodGet, "/scim/v2/Users?filter="+url.QueryEscape(`active eq "true"`), testCurrentToken, nil)
+	if payload := decodeResponse[testErrorResponse](t, unsupportedFilter); unsupportedFilter.Code != http.StatusBadRequest || payload.Status != "400" || payload.SCIMType != "invalidValue" {
+		t.Fatalf("unsupported filter = %d %#v", unsupportedFilter.Code, payload)
+	}
+	wrongMediaType := scimRequest(t, handler, http.MethodPost, "/scim/v2/Users", testCurrentToken, map[string]any{"userName": "invalid@valon.com"}, map[string]string{"Content-Type": "application/json"})
+	if payload := decodeResponse[testErrorResponse](t, wrongMediaType); wrongMediaType.Code != http.StatusBadRequest || payload.Status != "400" {
+		t.Fatalf("wrong media type = %d %#v", wrongMediaType.Code, payload)
+	}
+
+	bob, bobRecorder := createUser(t, handler, testCurrentToken, "bob@valon.com", true, nil)
+	carol, carolRecorder := createUser(t, handler, testCurrentToken, "carol@valon.com", true, nil)
+	if bobRecorder.Code != http.StatusCreated || carolRecorder.Code != http.StatusCreated {
+		t.Fatalf("users without externalId = %d/%d", bobRecorder.Code, carolRecorder.Code)
+	}
+	page := decodeResponse[testListResponse](t, scimRequest(t, handler, http.MethodGet, "/scim/v2/Users?startIndex=2&count=1", testCurrentToken, nil))
+	if page.TotalResults != 3 || page.StartIndex != 2 || page.ItemsPerPage != 1 {
+		t.Fatalf("pagination = %#v", page)
+	}
+	firstPage := decodeResponse[testListResponse](t, scimRequest(t, handler, http.MethodGet, "/scim/v2/Users?startIndex=0&count=1", testCurrentToken, nil))
+	if firstPage.TotalResults != 3 || firstPage.StartIndex != 1 || firstPage.ItemsPerPage != 1 {
+		t.Fatalf("startIndex below one = %#v", firstPage)
+	}
+	emptyPage := decodeResponse[testListResponse](t, scimRequest(t, handler, http.MethodGet, "/scim/v2/Users?count=-1", testCurrentToken, nil))
+	if emptyPage.TotalResults != 3 || emptyPage.StartIndex != 1 || emptyPage.ItemsPerPage != 0 || emptyPage.Resources == nil {
+		t.Fatalf("negative count = %#v", emptyPage)
+	}
+
+	patch := map[string]any{"schemas": []string{scim.PatchSchemaURN}, "Operations": []map[string]any{
+		{"op": "RePlAcE", "path": "active", "value": false},
+		{"op": "replace", "path": `emails[type eq "work"].value`, "value": "Alice@Valon.com"},
+		{"op": "replace", "value": map[string]any{"displayName": "Alice Updated"}},
+	}}
+	patchedRecorder := scimRequest(t, handler, http.MethodPatch, "/scim/v2/Users/"+created.ID, testCurrentToken, patch, map[string]string{"If-Match": created.Meta.Version})
+	patched := decodeResponse[scim.User](t, patchedRecorder)
+	if patchedRecorder.Code != http.StatusOK || patched.Active || patched.DisplayName != "Alice Updated" || patched.Meta.Version != `W/"2"` {
+		t.Fatalf("PATCH = %d %#v", patchedRecorder.Code, patched)
+	}
+	replayed := scimRequest(t, handler, http.MethodPatch, "/scim/v2/Users/"+created.ID, testCurrentToken, patch, map[string]string{"If-Match": created.Meta.Version})
+	if replayedUser := decodeResponse[scim.User](t, replayed); replayed.Code != http.StatusOK || replayedUser.Meta.Version != patched.Meta.Version {
+		t.Fatalf("replayed PATCH = %d %#v", replayed.Code, replayedUser)
+	}
+	differentPatch := map[string]any{"schemas": []string{scim.PatchSchemaURN}, "Operations": []map[string]any{{"op": "replace", "path": "displayName", "value": "Different Update"}}}
+	stale := scimRequest(t, handler, http.MethodPatch, "/scim/v2/Users/"+created.ID, testCurrentToken, differentPatch, map[string]string{"If-Match": created.Meta.Version})
+	if stale.Code != http.StatusPreconditionFailed {
+		t.Fatalf("different stale PATCH = %d %s", stale.Code, stale.Body.String())
+	}
+
+	put := map[string]any{"schemas": []string{scim.UserSchemaURN}, "externalId": "employee-123", "userName": "Alice@Valon.com", "emails": []map[string]any{{"value": "Alice@Valon.com", "type": "work", "primary": true}}}
+	putRecorder := scimRequest(t, handler, http.MethodPut, "/scim/v2/Users/"+created.ID, testCurrentToken, put, map[string]string{"If-Match": "*"})
+	if putUser := decodeResponse[scim.User](t, putRecorder); putRecorder.Code != http.StatusOK || putUser.Active {
+		t.Fatalf("PUT missing active = %d %#v", putRecorder.Code, putUser)
+	}
+	reactivate := map[string]any{"schemas": []string{scim.PatchSchemaURN}, "Operations": []map[string]any{{"op": "replace", "path": "active", "value": true}}}
+	reactivatedRecorder := scimRequest(t, handler, http.MethodPatch, "/scim/v2/Users/"+created.ID, testCurrentToken, reactivate, map[string]string{"If-Match": "*"})
+	if reactivated := decodeResponse[scim.User](t, reactivatedRecorder); reactivatedRecorder.Code != http.StatusOK || !reactivated.Active || reactivated.ID != created.ID {
+		t.Fatalf("reactivation = %d %#v", reactivatedRecorder.Code, reactivated)
+	}
+
+	conflictingEmail := map[string]any{"schemas": []string{scim.PatchSchemaURN}, "Operations": []map[string]any{{"op": "replace", "value": map[string]any{"emails": []map[string]any{{"value": "bob@valon.com", "type": "work", "primary": true}}}}}}
+	if response := scimRequest(t, handler, http.MethodPatch, "/scim/v2/Users/"+created.ID, testCurrentToken, conflictingEmail); response.Code != http.StatusConflict {
+		t.Fatalf("email conflict = %d %s", response.Code, response.Body.String())
+	}
+	if response := scimRequest(t, handler, http.MethodPost, "/scim/v2/Users", testCurrentToken, alicePayload); response.Code != http.StatusConflict {
+		t.Fatalf("duplicate create = %d %s", response.Code, response.Body.String())
+	}
+
+	for _, id := range []string{created.ID, bob.ID, carol.ID} {
+		if response := scimRequest(t, handler, http.MethodDelete, "/scim/v2/Users/"+id, testCurrentToken, nil, map[string]string{"If-Match": "*"}); response.Code != http.StatusNoContent {
+			t.Fatalf("DELETE %s = %d %s", id, response.Code, response.Body.String())
+		}
+		if response := scimRequest(t, handler, http.MethodDelete, "/scim/v2/Users/"+id, testCurrentToken, nil, map[string]string{"If-Match": "*"}); response.Code != http.StatusNoContent {
+			t.Fatalf("replayed DELETE %s = %d %s", id, response.Code, response.Body.String())
+		}
+		if response := scimRequest(t, handler, http.MethodGet, "/scim/v2/Users/"+id, testCurrentToken, nil); response.Code != http.StatusNotFound {
+			t.Fatalf("GET tombstone %s = %d", id, response.Code)
+		}
+	}
+	recreatedRecorder := scimRequest(t, handler, http.MethodPost, "/scim/v2/Users", testCurrentToken, alicePayload)
+	recreated := decodeResponse[scim.User](t, recreatedRecorder)
+	if recreatedRecorder.Code != http.StatusCreated || recreated.ID == created.ID {
+		t.Fatalf("recreated user = %d %#v", recreatedRecorder.Code, recreated)
+	}
+}
+
+func TestSCIMCredentialRotationAndClientNamespaces(t *testing.T) {
+	t.Parallel()
+
+	_, _, handler := newSCIMService(t, nil, nil, testSCIMConfig(map[string]config.SCIMClientConfig{
+		"rippling": ripplingClient(nil),
+		"entra":    {Credentials: []config.SCIMCredentialConfig{{ID: "current", BearerToken: "entra-token"}}},
+	}))
+	active := true
+	payload := map[string]any{"schemas": []string{scim.UserSchemaURN}, "externalId": "shared", "userName": "same@example.com", "active": active}
+	ripplingResponse := scimRequest(t, handler, http.MethodPost, "/scim/v2/Users", testNextToken, payload)
+	entraResponse := scimRequest(t, handler, http.MethodPost, "/scim/v2/Users", "entra-token", payload)
+	ripplingUser := decodeResponse[scim.User](t, ripplingResponse)
+	entraUser := decodeResponse[scim.User](t, entraResponse)
+	if ripplingResponse.Code != http.StatusCreated || entraResponse.Code != http.StatusCreated || ripplingUser.ID == entraUser.ID {
+		t.Fatalf("namespaced creates = %d/%d %#v/%#v", ripplingResponse.Code, entraResponse.Code, ripplingUser, entraUser)
+	}
+	if response := scimRequest(t, handler, http.MethodGet, "/scim/v2/Users/"+ripplingUser.ID, "entra-token", nil); response.Code != http.StatusNotFound {
+		t.Fatalf("cross-namespace GET = %d", response.Code)
+	}
+}
+
+func TestSCIMProjectionFailureRecoversAfterRestart(t *testing.T) {
+	t.Parallel()
+
+	db := &coretesting.StubIndexedDB{}
+	authorization := newRecordingAuthorization()
+	authorization.setFailures(true, false)
+	cfg := testSCIMConfig(map[string]config.SCIMClientConfig{
+		"rippling": ripplingClient([]string{"valon.com"}, employeeProjection()),
+	})
+	service, services, handler := newSCIMService(t, db, authorization, cfg)
+	_, failed := createUser(t, handler, testCurrentToken, "alice@valon.com", true, nil)
+	errorPayload := decodeResponse[testErrorResponse](t, failed)
+	if failed.Code != http.StatusServiceUnavailable || failed.Header().Get("Retry-After") != "1" || errorPayload.Status != "503" {
+		t.Fatalf("projection failure = %d %#v headers=%v", failed.Code, errorPayload, failed.Header())
+	}
+	coreUser, err := services.Users.FindUserByEmail(context.Background(), "alice@valon.com")
+	if err != nil {
+		t.Fatalf("FindUserByEmail: %v", err)
+	}
+	request := accessRequest(coreUser.ID)
+	if response, err := scim.WrapAuthorization(authorization, services.Users, service).CheckAccess(context.Background(), request); err != nil || response.Allowed {
+		t.Fatalf("pending projection access = %#v, %v", response, err)
+	}
+
+	authorization.setFailures(false, false)
+	restarted, _, restartedHandler := newSCIMService(t, db, authorization, cfg)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	restarted.Start(ctx)
+	var recovered scim.User
+	eventually(t, func() bool {
+		response := scimRequest(t, restartedHandler, http.MethodGet, "/scim/v2/Users?filter="+url.QueryEscape(`userName eq "alice@valon.com"`), testCurrentToken, nil)
+		if response.Code != http.StatusOK {
+			return false
+		}
+		list := decodeResponse[testListResponse](t, response)
+		if list.TotalResults != 1 {
+			return false
+		}
+		recovered = list.Resources[0]
+		return true
+	})
+	replayed := scimRequest(t, restartedHandler, http.MethodPost, "/scim/v2/Users", testCurrentToken, map[string]any{
+		"schemas": []string{scim.UserSchemaURN}, "userName": "alice@valon.com", "active": true,
+	})
+	replayedUser := decodeResponse[scim.User](t, replayed)
+	if replayed.Code != http.StatusCreated || replayedUser.ID != recovered.ID || replayedUser.Meta.Version != recovered.Meta.Version {
+		t.Fatalf("replayed recovered create = %d %#v, want id=%q version=%q", replayed.Code, replayedUser, recovered.ID, recovered.Meta.Version)
+	}
+	if response, err := scim.WrapAuthorization(authorization, services.Users, restarted).CheckAccess(context.Background(), request); err != nil || !response.Allowed {
+		t.Fatalf("recovered access = %#v, %v", response, err)
+	}
+	if relationship := authorization.relationshipForUser(coreUser.ID); relationship == nil || relationship.GetSourceLayer() != proto.SourceLayer_SOURCE_LAYER_RUNTIME || relationship.GetProperties().AsMap()["managedBy"] != "scim" {
+		t.Fatalf("projected relationship = %#v", relationship)
+	}
+}
+
+func TestSCIMPatchRetryReturnsRecoveredResult(t *testing.T) {
+	t.Parallel()
+
+	for _, testCase := range []struct {
+		name        string
+		withIfMatch bool
+	}{
+		{name: "without If-Match"},
+		{name: "with stale If-Match", withIfMatch: true},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			db := &coretesting.StubIndexedDB{}
+			authorization := newRecordingAuthorization()
+			cfg := testSCIMConfig(map[string]config.SCIMClientConfig{
+				"rippling": ripplingClient([]string{"valon.com"}, employeeProjection()),
+			})
+			service, services, handler := newSCIMService(t, db, authorization, cfg)
+			user, created := createUser(t, handler, testCurrentToken, "alice@valon.com", true, nil)
+			if created.Code != http.StatusCreated {
+				t.Fatalf("create = %d %s", created.Code, created.Body.String())
+			}
+
+			authorization.setFailures(false, true)
+			patch := map[string]any{"schemas": []string{scim.PatchSchemaURN}, "Operations": []map[string]any{
+				{"op": "add", "path": "emails", "value": map[string]any{"value": "alias@valon.com", "type": "other"}},
+				{"op": "replace", "path": "active", "value": false},
+			}}
+			headers := map[string]string{}
+			if testCase.withIfMatch {
+				headers["If-Match"] = user.Meta.Version
+			}
+			failed := scimRequest(t, handler, http.MethodPatch, "/scim/v2/Users/"+user.ID, testCurrentToken, patch, headers)
+			if failed.Code != http.StatusServiceUnavailable || failed.Header().Get("Retry-After") != "1" {
+				t.Fatalf("failed PATCH = %d %s headers=%v", failed.Code, failed.Body.String(), failed.Header())
+			}
+			coreUser, err := services.Users.FindUserByEmail(context.Background(), "alice@valon.com")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if access, err := scim.WrapAuthorization(authorization, services.Users, service).CheckAccess(context.Background(), accessRequest(coreUser.ID)); err != nil || access.Allowed {
+				t.Fatalf("pending deactivation access = %#v, %v", access, err)
+			}
+
+			authorization.setFailures(false, false)
+			restarted, _, restartedHandler := newSCIMService(t, db, authorization, cfg)
+			ctx, cancel := context.WithCancel(context.Background())
+			t.Cleanup(cancel)
+			restarted.Start(ctx)
+			eventually(t, func() bool {
+				response := scimRequest(t, restartedHandler, http.MethodGet, "/scim/v2/Users/"+user.ID, testCurrentToken, nil)
+				return response.Code == http.StatusOK && decodeResponse[scim.User](t, response).Meta.Version == `W/"2"`
+			})
+
+			replayed := scimRequest(t, restartedHandler, http.MethodPatch, "/scim/v2/Users/"+user.ID, testCurrentToken, patch, headers)
+			replayedUser := decodeResponse[scim.User](t, replayed)
+			if replayed.Code != http.StatusOK || replayedUser.Meta.Version != `W/"2"` || len(replayedUser.Emails) != 1 || replayedUser.Emails[0].Value != "alias@valon.com" {
+				t.Fatalf("replayed recovered PATCH = %d %#v", replayed.Code, replayedUser)
+			}
+		})
+	}
+}
+
+func TestSCIMEligibilityAllowsSafePendingUpdate(t *testing.T) {
+	t.Parallel()
+
+	authorization := newRecordingAuthorization()
+	cfg := testSCIMConfig(map[string]config.SCIMClientConfig{
+		"rippling": ripplingClient([]string{"valon.com"}, employeeProjection()),
+	})
+	service, services, handler := newSCIMService(t, nil, authorization, cfg)
+	user, created := createUser(t, handler, testCurrentToken, "alice@valon.com", true, nil)
+	if created.Code != http.StatusCreated {
+		t.Fatalf("create = %d %s", created.Code, created.Body.String())
+	}
+	coreUser, err := services.Users.FindUserByEmail(context.Background(), "alice@valon.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	projected := authorization.relationshipForUser(coreUser.ID)
+	if projected == nil {
+		t.Fatal("active user has no projected relationship")
+	}
+	authorization.removeRelationship(projected.GetTuple())
+	authorization.setFailures(true, false)
+	patch := map[string]any{"schemas": []string{scim.PatchSchemaURN}, "Operations": []map[string]any{{"op": "replace", "path": "displayName", "value": "Alice Updated"}}}
+	failed := scimRequest(t, handler, http.MethodPatch, "/scim/v2/Users/"+user.ID, testCurrentToken, patch)
+	if failed.Code != http.StatusServiceUnavailable || failed.Header().Get("Retry-After") != "1" {
+		t.Fatalf("failed safe update = %d %s headers=%v", failed.Code, failed.Body.String(), failed.Header())
+	}
+	if access, err := scim.WrapAuthorization(authorization, services.Users, service).CheckAccess(context.Background(), accessRequest(coreUser.ID)); err != nil || !access.Allowed {
+		t.Fatalf("safe pending update access = %#v, %v", access, err)
+	}
+}
+
+func TestSCIMOmittedActiveIsFailClosed(t *testing.T) {
+	t.Parallel()
+
+	authorization := newRecordingAuthorization()
+	cfg := testSCIMConfig(map[string]config.SCIMClientConfig{
+		"rippling": ripplingClient([]string{"valon.com"}, employeeProjection()),
+	})
+	service, services, handler := newSCIMService(t, nil, authorization, cfg)
+	response := scimRequest(t, handler, http.MethodPost, "/scim/v2/Users", testCurrentToken, map[string]any{
+		"schemas": []string{scim.UserSchemaURN}, "userName": "inactive@valon.com",
+	})
+	user := decodeResponse[scim.User](t, response)
+	if response.Code != http.StatusCreated || user.Active {
+		t.Fatalf("create without active = %d %#v", response.Code, user)
+	}
+	coreUser, err := services.Users.FindUserByEmail(context.Background(), "inactive@valon.com")
+	if err != nil {
+		t.Fatalf("FindUserByEmail: %v", err)
+	}
+	if authorization.additionCount() != 0 {
+		t.Fatalf("inactive projection additions = %d", authorization.additionCount())
+	}
+	if access, err := scim.WrapAuthorization(authorization, services.Users, service).CheckAccess(context.Background(), accessRequest(coreUser.ID)); err != nil || access.Allowed {
+		t.Fatalf("omitted-active access = %#v, %v", access, err)
+	}
+}
+
+func TestSCIMEligibilityIgnoresAnotherClientPendingIntent(t *testing.T) {
+	t.Parallel()
+
+	authorization := newRecordingAuthorization()
+	cfg := testSCIMConfig(map[string]config.SCIMClientConfig{
+		"rippling": ripplingClient([]string{"valon.com"}),
+		"entra": {
+			Credentials:             []config.SCIMCredentialConfig{{ID: "current", BearerToken: "entra-token"}},
+			ActiveUserRelationships: []config.SCIMRelationshipConfig{employeeProjection()},
+		},
+	})
+	service, services, handler := newSCIMService(t, nil, authorization, cfg)
+	if _, response := createUser(t, handler, testCurrentToken, "alice@valon.com", true, nil); response.Code != http.StatusCreated {
+		t.Fatalf("authoritative create = %d %s", response.Code, response.Body.String())
+	}
+	authorization.setFailures(true, false)
+	if _, response := createUser(t, handler, "entra-token", "alice@valon.com", true, nil); response.Code != http.StatusServiceUnavailable {
+		t.Fatalf("non-authoritative pending create = %d %s", response.Code, response.Body.String())
+	}
+	coreUser, err := services.Users.FindUserByEmail(context.Background(), "alice@valon.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if response, err := scim.WrapAuthorization(authorization, services.Users, service).CheckAccess(context.Background(), accessRequest(coreUser.ID)); err != nil || !response.Allowed {
+		t.Fatalf("authoritative access with unrelated intent = %#v, %v", response, err)
+	}
+}
+
+func TestSCIMAuthoritativeOwnershipSurvivesEmailDomainChange(t *testing.T) {
+	t.Parallel()
+
+	authorization := newRecordingAuthorization()
+	cfg := testSCIMConfig(map[string]config.SCIMClientConfig{
+		"rippling": ripplingClient([]string{"valon.com"}),
+	})
+	service, services, handler := newSCIMService(t, nil, authorization, cfg)
+	user, response := createUser(t, handler, testCurrentToken, "alice@valon.com", true, nil)
+	if response.Code != http.StatusCreated {
+		t.Fatalf("create = %d %s", response.Code, response.Body.String())
+	}
+	changeEmail := map[string]any{"schemas": []string{scim.PatchSchemaURN}, "Operations": []map[string]any{{"op": "replace", "path": "userName", "value": "alice@example.com"}}}
+	if response := scimRequest(t, handler, http.MethodPatch, "/scim/v2/Users/"+user.ID, testCurrentToken, changeEmail); response.Code != http.StatusOK {
+		t.Fatalf("email change = %d %s", response.Code, response.Body.String())
+	}
+	coreUser, err := services.Users.FindUserByEmail(context.Background(), "alice@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	gate := scim.WrapAuthorization(authorization, services.Users, service)
+	if response, err := gate.CheckAccess(context.Background(), accessRequest(coreUser.ID)); err != nil || !response.Allowed {
+		t.Fatalf("active changed-domain access = %#v, %v", response, err)
+	}
+	deactivate := map[string]any{"schemas": []string{scim.PatchSchemaURN}, "Operations": []map[string]any{{"op": "replace", "path": "active", "value": false}}}
+	if response := scimRequest(t, handler, http.MethodPatch, "/scim/v2/Users/"+user.ID, testCurrentToken, deactivate); response.Code != http.StatusOK {
+		t.Fatalf("deactivate = %d %s", response.Code, response.Body.String())
+	}
+	if response, err := gate.CheckAccess(context.Background(), accessRequest(coreUser.ID)); err != nil || response.Allowed {
+		t.Fatalf("inactive changed-domain access = %#v, %v", response, err)
+	}
+}
+
+func TestSCIMProjectionDriftConvergesThroughBackgroundController(t *testing.T) {
+	t.Parallel()
+
+	db := &coretesting.StubIndexedDB{}
+	authorization := newRecordingAuthorization()
+	initialCfg := testSCIMConfig(map[string]config.SCIMClientConfig{"rippling": ripplingClient(nil)})
+	_, services, initialHandler := newSCIMService(t, db, authorization, initialCfg)
+	user, response := createUser(t, initialHandler, testCurrentToken, "alice@valon.com", true, nil)
+	if response.Code != http.StatusCreated {
+		t.Fatalf("initial sync = %d %s", response.Code, response.Body.String())
+	}
+	coreUser, err := services.Users.FindUserByEmail(context.Background(), "alice@valon.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	staticRelationship := projectedRelationship(coreUser.ID, proto.SourceLayer_SOURCE_LAYER_STATIC_CONFIG)
+	authorization.setRelationship(staticRelationship)
+
+	retryTicks := make(chan time.Time, 1)
+	driftTicks := make(chan time.Time, 2)
+	projectedCfg := testSCIMConfig(map[string]config.SCIMClientConfig{"rippling": ripplingClient(nil, employeeProjection())})
+	projectedCfg.DriftInterval = "1h"
+	service, _, handler := newSCIMService(t, db, authorization, projectedCfg, scim.ServiceOptions{NewTicker: func(interval time.Duration) (<-chan time.Time, func()) {
+		if interval == 5*time.Millisecond {
+			return retryTicks, func() {}
+		}
+		return driftTicks, func() {}
+	}})
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	service.Start(ctx)
+	eventually(t, func() bool { return authorization.listCallCount() > 0 })
+	if authorization.additionCount() != 0 {
+		t.Fatalf("SCIM replaced static relationship with %d additions", authorization.additionCount())
+	}
+	get := scimRequest(t, handler, http.MethodGet, "/scim/v2/Users/"+user.ID, testCurrentToken, nil)
+	if stored := decodeResponse[scim.User](t, get); stored.Meta.Version != `W/"1"` {
+		t.Fatalf("drift changed SCIM version: %#v", stored.Meta)
+	}
+
+	authorization.removeRelationship(staticRelationship.GetTuple())
+	driftTicks <- time.Now()
+	eventually(t, func() bool { return authorization.additionCount() == 1 })
+	deactivate := map[string]any{"schemas": []string{scim.PatchSchemaURN}, "Operations": []map[string]any{{"op": "replace", "path": "active", "value": false}}}
+	if response := scimRequest(t, handler, http.MethodPatch, "/scim/v2/Users/"+user.ID, testCurrentToken, deactivate); response.Code != http.StatusOK {
+		t.Fatalf("deactivate = %d %s", response.Code, response.Body.String())
+	}
+	if authorization.deletionCount() != 1 {
+		t.Fatalf("owned projection deletions = %d", authorization.deletionCount())
+	}
+}
+
+func TestSCIMRetryTicksDoNotRunFullDriftScan(t *testing.T) {
+	t.Parallel()
+
+	authorization := newRecordingAuthorization()
+	cfg := testSCIMConfig(map[string]config.SCIMClientConfig{"rippling": ripplingClient(nil, employeeProjection())})
+	retryTicks := make(chan time.Time, 2)
+	driftTicks := make(chan time.Time, 2)
+	service, _, handler := newSCIMService(t, nil, authorization, cfg, scim.ServiceOptions{NewTicker: func(interval time.Duration) (<-chan time.Time, func()) {
+		if interval == 5*time.Millisecond {
+			return retryTicks, func() {}
+		}
+		return driftTicks, func() {}
+	}})
+	if _, response := createUser(t, handler, testCurrentToken, "alice@valon.com", true, nil); response.Code != http.StatusCreated {
+		t.Fatalf("create = %d %s", response.Code, response.Body.String())
+	}
+	baseline := authorization.listCallCount()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	service.Start(ctx)
+	eventually(t, func() bool { return authorization.listCallCount() == baseline+1 })
+	retryTicks <- time.Now()
+	driftTicks <- time.Now()
+	eventually(t, func() bool { return authorization.listCallCount() >= baseline+2 })
+	if got := authorization.listCallCount(); got != baseline+2 {
+		t.Fatalf("relationship scans after retry and drift ticks = %d, want %d", got, baseline+2)
+	}
+}
+
+func TestSCIMCrossReplicaConditionalMutation(t *testing.T) {
+	t.Parallel()
+
+	db := &coretesting.StubIndexedDB{}
+	cfg := testSCIMConfig(map[string]config.SCIMClientConfig{"rippling": ripplingClient(nil)})
+	_, _, firstHandler := newSCIMService(t, db, nil, cfg)
+	_, _, secondHandler := newSCIMService(t, db, nil, cfg)
+	user, response := createUser(t, firstHandler, testCurrentToken, "alice@valon.com", true, nil)
+	if response.Code != http.StatusCreated {
+		t.Fatalf("create = %d %s", response.Code, response.Body.String())
+	}
+
+	start := make(chan struct{})
+	statuses := make(chan *httptest.ResponseRecorder, 2)
+	for i, handler := range []http.Handler{firstHandler, secondHandler} {
+		go func(worker int, handler http.Handler) {
+			<-start
+			patch := map[string]any{"schemas": []string{scim.PatchSchemaURN}, "Operations": []map[string]any{{"op": "replace", "path": "displayName", "value": fmt.Sprintf("worker-%d", worker)}}}
+			statuses <- scimRequest(t, handler, http.MethodPatch, "/scim/v2/Users/"+user.ID, testCurrentToken, patch, map[string]string{"If-Match": user.Meta.Version})
+		}(i, handler)
+	}
+	close(start)
+	responses := []*httptest.ResponseRecorder{<-statuses, <-statuses}
+	successes := 0
+	for _, mutation := range responses {
+		switch mutation.Code {
+		case http.StatusOK:
+			successes++
+		case http.StatusPreconditionFailed:
+		case http.StatusServiceUnavailable:
+			if mutation.Header().Get("Retry-After") != "1" {
+				t.Fatalf("503 missing Retry-After: %v", mutation.Header())
+			}
+		case http.StatusConflict:
+			t.Fatalf("replica contention was misreported as uniqueness conflict: %s", mutation.Body.String())
+		default:
+			t.Fatalf("unexpected mutation status %d: %s", mutation.Code, mutation.Body.String())
+		}
+	}
+	if successes != 1 {
+		t.Fatalf("successful concurrent mutations = %d, responses=%d/%d", successes, responses[0].Code, responses[1].Code)
+	}
+	committed := decodeResponse[scim.User](t, scimRequest(t, firstHandler, http.MethodGet, "/scim/v2/Users/"+user.ID, testCurrentToken, nil))
+	if committed.Meta.Version != `W/"2"` {
+		t.Fatalf("committed version = %q", committed.Meta.Version)
+	}
+}
+
+func TestSCIMIntentCollisionReturnsRetryableUnavailable(t *testing.T) {
+	t.Parallel()
+
+	db := &transactionFaultDB{IndexedDB: &coretesting.StubIndexedDB{}}
+	cfg := testSCIMConfig(map[string]config.SCIMClientConfig{"rippling": ripplingClient(nil)})
+	_, _, handler := newSCIMService(t, db, nil, cfg)
+	user, response := createUser(t, handler, testCurrentToken, "alice@valon.com", true, nil)
+	if response.Code != http.StatusCreated {
+		t.Fatalf("create = %d %s", response.Code, response.Body.String())
+	}
+	db.arm(transactionFaultIntentAdd)
+	patch := map[string]any{"schemas": []string{scim.PatchSchemaURN}, "Operations": []map[string]any{{"op": "replace", "path": "displayName", "value": "Alice Updated"}}}
+	response = scimRequest(t, handler, http.MethodPatch, "/scim/v2/Users/"+user.ID, testCurrentToken, patch)
+	if response.Code != http.StatusServiceUnavailable || response.Header().Get("Retry-After") != "1" {
+		t.Fatalf("intent collision = %d %s headers=%v", response.Code, response.Body.String(), response.Header())
+	}
+}
+
+func TestSCIMMutationCurrentUserReadFailureReturnsRetryableUnavailable(t *testing.T) {
+	t.Parallel()
+
+	db := &transactionFaultDB{IndexedDB: &coretesting.StubIndexedDB{}}
+	cfg := testSCIMConfig(map[string]config.SCIMClientConfig{"rippling": ripplingClient(nil)})
+	_, _, handler := newSCIMService(t, db, nil, cfg)
+	user, response := createUser(t, handler, testCurrentToken, "alice@valon.com", true, nil)
+	if response.Code != http.StatusCreated {
+		t.Fatalf("create = %d %s", response.Code, response.Body.String())
+	}
+	db.arm(transactionFaultSCIMUserGet)
+	patch := map[string]any{"schemas": []string{scim.PatchSchemaURN}, "Operations": []map[string]any{{"op": "replace", "path": "displayName", "value": "Alice Updated"}}}
+	response = scimRequest(t, handler, http.MethodPatch, "/scim/v2/Users/"+user.ID, testCurrentToken, patch)
+	if response.Code != http.StatusServiceUnavailable || response.Header().Get("Retry-After") != "1" {
+		t.Fatalf("datastore failure = %d %s headers=%v", response.Code, response.Body.String(), response.Header())
+	}
+}
+
+func TestSCIMCreateUserLinkRaceReturnsRetryableUnavailable(t *testing.T) {
+	t.Parallel()
+
+	db := &transactionFaultDB{IndexedDB: &coretesting.StubIndexedDB{}}
+	cfg := testSCIMConfig(map[string]config.SCIMClientConfig{"rippling": ripplingClient(nil)})
+	_, services, handler := newSCIMService(t, db, nil, cfg)
+	db.arm(transactionFaultCoreUserAdd)
+	_, response := createUser(t, handler, testCurrentToken, "alice@valon.com", true, nil)
+	if response.Code != http.StatusServiceUnavailable || response.Header().Get("Retry-After") != "1" {
+		t.Fatalf("user link race = %d %s headers=%v", response.Code, response.Body.String(), response.Header())
+	}
+	if _, err := services.Users.FindOrCreateUser(context.Background(), "alice@valon.com"); err != nil {
+		t.Fatalf("create concurrent Gestalt user: %v", err)
+	}
+	_, response = createUser(t, handler, testCurrentToken, "alice@valon.com", true, nil)
+	if response.Code != http.StatusCreated {
+		t.Fatalf("retry create = %d %s", response.Code, response.Body.String())
+	}
+}
+
+func TestSCIMAuthorizationBoundary(t *testing.T) {
+	t.Parallel()
+
+	db := &coretesting.StubIndexedDB{}
+	authorization := newRecordingAuthorization()
+	cfg := testSCIMConfig(map[string]config.SCIMClientConfig{
+		"rippling": ripplingClient([]string{"valon.com"}, employeeProjection()),
+	})
+	service, services, handler := newSCIMService(t, db, authorization, cfg)
+	if _, response := createUser(t, handler, testCurrentToken, "active@valon.com", true, nil); response.Code != http.StatusCreated {
+		t.Fatalf("active create = %d %s", response.Code, response.Body.String())
+	}
+	if _, response := createUser(t, handler, testCurrentToken, "inactive@valon.com", false, nil); response.Code != http.StatusCreated {
+		t.Fatalf("inactive create = %d %s", response.Code, response.Body.String())
+	}
+	active, _ := services.Users.FindUserByEmail(context.Background(), "active@valon.com")
+	inactive, _ := services.Users.FindUserByEmail(context.Background(), "inactive@valon.com")
+	missing, _ := services.Users.FindOrCreateUser(context.Background(), "missing@valon.com")
+	exempt, _ := services.Users.FindOrCreateUser(context.Background(), "person@example.com")
+	requests := []*proto.CheckAccessRequest{
+		accessRequest(active.ID),
+		accessRequest(inactive.ID),
+		accessRequest(missing.ID),
+		accessRequest(exempt.ID),
+		{Subject: &proto.Subject{Type: "subject", Id: "service-account:sync"}, Action: &proto.Action{Name: "read"}, Resource: &proto.Resource{Type: "app", Id: "docs"}},
+	}
+	gate := scim.WrapAuthorization(authorization, services.Users, service)
+	want := []bool{true, false, false, true, true}
+	for i, request := range requests {
+		response, err := gate.CheckAccess(context.Background(), request)
+		if err != nil || response.Allowed != want[i] {
+			t.Fatalf("CheckAccess[%d] = %#v, %v, want %v", i, response, err, want[i])
+		}
+	}
+	batch, err := gate.CheckAccessMany(context.Background(), &proto.CheckAccessManyRequest{Requests: requests})
+	if err != nil || len(batch.Decisions) != len(want) {
+		t.Fatalf("CheckAccessMany = %#v, %v", batch, err)
+	}
+	for i, decision := range batch.Decisions {
+		if decision.Allowed != want[i] {
+			t.Fatalf("CheckAccessMany[%d] = %v, want %v", i, decision.Allowed, want[i])
+		}
+	}
+
+	db.Err = errors.New("datastore unavailable")
+	if response, err := gate.CheckAccess(context.Background(), accessRequest(active.ID)); err != nil || response.Allowed {
+		t.Fatalf("datastore failure did not fail closed: %#v, %v", response, err)
+	}
+	db.Err = nil
+	managed := projectedRelationship(active.ID, proto.SourceLayer_SOURCE_LAYER_RUNTIME)
+	if _, err := gate.AddRelationship(context.Background(), &proto.AddRelationshipRequest{Relationship: managed}); err == nil {
+		t.Fatal("ordinary add to SCIM-managed relationship succeeded")
+	}
+	if _, err := gate.DeleteRelationship(context.Background(), &proto.DeleteRelationshipRequest{RelationshipTuple: managed.Tuple}); err == nil {
+		t.Fatal("ordinary delete from SCIM-managed relationship succeeded")
+	}
+}
+
+func TestSCIMAuthorizationGateAppliesAtInvocationBroker(t *testing.T) {
+	t.Parallel()
+
+	authorization := newRecordingAuthorization()
+	cfg := testSCIMConfig(map[string]config.SCIMClientConfig{
+		"rippling": ripplingClient([]string{"valon.com"}),
+	})
+	service, services, handler := newSCIMService(t, nil, authorization, cfg)
+	user, response := createUser(t, handler, testCurrentToken, "alice@valon.com", true, nil)
+	if response.Code != http.StatusCreated {
+		t.Fatalf("create = %d %s", response.Code, response.Body.String())
+	}
+	coreUser, err := services.Users.FindUserByEmail(context.Background(), "alice@valon.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var executeCalls int
+	provider := &coretesting.StubIntegration{
+		N:        "docs",
+		ConnMode: core.ConnectionModeNone,
+		CatalogVal: &catalog.Catalog{Operations: []catalog.CatalogOperation{{
+			ID: "documents.read", Method: http.MethodGet,
+		}}},
+		ExecuteFn: func(context.Context, string, map[string]any, string) (*core.OperationResult, error) {
+			executeCalls++
+			return &core.OperationResult{Status: http.StatusOK}, nil
+		},
+	}
+	broker := invocation.NewBroker(
+		testutil.NewProviderRegistry(t, provider),
+		services.Users,
+		services.ExternalCredentials,
+		invocation.WithAuthorizationProvider(scim.WrapAuthorization(authorization, services.Users, service)),
+		invocation.WithProviderKinds(map[string]invocation.ProviderKind{"docs": invocation.ProviderKindApp}),
+	)
+	identity := &principal.Principal{
+		SubjectID: principal.UserSubjectID(coreUser.ID),
+		UserID:    coreUser.ID,
+		Kind:      principal.KindUser,
+	}
+	if _, err := broker.Invoke(context.Background(), identity, "docs", "", "documents.read", nil); err != nil {
+		t.Fatalf("active Invoke: %v", err)
+	}
+	deactivate := map[string]any{"schemas": []string{scim.PatchSchemaURN}, "Operations": []map[string]any{{"op": "replace", "path": "active", "value": false}}}
+	if response := scimRequest(t, handler, http.MethodPatch, "/scim/v2/Users/"+user.ID, testCurrentToken, deactivate); response.Code != http.StatusOK {
+		t.Fatalf("deactivate = %d %s", response.Code, response.Body.String())
+	}
+	if _, err := broker.Invoke(context.Background(), identity, "docs", "", "documents.read", nil); !errors.Is(err, invocation.ErrAuthorizationDenied) {
+		t.Fatalf("inactive Invoke error = %v, want ErrAuthorizationDenied", err)
+	}
+	if executeCalls != 1 {
+		t.Fatalf("provider execute calls = %d, want 1", executeCalls)
+	}
+}
+
+func accessRequest(coreUserID string) *proto.CheckAccessRequest {
+	return &proto.CheckAccessRequest{
+		Subject:  &proto.Subject{Type: "subject", Id: "user:" + coreUserID},
+		Action:   &proto.Action{Name: "read"},
+		Resource: &proto.Resource{Type: "app", Id: "docs"},
+	}
+}
+
+type recordingAuthorization struct {
+	mu          sync.Mutex
+	failAdd     bool
+	failDelete  bool
+	listCalls   int
+	additions   int
+	deletions   int
+	relations   map[string]*proto.Relationship
+	checkCalled int
+}
+
+func newRecordingAuthorization() *recordingAuthorization {
+	return &recordingAuthorization{relations: make(map[string]*proto.Relationship)}
+}
+
+func (a *recordingAuthorization) CheckAccess(context.Context, *proto.CheckAccessRequest) (*proto.CheckAccessResponse, error) {
+	a.mu.Lock()
+	a.checkCalled++
+	a.mu.Unlock()
+	return &proto.CheckAccessResponse{Allowed: true}, nil
+}
+
+func (a *recordingAuthorization) CheckAccessMany(_ context.Context, req *proto.CheckAccessManyRequest) (*proto.CheckAccessManyResponse, error) {
+	a.mu.Lock()
+	a.checkCalled += len(req.Requests)
+	a.mu.Unlock()
+	response := &proto.CheckAccessManyResponse{}
+	for range req.Requests {
+		response.Decisions = append(response.Decisions, &proto.CheckAccessResponse{Allowed: true})
+	}
+	return response, nil
+}
+
+func (a *recordingAuthorization) ListRelationships(_ context.Context, req *proto.ListRelationshipsRequest) (*proto.ListRelationshipsResponse, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.listCalls++
+	response := &proto.ListRelationshipsResponse{}
+	for _, relationship := range a.relations {
+		if req != nil && req.Filter != nil {
+			if req.Filter.Target != nil && !gproto.Equal(req.Filter.Target, relationship.Tuple.Target) {
+				continue
+			}
+			if req.Filter.Relation != "" && req.Filter.Relation != relationship.Tuple.Relation {
+				continue
+			}
+			if req.Filter.Resource != nil && !gproto.Equal(req.Filter.Resource, relationship.Tuple.Resource) {
+				continue
+			}
+		}
+		response.Relationships = append(response.Relationships, gproto.Clone(relationship).(*proto.Relationship))
+	}
+	return response, nil
+}
+
+func (a *recordingAuthorization) AddRelationship(_ context.Context, req *proto.AddRelationshipRequest) (*proto.AddRelationshipResponse, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.failAdd {
+		return nil, errors.New("injected add failure")
+	}
+	a.additions++
+	a.relations[relationshipKey(req.Relationship.Tuple)] = gproto.Clone(req.Relationship).(*proto.Relationship)
+	return &proto.AddRelationshipResponse{Relationship: req.Relationship}, nil
+}
+
+func (a *recordingAuthorization) DeleteRelationship(_ context.Context, req *proto.DeleteRelationshipRequest) (*proto.DeleteRelationshipResponse, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.failDelete {
+		return nil, errors.New("injected delete failure")
+	}
+	a.deletions++
+	delete(a.relations, relationshipKey(req.RelationshipTuple))
+	return &proto.DeleteRelationshipResponse{}, nil
+}
+
+func (a *recordingAuthorization) SetAuthorizationState(context.Context, *proto.SetAuthorizationStateRequest) (*proto.SetAuthorizationStateResponse, error) {
+	return &proto.SetAuthorizationStateResponse{}, nil
+}
+
+func (a *recordingAuthorization) GetActiveModelRef(context.Context) (*proto.GetActiveModelRefResponse, error) {
+	return &proto.GetActiveModelRefResponse{}, nil
+}
+
+func (a *recordingAuthorization) SetActiveModel(context.Context, *proto.SetActiveModelRequest) (*proto.SetActiveModelResponse, error) {
+	return &proto.SetActiveModelResponse{}, nil
+}
+
+func (a *recordingAuthorization) ListActiveModelResourceTypes(context.Context, *proto.ListActiveModelResourceTypesRequest) (*proto.ListActiveModelResourceTypesResponse, error) {
+	return &proto.ListActiveModelResourceTypesResponse{}, nil
+}
+
+func (a *recordingAuthorization) Ping(context.Context) error { return nil }
+func (a *recordingAuthorization) Close() error               { return nil }
+
+func (a *recordingAuthorization) setFailures(add, delete bool) {
+	a.mu.Lock()
+	a.failAdd = add
+	a.failDelete = delete
+	a.mu.Unlock()
+}
+
+func (a *recordingAuthorization) setRelationship(relationship *proto.Relationship) {
+	a.mu.Lock()
+	a.relations[relationshipKey(relationship.Tuple)] = gproto.Clone(relationship).(*proto.Relationship)
+	a.mu.Unlock()
+}
+
+func (a *recordingAuthorization) removeRelationship(tuple *proto.RelationshipTuple) {
+	a.mu.Lock()
+	delete(a.relations, relationshipKey(tuple))
+	a.mu.Unlock()
+}
+
+func (a *recordingAuthorization) relationshipForUser(coreUserID string) *proto.Relationship {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	for _, relationship := range a.relations {
+		if relationship.GetTuple().GetTarget().GetSubject().GetId() == "user:"+coreUserID {
+			return gproto.Clone(relationship).(*proto.Relationship)
+		}
+	}
+	return nil
+}
+
+func (a *recordingAuthorization) listCallCount() int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.listCalls
+}
+
+func (a *recordingAuthorization) additionCount() int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.additions
+}
+
+func (a *recordingAuthorization) deletionCount() int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.deletions
+}
+
+func projectedRelationship(coreUserID string, source proto.SourceLayer) *proto.Relationship {
+	return &proto.Relationship{
+		Tuple: &proto.RelationshipTuple{
+			Target:   &proto.RelationshipTarget{Kind: &proto.RelationshipTarget_Subject{Subject: &proto.Subject{Type: "subject", Id: "user:" + coreUserID}}},
+			Relation: "member",
+			Resource: &proto.Resource{Type: "group", Id: "valon-employees"},
+		},
+		SourceLayer: source,
+	}
+}
+
+func relationshipKey(tuple *proto.RelationshipTuple) string {
+	subject := tuple.GetTarget().GetSubject()
+	return subject.GetType() + "\x00" + subject.GetId() + "\x00" + tuple.GetRelation() + "\x00" + tuple.GetResource().GetType() + "\x00" + tuple.GetResource().GetId()
+}
+
+var _ core.AuthorizationProvider = (*recordingAuthorization)(nil)
+
+type transactionFault int
+
+const (
+	transactionFaultIntentAdd transactionFault = iota + 1
+	transactionFaultSCIMUserGet
+	transactionFaultCoreUserAdd
+)
+
+type transactionFaultDB struct {
+	coredb.IndexedDB
+	mu      sync.Mutex
+	fault   transactionFault
+	armed   bool
+	tripped bool
+}
+
+func (d *transactionFaultDB) arm(fault transactionFault) {
+	d.mu.Lock()
+	d.fault = fault
+	d.armed = true
+	d.tripped = false
+	d.mu.Unlock()
+}
+
+func (d *transactionFaultDB) trip(fault transactionFault) bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if !d.armed || d.tripped || d.fault != fault {
+		return false
+	}
+	d.tripped = true
+	return true
+}
+
+func (d *transactionFaultDB) Transaction(ctx context.Context, stores []string, mode idb.TransactionMode, opts idb.TransactionOptions) (idb.Transaction, error) {
+	tx, err := d.IndexedDB.Transaction(ctx, stores, mode, opts)
+	if err != nil {
+		return nil, err
+	}
+	return &transactionFaultTransaction{Transaction: tx, db: d}, nil
+}
+
+type transactionFaultTransaction struct {
+	idb.Transaction
+	db *transactionFaultDB
+}
+
+func (t *transactionFaultTransaction) ObjectStore(name string) idb.TransactionObjectStore {
+	return &transactionFaultStore{TransactionObjectStore: t.Transaction.ObjectStore(name), db: t.db, name: name}
+}
+
+type transactionFaultStore struct {
+	idb.TransactionObjectStore
+	db   *transactionFaultDB
+	name string
+}
+
+func (s *transactionFaultStore) Get(ctx context.Context, id string) (idb.Record, error) {
+	if s.name == coredata.StoreSCIMUsers && s.db.trip(transactionFaultSCIMUserGet) {
+		return nil, errors.New("injected datastore failure")
+	}
+	return s.TransactionObjectStore.Get(ctx, id)
+}
+
+func (s *transactionFaultStore) Add(ctx context.Context, record idb.Record) error {
+	switch s.name {
+	case coredata.StoreSCIMProjectionIntents:
+		if s.db.trip(transactionFaultIntentAdd) {
+			return idb.ErrAlreadyExists
+		}
+	case coredata.StoreUsers:
+		if s.db.trip(transactionFaultCoreUserAdd) {
+			return idb.ErrAlreadyExists
+		}
+	}
+	return s.TransactionObjectStore.Add(ctx, record)
+}
+
+var _ coredb.IndexedDB = (*transactionFaultDB)(nil)

--- a/gestaltd/internal/server/routes.go
+++ b/gestaltd/internal/server/routes.go
@@ -36,6 +36,7 @@ func (s *Server) routes() {
 	switch s.routeProfile {
 	case RouteProfilePublic:
 		s.mountCoreRoutes(r, metricsHidden)
+		s.mountSCIMRoutes(r)
 		s.mountMCPRoutes(r)
 		s.mountHTTPBindingRoutes(r)
 		s.mountS3ObjectAccessRoutes(r)
@@ -52,6 +53,7 @@ func (s *Server) routes() {
 		s.mountActivateRoute(r)
 	default:
 		s.mountCoreRoutes(r, metricsAuthenticated)
+		s.mountSCIMRoutes(r)
 		s.mountMCPRoutes(r)
 		s.mountHTTPBindingRoutes(r)
 		s.mountS3ObjectAccessRoutes(r)
@@ -61,6 +63,14 @@ func (s *Server) routes() {
 		s.mountMountedUIRoutes(r)
 		s.mountActivateRoute(r)
 	}
+}
+
+func (s *Server) mountSCIMRoutes(r chi.Router) {
+	if s.scimHandler == nil {
+		return
+	}
+	r.Handle("/scim/v2/*", s.scimHandler)
+	r.Handle("/scim/v2", s.scimHandler)
 }
 
 type metricsExposure int

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -115,6 +115,7 @@ func run(ctx context.Context, cfg *config.Config, result *bootstrap.Result, gest
 		// Dynamic session/MCP operation resolution uses MCPConnection below.
 		CatalogConnection:      httpCatalogConnectionMap(connMaps),
 		MCPConnection:          connMaps.MCPConnection,
+		SCIMHandler:            result.SCIMHandler,
 		ConnectionAuth:         result.ConnectionAuth,
 		ManualConnectionAuth:   result.ManualConnectionAuth,
 		AppDefs:                cfg.Apps,

--- a/gestaltd/internal/server/scim_routes_test.go
+++ b/gestaltd/internal/server/scim_routes_test.go
@@ -1,0 +1,39 @@
+package server_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/internal/server"
+)
+
+func TestSCIMRoutesAreMountedOnPublicListenersOnly(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name    string
+		profile server.RouteProfile
+		want    int
+	}{
+		{name: "combined", profile: server.RouteProfileAll, want: http.StatusNoContent},
+		{name: "public", profile: server.RouteProfilePublic, want: http.StatusNoContent},
+		{name: "management", profile: server.RouteProfileManagement, want: http.StatusNotFound},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			handler := newTestHandler(t, func(cfg *server.Config) {
+				cfg.RouteProfile = test.profile
+				cfg.SCIMHandler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					w.WriteHeader(http.StatusNoContent)
+				})
+			})
+			recorder := httptest.NewRecorder()
+			handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/scim/v2/Schemas", nil))
+			if recorder.Code != test.want {
+				t.Fatalf("status = %d, want %d", recorder.Code, test.want)
+			}
+		})
+	}
+}

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -161,6 +161,7 @@ type Server struct {
 	meterProvider                 metric.MeterProvider
 	prometheusMetrics             http.Handler
 	mcpHandler                    http.Handler
+	scimHandler                   http.Handler
 	hostServiceRelayTokens        *runtimehost.HostServiceRelayTokenManager
 	hostServiceMu                 sync.Mutex
 	hostServiceHandlers           map[uint64]http.Handler
@@ -250,6 +251,7 @@ type Config struct {
 	Readiness                     ReadinessChecker
 	PrometheusMetrics             http.Handler
 	MCPHandler                    http.Handler
+	SCIMHandler                   http.Handler
 	PublicHostServices            *runtimehost.PublicHostServiceRegistry
 	PublicGatewayTransport        *providergateway.ProviderGatewayTransport
 	S3                            map[string]s3sdk.S3
@@ -496,6 +498,7 @@ func New(cfg Config) (*Server, error) {
 		meterProvider:                 cfg.MeterProvider,
 		prometheusMetrics:             cfg.PrometheusMetrics,
 		mcpHandler:                    cfg.MCPHandler,
+		scimHandler:                   cfg.SCIMHandler,
 		hostServiceRelayTokens:        hostServiceRelayTokens,
 		publicHostServices:            cfg.PublicHostServices,
 		s3:                            cfg.S3,


### PR DESCRIPTION
## Summary

Adds a native, Users-only SCIM 2.0 server. Rippling is the first client; the contract also supports Entra and Auth0 outbound provisioning. Auth0 remains the login provider. SCIM controls authorization eligibility and configured relationship projections for authoritative employee domains.

## API

Base URL: `https://<gestalt-base-url>/scim/v2`  
Authentication: `Authorization: Bearer <deployment secret>`  
Media type: `application/scim+json`

| Method | Endpoint | Purpose |
| --- | --- | --- |
| `GET` | `/scim/v2/Schemas` | Core User schema |
| `GET` | `/scim/v2/Users` | List, filter, and paginate users |
| `POST` | `/scim/v2/Users` | Create a user |
| `GET` | `/scim/v2/Users/{id}` | Read a user |
| `PUT` | `/scim/v2/Users/{id}` | Fully replace a user |
| `PATCH` | `/scim/v2/Users/{id}` | Update selected attributes |
| `DELETE` | `/scim/v2/Users/{id}` | Tombstone and deprovision a user |

Implements the relevant parts of [RFC 7643](https://www.rfc-editor.org/rfc/rfc7643) and [RFC 7644](https://www.rfc-editor.org/rfc/rfc7644): bearer authentication, SCIM errors, equality filters, pagination, ETags/`If-Match`, and User lifecycle operations. Groups and other discovery or bulk endpoints are intentionally omitted.

## Rollout

[Toolshed PR #4585](https://github.com/valon-technologies/toolshed/pull/4585) adds the secret container and initial sync-only Rippling configuration. Authorization projection and the authoritative-domain gate are enabled only after roster validation.

## Verification

Contract, projection recovery, authorization-gate, concurrency, and vendor-compatibility tests are included. Go tests, lint, build, and the targeted race suite pass.

## Architecture

```mermaid
flowchart LR
  C["SCIM client<br/>Rippling first<br/>Entra and Auth0 compatible"] -->|"HTTPS + bearer token<br/>/scim/v2"| P["Gestalt public endpoint"]
  B["Employee browser"] -->|"OIDC login"| O["Auth0"]
  O -->|"OIDC callback"| P

  subgraph R["gestaltd replicas (same components in each)"]
    H["SCIM HTTP handler<br/>token selects client namespace"]
    S["SCIM User service"]
    W["retry + drift controller"]
    L["OIDC/session routes"]
    I["shared invocation broker"]
    G["SCIM eligibility wrapper"]
    H --> S
    W --> S
    L --> I
    I --> G
  end

  P --> H
  P --> L

  subgraph D["Shared durable datastore via IndexedDB API<br/>production: one Cloud SQL MySQL primary"]
    U["users<br/>core Gestalt identities"]
    SU["scim_users<br/>committed SCIM resources"]
    PI["scim_projection_intents<br/>durable pending work"]
    AR["authorization relationships<br/>current provider storage"]
  end

  S -->|"transactional core-user linking"| U
  S -->|"commit resource versions"| SU
  S -->|"persist and clear intents"| PI
  W -->|"scan and replay"| PI
  G -->|"read eligibility state"| U
  G -->|"read active committed state"| SU
  G -->|"deny lifecycle-sensitive pending state"| PI

  S -->|"List/Add/Delete relationships<br/>outside datastore transactions"| A["Selected authorization provider<br/>current: IndexedDB<br/>may be remote"]
  G -->|"eligible checks only"| A
  A -->|"current provider uses a separate transaction"| AR
```

Auth0 and SCIM are separate network paths. Every replica reads the same committed users and pending intents. The authorization provider is deliberately outside the datastore transaction, so relationship operations are observed before replay and carry SCIM ownership metadata.

## Example create request and recovery

```mermaid
sequenceDiagram
  participant C as Rippling
  participant P as Gestalt public endpoint
  participant R as gestaltd replica handling request
  participant D as Shared durable datastore
  participant A as Selected authorization provider
  participant W as Reconciler on any gestaltd replica

  C->>P: POST /scim/v2/Users<br/>Bearer token + application/scim+json
  Note over C,P: externalId=employee-123<br/>userName=alice@valon.com<br/>active=true
  P->>R: Route request to one replica
  R->>R: Authenticate token, select client namespace, validate payload
  R->>D: Transaction 1: enforce uniqueness, link core user, insert projection intent
  D-->>R: Commit durable intent
  Note over R,D: All replicas now observe pending lifecycle state and fail closed where required

  R->>A: ListRelationships(exact projected tuple)
  A-->>R: Existing tuple or empty result
  alt Desired tuple is absent
    R->>A: AddRelationship(tuple + SCIM ownership properties)
    A-->>R: Relationship applied
  else Tuple already exists
    Note over R,A: Do not adopt or overwrite existing ownership
  end

  alt Projection converges and final transaction commits
    R->>D: Transaction 2: verify intent/version, put scim_users, delete intent
    D-->>R: Commit SCIM version 1
    R-->>P: 201 Created + Location + ETag W/"1"
    P-->>C: 201 Created
  else Provider call or final commit fails
    Note over R,D: Transaction 1 intent remains durable<br/>Provider failures record retry and backoff when possible
    R-->>P: 503 Service Unavailable + Retry-After: 1
    P-->>C: 503 Service Unavailable
    W->>D: Read due intent from shared state
    W->>A: Re-read tuple and replay only missing work
    W->>D: Transaction 2: verify intent/version, put scim_users, delete intent
    Note over C,W: A client retry resumes or returns the converged operation
  end
```
