### PR TITLE
Add gestaltd.client.app attribution from registered UI referrers

### DIFF
--- a/gestaltd/internal/server/ingress_telemetry.go
+++ b/gestaltd/internal/server/ingress_telemetry.go
@@ -51,7 +51,7 @@ func (s *Server) uiAPIIngressTelemetryMiddleware(kind string) func(http.Handler)
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			dims := metricutil.HTTPMetricDims{IngressKind: kind}
 			if classifyClientKind(r) == metricutil.ClientKindWeb {
-				dims.ClientApp = classifyClientAppFromReferrer(s.mountedUIs, r)
+				dims.ClientApp = s.classifyClientAppFromReferrer(r)
 			}
 			metricutil.AddHTTPServerMetricDims(r.Context(), dims)
 			next.ServeHTTP(w, r)
@@ -63,20 +63,16 @@ func (s *Server) uiAPIIngressTelemetryHandler(kind string, next http.Handler) ht
 	return s.uiAPIIngressTelemetryMiddleware(kind)(next).ServeHTTP
 }
 
-func classifyClientAppFromReferrer(mountedUIs []MountedUI, r *http.Request) string {
+func (s *Server) classifyClientAppFromReferrer(r *http.Request) string {
 	referer := strings.TrimSpace(r.Referer())
 	if referer == "" || len(referer) > maxReferrerLen {
 		return metricutil.ClientAppUnknown
 	}
 	parsed, err := url.Parse(referer)
-	if err != nil || !referrerSameOrigin(r, parsed) {
+	if err != nil || !s.referrerSameOrigin(r, parsed) {
 		return metricutil.ClientAppUnknown
 	}
-	path := strings.TrimSpace(parsed.Path)
-	if path == "" {
-		path = "/"
-	}
-	mounted, ok := mountedUIForReferrerPath(mountedUIs, path)
+	mounted, ok := s.mountedUIForPath(parsed.Path)
 	if !ok {
 		return metricutil.ClientAppUnknown
 	}
@@ -87,58 +83,27 @@ func classifyClientAppFromReferrer(mountedUIs []MountedUI, r *http.Request) stri
 	return name
 }
 
-func mountedUIForReferrerPath(mountedUIs []MountedUI, path string) (MountedUI, bool) {
-	if path == "" {
-		path = "/"
-	}
-	if !strings.HasPrefix(path, "/") {
-		path = "/" + path
-	}
-
-	var (
-		best        MountedUI
-		bestLen     int
-		bestMatched bool
-	)
-	for i := range mountedUIs {
-		candidate := mountedUIs[i]
-		if candidate.Path == "" || !mountedUIPathMatches(path, candidate.Path) {
-			continue
-		}
-		if !bestMatched || len(candidate.Path) > bestLen {
-			best = candidate
-			bestLen = len(candidate.Path)
-			bestMatched = true
-		}
-	}
-	return best, bestMatched
-}
-
-func referrerSameOrigin(r *http.Request, referer *url.URL) bool {
+func (s *Server) referrerSameOrigin(r *http.Request, referer *url.URL) bool {
 	if referer == nil || referer.Host == "" || referer.Scheme == "" {
 		return false
 	}
-	if strings.TrimSpace(r.Host) == "" {
-		return false
-	}
-	if !strings.EqualFold(referer.Host, r.Host) {
-		return false
-	}
-	reqScheme := requestScheme(r)
-	return strings.EqualFold(referer.Scheme, reqScheme)
-}
 
-func requestScheme(r *http.Request) string {
-	if r.TLS != nil {
-		return "https"
-	}
-	if r.URL != nil {
-		if scheme := strings.TrimSpace(r.URL.Scheme); scheme != "" {
-			return scheme
+	expectedOrigin := strings.TrimSpace(s.publicBaseURL)
+	if expectedOrigin == "" {
+		if strings.TrimSpace(r.Host) == "" {
+			return false
 		}
+		scheme := "http"
+		if r.TLS != nil {
+			scheme = "https"
+		}
+		expectedOrigin = scheme + "://" + r.Host
 	}
-	if proto := strings.TrimSpace(r.Header.Get("X-Forwarded-Proto")); proto != "" {
-		return strings.ToLower(strings.TrimSpace(strings.Split(proto, ",")[0]))
+
+	canonicalExpected, ok := canonicalOriginFromBaseURL(expectedOrigin)
+	if !ok {
+		return false
 	}
-	return "http"
+	canonicalReferer := strings.ToLower(referer.Scheme) + "://" + canonicalHost(referer)
+	return canonicalReferer == canonicalExpected
 }

--- a/gestaltd/internal/server/ingress_telemetry.go
+++ b/gestaltd/internal/server/ingress_telemetry.go
@@ -2,10 +2,13 @@ package server
 
 import (
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/valon-technologies/gestalt/server/services/observability/metricutil"
 )
+
+const maxReferrerLen = 2048
 
 func clientKindTelemetryMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -41,4 +44,101 @@ func ingressKindTelemetryMiddleware(kind string) func(http.Handler) http.Handler
 
 func ingressKindTelemetryHandler(kind string, next http.Handler) http.HandlerFunc {
 	return ingressKindTelemetryMiddleware(kind)(next).ServeHTTP
+}
+
+func (s *Server) uiAPIIngressTelemetryMiddleware(kind string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			dims := metricutil.HTTPMetricDims{IngressKind: kind}
+			if classifyClientKind(r) == metricutil.ClientKindWeb {
+				dims.ClientApp = classifyClientAppFromReferrer(s.mountedUIs, r)
+			}
+			metricutil.AddHTTPServerMetricDims(r.Context(), dims)
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func (s *Server) uiAPIIngressTelemetryHandler(kind string, next http.Handler) http.HandlerFunc {
+	return s.uiAPIIngressTelemetryMiddleware(kind)(next).ServeHTTP
+}
+
+func classifyClientAppFromReferrer(mountedUIs []MountedUI, r *http.Request) string {
+	referer := strings.TrimSpace(r.Referer())
+	if referer == "" || len(referer) > maxReferrerLen {
+		return metricutil.ClientAppUnknown
+	}
+	parsed, err := url.Parse(referer)
+	if err != nil || !referrerSameOrigin(r, parsed) {
+		return metricutil.ClientAppUnknown
+	}
+	path := strings.TrimSpace(parsed.Path)
+	if path == "" {
+		path = "/"
+	}
+	mounted, ok := mountedUIForReferrerPath(mountedUIs, path)
+	if !ok {
+		return metricutil.ClientAppUnknown
+	}
+	name := strings.TrimSpace(mounted.Name)
+	if name == "" {
+		return metricutil.ClientAppUnknown
+	}
+	return name
+}
+
+func mountedUIForReferrerPath(mountedUIs []MountedUI, path string) (MountedUI, bool) {
+	if path == "" {
+		path = "/"
+	}
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+
+	var (
+		best        MountedUI
+		bestLen     int
+		bestMatched bool
+	)
+	for i := range mountedUIs {
+		candidate := mountedUIs[i]
+		if candidate.Path == "" || !mountedUIPathMatches(path, candidate.Path) {
+			continue
+		}
+		if !bestMatched || len(candidate.Path) > bestLen {
+			best = candidate
+			bestLen = len(candidate.Path)
+			bestMatched = true
+		}
+	}
+	return best, bestMatched
+}
+
+func referrerSameOrigin(r *http.Request, referer *url.URL) bool {
+	if referer == nil || referer.Host == "" || referer.Scheme == "" {
+		return false
+	}
+	if strings.TrimSpace(r.Host) == "" {
+		return false
+	}
+	if !strings.EqualFold(referer.Host, r.Host) {
+		return false
+	}
+	reqScheme := requestScheme(r)
+	return strings.EqualFold(referer.Scheme, reqScheme)
+}
+
+func requestScheme(r *http.Request) string {
+	if r.TLS != nil {
+		return "https"
+	}
+	if r.URL != nil {
+		if scheme := strings.TrimSpace(r.URL.Scheme); scheme != "" {
+			return scheme
+		}
+	}
+	if proto := strings.TrimSpace(r.Header.Get("X-Forwarded-Proto")); proto != "" {
+		return strings.ToLower(strings.TrimSpace(strings.Split(proto, ",")[0]))
+	}
+	return "http"
 }

--- a/gestaltd/internal/server/ingress_telemetry_metrics_test.go
+++ b/gestaltd/internal/server/ingress_telemetry_metrics_test.go
@@ -143,6 +143,8 @@ func TestIngressTelemetryRequestMetrics(t *testing.T) {
 			},
 		} {
 			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
 				req, _ := http.NewRequest(http.MethodGet, srv.URL+"/api/v1/"+providerName+"/list", nil)
 				req.Header.Set("Sec-Fetch-Site", "same-origin")
 				req.Header.Set("Referer", tc.referer)

--- a/gestaltd/internal/server/ingress_telemetry_metrics_test.go
+++ b/gestaltd/internal/server/ingress_telemetry_metrics_test.go
@@ -214,5 +214,84 @@ func TestIngressTelemetryRequestMetrics(t *testing.T) {
 			return metrictest.HasFloat64Histogram(rm, "http.server.request.duration", attrs)
 		})
 		metrictest.RequireFloat64Histogram(t, rm, "http.server.request.duration", attrs)
+		metrictest.RequireFloat64HistogramOmitsAttr(t, rm, "http.server.request.duration", attrs, "gestaltd.client.app")
+	})
+
+	t.Run("public rest web labels matched client app from referer", func(t *testing.T) {
+		t.Parallel()
+
+		metrics := metrictest.NewManualMeterProvider(t)
+		ts := startPublicRESTServer(t, server.RouteProfilePublic, func(cfg *server.Config) {
+			cfg.MeterProvider = metrics.Provider
+			cfg.MountedUIs = []server.MountedUI{{
+				Name: "app:telemetry-ui",
+				Path: "/telemetry-ui",
+				Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					_, _ = w.Write([]byte("ok"))
+				}),
+			}}
+		})
+
+		req, err := http.NewRequest(http.MethodGet, ts.URL+"/api/v2/identity/userinfo", nil)
+		if err != nil {
+			t.Fatalf("NewRequest: %v", err)
+		}
+		req.Header.Set("Sec-Fetch-Site", "same-origin")
+		req.Header.Set("Referer", ts.URL+"/telemetry-ui/page")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("request: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		attrs := map[string]string{
+			"http.route":            "/api/v2/*",
+			"gestaltd.ingress.kind": metricutil.IngressKindPublicREST,
+			"gestaltd.client.kind":  metricutil.ClientKindWeb,
+			"gestaltd.client.app":   "app:telemetry-ui",
+		}
+		rm := collectMetricsUntil(t, metrics, func(rm metricdata.ResourceMetrics) bool {
+			return metrictest.HasFloat64Histogram(rm, "http.server.request.duration", attrs)
+		})
+		metrictest.RequireFloat64Histogram(t, rm, "http.server.request.duration", attrs)
+	})
+
+	t.Run("public rest web labels unknown client app without matching referer", func(t *testing.T) {
+		t.Parallel()
+
+		metrics := metrictest.NewManualMeterProvider(t)
+		ts := startPublicRESTServer(t, server.RouteProfilePublic, func(cfg *server.Config) {
+			cfg.MeterProvider = metrics.Provider
+			cfg.MountedUIs = []server.MountedUI{{
+				Name: "app:telemetry-ui",
+				Path: "/telemetry-ui",
+				Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					_, _ = w.Write([]byte("ok"))
+				}),
+			}}
+		})
+
+		req, err := http.NewRequest(http.MethodGet, ts.URL+"/api/v2/identity/userinfo", nil)
+		if err != nil {
+			t.Fatalf("NewRequest: %v", err)
+		}
+		req.Header.Set("Sec-Fetch-Site", "same-origin")
+		req.Header.Set("Referer", ts.URL+"/other-ui/page")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("request: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		attrs := map[string]string{
+			"http.route":            "/api/v2/*",
+			"gestaltd.ingress.kind": metricutil.IngressKindPublicREST,
+			"gestaltd.client.kind":  metricutil.ClientKindWeb,
+			"gestaltd.client.app":   metricutil.ClientAppUnknown,
+		}
+		rm := collectMetricsUntil(t, metrics, func(rm metricdata.ResourceMetrics) bool {
+			return metrictest.HasFloat64Histogram(rm, "http.server.request.duration", attrs)
+		})
+		metrictest.RequireFloat64Histogram(t, rm, "http.server.request.duration", attrs)
 	})
 }

