### PR TITLE
Stop inferring app access defaults from read-only hints

### DIFF
--- a/gestaltd/internal/server/handlers_app_access.go
+++ b/gestaltd/internal/server/handlers_app_access.go
@@ -231,50 +231,20 @@ func appAccessCapabilityCatalog(prov core.Provider, cat *catalog.Catalog) *catal
 	return cat
 }
 
-func defaultAppAccessOperations(cat *catalog.Catalog) []string {
-	if cat == nil {
-		return nil
-	}
-	readOnly := make([]string, 0, len(cat.Operations))
-	all := make([]string, 0, len(cat.Operations))
-	for i := range cat.Operations {
-		op := &cat.Operations[i]
-		if !catalog.OperationVisibleByDefault(*op) {
-			continue
-		}
-		all = append(all, op.ID)
-		isReadOnly := op.ReadOnly
-		if op.Annotations.ReadOnlyHint != nil {
-			isReadOnly = isReadOnly || *op.Annotations.ReadOnlyHint
-		}
-		if isReadOnly {
-			readOnly = append(readOnly, op.ID)
-		}
-	}
-	// Providers that declare read-only hints get a safe read-first profile.
-	// Older providers without that metadata retain their existing behavior until
-	// they publish capability annotations.
-	if len(readOnly) > 0 {
-		slices.Sort(readOnly)
-		return readOnly
-	}
-	slices.Sort(all)
-	return all
-}
-
 func defaultAppAccessOperationsForProvider(prov core.Provider, cat *catalog.Catalog) []string {
+	operations := catOperations(cat)
 	if provider, ok := prov.(core.AppAccessDefaultsProvider); ok {
-		operations, configured := provider.DefaultAppAccessOperations()
+		defaults, configured := provider.DefaultAppAccessOperations()
 		if configured {
-			valid := make(map[string]struct{}, len(catOperations(cat)))
-			for _, operation := range catOperations(cat) {
+			valid := make(map[string]struct{}, len(operations))
+			for _, operation := range operations {
 				valid[operation] = struct{}{}
 			}
-			filtered, _ := normalizeRequestedAppAccess(operations, valid)
+			filtered, _ := normalizeRequestedAppAccess(defaults, valid)
 			return filtered
 		}
 	}
-	return defaultAppAccessOperations(cat)
+	return operations
 }
 
 func catOperations(cat *catalog.Catalog) []string {
@@ -288,6 +258,7 @@ func catOperations(cat *catalog.Catalog) []string {
 			operations = append(operations, operation.ID)
 		}
 	}
+	slices.Sort(operations)
 	return operations
 }
 

--- a/gestaltd/internal/server/handlers_app_access_test.go
+++ b/gestaltd/internal/server/handlers_app_access_test.go
@@ -34,10 +34,13 @@ func TestAppAccessHandlers(t *testing.T) {
 			t.Fatal("defaultsInitialized = true before a profile was persisted")
 		}
 		if len(body.EnabledOperations) != 2 {
-			t.Fatalf("enabled operations = %#v, want catalog defaults", body.EnabledOperations)
+			t.Fatalf("enabled operations = %#v, want all catalog defaults regardless of read-only hints", body.EnabledOperations)
 		}
 		if got := body.Operations[0].Title; got != "Chat Post Message" {
 			t.Fatalf("fallback operation title = %q, want human-readable title", got)
+		}
+		if !body.Operations[1].ReadOnly {
+			t.Fatal("conversations.list readOnly = false, want read-only hint preserved as metadata")
 		}
 	})
 
@@ -112,23 +115,6 @@ func TestAppAccessHandlers(t *testing.T) {
 			t.Fatalf("status = %d, want %d: %s", response.Code, http.StatusUnauthorized, response.Body.String())
 		}
 	})
-}
-
-func TestDefaultAppAccessOperationsTreatReadOnlyHintsAsMetadata(t *testing.T) {
-	t.Parallel()
-
-	readOnly := true
-	hidden := false
-	cat := &catalog.Catalog{Operations: []catalog.CatalogOperation{
-		{ID: "values.get", Annotations: catalog.CapabilityAnnotations{ReadOnlyHint: &readOnly}},
-		{ID: "values.update"},
-		{ID: "internal.operation", Visible: &hidden},
-	}}
-
-	got := defaultAppAccessOperationsForProvider(nil, cat)
-	if len(got) != 2 || got[0] != "values.get" || got[1] != "values.update" {
-		t.Fatalf("default operations = %#v, want all visible operations", got)
-	}
 }
 
 func TestAppAccessHandlersUseSessionCatalogBeforeInitializingProfile(t *testing.T) {
@@ -275,12 +261,17 @@ func TestEnsureAppAccessDefaultsKeepsEmailSubjectOwner(t *testing.T) {
 func newAppAccessTestFixture(t *testing.T) (*Server, *principal.Principal, *principal.Principal) {
 	t.Helper()
 	services := testutil.NewStubServices(t)
+	readOnly := true
 	provider := &coretesting.StubIntegration{
 		N:        "slack",
 		ConnMode: core.ConnectionModeNone,
 		CatalogVal: &catalog.Catalog{Operations: []catalog.CatalogOperation{
 			{ID: "chat.postMessage", Method: http.MethodPost},
-			{ID: "conversations.list", Method: http.MethodGet},
+			{
+				ID:          "conversations.list",
+				Method:      http.MethodGet,
+				Annotations: catalog.CapabilityAnnotations{ReadOnlyHint: &readOnly},
+			},
 		}},
 	}
 	server := &Server{

--- a/gestaltd/internal/server/handlers_app_access_test.go
+++ b/gestaltd/internal/server/handlers_app_access_test.go
@@ -114,6 +114,23 @@ func TestAppAccessHandlers(t *testing.T) {
 	})
 }
 
+func TestDefaultAppAccessOperationsTreatReadOnlyHintsAsMetadata(t *testing.T) {
+	t.Parallel()
+
+	readOnly := true
+	hidden := false
+	cat := &catalog.Catalog{Operations: []catalog.CatalogOperation{
+		{ID: "values.get", Annotations: catalog.CapabilityAnnotations{ReadOnlyHint: &readOnly}},
+		{ID: "values.update"},
+		{ID: "internal.operation", Visible: &hidden},
+	}}
+
+	got := defaultAppAccessOperationsForProvider(nil, cat)
+	if len(got) != 2 || got[0] != "values.get" || got[1] != "values.update" {
+		t.Fatalf("default operations = %#v, want all visible operations", got)
+	}
+}
+
 func TestAppAccessHandlersUseSessionCatalogBeforeInitializingProfile(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Problem Statement

When an app did not declare explicit default operations, app capability initialization treated `readOnlyHint` metadata as authorization policy. If any operation carried the hint, only hinted operations were persisted to the user profile. Google Sheets marks its three read operations this way, so affected users received only `get`, `values.batchGet`, and `values.get` despite holding the full read/write OAuth scope; logout, login, and reconnect preserved that profile.

## Solution

Default new app capability profiles to every visible catalog operation unless the app explicitly declares `spec.access.defaultOperations`. This removes the read-only inference entirely while preserving explicit app defaults, hidden-operation filtering, user-selected profiles, and broker enforcement. Existing profiles are deliberately not rewritten because stored defaults cannot be distinguished safely from intentional user choices.

### App Operations

- Treat `readOnlyHint` as descriptive metadata rather than an implicit capability restriction.
- Grant all visible operations when no explicit app default is configured.
- Continue validating explicit defaults against the visible operation catalog.
- Keep existing persisted profiles unchanged for targeted repair through the existing access endpoint.

### Workflows

None.