### PR TITLE
Mount HTTP bindings under host-owned webhook routes

### DIFF
--- a/gestaltd/internal/server/app_registry_step12_test.go
+++ b/gestaltd/internal/server/app_registry_step12_test.go
@@ -47,7 +47,7 @@ func TestRegistryOnlyStaticSurfaceStartsUnavailable(t *testing.T) {
 		t.Fatalf("status = %d, want 503: %s", resp.StatusCode, body)
 	}
 
-	httpResp, err := http.Get(ts.URL + "/api/v1/g-issues/status")
+	httpResp, err := http.Get(ts.URL + "/api/v1/g-issues/webhooks/status")
 	if err != nil {
 		t.Fatalf("GET HTTP binding: %v", err)
 	}

--- a/gestaltd/internal/server/http_binding_streaming_test.go
+++ b/gestaltd/internal/server/http_binding_streaming_test.go
@@ -103,7 +103,7 @@ func TestHTTPBindingStreaming(t *testing.T) {
 			cfg.AppDefs = map[string]*config.ProviderEntry{"streamer": streamingAppEntry(provider)}
 		})
 
-		resp, err := http.Post(ts.URL+"/api/v1/streamer/hooks/echo", "application/json", bytes.NewReader([]byte(`{"message":"hello"}`)))
+		resp, err := http.Post(ts.URL+"/api/v1/streamer/webhooks/hooks/echo", "application/json", bytes.NewReader([]byte(`{"message":"hello"}`)))
 		if err != nil {
 			t.Fatalf("POST: %v", err)
 		}
@@ -160,7 +160,7 @@ func TestHTTPBindingStreaming(t *testing.T) {
 			}
 		})
 
-		resp, err := http.Post(ts.URL+"/api/v1/unary/hooks/ping", "application/json", bytes.NewReader([]byte(`{"message":"hello"}`)))
+		resp, err := http.Post(ts.URL+"/api/v1/unary/webhooks/hooks/ping", "application/json", bytes.NewReader([]byte(`{"message":"hello"}`)))
 		if err != nil {
 			t.Fatalf("POST: %v", err)
 		}
@@ -196,7 +196,7 @@ func TestHTTPBindingStreaming(t *testing.T) {
 		})
 
 		ctx, cancel := context.WithCancel(context.Background())
-		req, err := http.NewRequestWithContext(ctx, http.MethodPost, ts.URL+"/api/v1/streamer/hooks/echo", nil)
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, ts.URL+"/api/v1/streamer/webhooks/hooks/echo", nil)
 		if err != nil {
 			t.Fatalf("NewRequest: %v", err)
 		}
@@ -237,7 +237,7 @@ func TestHTTPBindingStreamingWithGuardedInvoker(t *testing.T) {
 		cfg.Invoker = invocation.NewGuarded(broker, nil, "http", nil, invocation.WithoutRateLimit())
 	})
 
-	resp, err := http.Post(ts.URL+"/api/v1/streamer/hooks/echo", "application/json", bytes.NewReader([]byte(`{"message":"hello"}`)))
+	resp, err := http.Post(ts.URL+"/api/v1/streamer/webhooks/hooks/echo", "application/json", bytes.NewReader([]byte(`{"message":"hello"}`)))
 	if err != nil {
 		t.Fatalf("POST: %v", err)
 	}