--- a/gestaltd/internal/server/ingress_telemetry_metrics_test.go
+++ b/gestaltd/internal/server/ingress_telemetry_metrics_test.go
@@ -90,6 +90,80 @@ func TestIngressTelemetryRequestMetrics(t *testing.T) {
 			return metrictest.HasFloat64Histogram(rm, "http.server.request.duration", attrs)
 		})
 		metrictest.RequireFloat64Histogram(t, rm, "http.server.request.duration", attrs)
+		metrictest.RequireFloat64HistogramOmitsAttr(t, rm, "http.server.request.duration", attrs, "gestaltd.client.app")
+	})
+
+	t.Run("app invoke v1 labels matched and unknown web client apps", func(t *testing.T) {
+		t.Parallel()
+
+		metrics := metrictest.NewManualMeterProvider(t)
+		const providerName = "ingress-web-metrics"
+		srv := newTestServer(t, func(cfg *server.Config) {
+			cfg.MeterProvider = metrics.Provider
+			cfg.PublicBaseURL = "https://valon.tools"
+			cfg.MountedUIs = []server.MountedUI{{
+				Name: "app:telemetry-ui",
+				Path: "/telemetry-ui",
+				Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					_, _ = w.Write([]byte("ok"))
+				}),
+			}}
+			cfg.Providers = testutil.NewProviderRegistry(t, &stubIntegrationWithCatalog{
+				StubIntegration: coretesting.StubIntegration{
+					N:        providerName,
+					ConnMode: core.ConnectionModeNone,
+					ExecuteFn: func(_ context.Context, operation string, _ map[string]any, _ string) (*core.OperationResult, error) {
+						return &core.OperationResult{Status: http.StatusOK, Body: []byte(`{"operation":"` + operation + `"}`)}, nil
+					},
+				},
+				catalog: &catalog.Catalog{
+					Name: providerName,
+					Operations: []catalog.CatalogOperation{
+						{ID: "list", Method: http.MethodGet, Path: "/list"},
+					},
+				},
+			})
+		})
+		testutil.CloseOnCleanup(t, srv)
+
+		for _, tc := range []struct {
+			name      string
+			referer   string
+			clientApp string
+		}{
+			{
+				name:      "matched",
+				referer:   "https://valon.tools/telemetry-ui/page",
+				clientApp: "app:telemetry-ui",
+			},
+			{
+				name:      "unknown",
+				referer:   "https://valon.tools/other-ui/page",
+				clientApp: metricutil.ClientAppUnknown,
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				req, _ := http.NewRequest(http.MethodGet, srv.URL+"/api/v1/"+providerName+"/list", nil)
+				req.Header.Set("Sec-Fetch-Site", "same-origin")
+				req.Header.Set("Referer", tc.referer)
+				resp, err := http.DefaultClient.Do(req)
+				if err != nil {
+					t.Fatalf("request: %v", err)
+				}
+				defer func() { _ = resp.Body.Close() }()
+
+				attrs := map[string]string{
+					"http.route":            "/api/v1/{integration}/{operation}",
+					"gestaltd.ingress.kind": metricutil.IngressKindAppInvokeV1,
+					"gestaltd.client.kind":  metricutil.ClientKindWeb,
+					"gestaltd.client.app":   tc.clientApp,
+				}
+				rm := collectMetricsUntil(t, metrics, func(rm metricdata.ResourceMetrics) bool {
+					return metrictest.HasFloat64Histogram(rm, "http.server.request.duration", attrs)
+				})
+				metrictest.RequireFloat64Histogram(t, rm, "http.server.request.duration", attrs)
+			})
+		}
 	})
 
 	t.Run("rejected app invoke retains ingress kind", func(t *testing.T) {
@@ -237,7 +311,7 @@ func TestIngressTelemetryRequestMetrics(t *testing.T) {
 			t.Fatalf("NewRequest: %v", err)
 		}
 		req.Header.Set("Sec-Fetch-Site", "same-origin")
-		req.Header.Set("Referer", ts.URL+"/telemetry-ui/page")
+		req.Header.Set("Referer", "https://gestalt.test/telemetry-ui/page")
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
 			t.Fatalf("request: %v", err)
@@ -276,7 +350,7 @@ func TestIngressTelemetryRequestMetrics(t *testing.T) {
 			t.Fatalf("NewRequest: %v", err)
 		}
 		req.Header.Set("Sec-Fetch-Site", "same-origin")
-		req.Header.Set("Referer", ts.URL+"/other-ui/page")
+		req.Header.Set("Referer", "https://gestalt.test/other-ui/page")
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
 			t.Fatalf("request: %v", err)

--- a/gestaltd/internal/server/ingress_telemetry_test.go
+++ b/gestaltd/internal/server/ingress_telemetry_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/valon-technologies/gestalt/server/services/observability/metricutil"
@@ -53,5 +54,99 @@ func TestClassifyClientKind(t *testing.T) {
 				t.Fatalf("classifyClientKind() = %q, want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestClassifyClientAppFromReferrer(t *testing.T) {
+	t.Parallel()
+
+	mounted := []MountedUI{
+		{Name: "app:sample", Path: "/sample"},
+		{Name: "app:nested", Path: "/nested"},
+	}
+
+	tests := []struct {
+		name    string
+		target  string
+		referer string
+		headers func(*http.Request)
+		want    string
+	}{
+		{
+			name:    "matches registered ui by longest prefix",
+			target:  "http://valon.tools/api/v2/identity/userinfo",
+			referer: "http://valon.tools/nested/page",
+			headers: func(r *http.Request) {
+				r.Header.Set("Sec-Fetch-Site", "same-origin")
+			},
+			want: "app:nested",
+		},
+		{
+			name:    "unknown without referer",
+			target:  "http://valon.tools/api/v2/identity/userinfo",
+			referer: "",
+			headers: func(r *http.Request) {
+				r.Header.Set("Sec-Fetch-Site", "same-origin")
+			},
+			want: metricutil.ClientAppUnknown,
+		},
+		{
+			name:    "unknown for cross origin referer",
+			target:  "http://valon.tools/api/v2/identity/userinfo",
+			referer: "http://example.com/sample/",
+			headers: func(r *http.Request) {
+				r.Header.Set("Sec-Fetch-Site", "cross-site")
+			},
+			want: metricutil.ClientAppUnknown,
+		},
+		{
+			name:    "unknown for unmatched same origin referer",
+			target:  "http://valon.tools/api/v2/identity/userinfo",
+			referer: "http://valon.tools/other/",
+			headers: func(r *http.Request) {
+				r.Header.Set("Sec-Fetch-Site", "same-origin")
+			},
+			want: metricutil.ClientAppUnknown,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			req := httptest.NewRequest(http.MethodGet, tc.target, nil)
+			req.Host = "valon.tools"
+			if tc.referer != "" {
+				req.Header.Set("Referer", tc.referer)
+			}
+			if tc.headers != nil {
+				tc.headers(req)
+			}
+			if got := classifyClientAppFromReferrer(mounted, req); got != tc.want {
+				t.Fatalf("classifyClientAppFromReferrer() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestReferrerSameOrigin(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(http.MethodGet, "http://valon.tools/api/v2/foo", nil)
+	req.Host = "valon.tools"
+
+	same, err := url.Parse("http://valon.tools/sample/")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if !referrerSameOrigin(req, same) {
+		t.Fatal("expected same-origin referer")
+	}
+
+	cross, err := url.Parse("https://valon.tools/sample/")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if referrerSameOrigin(req, cross) {
+		t.Fatal("expected different scheme to be cross-origin")
 	}
 }

--- a/gestaltd/internal/server/ingress_telemetry_test.go
+++ b/gestaltd/internal/server/ingress_telemetry_test.go
@@ -60,68 +60,49 @@ func TestClassifyClientKind(t *testing.T) {
 func TestClassifyClientAppFromReferrer(t *testing.T) {
 	t.Parallel()
 
-	mounted := []MountedUI{
-		{Name: "app:sample", Path: "/sample"},
-		{Name: "app:nested", Path: "/nested"},
+	s := &Server{
+		publicBaseURL: "https://valon.tools",
+		mountedUIs: []MountedUI{
+			{Name: "app:nested", Path: "/nested"},
+			{Name: "app:deeply-nested", Path: "/nested/admin"},
+		},
 	}
 
 	tests := []struct {
 		name    string
-		target  string
 		referer string
-		headers func(*http.Request)
 		want    string
 	}{
 		{
 			name:    "matches registered ui by longest prefix",
-			target:  "http://valon.tools/api/v2/identity/userinfo",
-			referer: "http://valon.tools/nested/page",
-			headers: func(r *http.Request) {
-				r.Header.Set("Sec-Fetch-Site", "same-origin")
-			},
-			want: "app:nested",
+			referer: "https://valon.tools/nested/admin/page",
+			want:    "app:deeply-nested",
 		},
 		{
 			name:    "unknown without referer",
-			target:  "http://valon.tools/api/v2/identity/userinfo",
 			referer: "",
-			headers: func(r *http.Request) {
-				r.Header.Set("Sec-Fetch-Site", "same-origin")
-			},
-			want: metricutil.ClientAppUnknown,
+			want:    metricutil.ClientAppUnknown,
 		},
 		{
 			name:    "unknown for cross origin referer",
-			target:  "http://valon.tools/api/v2/identity/userinfo",
-			referer: "http://example.com/sample/",
-			headers: func(r *http.Request) {
-				r.Header.Set("Sec-Fetch-Site", "cross-site")
-			},
-			want: metricutil.ClientAppUnknown,
+			referer: "https://example.com/nested/",
+			want:    metricutil.ClientAppUnknown,
 		},
 		{
 			name:    "unknown for unmatched same origin referer",
-			target:  "http://valon.tools/api/v2/identity/userinfo",
-			referer: "http://valon.tools/other/",
-			headers: func(r *http.Request) {
-				r.Header.Set("Sec-Fetch-Site", "same-origin")
-			},
-			want: metricutil.ClientAppUnknown,
+			referer: "https://valon.tools/other/",
+			want:    metricutil.ClientAppUnknown,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			req := httptest.NewRequest(http.MethodGet, tc.target, nil)
-			req.Host = "valon.tools"
+			req := httptest.NewRequest(http.MethodGet, "http://internal/api/v2/identity/userinfo", nil)
 			if tc.referer != "" {
 				req.Header.Set("Referer", tc.referer)
 			}
-			if tc.headers != nil {
-				tc.headers(req)
-			}
-			if got := classifyClientAppFromReferrer(mounted, req); got != tc.want {
+			if got := s.classifyClientAppFromReferrer(req); got != tc.want {
 				t.Fatalf("classifyClientAppFromReferrer() = %q, want %q", got, tc.want)
 			}
 		})
@@ -131,22 +112,31 @@ func TestClassifyClientAppFromReferrer(t *testing.T) {
 func TestReferrerSameOrigin(t *testing.T) {
 	t.Parallel()
 
-	req := httptest.NewRequest(http.MethodGet, "http://valon.tools/api/v2/foo", nil)
-	req.Host = "valon.tools"
+	s := &Server{publicBaseURL: "https://valon.tools"}
+	req := httptest.NewRequest(http.MethodGet, "http://internal/api/v2/foo", nil)
+	req.Header.Set("X-Forwarded-Proto", "http")
 
-	same, err := url.Parse("http://valon.tools/sample/")
-	if err != nil {
-		t.Fatalf("Parse: %v", err)
-	}
-	if !referrerSameOrigin(req, same) {
-		t.Fatal("expected same-origin referer")
+	tests := []struct {
+		name    string
+		referer string
+		want    bool
+	}{
+		{name: "same origin", referer: "https://valon.tools/sample/", want: true},
+		{name: "canonical default port", referer: "https://valon.tools:443/sample/", want: true},
+		{name: "different scheme", referer: "http://valon.tools/sample/", want: false},
+		{name: "non-default port", referer: "https://valon.tools:8443/sample/", want: false},
 	}
 
-	cross, err := url.Parse("https://valon.tools/sample/")
-	if err != nil {
-		t.Fatalf("Parse: %v", err)
-	}
-	if referrerSameOrigin(req, cross) {
-		t.Fatal("expected different scheme to be cross-origin")
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			referer, err := url.Parse(tc.referer)
+			if err != nil {
+				t.Fatalf("Parse: %v", err)
+			}
+			if got := s.referrerSameOrigin(req, referer); got != tc.want {
+				t.Fatalf("referrerSameOrigin() = %t, want %t", got, tc.want)
+			}
+		})
 	}
 }

--- a/gestaltd/internal/server/routes.go
+++ b/gestaltd/internal/server/routes.go
@@ -258,7 +258,7 @@ func (s *Server) mountPublicRESTRoutes(r chi.Router) {
 			r.MethodNotAllowed(apiMethodNotAllowed)
 			return
 		}
-		r.Handle("/*", ingressKindTelemetryHandler(metricutil.IngressKindPublicREST, s.publicRESTHandler))
+		r.Handle("/*", s.uiAPIIngressTelemetryHandler(metricutil.IngressKindPublicREST, s.publicRESTHandler))
 		r.NotFound(apiNotFound)
 		r.MethodNotAllowed(apiMethodNotAllowed)
 	})

--- a/gestaltd/internal/server/routes_user.go
+++ b/gestaltd/internal/server/routes_user.go
@@ -37,7 +37,7 @@ func (s *Server) mountAuthenticatedRoutes(r chi.Router) {
 
 	r.With(s.pluginRouteAuthMiddleware("name")).Get("/apps/{name}/operations", s.listOperations)
 	r.Group(func(r chi.Router) {
-		r.Use(ingressKindTelemetryMiddleware(metricutil.IngressKindAppInvokeV1))
+		r.Use(s.uiAPIIngressTelemetryMiddleware(metricutil.IngressKindAppInvokeV1))
 		r.Use(s.pluginRouteAuthMiddleware("integration"))
 		r.Get("/{integration}/{operation}", s.executeOperation)
 		r.Post("/{integration}/{operation}", s.executeOperation)

--- a/gestaltd/services/observability/metricutil/attrs.go
+++ b/gestaltd/services/observability/metricutil/attrs.go
@@ -35,6 +35,7 @@ const (
 	attrGestaltdIndexedDBIndexName = attribute.Key("gestaltd.idb.index.name")
 	attrGestaltdIngressKind        = attribute.Key("gestaltd.ingress.kind")
 	attrGestaltdClientKind         = attribute.Key("gestaltd.client.kind")
+	attrGestaltdClientApp          = attribute.Key("gestaltd.client.app")
 
 	attrDBSystemName     = attribute.Key("db.system.name")
 	attrDBNamespace      = attribute.Key("db.namespace")
@@ -63,6 +64,8 @@ const (
 	ClientKindWeb     = "web"
 	ClientKindUnknown = "unknown"
 
+	ClientAppUnknown = "unknown"
+
 	HeaderGestaltClient = "X-Gestalt-Client"
 )
 
@@ -81,6 +84,7 @@ type HTTPMetricDims struct {
 	UIName          string
 	IngressKind     string
 	ClientKind      string
+	ClientApp       string
 }
 
 type RPCMetricDims struct {
@@ -110,6 +114,7 @@ func HTTPServerAttrs(dims HTTPMetricDims) []attribute.KeyValue {
 	attrs = appendStringAttr(attrs, attrGestaltdUIName, dims.UIName)
 	attrs = appendStringAttr(attrs, attrGestaltdIngressKind, dims.IngressKind)
 	attrs = appendStringAttr(attrs, attrGestaltdClientKind, dims.ClientKind)
+	attrs = appendStringAttr(attrs, attrGestaltdClientApp, dims.ClientApp)
 	return attrs
 }
 

--- a/gestaltd/services/observability/metricutil/attrs_test.go
+++ b/gestaltd/services/observability/metricutil/attrs_test.go
@@ -13,15 +13,19 @@ func TestHTTPServerAttrsIngressAndClientKinds(t *testing.T) {
 	attrs := metricutil.HTTPServerAttrs(metricutil.HTTPMetricDims{
 		IngressKind: metricutil.IngressKindAppInvokeV1,
 		ClientKind:  metricutil.ClientKindCLI,
+		ClientApp:   metricutil.ClientAppUnknown,
 	})
-	if len(attrs) != 2 {
-		t.Fatalf("len(attrs) = %d, want 2", len(attrs))
+	if len(attrs) != 3 {
+		t.Fatalf("len(attrs) = %d, want 3", len(attrs))
 	}
 	if attrs[0] != attribute.String("gestaltd.ingress.kind", metricutil.IngressKindAppInvokeV1) {
 		t.Fatalf("ingress attr = %+v", attrs[0])
 	}
 	if attrs[1] != attribute.String("gestaltd.client.kind", metricutil.ClientKindCLI) {
 		t.Fatalf("client attr = %+v", attrs[1])
+	}
+	if attrs[2] != attribute.String("gestaltd.client.app", metricutil.ClientAppUnknown) {
+		t.Fatalf("client app attr = %+v", attrs[2])
 	}
 }
 


### PR DESCRIPTION
## Summary
- Emit `gestaltd.client.app` on `public_rest` and `app_invoke_v1` routes for web clients by matching same-origin `Referer` headers to the longest registered mounted UI path prefix.
- Use `unknown` when no UI matches; omit the attribute for non-web clients.
- Add unit and request-to-metric tests. This dimension is best-effort telemetry only and is never used for authorization.

## Test plan
- [x] `go test ./gestaltd/internal/server/... -run 'IngressTelemetry|ClassifyClient|ReferrerSame'`
- [x] `go test ./gestaltd/services/observability/metricutil/...`


Made with [Cursor](https://cursor.com)