### PR TITLE
Handle transactional SCIM record misses remotely

### DIFF
--- a/gestaltd/internal/scim/service.go
+++ b/gestaltd/internal/scim/service.go
@@ -700,6 +700,17 @@ func normalizedEmail(raw string) string {
 	return normalize(parsed.Address)
 }
 
+func getTransactionRecord(ctx context.Context, store idb.TransactionObjectStore, id string) (idb.Record, error) {
+	records, err := store.GetAll(ctx, id, 1)
+	if err != nil {
+		return nil, err
+	}
+	if len(records) == 0 {
+		return nil, idb.ErrNotFound
+	}
+	return records[0], nil
+}
+
 func displayName(resource persistedUser) string {
 	if value := strings.TrimSpace(resource.DisplayName); value != "" {
 		return value
@@ -1035,7 +1046,7 @@ func (s *Service) convergeUserLocked(ctx context.Context, userID string) error {
 			_ = tx.Abort(context.WithoutCancel(ctx))
 		}
 	}()
-	latest, err := tx.ObjectStore(coredata.StoreSCIMProjectionIntents).Get(ctx, intent.id)
+	latest, err := getTransactionRecord(ctx, tx.ObjectStore(coredata.StoreSCIMProjectionIntents), intent.id)
 	if errors.Is(err, idb.ErrNotFound) {
 		alreadyCommitted, committedErr := intentAlreadyCommitted(ctx, tx, intent)
 		if committedErr != nil {
@@ -1051,11 +1062,13 @@ func (s *Service) convergeUserLocked(ctx context.Context, userID string) error {
 	}
 	createdAt := intent.createdAt
 	lastFingerprint := intent.operationFingerprint
-	if existing, getErr := tx.ObjectStore(coredata.StoreSCIMUsers).Get(ctx, intent.userID); getErr == nil {
+	if existing, getErr := getTransactionRecord(ctx, tx.ObjectStore(coredata.StoreSCIMUsers), intent.userID); getErr == nil {
 		createdAt = recordTime(existing, "created_at")
 		if lastFingerprint == "" {
 			lastFingerprint = recordString(existing, "last_operation_fingerprint")
 		}
+	} else if !errors.Is(getErr, idb.ErrNotFound) {
+		return unavailable("could not inspect current SCIM User")
 	}
 	row := idb.Record{
 		"id": intent.userID, "client_id": intent.clientID, "core_user_id": intent.coreUserID,
@@ -1091,7 +1104,7 @@ func (s *Service) convergeUserLocked(ctx context.Context, userID string) error {
 }
 
 func intentAlreadyCommitted(ctx context.Context, tx idb.Transaction, intent intentRow) (bool, error) {
-	rec, err := tx.ObjectStore(coredata.StoreSCIMUsers).Get(ctx, intent.userID)
+	rec, err := getTransactionRecord(ctx, tx.ObjectStore(coredata.StoreSCIMUsers), intent.userID)
 	if errors.Is(err, idb.ErrNotFound) {
 		return false, nil
 	}
@@ -1119,7 +1132,7 @@ func (s *Service) recordProjectionFailure(ctx context.Context, rec idb.Record, p
 			_ = tx.Abort(context.WithoutCancel(ctx))
 		}
 	}()
-	latest, err := tx.ObjectStore(coredata.StoreSCIMProjectionIntents).Get(ctx, recordString(rec, "id"))
+	latest, err := getTransactionRecord(ctx, tx.ObjectStore(coredata.StoreSCIMProjectionIntents), recordString(rec, "id"))
 	if errors.Is(err, idb.ErrNotFound) {
 		return nil
 	}

--- a/gestaltd/internal/scim/users_http_test.go
+++ b/gestaltd/internal/scim/users_http_test.go
@@ -303,14 +303,14 @@ func TestSCIMUsersHTTPContract(t *testing.T) {
 	}
 }
 
-func TestSCIMCreateSupportsTerminalTransactionalIndexMisses(t *testing.T) {
+func TestSCIMCreateSupportsTerminalTransactionalMisses(t *testing.T) {
 	t.Parallel()
 
 	db := &transactionFaultDB{IndexedDB: &coretesting.StubIndexedDB{}}
 	_, _, handler := newSCIMService(t, db, nil, testSCIMConfig(map[string]config.SCIMClientConfig{
 		"rippling": ripplingClient(nil),
 	}))
-	db.arm(transactionFaultTerminalIndexMiss)
+	db.arm(transactionFaultTerminalMiss)
 
 	_, response := createUser(t, handler, testCurrentToken, "alice@valon.com", true, nil)
 	if response.Code != http.StatusCreated {
@@ -1059,7 +1059,7 @@ const (
 	transactionFaultIntentAdd transactionFault = iota + 1
 	transactionFaultSCIMUserGet
 	transactionFaultCoreUserAdd
-	transactionFaultTerminalIndexMiss
+	transactionFaultTerminalMiss
 )
 
 type transactionFaultDB struct {
@@ -1086,6 +1086,12 @@ func (d *transactionFaultDB) trip(fault transactionFault) bool {
 	}
 	d.tripped = true
 	return true
+}
+
+func (d *transactionFaultDB) active(fault transactionFault) bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.armed && d.fault == fault
 }
 
 func (d *transactionFaultDB) Transaction(ctx context.Context, stores []string, mode idb.TransactionMode, opts idb.TransactionOptions) (idb.Transaction, error) {
@@ -1120,7 +1126,11 @@ func (s *transactionFaultStore) Get(ctx context.Context, id string) (idb.Record,
 	if s.name == coredata.StoreSCIMUsers && s.db.trip(transactionFaultSCIMUserGet) {
 		return nil, errors.New("injected datastore failure")
 	}
-	return s.TransactionObjectStore.Get(ctx, id)
+	record, err := s.TransactionObjectStore.Get(ctx, id)
+	if errors.Is(err, idb.ErrNotFound) && s.db.active(transactionFaultTerminalMiss) {
+		_ = s.tx.Abort(ctx)
+	}
+	return record, err
 }
 
 func (s *transactionFaultStore) Add(ctx context.Context, record idb.Record) error {
@@ -1145,7 +1155,7 @@ type transactionFaultIndex struct {
 
 func (i *transactionFaultIndex) Get(ctx context.Context, query any) (idb.Record, error) {
 	record, err := i.TransactionIndex.Get(ctx, query)
-	if errors.Is(err, idb.ErrNotFound) && i.db.trip(transactionFaultTerminalIndexMiss) {
+	if errors.Is(err, idb.ErrNotFound) && i.db.active(transactionFaultTerminalMiss) {
 		_ = i.tx.Abort(ctx)
 	}
 	return record, err


### PR DESCRIPTION
## Summary

- use bounded transactional GetAll calls when a missing primary-key record is an expected state and the transaction must continue
- cover intent finalization, superseded-intent checks, and projection-failure recording
- extend the Users HTTP regression to emulate providers that make both index and primary-key Get misses terminal

## Production impact

The first compatibility fix allows SCIM creates to persist their durable projection intent. Finalization then encounters the same legacy remote-provider behavior while checking whether scim_users already contains the new resource, causing the subsequent Put to return 503. This change keeps that expected miss non-terminal so the retained intent can finalize.

## Verification

- go test ./internal/scim ./internal/bootstrap -count=1
- go test ./cmd/gestaltd ./core/... ./internal/... ./sdk/... ./services/... ./tools/...

The literal go test ./... remains independently blocked on main because cmd/reseed-fp-cred imports github.com/go-sql-driver/mysql without declaring the module.