--- a/gestaltd/internal/server/http_bindings.go
+++ b/gestaltd/internal/server/http_bindings.go
@@ -107,7 +107,7 @@ func mountedHTTPBindingsFromEntries(entries map[string]*config.ProviderEntry, pr
 			if scheme == nil {
 				return nil, fmt.Errorf("http binding %s.%s references undefined security scheme %q", pluginName, bindingName, securityName)
 			}
-			mounted = append(mounted, MountedHTTPBinding{
+			mountedBinding := MountedHTTPBinding{
 				Name:           bindingName,
 				AppName:        pluginName,
 				Path:           mountedHTTPBindingPath(pluginName, relativePath),
@@ -118,7 +118,13 @@ func mountedHTTPBindingsFromEntries(entries map[string]*config.ProviderEntry, pr
 				RequestBody:    binding.RequestBody,
 				SecurityName:   securityName,
 				Security:       scheme,
-			})
+			}
+			mounted = append(mounted, mountedBinding)
+
+			// Keep the pre-namespace route as a temporary rollback alias while
+			// callers migrate to the host-owned /webhooks namespace.
+			mountedBinding.Path = legacyMountedHTTPBindingPath(pluginName, relativePath)
+			mounted = append(mounted, mountedBinding)
 		}
 	}
 	if err := validateMountedHTTPBindingRoutes(mounted, mountedUIs); err != nil {
@@ -146,6 +152,14 @@ func normalizeHTTPBindingMountedPath(pathValue string) (string, error) {
 }
 
 func mountedHTTPBindingPath(pluginName, relativePath string) string {
+	base := legacyMountedHTTPBindingPath(pluginName, "/") + "/webhooks"
+	if relativePath == "" || relativePath == "/" {
+		return base
+	}
+	return base + relativePath
+}
+
+func legacyMountedHTTPBindingPath(pluginName, relativePath string) string {
 	base := "/api/v1/" + strings.TrimSpace(pluginName)
 	if relativePath == "" || relativePath == "/" {
 		return base

--- a/gestaltd/internal/server/http_bindings.go
+++ b/gestaltd/internal/server/http_bindings.go
@@ -37,6 +37,8 @@ var coreAPIRouteNamespaces = []string{
 	"/api/v1/s3",
 }
 
+const httpBindingRouteNamespace = "/webhooks"
+
 func mountedHTTPBindingsFromEntries(entries map[string]*config.ProviderEntry, providers *registry.ProviderMap[core.Provider], mountedUIs []MountedUI) ([]MountedHTTPBinding, error) {
 	if len(entries) == 0 {
 		return nil, nil
@@ -49,6 +51,7 @@ func mountedHTTPBindingsFromEntries(entries map[string]*config.ProviderEntry, pr
 	slices.Sort(names)
 
 	mounted := make([]MountedHTTPBinding, 0)
+	legacyMounted := make([]MountedHTTPBinding, 0)
 	for _, pluginName := range names {
 		entry := entries[pluginName]
 		if entry == nil {
@@ -101,6 +104,9 @@ func mountedHTTPBindingsFromEntries(entries map[string]*config.ProviderEntry, pr
 				if relativePathConflictsWithGenericOperation(relativePath, target, operationIDs) {
 					return nil, fmt.Errorf("http binding %s.%s path %q conflicts with the generic operation route", pluginName, bindingName, binding.Path)
 				}
+				if relativePathConflictsWithGenericOperation(namespacedHTTPBindingRelativePath(relativePath), target, operationIDs) {
+					return nil, fmt.Errorf("http binding %s.%s namespaced path conflicts with the generic operation route", pluginName, bindingName)
+				}
 			}
 			securityName := strings.TrimSpace(binding.Security)
 			scheme := schemes[securityName]
@@ -124,9 +130,10 @@ func mountedHTTPBindingsFromEntries(entries map[string]*config.ProviderEntry, pr
 			// Keep the pre-namespace route as a temporary rollback alias while
 			// callers migrate to the host-owned /webhooks namespace.
 			mountedBinding.Path = legacyMountedHTTPBindingPath(pluginName, relativePath)
-			mounted = append(mounted, mountedBinding)
+			legacyMounted = append(legacyMounted, mountedBinding)
 		}
 	}
+	mounted = appendNonConflictingLegacyHTTPBindings(mounted, legacyMounted)
 	if err := validateMountedHTTPBindingRoutes(mounted, mountedUIs); err != nil {
 		return nil, err
 	}
@@ -152,11 +159,14 @@ func normalizeHTTPBindingMountedPath(pathValue string) (string, error) {
 }
 
 func mountedHTTPBindingPath(pluginName, relativePath string) string {
-	base := legacyMountedHTTPBindingPath(pluginName, "/") + "/webhooks"
+	return legacyMountedHTTPBindingPath(pluginName, namespacedHTTPBindingRelativePath(relativePath))
+}
+
+func namespacedHTTPBindingRelativePath(relativePath string) string {
 	if relativePath == "" || relativePath == "/" {
-		return base
+		return httpBindingRouteNamespace
 	}
-	return base + relativePath
+	return httpBindingRouteNamespace + relativePath
 }
 
 func legacyMountedHTTPBindingPath(pluginName, relativePath string) string {
@@ -165,6 +175,20 @@ func legacyMountedHTTPBindingPath(pluginName, relativePath string) string {
 		return base
 	}
 	return base + relativePath
+}
+
+func appendNonConflictingLegacyHTTPBindings(canonical, legacy []MountedHTTPBinding) []MountedHTTPBinding {
+	canonicalRoutes := make(map[string]struct{}, len(canonical))
+	for i := range canonical {
+		canonicalRoutes[canonical[i].Method+" "+canonical[i].Path] = struct{}{}
+	}
+	for i := range legacy {
+		if _, exists := canonicalRoutes[legacy[i].Method+" "+legacy[i].Path]; exists {
+			continue
+		}
+		canonical = append(canonical, legacy[i])
+	}
+	return canonical
 }
 
 func relativePathConflictsWithGenericOperation(relativePath, target string, operationIDs map[string]struct{}) bool {

--- a/gestaltd/internal/server/http_bindings_test.go
+++ b/gestaltd/internal/server/http_bindings_test.go
@@ -6,6 +6,33 @@ import (
 	"testing"
 )
 
+func TestMountedHTTPBindingPaths(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		relativePath string
+		canonical    string
+		legacy       string
+	}{
+		{name: "binding path", relativePath: "/event", canonical: "/api/v1/github/webhooks/event", legacy: "/api/v1/github/event"},
+		{name: "root binding", relativePath: "/", canonical: "/api/v1/github/webhooks", legacy: "/api/v1/github"},
+		{name: "nested webhooks suffix", relativePath: "/webhooks/event", canonical: "/api/v1/github/webhooks/webhooks/event", legacy: "/api/v1/github/webhooks/event"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			if got := mountedHTTPBindingPath("github", test.relativePath); got != test.canonical {
+				t.Fatalf("mountedHTTPBindingPath() = %q, want %q", got, test.canonical)
+			}
+			if got := legacyMountedHTTPBindingPath("github", test.relativePath); got != test.legacy {
+				t.Fatalf("legacyMountedHTTPBindingPath() = %q, want %q", got, test.legacy)
+			}
+		})
+	}
+}
+
 func TestValidateMountedHTTPBindingRoutesRejectsCoreRouteNamespace(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/server/http_bindings_test.go
+++ b/gestaltd/internal/server/http_bindings_test.go
@@ -4,6 +4,9 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 )
 
 func TestMountedHTTPBindingPaths(t *testing.T) {
@@ -30,6 +33,53 @@ func TestMountedHTTPBindingPaths(t *testing.T) {
 				t.Fatalf("legacyMountedHTTPBindingPath() = %q, want %q", got, test.legacy)
 			}
 		})
+	}
+}
+
+func TestMountedHTTPBindingsSkipLegacyAliasThatConflictsWithCanonicalRoute(t *testing.T) {
+	t.Parallel()
+
+	bindings, err := mountedHTTPBindingsFromEntries(map[string]*config.ProviderEntry{
+		"events": {
+			SecuritySchemes: map[string]*config.HTTPSecurityScheme{
+				"none": {Type: providermanifestv1.HTTPSecuritySchemeTypeNone},
+			},
+			HTTP: map[string]*config.HTTPBinding{
+				"event": {
+					Path:     "/event",
+					Method:   http.MethodPost,
+					Security: "none",
+					Target:   "receive_event",
+				},
+				"nested_event": {
+					Path:     "/webhooks/event",
+					Method:   http.MethodPost,
+					Security: "none",
+					Target:   "receive_nested_event",
+				},
+			},
+		},
+	}, nil, nil)
+	if err != nil {
+		t.Fatalf("mountedHTTPBindingsFromEntries: %v", err)
+	}
+
+	routes := make(map[string]string, len(bindings))
+	for i := range bindings {
+		routes[bindings[i].Method+" "+bindings[i].Path] = bindings[i].Name
+	}
+	want := map[string]string{
+		"POST /api/v1/events/webhooks/event":          "event",
+		"POST /api/v1/events/webhooks/webhooks/event": "nested_event",
+		"POST /api/v1/events/event":                   "event",
+	}
+	if len(routes) != len(want) {
+		t.Fatalf("routes = %#v, want %#v", routes, want)
+	}
+	for route, bindingName := range want {
+		if got := routes[route]; got != bindingName {
+			t.Fatalf("route %q binding = %q, want %q", route, got, bindingName)
+		}
 	}
 }
 

--- a/gestaltd/internal/server/metrics_test.go
+++ b/gestaltd/internal/server/metrics_test.go
@@ -739,7 +739,7 @@ func TestHTTPBindingOperationMetricsIncludeBinding(t *testing.T) {
 	})
 	testutil.CloseOnCleanup(t, srv)
 
-	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/api/v1/"+providerName+"/delivery", strings.NewReader(`{"event":"opened"}`))
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/api/v1/"+providerName+"/webhooks/delivery", strings.NewReader(`{"event":"opened"}`))
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -775,7 +775,7 @@ func TestHTTPBindingOperationMetricsIncludeBinding(t *testing.T) {
 		"gestalt.result_status_class": "2xx",
 	}
 	httpAttrs := map[string]string{
-		"http.route":                  "/api/v1/" + providerName + "/delivery",
+		"http.route":                  "/api/v1/" + providerName + "/webhooks/delivery",
 		"gestaltd.provider.name":      providerName,
 		"gestaltd.operation.name":     "receive_event",
 		"gestaltd.invocation.surface": "http_binding",

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -10273,6 +10273,52 @@ func TestHostedHTTPBinding_RejectsGenericOperationRouteConflicts(t *testing.T) {
 	}
 }
 
+func TestHostedHTTPBinding_RejectsWebhooksOperationRouteConflict(t *testing.T) {
+	t.Parallel()
+
+	svc := testutil.NewStubServices(t)
+	providers := testutil.NewProviderRegistry(t, &stubIntegrationWithOps{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "reports",
+			ConnMode: core.ConnectionModeNone,
+		},
+		ops: []core.Operation{
+			{Name: "webhooks", Method: http.MethodPost},
+			{Name: "handle_event", Method: http.MethodPost},
+		},
+	})
+	cfg := server.Config{
+		Auth:        &coretesting.StubAuthProvider{N: "none"},
+		Services:    svc,
+		Providers:   providers,
+		Invoker:     invocation.NewBroker(providers, svc.Users, svc.ExternalCredentials),
+		StateSecret: []byte("0123456789abcdef0123456789abcdef"),
+		AppDefs: map[string]*config.ProviderEntry{
+			"reports": {
+				SecuritySchemes: map[string]*config.HTTPSecurityScheme{
+					"none": {Type: providermanifestv1.HTTPSecuritySchemeTypeNone},
+				},
+				HTTP: map[string]*config.HTTPBinding{
+					"event": {
+						Path:     "/",
+						Method:   http.MethodPost,
+						Security: "none",
+						Target:   "handle_event",
+					},
+				},
+			},
+		},
+	}
+
+	_, err := server.New(cfg)
+	if err == nil {
+		t.Fatal("expected webhooks operation route conflict")
+	}
+	if !strings.Contains(err.Error(), "generic operation route") {
+		t.Fatalf("error = %v, want generic operation route conflict", err)
+	}
+}
+
 func TestHostedHTTPBinding_AllowsOverrideOfGenericOperationRoute(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -10356,43 +10356,52 @@ func TestHostedHTTPBinding_AddsRequestHeadersToWorkflowContext(t *testing.T) {
 	testutil.CloseOnCleanup(t, ts)
 
 	const body = `{"event":"opened"}`
-	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/"+providerName+"/delivery", strings.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-Slack-Request-Timestamp", "123")
-	req.Header.Set("X-Slack-Signature", "v0=abc")
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("http binding request: %v", err)
+	paths := []string{
+		"/api/v1/" + providerName + "/webhooks/delivery",
+		"/api/v1/" + providerName + "/delivery",
 	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("http binding status = %d, want %d", resp.StatusCode, http.StatusOK)
-	}
+	for _, requestPath := range paths {
+		req, _ := http.NewRequest(http.MethodPost, ts.URL+requestPath, strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("X-Slack-Request-Timestamp", "123")
+		req.Header.Set("X-Slack-Signature", "v0=abc")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("http binding request: %v", err)
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("http binding status = %d, want %d", resp.StatusCode, http.StatusOK)
+		}
 
-	var workflow map[string]any
-	select {
-	case workflow = <-workflowSeen:
-	case <-time.After(200 * time.Millisecond):
-		t.Fatal("timed out waiting for http binding invocation")
-	}
-	httpContext := invocation.WorkflowContextMap(workflow, "http")
-	if httpContext == nil {
-		t.Fatal("workflow http context is missing")
-	}
-	headers, ok := httpContext["headers"].(map[string]any)
-	if !ok {
-		t.Fatalf("workflow http headers = %#v, want map", httpContext["headers"])
-	}
-	signatures, ok := headers["X-Slack-Signature"].([]string)
-	if !ok || len(signatures) != 1 || signatures[0] != "v0=abc" {
-		t.Fatalf("X-Slack-Signature header = %#v, want [v0=abc]", headers["X-Slack-Signature"])
-	}
-	timestamps, ok := headers["X-Slack-Request-Timestamp"].([]string)
-	if !ok || len(timestamps) != 1 || timestamps[0] != "123" {
-		t.Fatalf("X-Slack-Request-Timestamp header = %#v, want [123]", headers["X-Slack-Request-Timestamp"])
-	}
-	if got, want := invocation.WorkflowContextString(httpContext, "rawBodyBase64"), base64.StdEncoding.EncodeToString([]byte(body)); got != want {
-		t.Fatalf("workflow http rawBodyBase64 = %q, want %q", got, want)
+		var workflow map[string]any
+		select {
+		case workflow = <-workflowSeen:
+		case <-time.After(200 * time.Millisecond):
+			t.Fatal("timed out waiting for http binding invocation")
+		}
+		httpContext := invocation.WorkflowContextMap(workflow, "http")
+		if httpContext == nil {
+			t.Fatal("workflow http context is missing")
+		}
+		if got := invocation.WorkflowContextString(httpContext, "path"); got != requestPath {
+			t.Fatalf("workflow http path = %q, want %q", got, requestPath)
+		}
+		headers, ok := httpContext["headers"].(map[string]any)
+		if !ok {
+			t.Fatalf("workflow http headers = %#v, want map", httpContext["headers"])
+		}
+		signatures, ok := headers["X-Slack-Signature"].([]string)
+		if !ok || len(signatures) != 1 || signatures[0] != "v0=abc" {
+			t.Fatalf("X-Slack-Signature header = %#v, want [v0=abc]", headers["X-Slack-Signature"])
+		}
+		timestamps, ok := headers["X-Slack-Request-Timestamp"].([]string)
+		if !ok || len(timestamps) != 1 || timestamps[0] != "123" {
+			t.Fatalf("X-Slack-Request-Timestamp header = %#v, want [123]", headers["X-Slack-Request-Timestamp"])
+		}
+		if got, want := invocation.WorkflowContextString(httpContext, "rawBodyBase64"), base64.StdEncoding.EncodeToString([]byte(body)); got != want {
+			t.Fatalf("workflow http rawBodyBase64 = %q, want %q", got, want)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- make gestaltd prepend `/api/v1/{app}/webhooks` to every provider-declared `spec.http` path
- retain the previous `/api/v1/{app}/*` mounts as host-owned rollback aliases
- preserve binding security, dispatch, streaming, workflow context, and telemetry for both paths
- leave generic `/api/v1/{app}/{operation}` routes unchanged

## Route contract

| Manifest path | Canonical route | Temporary legacy alias |
| --- | --- | --- |
| `/event` | `/api/v1/github/webhooks/event` | `/api/v1/github/event` |
| `/interactions` | `/api/v1/slack/webhooks/interactions` | `/api/v1/slack/interactions` |
| `/responses` | `/api/v1/llm/webhooks/responses` | `/api/v1/llm/responses` |

Providers continue to declare suffixes only; they do not opt into or reproduce the host-owned namespace.

This replaces the provider-owned alias approach in valon-technologies/gestalt-providers#1306 and valon-technologies/toolshed#4603. No provider snapshots, Toolshed pins, or documentation files change in this PR.

## Tests

- `cd gestaltd && go test ./...`