### PR TITLE
Fix SCIM uniqueness checks against remote IndexedDB

### DIFF
--- a/gestaltd/internal/scim/service.go
+++ b/gestaltd/internal/scim/service.go
@@ -725,13 +725,17 @@ func ensureUnique(ctx context.Context, tx idb.Transaction, clientID, userID stri
 	for _, storeName := range []string{coredata.StoreSCIMUsers, coredata.StoreSCIMProjectionIntents} {
 		store := tx.ObjectStore(storeName)
 		for _, check := range checks {
-			rec, err := store.Index(check.index).Get(ctx, check.key)
-			if errors.Is(err, idb.ErrNotFound) {
-				continue
-			}
+			// Use GetAll for compatibility with remote providers that treat a
+			// transactional Get miss as terminal. An empty GetAll is a successful
+			// query, so subsequent uniqueness checks can use the same transaction.
+			records, err := store.Index(check.index).GetAll(ctx, check.key, 1)
 			if err != nil {
 				return unavailable("could not validate SCIM uniqueness")
 			}
+			if len(records) == 0 {
+				continue
+			}
+			rec := records[0]
 			if recordString(rec, "user_id") != userID && recordString(rec, "id") != userID {
 				return conflict(check.name + " is already assigned in this SCIM client namespace")
 			}

--- a/gestaltd/internal/scim/users_http_test.go
+++ b/gestaltd/internal/scim/users_http_test.go
@@ -303,6 +303,26 @@ func TestSCIMUsersHTTPContract(t *testing.T) {
 	}
 }
 
+func TestSCIMCreateSupportsTerminalTransactionalIndexMisses(t *testing.T) {
+	t.Parallel()
+
+	db := &transactionFaultDB{IndexedDB: &coretesting.StubIndexedDB{}}
+	_, _, handler := newSCIMService(t, db, nil, testSCIMConfig(map[string]config.SCIMClientConfig{
+		"rippling": ripplingClient(nil),
+	}))
+	db.arm(transactionFaultTerminalIndexMiss)
+
+	_, response := createUser(t, handler, testCurrentToken, "alice@valon.com", true, nil)
+	if response.Code != http.StatusCreated {
+		t.Fatalf("create with empty uniqueness indexes = %d %s", response.Code, response.Body.String())
+	}
+
+	_, response = createUser(t, handler, testCurrentToken, "alice@valon.com", true, map[string]any{"displayName": "Different Alice"})
+	if response.Code != http.StatusConflict {
+		t.Fatalf("duplicate create = %d %s", response.Code, response.Body.String())
+	}
+}
+
 func TestSCIMCredentialRotationAndClientNamespaces(t *testing.T) {
 	t.Parallel()
 
@@ -1039,6 +1059,7 @@ const (
 	transactionFaultIntentAdd transactionFault = iota + 1
 	transactionFaultSCIMUserGet
 	transactionFaultCoreUserAdd
+	transactionFaultTerminalIndexMiss
 )
 
 type transactionFaultDB struct {
@@ -1081,13 +1102,18 @@ type transactionFaultTransaction struct {
 }
 
 func (t *transactionFaultTransaction) ObjectStore(name string) idb.TransactionObjectStore {
-	return &transactionFaultStore{TransactionObjectStore: t.Transaction.ObjectStore(name), db: t.db, name: name}
+	return &transactionFaultStore{TransactionObjectStore: t.Transaction.ObjectStore(name), tx: t.Transaction, db: t.db, name: name}
 }
 
 type transactionFaultStore struct {
 	idb.TransactionObjectStore
+	tx   idb.Transaction
 	db   *transactionFaultDB
 	name string
+}
+
+func (s *transactionFaultStore) Index(name string) idb.TransactionIndex {
+	return &transactionFaultIndex{TransactionIndex: s.TransactionObjectStore.Index(name), tx: s.tx, db: s.db}
 }
 
 func (s *transactionFaultStore) Get(ctx context.Context, id string) (idb.Record, error) {
@@ -1109,6 +1135,20 @@ func (s *transactionFaultStore) Add(ctx context.Context, record idb.Record) erro
 		}
 	}
 	return s.TransactionObjectStore.Add(ctx, record)
+}
+
+type transactionFaultIndex struct {
+	idb.TransactionIndex
+	tx idb.Transaction
+	db *transactionFaultDB
+}
+
+func (i *transactionFaultIndex) Get(ctx context.Context, query any) (idb.Record, error) {
+	record, err := i.TransactionIndex.Get(ctx, query)
+	if errors.Is(err, idb.ErrNotFound) && i.db.trip(transactionFaultTerminalIndexMiss) {
+		_ = i.tx.Abort(ctx)
+	}
+	return record, err
 }
 
 var _ coredb.IndexedDB = (*transactionFaultDB)(nil)


### PR DESCRIPTION
## Summary

- query unique SCIM indexes with bounded GetAll calls so an empty result remains non-terminal on older remote IndexedDB providers
- preserve username, email, and external ID conflict handling
- add an HTTP-level regression covering successful create and duplicate rejection with terminal transactional Get misses

## Production impact

The currently deployed relational IndexedDB provider treats a transactional Index.Get miss as terminal. Initial SCIM creates therefore fail during uniqueness validation. Empty Index.GetAll queries are successful on that provider, allowing the rest of the mutation transaction to complete.

## Verification

- go test ./internal/scim ./internal/bootstrap -count=1
- go test ./cmd/gestaltd ./core/... ./internal/... ./sdk/... ./services/... ./tools/...

The literal go test ./... remains blocked on main because cmd/reseed-fp-cred imports github.com/go-sql-driver/mysql without declaring the module. Every other gestaltd package passed.