### PR TITLE
Bump gestalt CLI to 0.0.2-alpha.15

### DIFF
--- a/gestalt/Cargo.toml
+++ b/gestalt/Cargo.toml
@@ -3,5 +3,5 @@ resolver = "2"
 members = ["cli"]
 
 [workspace.package]
-version = "0.0.2-alpha.14"
+version = "0.0.2-alpha.15"
 edition = "2024"


### PR DESCRIPTION
## Summary
- Bump gestalt CLI to `0.0.2-alpha.15` so releases include `X-Gestalt-Client: cli` on shared HTTP transports (gestalt #3136).

## Test plan
- [x] Version bump only; ingress header behavior covered by gestaltd/CLI tests in #3136
- [ ] Merge and tag `gestalt/v0.0.2-alpha.15` to publish the release

Made with [Cursor](https://cursor.com)