### PR TITLE
Add ingress and client telemetry dimensions (P1 PR 1)

### DIFF
--- a/gestalt/cli/src/api.rs
+++ b/gestalt/cli/src/api.rs
@@ -76,6 +76,7 @@ pub fn fetch_auth_info(base_url: &str) -> Result<AuthInfo> {
     let auth_info_url = format!("{}{}", base_url.trim_end_matches('/'), AUTH_INFO_PATH);
     let client = Client::builder()
         .timeout(std::time::Duration::from_secs(5))
+        .default_headers(http::gestalt_cli_headers())
         .build()
         .context("failed to build HTTP client")?;
     let resp = client
@@ -239,7 +240,7 @@ impl ApiClient {
     }
 
     pub fn new(base_url: &str, token: &str) -> Result<Self> {
-        let mut default_headers = header::HeaderMap::new();
+        let mut default_headers = http::gestalt_cli_headers();
         default_headers.insert(
             header::ACCEPT,
             HeaderValue::from_static(http::APPLICATION_JSON),
@@ -273,6 +274,18 @@ impl ApiClient {
 
     pub fn token(&self) -> &str {
         &self.token
+    }
+
+    pub fn sync_rest_transport(
+        &self,
+        timeout: std::time::Duration,
+    ) -> gestalt_sdk::public::rest_transport::SyncRestTransport {
+        gestalt_sdk::public::rest_transport::SyncRestTransport::new(
+            self.base_url(),
+            std::sync::Arc::new(gestalt_sdk::public::auth::BearerAuth::new(self.token())),
+        )
+        .with_timeout(timeout)
+        .with_gestalt_client_kind(http::GESTALT_CLIENT_KIND_CLI)
     }
 
     pub fn get(&self, path: &str) -> Result<serde_json::Value> {

--- a/gestalt/cli/src/commands/agents/requests.rs
+++ b/gestalt/cli/src/commands/agents/requests.rs
@@ -1,6 +1,5 @@
 use anyhow::{Context, Result, bail};
 use serde_json::{Map, Value, json};
-use std::sync::Arc;
 use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 
 use crate::api::ApiClient;
@@ -19,7 +18,6 @@ use gestalt_sdk::agent::{
     AgentSessionState, AgentTextOutput, AgentToolConfig, AgentToolConfigSource,
 };
 use gestalt_sdk::app::AgentToolRef;
-use gestalt_sdk::public::auth::BearerAuth;
 use gestalt_sdk::public::generated::app_client::AgentClient;
 use gestalt_sdk::public::rest_transport::SyncRestTransport;
 use gestalt_sdk::rpc_support::GestaltError;
@@ -36,8 +34,7 @@ pub(crate) const DEFAULT_SESSION_LIST_LIMIT: usize = 50;
 pub(crate) const INTERRUPT_CANCEL_REASON: &str = "operator interrupted";
 
 fn agent_client(api: &ApiClient) -> Result<AgentClient<SyncRestTransport>> {
-    let transport = SyncRestTransport::new(api.base_url(), Arc::new(BearerAuth::new(api.token())))
-        .with_timeout(std::time::Duration::from_secs(30));
+    let transport = api.sync_rest_transport(std::time::Duration::from_secs(30));
     Ok(AgentClient::new(transport))
 }
 

--- a/gestalt/cli/src/commands/auth.rs
+++ b/gestalt/cli/src/commands/auth.rs
@@ -73,6 +73,7 @@ where
     let client = reqwest::blocking::Client::builder()
         .timeout(std::time::Duration::from_secs(10))
         .cookie_store(true)
+        .default_headers(http::gestalt_cli_headers())
         .build()
         .context("failed to build HTTP client")?;
     let resp = client

--- a/gestalt/cli/src/commands/invoke.rs
+++ b/gestalt/cli/src/commands/invoke.rs
@@ -214,11 +214,7 @@ fn execute(
         param_map = params::merge_params(file_map, param_map);
     }
 
-    let transport = gestalt_sdk::public::rest_transport::SyncRestTransport::new(
-        client.base_url(),
-        std::sync::Arc::new(gestalt_sdk::public::auth::BearerAuth::new(client.token())),
-    )
-    .with_timeout(std::time::Duration::from_secs(60));
+    let transport = client.sync_rest_transport(std::time::Duration::from_secs(60));
     let app_client = gestalt_sdk::public::generated::app_client::AppClient::new(transport);
 
     let headers = params::assemble_headers(options.headers);

--- a/gestalt/cli/src/commands/tokens.rs
+++ b/gestalt/cli/src/commands/tokens.rs
@@ -1,11 +1,9 @@
 use anyhow::{Context, Result};
-use std::sync::Arc;
 
 use crate::api::ApiClient;
 use crate::output::{self, Format};
 
 use gestalt_sdk::identity::{GetGrantRequest, ListGrantsRequest, RevokeGrantRequest, TokenRequest};
-use gestalt_sdk::public::auth::BearerAuth;
 use gestalt_sdk::public::generated::app_client::IdentityClient;
 use gestalt_sdk::public::rest_transport::SyncRestTransport;
 
@@ -14,8 +12,7 @@ const SUBJECT_TOKEN_TYPE_ACCESS_TOKEN: &str = "urn:ietf:params:oauth:token-type:
 const DEFAULT_CLIENT_ID: &str = "gestalt-cli";
 
 fn identity_client(api: &ApiClient) -> Result<IdentityClient<SyncRestTransport>> {
-    let transport = SyncRestTransport::new(api.base_url(), Arc::new(BearerAuth::new(api.token())))
-        .with_timeout(std::time::Duration::from_secs(30));
+    let transport = api.sync_rest_transport(std::time::Duration::from_secs(30));
     Ok(IdentityClient::new(transport))
 }
 

--- a/gestalt/cli/src/http.rs
+++ b/gestalt/cli/src/http.rs
@@ -7,9 +7,19 @@ pub const APPLICATION_X_WWW_FORM_URLENCODED: &str = "application/x-www-form-urle
 pub const TEXT_HTML: &str = "text/html";
 pub const TEXT_PLAIN: &str = "text/plain";
 pub const CACHE_CONTROL_NO_STORE: &str = "no-store";
+pub const GESTALT_CLIENT_KIND_CLI: &str = "cli";
 
 const CONNECTION_CLOSE: &str = "close";
 const UTF_8: &str = "utf-8";
+
+pub fn gestalt_cli_headers() -> header::HeaderMap {
+    let mut headers = header::HeaderMap::new();
+    headers.insert(
+        header::HeaderName::from_static("x-gestalt-client"),
+        header::HeaderValue::from_static(GESTALT_CLIENT_KIND_CLI),
+    );
+    headers
+}
 
 pub fn write_response<W: Write>(
     mut writer: W,

--- a/gestalt/cli/src/main.rs
+++ b/gestalt/cli/src/main.rs
@@ -35,11 +35,7 @@ fn run() -> anyhow::Result<()> {
         },
         Commands::Authorization { command } => {
             let api = ApiClient::from_env(url)?;
-            let transport = gestalt_sdk::public::rest_transport::SyncRestTransport::new(
-                api.base_url(),
-                std::sync::Arc::new(gestalt_sdk::public::auth::BearerAuth::new(api.token())),
-            )
-            .with_timeout(std::time::Duration::from_secs(30));
+            let transport = api.sync_rest_transport(std::time::Duration::from_secs(30));
             let authz =
                 gestalt_sdk::public::generated::app_client::AuthorizationClient::new(transport);
             commands::authorization::dispatch(&authz, command, format)
@@ -49,11 +45,7 @@ fn run() -> anyhow::Result<()> {
         Commands::Describe(args) => dispatch_app_command(AppCommands::Describe(args), url, format),
         Commands::Workflow { command } => {
             let api = ApiClient::from_env(url)?;
-            let transport = gestalt_sdk::public::rest_transport::SyncRestTransport::new(
-                api.base_url(),
-                std::sync::Arc::new(gestalt_sdk::public::auth::BearerAuth::new(api.token())),
-            )
-            .with_timeout(std::time::Duration::from_secs(30));
+            let transport = api.sync_rest_transport(std::time::Duration::from_secs(30));
             let workflow =
                 gestalt_sdk::public::generated::app_client::WorkflowClient::new(transport);
             commands::workflows::dispatch(&api, &workflow, command, format)

--- a/gestaltd/internal/server/ingress_telemetry.go
+++ b/gestaltd/internal/server/ingress_telemetry.go
@@ -1,0 +1,44 @@
+package server
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/services/observability/metricutil"
+)
+
+func clientKindTelemetryMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		metricutil.AddHTTPServerMetricDims(r.Context(), metricutil.HTTPMetricDims{
+			ClientKind: classifyClientKind(r),
+		})
+		next.ServeHTTP(w, r)
+	})
+}
+
+func classifyClientKind(r *http.Request) string {
+	if r.Header.Get(metricutil.HeaderGestaltClient) == metricutil.ClientKindCLI {
+		return metricutil.ClientKindCLI
+	}
+	for name := range r.Header {
+		if strings.HasPrefix(strings.ToLower(name), "sec-fetch-") {
+			return metricutil.ClientKindWeb
+		}
+	}
+	return metricutil.ClientKindUnknown
+}
+
+func ingressKindTelemetryMiddleware(kind string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			metricutil.AddHTTPServerMetricDims(r.Context(), metricutil.HTTPMetricDims{
+				IngressKind: kind,
+			})
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func ingressKindTelemetryHandler(kind string, next http.Handler) http.HandlerFunc {
+	return ingressKindTelemetryMiddleware(kind)(next).ServeHTTP
+}

--- a/gestaltd/internal/server/ingress_telemetry_metrics_test.go
+++ b/gestaltd/internal/server/ingress_telemetry_metrics_test.go
@@ -1,0 +1,218 @@
+package server_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/catalog"
+	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+	"github.com/valon-technologies/gestalt/server/internal/server"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
+	"github.com/valon-technologies/gestalt/server/internal/testutil/metrictest"
+	"github.com/valon-technologies/gestalt/server/services/observability/metricutil"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+func TestIngressTelemetryRequestMetrics(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ready request labels unknown client without ingress kind", func(t *testing.T) {
+		t.Parallel()
+
+		metrics := metrictest.NewManualMeterProvider(t)
+		srv := newTestServer(t, func(cfg *server.Config) {
+			cfg.MeterProvider = metrics.Provider
+		})
+		testutil.CloseOnCleanup(t, srv)
+
+		req, _ := http.NewRequest(http.MethodGet, srv.URL+"/ready", nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("request: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		attrs := map[string]string{
+			"http.route":           "/ready",
+			"gestaltd.client.kind": metricutil.ClientKindUnknown,
+		}
+		rm := collectMetricsUntil(t, metrics, func(rm metricdata.ResourceMetrics) bool {
+			return metrictest.HasFloat64Histogram(rm, "http.server.request.duration", attrs)
+		})
+		metrictest.RequireFloat64Histogram(t, rm, "http.server.request.duration", attrs)
+		metrictest.RequireFloat64HistogramOmitsAttr(t, rm, "http.server.request.duration", attrs, "gestaltd.ingress.kind")
+	})
+
+	t.Run("app invoke v1 labels cli client and ingress kind", func(t *testing.T) {
+		t.Parallel()
+
+		metrics := metrictest.NewManualMeterProvider(t)
+		const providerName = "ingress-metrics"
+		srv := newTestServer(t, func(cfg *server.Config) {
+			cfg.MeterProvider = metrics.Provider
+			cfg.Providers = testutil.NewProviderRegistry(t, &stubIntegrationWithCatalog{
+				StubIntegration: coretesting.StubIntegration{
+					N:        providerName,
+					ConnMode: core.ConnectionModeNone,
+					ExecuteFn: func(_ context.Context, operation string, _ map[string]any, _ string) (*core.OperationResult, error) {
+						return &core.OperationResult{Status: http.StatusOK, Body: []byte(`{"operation":"` + operation + `"}`)}, nil
+					},
+				},
+				catalog: &catalog.Catalog{
+					Name: providerName,
+					Operations: []catalog.CatalogOperation{
+						{ID: "list", Method: http.MethodGet, Path: "/list"},
+					},
+				},
+			})
+		})
+		testutil.CloseOnCleanup(t, srv)
+
+		req, _ := http.NewRequest(http.MethodGet, srv.URL+"/api/v1/"+providerName+"/list", nil)
+		req.Header.Set(metricutil.HeaderGestaltClient, metricutil.ClientKindCLI)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("request: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+		}
+
+		attrs := map[string]string{
+			"http.route":            "/api/v1/{integration}/{operation}",
+			"gestaltd.ingress.kind": metricutil.IngressKindAppInvokeV1,
+			"gestaltd.client.kind":  metricutil.ClientKindCLI,
+		}
+		rm := collectMetricsUntil(t, metrics, func(rm metricdata.ResourceMetrics) bool {
+			return metrictest.HasFloat64Histogram(rm, "http.server.request.duration", attrs)
+		})
+		metrictest.RequireFloat64Histogram(t, rm, "http.server.request.duration", attrs)
+	})
+
+	t.Run("rejected app invoke retains ingress kind", func(t *testing.T) {
+		t.Parallel()
+
+		metrics := metrictest.NewManualMeterProvider(t)
+		srv := newTestServer(t, func(cfg *server.Config) {
+			cfg.MeterProvider = metrics.Provider
+		})
+		testutil.CloseOnCleanup(t, srv)
+
+		req, _ := http.NewRequest(http.MethodGet, srv.URL+"/api/v1/not-a-provider/not-an-operation", nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("request: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode == http.StatusOK {
+			t.Fatal("expected rejected app invocation")
+		}
+
+		attrs := map[string]string{
+			"http.route":            "/api/v1/{integration}/{operation}",
+			"gestaltd.ingress.kind": metricutil.IngressKindAppInvokeV1,
+		}
+		rm := collectMetricsUntil(t, metrics, func(rm metricdata.ResourceMetrics) bool {
+			return metrictest.HasFloat64Histogram(rm, "http.server.request.duration", attrs)
+		})
+		metrictest.RequireFloat64Histogram(t, rm, "http.server.request.duration", attrs)
+	})
+
+	t.Run("catalog route labels cli client without ingress kind", func(t *testing.T) {
+		t.Parallel()
+
+		metrics := metrictest.NewManualMeterProvider(t)
+		srv := newTestServer(t, func(cfg *server.Config) {
+			cfg.MeterProvider = metrics.Provider
+		})
+		testutil.CloseOnCleanup(t, srv)
+
+		req, _ := http.NewRequest(http.MethodGet, srv.URL+"/api/v1/catalog/apps", nil)
+		req.Header.Set(metricutil.HeaderGestaltClient, metricutil.ClientKindCLI)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("request: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+		}
+
+		attrs := map[string]string{
+			"http.route":           "/api/v1/catalog/apps",
+			"gestaltd.client.kind": metricutil.ClientKindCLI,
+		}
+		rm := collectMetricsUntil(t, metrics, func(rm metricdata.ResourceMetrics) bool {
+			return metrictest.HasFloat64Histogram(rm, "http.server.request.duration", attrs)
+		})
+		metrictest.RequireFloat64Histogram(t, rm, "http.server.request.duration", attrs)
+		metrictest.RequireFloat64HistogramOmitsAttr(t, rm, "http.server.request.duration", attrs, "gestaltd.ingress.kind")
+	})
+
+	t.Run("mounted ui labels web client and ingress kind", func(t *testing.T) {
+		t.Parallel()
+
+		metrics := metrictest.NewManualMeterProvider(t)
+		srv := newTestServer(t, func(cfg *server.Config) {
+			cfg.MeterProvider = metrics.Provider
+			cfg.MountedUIs = []server.MountedUI{{
+				Path: "/telemetry-ui",
+				Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					_, _ = w.Write([]byte("ok"))
+				}),
+			}}
+		})
+		testutil.CloseOnCleanup(t, srv)
+
+		req, _ := http.NewRequest(http.MethodGet, srv.URL+"/telemetry-ui/", nil)
+		req.Header.Set("Sec-Fetch-Dest", "document")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("request: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		attrs := map[string]string{
+			"http.route":            "/telemetry-ui/*",
+			"gestaltd.ingress.kind": metricutil.IngressKindMountedUI,
+			"gestaltd.client.kind":  metricutil.ClientKindWeb,
+		}
+		rm := collectMetricsUntil(t, metrics, func(rm metricdata.ResourceMetrics) bool {
+			return metrictest.HasFloat64Histogram(rm, "http.server.request.duration", attrs)
+		})
+		metrictest.RequireFloat64Histogram(t, rm, "http.server.request.duration", attrs)
+	})
+
+	t.Run("public rest labels cli client and ingress kind", func(t *testing.T) {
+		t.Parallel()
+
+		metrics := metrictest.NewManualMeterProvider(t)
+		ts := startPublicRESTServer(t, server.RouteProfilePublic, func(cfg *server.Config) {
+			cfg.MeterProvider = metrics.Provider
+		})
+
+		req, err := http.NewRequest(http.MethodGet, ts.URL+"/api/v2/identity/userinfo", nil)
+		if err != nil {
+			t.Fatalf("NewRequest: %v", err)
+		}
+		req.Header.Set(metricutil.HeaderGestaltClient, metricutil.ClientKindCLI)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("request: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		attrs := map[string]string{
+			"http.route":            "/api/v2/*",
+			"gestaltd.ingress.kind": metricutil.IngressKindPublicREST,
+			"gestaltd.client.kind":  metricutil.ClientKindCLI,
+		}
+		rm := collectMetricsUntil(t, metrics, func(rm metricdata.ResourceMetrics) bool {
+			return metrictest.HasFloat64Histogram(rm, "http.server.request.duration", attrs)
+		})
+		metrictest.RequireFloat64Histogram(t, rm, "http.server.request.duration", attrs)
+	})
+}

--- a/gestaltd/internal/server/ingress_telemetry_test.go
+++ b/gestaltd/internal/server/ingress_telemetry_test.go
@@ -1,0 +1,57 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/services/observability/metricutil"
+)
+
+func TestClassifyClientKind(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		header func(*http.Request)
+		want   string
+	}{
+		{
+			name: "cli header",
+			header: func(r *http.Request) {
+				r.Header.Set(metricutil.HeaderGestaltClient, metricutil.ClientKindCLI)
+			},
+			want: metricutil.ClientKindCLI,
+		},
+		{
+			name: "sec fetch site",
+			header: func(r *http.Request) {
+				r.Header.Set("Sec-Fetch-Site", "same-origin")
+			},
+			want: metricutil.ClientKindWeb,
+		},
+		{
+			name: "any sec fetch header",
+			header: func(r *http.Request) {
+				r.Header.Set("Sec-Fetch-Dest", "document")
+			},
+			want: metricutil.ClientKindWeb,
+		},
+		{
+			name:   "unknown",
+			header: func(*http.Request) {},
+			want:   metricutil.ClientKindUnknown,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			tc.header(req)
+			if got := classifyClientKind(req); got != tc.want {
+				t.Fatalf("classifyClientKind() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/gestaltd/internal/server/routes.go
+++ b/gestaltd/internal/server/routes.go
@@ -24,6 +24,7 @@ func (s *Server) connectMiddleware(next http.Handler) http.Handler {
 
 func (s *Server) routes() {
 	r := s.router
+	r.Use(clientKindTelemetryMiddleware)
 	r.Use(requestMetaMiddleware)
 	r.Use(routePatternTelemetryMiddleware)
 	r.Use(s.securityHeadersMiddleware)
@@ -188,13 +189,13 @@ func (s *Server) mountMountedUIRoutes(r chi.Router) {
 			rootHandler = handler
 			continue
 		}
-		r.Get(path, func(w http.ResponseWriter, r *http.Request) {
+		r.Get(path, ingressKindTelemetryHandler(metricutil.IngressKindMountedUI, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			redirectPreservingQuery(w, r, path+"/", http.StatusMovedPermanently)
-		})
-		r.Handle(path+"/*", handler)
+		})))
+		r.Handle(path+"/*", ingressKindTelemetryHandler(metricutil.IngressKindMountedUI, handler))
 	}
 	if rootHandler != nil {
-		r.NotFound(rootHandler.ServeHTTP)
+		r.NotFound(ingressKindTelemetryHandler(metricutil.IngressKindMountedUI, rootHandler).ServeHTTP)
 	}
 }
 
@@ -257,7 +258,7 @@ func (s *Server) mountPublicRESTRoutes(r chi.Router) {
 			r.MethodNotAllowed(apiMethodNotAllowed)
 			return
 		}
-		r.Handle("/*", s.publicRESTHandler)
+		r.Handle("/*", ingressKindTelemetryHandler(metricutil.IngressKindPublicREST, s.publicRESTHandler))
 		r.NotFound(apiNotFound)
 		r.MethodNotAllowed(apiMethodNotAllowed)
 	})

--- a/gestaltd/internal/server/routes_user.go
+++ b/gestaltd/internal/server/routes_user.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"github.com/go-chi/chi/v5"
+	"github.com/valon-technologies/gestalt/server/services/observability/metricutil"
 )
 
 func (s *Server) mountAuthenticatedRoutes(r chi.Router) {
@@ -35,6 +36,10 @@ func (s *Server) mountAuthenticatedRoutes(r chi.Router) {
 	})
 
 	r.With(s.pluginRouteAuthMiddleware("name")).Get("/apps/{name}/operations", s.listOperations)
-	r.With(s.pluginRouteAuthMiddleware("integration")).Get("/{integration}/{operation}", s.executeOperation)
-	r.With(s.pluginRouteAuthMiddleware("integration")).Post("/{integration}/{operation}", s.executeOperation)
+	r.Group(func(r chi.Router) {
+		r.Use(ingressKindTelemetryMiddleware(metricutil.IngressKindAppInvokeV1))
+		r.Use(s.pluginRouteAuthMiddleware("integration"))
+		r.Get("/{integration}/{operation}", s.executeOperation)
+		r.Post("/{integration}/{operation}", s.executeOperation)
+	})
 }

--- a/gestaltd/services/observability/metricutil/attrs.go
+++ b/gestaltd/services/observability/metricutil/attrs.go
@@ -33,6 +33,8 @@ const (
 	attrGestaltdRPCRole            = attribute.Key("gestaltd.rpc.role")
 	attrGestaltdHostServiceName    = attribute.Key("gestaltd.host_service.name")
 	attrGestaltdIndexedDBIndexName = attribute.Key("gestaltd.idb.index.name")
+	attrGestaltdIngressKind        = attribute.Key("gestaltd.ingress.kind")
+	attrGestaltdClientKind         = attribute.Key("gestaltd.client.kind")
 
 	attrDBSystemName     = attribute.Key("db.system.name")
 	attrDBNamespace      = attribute.Key("db.namespace")
@@ -52,6 +54,16 @@ const (
 	RPCRoleHostServiceServer = "host_service_server"
 
 	DBSystemNameGestaltdIndexedDB = "gestaltd.indexeddb"
+
+	IngressKindMountedUI   = "mounted_ui"
+	IngressKindPublicREST  = "public_rest"
+	IngressKindAppInvokeV1 = "app_invoke_v1"
+
+	ClientKindCLI     = "cli"
+	ClientKindWeb     = "web"
+	ClientKindUnknown = "unknown"
+
+	HeaderGestaltClient = "X-Gestalt-Client"
 )
 
 type TelemetryProviders interface {
@@ -67,6 +79,8 @@ type HTTPMetricDims struct {
 	Surface         string
 	HTTPBindingName string
 	UIName          string
+	IngressKind     string
+	ClientKind      string
 }
 
 type RPCMetricDims struct {
@@ -86,7 +100,7 @@ type DBMetricDims struct {
 }
 
 func HTTPServerAttrs(dims HTTPMetricDims) []attribute.KeyValue {
-	attrs := make([]attribute.KeyValue, 0, 7)
+	attrs := make([]attribute.KeyValue, 0, 9)
 	attrs = appendStringAttr(attrs, attrGestaltdProviderName, dims.ProviderName)
 	attrs = appendStringAttr(attrs, attrGestaltdOperationName, dims.OperationName)
 	attrs = appendStringAttr(attrs, attrGestaltdOperationTransport, dims.Transport)
@@ -94,6 +108,8 @@ func HTTPServerAttrs(dims HTTPMetricDims) []attribute.KeyValue {
 	attrs = appendStringAttr(attrs, attrGestaltdInvocationSurface, dims.Surface)
 	attrs = appendStringAttr(attrs, attrGestaltdHTTPBindingName, dims.HTTPBindingName)
 	attrs = appendStringAttr(attrs, attrGestaltdUIName, dims.UIName)
+	attrs = appendStringAttr(attrs, attrGestaltdIngressKind, dims.IngressKind)
+	attrs = appendStringAttr(attrs, attrGestaltdClientKind, dims.ClientKind)
 	return attrs
 }
 

--- a/gestaltd/services/observability/metricutil/attrs_test.go
+++ b/gestaltd/services/observability/metricutil/attrs_test.go
@@ -1,0 +1,34 @@
+package metricutil_test
+
+import (
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/services/observability/metricutil"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+func TestHTTPServerAttrsIngressAndClientKinds(t *testing.T) {
+	t.Parallel()
+
+	attrs := metricutil.HTTPServerAttrs(metricutil.HTTPMetricDims{
+		IngressKind: metricutil.IngressKindAppInvokeV1,
+		ClientKind:  metricutil.ClientKindCLI,
+	})
+	if len(attrs) != 2 {
+		t.Fatalf("len(attrs) = %d, want 2", len(attrs))
+	}
+	if attrs[0] != attribute.String("gestaltd.ingress.kind", metricutil.IngressKindAppInvokeV1) {
+		t.Fatalf("ingress attr = %+v", attrs[0])
+	}
+	if attrs[1] != attribute.String("gestaltd.client.kind", metricutil.ClientKindCLI) {
+		t.Fatalf("client attr = %+v", attrs[1])
+	}
+}
+
+func TestHTTPServerAttrsOmitsUnsetDimensions(t *testing.T) {
+	t.Parallel()
+
+	if attrs := metricutil.HTTPServerAttrs(metricutil.HTTPMetricDims{}); len(attrs) != 0 {
+		t.Fatalf("expected no attrs for empty dims, got %+v", attrs)
+	}
+}

--- a/sdk/rust/src/public/rest_request.rs
+++ b/sdk/rust/src/public/rest_request.rs
@@ -11,7 +11,7 @@ use base64::engine::general_purpose::STANDARD as BASE64;
 use http::HeaderMap;
 use reqwest::Method as HttpMethod;
 use reqwest::Url;
-use reqwest::header::{ACCEPT, AUTHORIZATION, CONTENT_TYPE, HeaderValue};
+use reqwest::header::{ACCEPT, AUTHORIZATION, CONTENT_TYPE, HeaderName, HeaderValue};
 use serde_json::{Map, Value};
 
 use crate::public::auth::Auth;
@@ -43,6 +43,7 @@ pub(crate) fn build_rest_request(
     request_bytes: &[u8],
     base_url: &str,
     auth: &Arc<dyn Auth>,
+    gestalt_client_kind: Option<&str>,
 ) -> Result<PreparedRequest, GestaltError> {
     let encode = method.encode_request_json.ok_or_else(|| {
         GestaltError::new(
@@ -69,6 +70,14 @@ pub(crate) fn build_rest_request(
         headers.insert(
             AUTHORIZATION,
             HeaderValue::from_str(&authorization).map_err(|err| {
+                GestaltError::new(gestalt_error_code::INVALID_ARGUMENT, err.to_string())
+            })?,
+        );
+    }
+    if let Some(kind) = gestalt_client_kind {
+        headers.insert(
+            HeaderName::from_static("x-gestalt-client"),
+            HeaderValue::from_str(kind).map_err(|err| {
                 GestaltError::new(gestalt_error_code::INVALID_ARGUMENT, err.to_string())
             })?,
         );

--- a/sdk/rust/src/public/rest_transport.rs
+++ b/sdk/rust/src/public/rest_transport.rs
@@ -23,6 +23,7 @@ pub struct RestTransport {
     base_url: String,
     auth: Arc<dyn Auth>,
     client: reqwest::Client,
+    gestalt_client_kind: Option<String>,
 }
 
 impl RestTransport {
@@ -35,7 +36,14 @@ impl RestTransport {
                 .use_rustls_tls()
                 .build()
                 .expect("reqwest client"),
+            gestalt_client_kind: None,
         }
+    }
+
+    /// Sets the `X-Gestalt-Client` header value sent on every request.
+    pub fn with_gestalt_client_kind(mut self, kind: impl Into<String>) -> Self {
+        self.gestalt_client_kind = Some(kind.into());
+        self
     }
 
     /// Applies a per-request timeout to the underlying HTTP client.
@@ -93,6 +101,7 @@ impl UnaryTransport for RestTransport {
         let base_url = self.base_url.clone();
         let auth = Arc::clone(&self.auth);
         let client = self.client.clone();
+        let gestalt_client_kind = self.gestalt_client_kind.clone();
         let request_bytes = request.encode_to_vec();
         let method = method.clone();
 
@@ -103,7 +112,13 @@ impl UnaryTransport for RestTransport {
                     format!("method {} has no REST decoder", method.full_method),
                 )
             })?;
-            let prepared = build_rest_request(&method, &request_bytes, &base_url, &auth)?;
+            let prepared = build_rest_request(
+                &method,
+                &request_bytes,
+                &base_url,
+                &auth,
+                gestalt_client_kind.as_deref(),
+            )?;
             let mut builder = client
                 .request(prepared.method, prepared.url)
                 .headers(prepared.headers);
@@ -125,6 +140,7 @@ pub struct SyncRestTransport {
     base_url: String,
     auth: Arc<dyn Auth>,
     client: reqwest::blocking::Client,
+    gestalt_client_kind: Option<String>,
 }
 
 impl SyncRestTransport {
@@ -137,7 +153,14 @@ impl SyncRestTransport {
                 .use_rustls_tls()
                 .build()
                 .expect("reqwest blocking client"),
+            gestalt_client_kind: None,
         }
+    }
+
+    /// Sets the `X-Gestalt-Client` header value sent on every request.
+    pub fn with_gestalt_client_kind(mut self, kind: impl Into<String>) -> Self {
+        self.gestalt_client_kind = Some(kind.into());
+        self
     }
 
     /// Applies a per-request timeout to the underlying HTTP client.
@@ -168,8 +191,13 @@ impl SyncUnaryTransport for SyncRestTransport {
                 format!("method {} has no REST decoder", method.full_method),
             )
         })?;
-        let prepared =
-            build_rest_request(method, &request.encode_to_vec(), &self.base_url, &self.auth)?;
+        let prepared = build_rest_request(
+            method,
+            &request.encode_to_vec(),
+            &self.base_url,
+            &self.auth,
+            self.gestalt_client_kind.as_deref(),
+        )?;
         let mut builder = self
             .client
             .request(prepared.method, prepared.url)

--- a/sdk/rust/tests/public_transport_client.rs
+++ b/sdk/rust/tests/public_transport_client.rs
@@ -10,7 +10,7 @@ use gestalt::public::generated::app_client::AppClient;
 use gestalt::public::rest_transport::RestTransport;
 use gestalt::rpc_support::gestalt_error_code;
 use serde_json::json;
-use wiremock::matchers::{method, path};
+use wiremock::matchers::{header, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 #[tokio::test]
@@ -53,14 +53,15 @@ async fn rest_transport_invoke_success() {
     });
     Mock::given(method("POST"))
         .and(path("/api/v2/app/example/operations/sync"))
+        .and(header("X-Gestalt-Client", "cli"))
         .respond_with(ResponseTemplate::new(200).set_body_json(body))
         .mount(&server)
         .await;
 
-    let client = AppClient::new(RestTransport::new(
-        server.uri(),
-        Arc::new(BearerAuth::new("test-token")),
-    ));
+    let client = AppClient::new(
+        RestTransport::new(server.uri(), Arc::new(BearerAuth::new("test-token")))
+            .with_gestalt_client_kind("cli"),
+    );
     let result = client
         .invoke(AppInvokeRequest {
             app: "example".to_string(),

--- a/sdk/rust/tests/sync_rest_transport.rs
+++ b/sdk/rust/tests/sync_rest_transport.rs
@@ -12,7 +12,7 @@ use gestalt::public::generated::app_client::AuthorizationClient;
 use gestalt::public::rest_transport::SyncRestTransport;
 use gestalt::rpc_support::gestalt_error_code;
 use serde_json::json;
-use wiremock::matchers::{method, path, query_param};
+use wiremock::matchers::{header, method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 // wiremock::MockServer::start() is async, so we use a one-shot tokio runtime
@@ -23,7 +23,8 @@ fn start_mock_server() -> MockServer {
 }
 
 fn sync_client(server: &MockServer) -> AuthorizationClient<SyncRestTransport> {
-    let transport = SyncRestTransport::new(server.uri(), Arc::new(BearerAuth::new("test-token")));
+    let transport = SyncRestTransport::new(server.uri(), Arc::new(BearerAuth::new("test-token")))
+        .with_gestalt_client_kind("cli");
     AuthorizationClient::new(transport)
 }
 
@@ -34,6 +35,7 @@ fn sync_rest_transport_check_access_success() {
     rt.block_on(async {
         Mock::given(method("POST"))
             .and(path("/api/v2/authorization/access:check"))
+            .and(header("X-Gestalt-Client", "cli"))
             .respond_with(
                 ResponseTemplate::new(200)
                     .set_body_json(json!({"allowed": true, "modelId": "model-1"})),


### PR DESCRIPTION
## Summary
- Add `gestaltd.ingress.kind` (`mounted_ui`, `public_rest`, `app_invoke_v1`) at route mount boundaries and `gestaltd.client.kind` (`cli`, `web`, `unknown`) via global middleware before dispatch.
- Tag app-invoke ingress before auth so rejected invocations still carry the ingress dimension.
- Send `X-Gestalt-Client: cli` from the Gestalt CLI through shared v1 HTTP clients and v2 REST transports (`ApiClient::sync_rest_transport`).
- Add request-to-metric tests for ready, catalog, app invoke, public REST, mounted UI, and auth-rejected app invoke paths.

## Test plan
- [x] `go test ./internal/server/... -run Ingress -count=1`
- [x] `go test ./services/observability/metricutil/... -count=1`
- [x] `cargo test` in `gestalt/cli`
- [x] `cargo test --lib` and sync/async REST transport tests in `sdk/rust`


Made with [Cursor](https://cursor.com)