### PR TITLE
Add gestaltd.client.version ingress telemetry for CLI releases

### DIFF
--- a/gestalt/Cargo.toml
+++ b/gestalt/Cargo.toml
@@ -3,5 +3,5 @@ resolver = "2"
 members = ["cli"]
 
 [workspace.package]
-version = "0.0.2-alpha.16"
+version = "0.0.2-alpha.17"
 edition = "2024"

--- a/gestalt/cli/src/api.rs
+++ b/gestalt/cli/src/api.rs
@@ -286,6 +286,7 @@ impl ApiClient {
         )
         .with_timeout(timeout)
         .with_gestalt_client_kind(http::GESTALT_CLIENT_KIND_CLI)
+        .with_gestalt_client_version(env!("CARGO_PKG_VERSION"))
     }
 
     pub fn get(&self, path: &str) -> Result<serde_json::Value> {

--- a/gestalt/cli/src/http.rs
+++ b/gestalt/cli/src/http.rs
@@ -8,7 +8,9 @@ pub const TEXT_HTML: &str = "text/html";
 pub const TEXT_PLAIN: &str = "text/plain";
 pub const CACHE_CONTROL_NO_STORE: &str = "no-store";
 pub const GESTALT_CLIENT_KIND_CLI: &str = "cli";
-pub const GESTALT_CLIENT_VERSION_HEADER: &str = "x-gestalt-client-version";
+
+const GESTALT_CLIENT_HEADER: &str = "x-gestalt-client";
+const GESTALT_CLIENT_VERSION_HEADER: &str = "x-gestalt-client-version";
 
 const CONNECTION_CLOSE: &str = "close";
 const UTF_8: &str = "utf-8";
@@ -16,7 +18,7 @@ const UTF_8: &str = "utf-8";
 pub fn gestalt_cli_headers() -> header::HeaderMap {
     let mut headers = header::HeaderMap::new();
     headers.insert(
-        header::HeaderName::from_static("x-gestalt-client"),
+        header::HeaderName::from_static(GESTALT_CLIENT_HEADER),
         header::HeaderValue::from_static(GESTALT_CLIENT_KIND_CLI),
     );
     headers.insert(

--- a/gestalt/cli/src/http.rs
+++ b/gestalt/cli/src/http.rs
@@ -8,6 +8,7 @@ pub const TEXT_HTML: &str = "text/html";
 pub const TEXT_PLAIN: &str = "text/plain";
 pub const CACHE_CONTROL_NO_STORE: &str = "no-store";
 pub const GESTALT_CLIENT_KIND_CLI: &str = "cli";
+pub const GESTALT_CLIENT_VERSION_HEADER: &str = "x-gestalt-client-version";
 
 const CONNECTION_CLOSE: &str = "close";
 const UTF_8: &str = "utf-8";
@@ -17,6 +18,10 @@ pub fn gestalt_cli_headers() -> header::HeaderMap {
     headers.insert(
         header::HeaderName::from_static("x-gestalt-client"),
         header::HeaderValue::from_static(GESTALT_CLIENT_KIND_CLI),
+    );
+    headers.insert(
+        header::HeaderName::from_static(GESTALT_CLIENT_VERSION_HEADER),
+        header::HeaderValue::from_static(env!("CARGO_PKG_VERSION")),
     );
     headers
 }

--- a/gestaltd/internal/server/ingress_telemetry.go
+++ b/gestaltd/internal/server/ingress_telemetry.go
@@ -28,9 +28,14 @@ type subjectLabelRecorderKey struct{}
 
 func clientKindTelemetryMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		metricutil.AddHTTPServerMetricDims(r.Context(), metricutil.HTTPMetricDims{
-			ClientKind: classifyClientKind(r),
-		})
+		kind := classifyClientKind(r)
+		dims := metricutil.HTTPMetricDims{ClientKind: kind}
+		if kind == metricutil.ClientKindCLI {
+			dims.ClientVersion = metricutil.ClassifyKnownCLIVersion(
+				r.Header.Get(metricutil.HeaderGestaltClientVersion),
+			)
+		}
+		metricutil.AddHTTPServerMetricDims(r.Context(), dims)
 		next.ServeHTTP(w, r)
 	})
 }

--- a/gestaltd/internal/server/ingress_telemetry.go
+++ b/gestaltd/internal/server/ingress_telemetry.go
@@ -28,16 +28,20 @@ type subjectLabelRecorderKey struct{}
 
 func clientKindTelemetryMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		kind := classifyClientKind(r)
-		dims := metricutil.HTTPMetricDims{ClientKind: kind}
-		if kind == metricutil.ClientKindCLI {
-			dims.ClientVersion = metricutil.ClassifyKnownCLIVersion(
-				r.Header.Get(metricutil.HeaderGestaltClientVersion),
-			)
-		}
-		metricutil.AddHTTPServerMetricDims(r.Context(), dims)
+		metricutil.AddHTTPServerMetricDims(r.Context(), classifyClientMetricDims(r))
 		next.ServeHTTP(w, r)
 	})
+}
+
+func classifyClientMetricDims(r *http.Request) metricutil.HTTPMetricDims {
+	kind := classifyClientKind(r)
+	dims := metricutil.HTTPMetricDims{ClientKind: kind}
+	if kind == metricutil.ClientKindCLI {
+		dims.ClientVersion = metricutil.ClassifyKnownCLIVersion(
+			r.Header.Get(metricutil.HeaderGestaltClientVersion),
+		)
+	}
+	return dims
 }
 
 func classifyClientKind(r *http.Request) string {

--- a/gestaltd/internal/server/ingress_telemetry_metrics_test.go
+++ b/gestaltd/internal/server/ingress_telemetry_metrics_test.go
@@ -83,10 +83,11 @@ func TestIngressTelemetryRequestMetrics(t *testing.T) {
 		}
 
 		attrs := map[string]string{
-			"http.route":             "/api/v1/{integration}/{operation}",
-			"gestaltd.ingress.kind":  metricutil.IngressKindAppInvokeV1,
-			"gestaltd.client.kind":   metricutil.ClientKindCLI,
-			"gestaltd.subject.label": "anonymous@gestalt",
+			"http.route":               "/api/v1/{integration}/{operation}",
+			"gestaltd.ingress.kind":    metricutil.IngressKindAppInvokeV1,
+			"gestaltd.client.kind":     metricutil.ClientKindCLI,
+			"gestaltd.client.version":  metricutil.ClientVersionUnknown,
+			"gestaltd.subject.label":   "anonymous@gestalt",
 		}
 		rm := collectMetricsUntil(t, metrics, func(rm metricdata.ResourceMetrics) bool {
 			return metrictest.HasFloat64Histogram(rm, "http.server.request.duration", attrs)
@@ -358,8 +359,9 @@ func TestIngressTelemetryRequestMetrics(t *testing.T) {
 		}
 
 		attrs := map[string]string{
-			"http.route":           "/api/v1/catalog/apps",
-			"gestaltd.client.kind": metricutil.ClientKindCLI,
+			"http.route":              "/api/v1/catalog/apps",
+			"gestaltd.client.kind":    metricutil.ClientKindCLI,
+			"gestaltd.client.version": metricutil.ClientVersionUnknown,
 		}
 		rm := collectMetricsUntil(t, metrics, func(rm metricdata.ResourceMetrics) bool {
 			return metrictest.HasFloat64Histogram(rm, "http.server.request.duration", attrs)
@@ -367,6 +369,83 @@ func TestIngressTelemetryRequestMetrics(t *testing.T) {
 		metrictest.RequireFloat64Histogram(t, rm, "http.server.request.duration", attrs)
 		metrictest.RequireFloat64HistogramOmitsAttr(t, rm, "http.server.request.duration", attrs, "gestaltd.ingress.kind")
 		metrictest.RequireFloat64HistogramOmitsAttr(t, rm, "http.server.request.duration", attrs, "gestaltd.subject.label")
+	})
+
+	t.Run("app invoke v1 labels allowlisted cli version", func(t *testing.T) {
+		t.Parallel()
+
+		metrics := metrictest.NewManualMeterProvider(t)
+		const providerName = "ingress-cli-version-metrics"
+		srv := newTestServer(t, func(cfg *server.Config) {
+			cfg.MeterProvider = metrics.Provider
+			cfg.Providers = testutil.NewProviderRegistry(t, &stubIntegrationWithCatalog{
+				StubIntegration: coretesting.StubIntegration{
+					N:        providerName,
+					ConnMode: core.ConnectionModeNone,
+					ExecuteFn: func(_ context.Context, operation string, _ map[string]any, _ string) (*core.OperationResult, error) {
+						return &core.OperationResult{Status: http.StatusOK, Body: []byte(`{"operation":"` + operation + `"}`)}, nil
+					},
+				},
+				catalog: &catalog.Catalog{
+					Name: providerName,
+					Operations: []catalog.CatalogOperation{
+						{ID: "list", Method: http.MethodGet, Path: "/list"},
+					},
+				},
+			})
+		})
+		testutil.CloseOnCleanup(t, srv)
+
+		req, _ := http.NewRequest(http.MethodGet, srv.URL+"/api/v1/"+providerName+"/list", nil)
+		req.Header.Set(metricutil.HeaderGestaltClient, metricutil.ClientKindCLI)
+		req.Header.Set(metricutil.HeaderGestaltClientVersion, "0.0.2-alpha.17")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("request: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+		}
+
+		attrs := map[string]string{
+			"http.route":              "/api/v1/{integration}/{operation}",
+			"gestaltd.ingress.kind":   metricutil.IngressKindAppInvokeV1,
+			"gestaltd.client.kind":    metricutil.ClientKindCLI,
+			"gestaltd.client.version": "0.0.2-alpha.17",
+		}
+		rm := collectMetricsUntil(t, metrics, func(rm metricdata.ResourceMetrics) bool {
+			return metrictest.HasFloat64Histogram(rm, "http.server.request.duration", attrs)
+		})
+		metrictest.RequireFloat64Histogram(t, rm, "http.server.request.duration", attrs)
+	})
+
+	t.Run("ready request omits cli version for non-cli clients", func(t *testing.T) {
+		t.Parallel()
+
+		metrics := metrictest.NewManualMeterProvider(t)
+		srv := newTestServer(t, func(cfg *server.Config) {
+			cfg.MeterProvider = metrics.Provider
+		})
+		testutil.CloseOnCleanup(t, srv)
+
+		req, _ := http.NewRequest(http.MethodGet, srv.URL+"/ready", nil)
+		req.Header.Set(metricutil.HeaderGestaltClientVersion, "0.0.2-alpha.17")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("request: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		attrs := map[string]string{
+			"http.route":           "/ready",
+			"gestaltd.client.kind": metricutil.ClientKindUnknown,
+		}
+		rm := collectMetricsUntil(t, metrics, func(rm metricdata.ResourceMetrics) bool {
+			return metrictest.HasFloat64Histogram(rm, "http.server.request.duration", attrs)
+		})
+		metrictest.RequireFloat64Histogram(t, rm, "http.server.request.duration", attrs)
+		metrictest.RequireFloat64HistogramOmitsAttr(t, rm, "http.server.request.duration", attrs, "gestaltd.client.version")
 	})
 
 	t.Run("mounted ui labels web client and ingress kind", func(t *testing.T) {
@@ -424,10 +503,11 @@ func TestIngressTelemetryRequestMetrics(t *testing.T) {
 		defer func() { _ = resp.Body.Close() }()
 
 		attrs := map[string]string{
-			"http.route":             "/api/v2/*",
-			"gestaltd.ingress.kind":  metricutil.IngressKindPublicREST,
-			"gestaltd.client.kind":   metricutil.ClientKindCLI,
-			"gestaltd.subject.label": metricutil.SubjectLabelUnknown,
+			"http.route":               "/api/v2/*",
+			"gestaltd.ingress.kind":    metricutil.IngressKindPublicREST,
+			"gestaltd.client.kind":     metricutil.ClientKindCLI,
+			"gestaltd.client.version":  metricutil.ClientVersionUnknown,
+			"gestaltd.subject.label":   metricutil.SubjectLabelUnknown,
 		}
 		rm := collectMetricsUntil(t, metrics, func(rm metricdata.ResourceMetrics) bool {
 			return metrictest.HasFloat64Histogram(rm, "http.server.request.duration", attrs)

--- a/gestaltd/internal/server/ingress_telemetry_metrics_test.go
+++ b/gestaltd/internal/server/ingress_telemetry_metrics_test.go
@@ -73,6 +73,7 @@ func TestIngressTelemetryRequestMetrics(t *testing.T) {
 
 		req, _ := http.NewRequest(http.MethodGet, srv.URL+"/api/v1/"+providerName+"/list", nil)
 		req.Header.Set(metricutil.HeaderGestaltClient, metricutil.ClientKindCLI)
+		req.Header.Set(metricutil.HeaderGestaltClientVersion, "0.0.2-alpha.17")
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
 			t.Fatalf("request: %v", err)
@@ -86,7 +87,7 @@ func TestIngressTelemetryRequestMetrics(t *testing.T) {
 			"http.route":               "/api/v1/{integration}/{operation}",
 			"gestaltd.ingress.kind":    metricutil.IngressKindAppInvokeV1,
 			"gestaltd.client.kind":     metricutil.ClientKindCLI,
-			"gestaltd.client.version":  metricutil.ClientVersionUnknown,
+			"gestaltd.client.version":  "0.0.2-alpha.17",
 			"gestaltd.subject.label":   "anonymous@gestalt",
 		}
 		rm := collectMetricsUntil(t, metrics, func(rm metricdata.ResourceMetrics) bool {
@@ -369,83 +370,6 @@ func TestIngressTelemetryRequestMetrics(t *testing.T) {
 		metrictest.RequireFloat64Histogram(t, rm, "http.server.request.duration", attrs)
 		metrictest.RequireFloat64HistogramOmitsAttr(t, rm, "http.server.request.duration", attrs, "gestaltd.ingress.kind")
 		metrictest.RequireFloat64HistogramOmitsAttr(t, rm, "http.server.request.duration", attrs, "gestaltd.subject.label")
-	})
-
-	t.Run("app invoke v1 labels allowlisted cli version", func(t *testing.T) {
-		t.Parallel()
-
-		metrics := metrictest.NewManualMeterProvider(t)
-		const providerName = "ingress-cli-version-metrics"
-		srv := newTestServer(t, func(cfg *server.Config) {
-			cfg.MeterProvider = metrics.Provider
-			cfg.Providers = testutil.NewProviderRegistry(t, &stubIntegrationWithCatalog{
-				StubIntegration: coretesting.StubIntegration{
-					N:        providerName,
-					ConnMode: core.ConnectionModeNone,
-					ExecuteFn: func(_ context.Context, operation string, _ map[string]any, _ string) (*core.OperationResult, error) {
-						return &core.OperationResult{Status: http.StatusOK, Body: []byte(`{"operation":"` + operation + `"}`)}, nil
-					},
-				},
-				catalog: &catalog.Catalog{
-					Name: providerName,
-					Operations: []catalog.CatalogOperation{
-						{ID: "list", Method: http.MethodGet, Path: "/list"},
-					},
-				},
-			})
-		})
-		testutil.CloseOnCleanup(t, srv)
-
-		req, _ := http.NewRequest(http.MethodGet, srv.URL+"/api/v1/"+providerName+"/list", nil)
-		req.Header.Set(metricutil.HeaderGestaltClient, metricutil.ClientKindCLI)
-		req.Header.Set(metricutil.HeaderGestaltClientVersion, "0.0.2-alpha.17")
-		resp, err := http.DefaultClient.Do(req)
-		if err != nil {
-			t.Fatalf("request: %v", err)
-		}
-		defer func() { _ = resp.Body.Close() }()
-		if resp.StatusCode != http.StatusOK {
-			t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
-		}
-
-		attrs := map[string]string{
-			"http.route":              "/api/v1/{integration}/{operation}",
-			"gestaltd.ingress.kind":   metricutil.IngressKindAppInvokeV1,
-			"gestaltd.client.kind":    metricutil.ClientKindCLI,
-			"gestaltd.client.version": "0.0.2-alpha.17",
-		}
-		rm := collectMetricsUntil(t, metrics, func(rm metricdata.ResourceMetrics) bool {
-			return metrictest.HasFloat64Histogram(rm, "http.server.request.duration", attrs)
-		})
-		metrictest.RequireFloat64Histogram(t, rm, "http.server.request.duration", attrs)
-	})
-
-	t.Run("ready request omits cli version for non-cli clients", func(t *testing.T) {
-		t.Parallel()
-
-		metrics := metrictest.NewManualMeterProvider(t)
-		srv := newTestServer(t, func(cfg *server.Config) {
-			cfg.MeterProvider = metrics.Provider
-		})
-		testutil.CloseOnCleanup(t, srv)
-
-		req, _ := http.NewRequest(http.MethodGet, srv.URL+"/ready", nil)
-		req.Header.Set(metricutil.HeaderGestaltClientVersion, "0.0.2-alpha.17")
-		resp, err := http.DefaultClient.Do(req)
-		if err != nil {
-			t.Fatalf("request: %v", err)
-		}
-		defer func() { _ = resp.Body.Close() }()
-
-		attrs := map[string]string{
-			"http.route":           "/ready",
-			"gestaltd.client.kind": metricutil.ClientKindUnknown,
-		}
-		rm := collectMetricsUntil(t, metrics, func(rm metricdata.ResourceMetrics) bool {
-			return metrictest.HasFloat64Histogram(rm, "http.server.request.duration", attrs)
-		})
-		metrictest.RequireFloat64Histogram(t, rm, "http.server.request.duration", attrs)
-		metrictest.RequireFloat64HistogramOmitsAttr(t, rm, "http.server.request.duration", attrs, "gestaltd.client.version")
 	})
 
 	t.Run("mounted ui labels web client and ingress kind", func(t *testing.T) {

--- a/gestaltd/internal/server/ingress_telemetry_metrics_test.go
+++ b/gestaltd/internal/server/ingress_telemetry_metrics_test.go
@@ -84,11 +84,11 @@ func TestIngressTelemetryRequestMetrics(t *testing.T) {
 		}
 
 		attrs := map[string]string{
-			"http.route":               "/api/v1/{integration}/{operation}",
-			"gestaltd.ingress.kind":    metricutil.IngressKindAppInvokeV1,
-			"gestaltd.client.kind":     metricutil.ClientKindCLI,
-			"gestaltd.client.version":  "0.0.2-alpha.17",
-			"gestaltd.subject.label":   "anonymous@gestalt",
+			"http.route":              "/api/v1/{integration}/{operation}",
+			"gestaltd.ingress.kind":   metricutil.IngressKindAppInvokeV1,
+			"gestaltd.client.kind":    metricutil.ClientKindCLI,
+			"gestaltd.client.version": "0.0.2-alpha.17",
+			"gestaltd.subject.label":  "anonymous@gestalt",
 		}
 		rm := collectMetricsUntil(t, metrics, func(rm metricdata.ResourceMetrics) bool {
 			return metrictest.HasFloat64Histogram(rm, "http.server.request.duration", attrs)
@@ -427,11 +427,11 @@ func TestIngressTelemetryRequestMetrics(t *testing.T) {
 		defer func() { _ = resp.Body.Close() }()
 
 		attrs := map[string]string{
-			"http.route":               "/api/v2/*",
-			"gestaltd.ingress.kind":    metricutil.IngressKindPublicREST,
-			"gestaltd.client.kind":     metricutil.ClientKindCLI,
-			"gestaltd.client.version":  metricutil.ClientVersionUnknown,
-			"gestaltd.subject.label":   metricutil.SubjectLabelUnknown,
+			"http.route":              "/api/v2/*",
+			"gestaltd.ingress.kind":   metricutil.IngressKindPublicREST,
+			"gestaltd.client.kind":    metricutil.ClientKindCLI,
+			"gestaltd.client.version": metricutil.ClientVersionUnknown,
+			"gestaltd.subject.label":  metricutil.SubjectLabelUnknown,
 		}
 		rm := collectMetricsUntil(t, metrics, func(rm metricdata.ResourceMetrics) bool {
 			return metrictest.HasFloat64Histogram(rm, "http.server.request.duration", attrs)

--- a/gestaltd/internal/server/ingress_telemetry_test.go
+++ b/gestaltd/internal/server/ingress_telemetry_test.go
@@ -66,9 +66,9 @@ func TestClassifyClientMetricDims(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name    string
-		header  func(*http.Request)
-		want    metricutil.HTTPMetricDims
+		name   string
+		header func(*http.Request)
+		want   metricutil.HTTPMetricDims
 	}{
 		{
 			name: "cli with allowlisted version",

--- a/gestaltd/internal/server/ingress_telemetry_test.go
+++ b/gestaltd/internal/server/ingress_telemetry_test.go
@@ -62,6 +62,58 @@ func TestClassifyClientKind(t *testing.T) {
 	}
 }
 
+func TestClassifyClientMetricDims(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		header  func(*http.Request)
+		want    metricutil.HTTPMetricDims
+	}{
+		{
+			name: "cli with allowlisted version",
+			header: func(r *http.Request) {
+				r.Header.Set(metricutil.HeaderGestaltClient, metricutil.ClientKindCLI)
+				r.Header.Set(metricutil.HeaderGestaltClientVersion, "0.0.2-alpha.17")
+			},
+			want: metricutil.HTTPMetricDims{
+				ClientKind:    metricutil.ClientKindCLI,
+				ClientVersion: "0.0.2-alpha.17",
+			},
+		},
+		{
+			name: "cli without version header",
+			header: func(r *http.Request) {
+				r.Header.Set(metricutil.HeaderGestaltClient, metricutil.ClientKindCLI)
+			},
+			want: metricutil.HTTPMetricDims{
+				ClientKind:    metricutil.ClientKindCLI,
+				ClientVersion: metricutil.ClientVersionUnknown,
+			},
+		},
+		{
+			name: "non-cli omits version",
+			header: func(r *http.Request) {
+				r.Header.Set(metricutil.HeaderGestaltClientVersion, "0.0.2-alpha.17")
+			},
+			want: metricutil.HTTPMetricDims{
+				ClientKind: metricutil.ClientKindUnknown,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			tc.header(req)
+			if got := classifyClientMetricDims(req); got != tc.want {
+				t.Fatalf("classifyClientMetricDims() = %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestClassifyClientAppFromReferrer(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/services/observability/metricutil/attrs.go
+++ b/gestaltd/services/observability/metricutil/attrs.go
@@ -36,6 +36,7 @@ const (
 	attrGestaltdIngressKind        = attribute.Key("gestaltd.ingress.kind")
 	attrGestaltdClientKind         = attribute.Key("gestaltd.client.kind")
 	attrGestaltdClientApp          = attribute.Key("gestaltd.client.app")
+	attrGestaltdClientVersion      = attribute.Key("gestaltd.client.version")
 	attrGestaltdSubjectLabel       = attribute.Key("gestaltd.subject.label")
 
 	attrDBSystemName     = attribute.Key("db.system.name")
@@ -88,6 +89,7 @@ type HTTPMetricDims struct {
 	IngressKind     string
 	ClientKind      string
 	ClientApp       string
+	ClientVersion   string
 	SubjectLabel    string
 }
 
@@ -119,6 +121,7 @@ func HTTPServerAttrs(dims HTTPMetricDims) []attribute.KeyValue {
 	attrs = appendStringAttr(attrs, attrGestaltdIngressKind, dims.IngressKind)
 	attrs = appendStringAttr(attrs, attrGestaltdClientKind, dims.ClientKind)
 	attrs = appendStringAttr(attrs, attrGestaltdClientApp, dims.ClientApp)
+	attrs = appendStringAttr(attrs, attrGestaltdClientVersion, dims.ClientVersion)
 	attrs = appendStringAttr(attrs, attrGestaltdSubjectLabel, dims.SubjectLabel)
 	return attrs
 }

--- a/gestaltd/services/observability/metricutil/cli_version.go
+++ b/gestaltd/services/observability/metricutil/cli_version.go
@@ -1,9 +1,6 @@
 package metricutil
 
-import (
-	"strings"
-	"unicode"
-)
+import "strings"
 
 const (
 	HeaderGestaltClientVersion = "X-Gestalt-Client-Version"
@@ -14,31 +11,32 @@ const (
 	maxKnownCLIVersions    = 20
 )
 
-// knownCLIVersions is the server-owned allowlist of CLI releases that may be
-// emitted as gestaltd.client.version. When full, add the next release and drop
-// the oldest entry before deploying gestaltd and publishing the CLI.
 var knownCLIVersions = []string{
 	"0.0.2-alpha.17",
 }
 
-// ClassifyKnownCLIVersion returns the canonical allowlisted semver for raw or
-// ClientVersionUnknown when the header is missing, malformed, oversized, or
-// unrecognized.
 func ClassifyKnownCLIVersion(raw string) string {
-	return classifyVersionAgainstAllowlist(knownCLIVersions, raw)
+	return classifyKnownCLIVersion(knownCLIVersions, raw)
 }
 
-func classifyVersionAgainstAllowlist(allowlist []string, raw string) string {
+func classifyKnownCLIVersion(versions []string, raw string) string {
 	raw = strings.TrimSpace(raw)
-	if raw == "" || len(raw) > maxCLIVersionHeaderLen || !validCLIVersionFormat(raw) {
+	if raw == "" || len(raw) > maxCLIVersionHeaderLen {
 		return ClientVersionUnknown
 	}
-	for _, known := range allowlist {
+	for _, known := range effectiveKnownCLIVersions(versions) {
 		if raw == known {
 			return known
 		}
 	}
 	return ClientVersionUnknown
+}
+
+func effectiveKnownCLIVersions(versions []string) []string {
+	if len(versions) <= maxKnownCLIVersions {
+		return versions
+	}
+	return versions[len(versions)-maxKnownCLIVersions:]
 }
 
 func appendKnownCLIVersion(versions []string, version string, max int) []string {
@@ -55,44 +53,4 @@ func appendKnownCLIVersion(versions []string, version string, max int) []string 
 		return append(versions, version)
 	}
 	return append(versions[1:], version)
-}
-
-func validCLIVersionFormat(version string) bool {
-	parts := strings.SplitN(version, "-", 2)
-	core := parts[0]
-	segments := strings.Split(core, ".")
-	if len(segments) != 3 {
-		return false
-	}
-	for _, segment := range segments {
-		if segment == "" || !isNumericSegment(segment) {
-			return false
-		}
-	}
-	if len(parts) == 1 {
-		return true
-	}
-	prerelease := parts[1]
-	if prerelease == "" {
-		return false
-	}
-	for _, r := range prerelease {
-		switch {
-		case unicode.IsDigit(r):
-		case unicode.IsLetter(r):
-		case r == '.' || r == '-':
-		default:
-			return false
-		}
-	}
-	return true
-}
-
-func isNumericSegment(segment string) bool {
-	for _, r := range segment {
-		if r < '0' || r > '9' {
-			return false
-		}
-	}
-	return true
 }

--- a/gestaltd/services/observability/metricutil/cli_version.go
+++ b/gestaltd/services/observability/metricutil/cli_version.go
@@ -1,0 +1,98 @@
+package metricutil
+
+import (
+	"strings"
+	"unicode"
+)
+
+const (
+	HeaderGestaltClientVersion = "X-Gestalt-Client-Version"
+
+	ClientVersionUnknown = "unknown"
+
+	maxCLIVersionHeaderLen = 64
+	maxKnownCLIVersions    = 20
+)
+
+// knownCLIVersions is the server-owned allowlist of CLI releases that may be
+// emitted as gestaltd.client.version. When full, add the next release and drop
+// the oldest entry before deploying gestaltd and publishing the CLI.
+var knownCLIVersions = []string{
+	"0.0.2-alpha.17",
+}
+
+// ClassifyKnownCLIVersion returns the canonical allowlisted semver for raw or
+// ClientVersionUnknown when the header is missing, malformed, oversized, or
+// unrecognized.
+func ClassifyKnownCLIVersion(raw string) string {
+	return classifyVersionAgainstAllowlist(knownCLIVersions, raw)
+}
+
+func classifyVersionAgainstAllowlist(allowlist []string, raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || len(raw) > maxCLIVersionHeaderLen || !validCLIVersionFormat(raw) {
+		return ClientVersionUnknown
+	}
+	for _, known := range allowlist {
+		if raw == known {
+			return known
+		}
+	}
+	return ClientVersionUnknown
+}
+
+func appendKnownCLIVersion(versions []string, version string, max int) []string {
+	version = strings.TrimSpace(version)
+	if version == "" || max <= 0 {
+		return versions
+	}
+	for _, known := range versions {
+		if known == version {
+			return versions
+		}
+	}
+	if len(versions) < max {
+		return append(versions, version)
+	}
+	return append(versions[1:], version)
+}
+
+func validCLIVersionFormat(version string) bool {
+	parts := strings.SplitN(version, "-", 2)
+	core := parts[0]
+	segments := strings.Split(core, ".")
+	if len(segments) != 3 {
+		return false
+	}
+	for _, segment := range segments {
+		if segment == "" || !isNumericSegment(segment) {
+			return false
+		}
+	}
+	if len(parts) == 1 {
+		return true
+	}
+	prerelease := parts[1]
+	if prerelease == "" {
+		return false
+	}
+	for _, r := range prerelease {
+		switch {
+		case unicode.IsDigit(r):
+		case unicode.IsLetter(r):
+		case r == '.' || r == '-':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func isNumericSegment(segment string) bool {
+	for _, r := range segment {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}

--- a/gestaltd/services/observability/metricutil/cli_version_test.go
+++ b/gestaltd/services/observability/metricutil/cli_version_test.go
@@ -9,11 +9,10 @@ import (
 func TestClassifyKnownCLIVersionRecognizesAllowlistedRelease(t *testing.T) {
 	t.Parallel()
 
-	if got := ClassifyKnownCLIVersion("0.0.2-alpha.17"); got != "0.0.2-alpha.17" {
-		t.Fatalf("ClassifyKnownCLIVersion() = %q, want %q", got, "0.0.2-alpha.17")
-	}
-	if got := ClassifyKnownCLIVersion(" 0.0.2-alpha.17 "); got != "0.0.2-alpha.17" {
-		t.Fatalf("ClassifyKnownCLIVersion(trimmed) = %q, want %q", got, "0.0.2-alpha.17")
+	for _, raw := range []string{"0.0.2-alpha.17", " 0.0.2-alpha.17 "} {
+		if got := ClassifyKnownCLIVersion(raw); got != "0.0.2-alpha.17" {
+			t.Fatalf("ClassifyKnownCLIVersion(%q) = %q, want %q", raw, got, "0.0.2-alpha.17")
+		}
 	}
 }
 
@@ -24,12 +23,8 @@ func TestClassifyKnownCLIVersionRejectsInvalidHeaders(t *testing.T) {
 		"",
 		"   ",
 		"not-a-version",
-		"1.2",
-		"1.2.3.4",
-		"v1.2.3",
-		"0.0.2-alpha.",
-		"0.0.2-alpha.17-extra",
 		"0.0.2-alpha.16",
+		"0.0.2-alpha.17-extra",
 		strings.Repeat("0", maxCLIVersionHeaderLen+1),
 	} {
 		if got := ClassifyKnownCLIVersion(raw); got != ClientVersionUnknown {
@@ -61,6 +56,12 @@ func TestAppendKnownCLIVersionEvictsOldestAtCapacity(t *testing.T) {
 	}
 	if versions[len(versions)-1] != versionForIndex(maxKnownCLIVersions+1) {
 		t.Fatalf("newest version = %q, want %q", versions[len(versions)-1], versionForIndex(maxKnownCLIVersions+1))
+	}
+	if got := classifyKnownCLIVersion(versions, versionForIndex(1)); got != ClientVersionUnknown {
+		t.Fatalf("classifyKnownCLIVersion(evicted) = %q, want %q", got, ClientVersionUnknown)
+	}
+	if got := classifyKnownCLIVersion(versions, versionForIndex(maxKnownCLIVersions+1)); got != versionForIndex(maxKnownCLIVersions+1) {
+		t.Fatalf("classifyKnownCLIVersion(newest) = %q, want %q", got, versionForIndex(maxKnownCLIVersions+1))
 	}
 }
 

--- a/gestaltd/services/observability/metricutil/cli_version_test.go
+++ b/gestaltd/services/observability/metricutil/cli_version_test.go
@@ -1,0 +1,79 @@
+package metricutil
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestClassifyKnownCLIVersionRecognizesAllowlistedRelease(t *testing.T) {
+	t.Parallel()
+
+	if got := ClassifyKnownCLIVersion("0.0.2-alpha.17"); got != "0.0.2-alpha.17" {
+		t.Fatalf("ClassifyKnownCLIVersion() = %q, want %q", got, "0.0.2-alpha.17")
+	}
+	if got := ClassifyKnownCLIVersion(" 0.0.2-alpha.17 "); got != "0.0.2-alpha.17" {
+		t.Fatalf("ClassifyKnownCLIVersion(trimmed) = %q, want %q", got, "0.0.2-alpha.17")
+	}
+}
+
+func TestClassifyKnownCLIVersionRejectsInvalidHeaders(t *testing.T) {
+	t.Parallel()
+
+	for _, raw := range []string{
+		"",
+		"   ",
+		"not-a-version",
+		"1.2",
+		"1.2.3.4",
+		"v1.2.3",
+		"0.0.2-alpha.",
+		"0.0.2-alpha.17-extra",
+		"0.0.2-alpha.16",
+		strings.Repeat("0", maxCLIVersionHeaderLen+1),
+	} {
+		if got := ClassifyKnownCLIVersion(raw); got != ClientVersionUnknown {
+			t.Fatalf("ClassifyKnownCLIVersion(%q) = %q, want %q", raw, got, ClientVersionUnknown)
+		}
+	}
+}
+
+func TestAppendKnownCLIVersionEvictsOldestAtCapacity(t *testing.T) {
+	t.Parallel()
+
+	versions := make([]string, 0, maxKnownCLIVersions)
+	for i := 1; i <= maxKnownCLIVersions; i++ {
+		versions = appendKnownCLIVersion(versions, versionForIndex(i), maxKnownCLIVersions)
+	}
+	if len(versions) != maxKnownCLIVersions {
+		t.Fatalf("len(versions) = %d, want %d", len(versions), maxKnownCLIVersions)
+	}
+	if versions[0] != versionForIndex(1) {
+		t.Fatalf("oldest version = %q, want %q", versions[0], versionForIndex(1))
+	}
+
+	versions = appendKnownCLIVersion(versions, versionForIndex(maxKnownCLIVersions+1), maxKnownCLIVersions)
+	if len(versions) != maxKnownCLIVersions {
+		t.Fatalf("len(versions) after eviction = %d, want %d", len(versions), maxKnownCLIVersions)
+	}
+	if versions[0] != versionForIndex(2) {
+		t.Fatalf("oldest version after eviction = %q, want %q", versions[0], versionForIndex(2))
+	}
+	if versions[len(versions)-1] != versionForIndex(maxKnownCLIVersions+1) {
+		t.Fatalf("newest version = %q, want %q", versions[len(versions)-1], versionForIndex(maxKnownCLIVersions+1))
+	}
+}
+
+func TestAppendKnownCLIVersionIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	versions := []string{"0.0.2-alpha.1"}
+	got := appendKnownCLIVersion(versions, "0.0.2-alpha.1", maxKnownCLIVersions)
+	if len(got) != 1 || got[0] != "0.0.2-alpha.1" {
+		t.Fatalf("appendKnownCLIVersion() = %#v, want unchanged slice", got)
+	}
+}
+
+func versionForIndex(i int) string {
+	return fmt.Sprintf("0.0.2-alpha.%d", i)
+}

--- a/sdk/rust/src/public/rest_request.rs
+++ b/sdk/rust/src/public/rest_request.rs
@@ -44,6 +44,7 @@ pub(crate) fn build_rest_request(
     base_url: &str,
     auth: &Arc<dyn Auth>,
     gestalt_client_kind: Option<&str>,
+    gestalt_client_version: Option<&str>,
 ) -> Result<PreparedRequest, GestaltError> {
     let encode = method.encode_request_json.ok_or_else(|| {
         GestaltError::new(
@@ -78,6 +79,14 @@ pub(crate) fn build_rest_request(
         headers.insert(
             HeaderName::from_static("x-gestalt-client"),
             HeaderValue::from_str(kind).map_err(|err| {
+                GestaltError::new(gestalt_error_code::INVALID_ARGUMENT, err.to_string())
+            })?,
+        );
+    }
+    if let Some(version) = gestalt_client_version {
+        headers.insert(
+            HeaderName::from_static("x-gestalt-client-version"),
+            HeaderValue::from_str(version).map_err(|err| {
                 GestaltError::new(gestalt_error_code::INVALID_ARGUMENT, err.to_string())
             })?,
         );

--- a/sdk/rust/src/public/rest_request.rs
+++ b/sdk/rust/src/public/rest_request.rs
@@ -23,6 +23,9 @@ use crate::public::rest_mapping::{
 };
 use crate::rpc_support::gestalt_error_code;
 
+const HEADER_GESTALT_CLIENT: &str = "x-gestalt-client";
+const HEADER_GESTALT_CLIENT_VERSION: &str = "x-gestalt-client-version";
+
 /// Assembled REST request, ready for an HTTP send.
 pub(crate) struct PreparedRequest {
     /// Target URL with path substitution and query string applied.
@@ -77,7 +80,7 @@ pub(crate) fn build_rest_request(
     }
     if let Some(kind) = gestalt_client_kind {
         headers.insert(
-            HeaderName::from_static("x-gestalt-client"),
+            HeaderName::from_static(HEADER_GESTALT_CLIENT),
             HeaderValue::from_str(kind).map_err(|err| {
                 GestaltError::new(gestalt_error_code::INVALID_ARGUMENT, err.to_string())
             })?,
@@ -85,7 +88,7 @@ pub(crate) fn build_rest_request(
     }
     if let Some(version) = gestalt_client_version {
         headers.insert(
-            HeaderName::from_static("x-gestalt-client-version"),
+            HeaderName::from_static(HEADER_GESTALT_CLIENT_VERSION),
             HeaderValue::from_str(version).map_err(|err| {
                 GestaltError::new(gestalt_error_code::INVALID_ARGUMENT, err.to_string())
             })?,

--- a/sdk/rust/src/public/rest_transport.rs
+++ b/sdk/rust/src/public/rest_transport.rs
@@ -24,6 +24,7 @@ pub struct RestTransport {
     auth: Arc<dyn Auth>,
     client: reqwest::Client,
     gestalt_client_kind: Option<String>,
+    gestalt_client_version: Option<String>,
 }
 
 impl RestTransport {
@@ -37,12 +38,19 @@ impl RestTransport {
                 .build()
                 .expect("reqwest client"),
             gestalt_client_kind: None,
+            gestalt_client_version: None,
         }
     }
 
     /// Sets the `X-Gestalt-Client` header value sent on every request.
     pub fn with_gestalt_client_kind(mut self, kind: impl Into<String>) -> Self {
         self.gestalt_client_kind = Some(kind.into());
+        self
+    }
+
+    /// Sets the `X-Gestalt-Client-Version` header value sent on every request.
+    pub fn with_gestalt_client_version(mut self, version: impl Into<String>) -> Self {
+        self.gestalt_client_version = Some(version.into());
         self
     }
 
@@ -102,6 +110,7 @@ impl UnaryTransport for RestTransport {
         let auth = Arc::clone(&self.auth);
         let client = self.client.clone();
         let gestalt_client_kind = self.gestalt_client_kind.clone();
+        let gestalt_client_version = self.gestalt_client_version.clone();
         let request_bytes = request.encode_to_vec();
         let method = method.clone();
 
@@ -118,6 +127,7 @@ impl UnaryTransport for RestTransport {
                 &base_url,
                 &auth,
                 gestalt_client_kind.as_deref(),
+                gestalt_client_version.as_deref(),
             )?;
             let mut builder = client
                 .request(prepared.method, prepared.url)
@@ -141,6 +151,7 @@ pub struct SyncRestTransport {
     auth: Arc<dyn Auth>,
     client: reqwest::blocking::Client,
     gestalt_client_kind: Option<String>,
+    gestalt_client_version: Option<String>,
 }
 
 impl SyncRestTransport {
@@ -154,12 +165,19 @@ impl SyncRestTransport {
                 .build()
                 .expect("reqwest blocking client"),
             gestalt_client_kind: None,
+            gestalt_client_version: None,
         }
     }
 
     /// Sets the `X-Gestalt-Client` header value sent on every request.
     pub fn with_gestalt_client_kind(mut self, kind: impl Into<String>) -> Self {
         self.gestalt_client_kind = Some(kind.into());
+        self
+    }
+
+    /// Sets the `X-Gestalt-Client-Version` header value sent on every request.
+    pub fn with_gestalt_client_version(mut self, version: impl Into<String>) -> Self {
+        self.gestalt_client_version = Some(version.into());
         self
     }
 
@@ -197,6 +215,7 @@ impl SyncUnaryTransport for SyncRestTransport {
             &self.base_url,
             &self.auth,
             self.gestalt_client_kind.as_deref(),
+            self.gestalt_client_version.as_deref(),
         )?;
         let mut builder = self
             .client


### PR DESCRIPTION
## Summary
- Add a capped (20-entry) server-owned CLI version allowlist and classify `X-Gestalt-Client-Version` on `gestaltd.client.kind:cli` requests as an allowlisted semver or `unknown`.
- Emit `gestaltd.client.version` on HTTP server metrics and omit it for non-CLI traffic.
- Send `X-Gestalt-Client-Version` from shared CLI HTTP transports (reqwest defaults and sync REST transport) and bump the CLI to `0.0.2-alpha.17`.
- Add unit tests for allowlist recognition, eviction, invalid headers, and request-to-metric coverage.

## Test plan
- [x] `go test ./services/observability/metricutil/... -run 'TestClassifyKnownCLIVersion|TestAppendKnownCLIVersion'`
- [x] `go test ./internal/server/... -run TestIngressTelemetry`
- [x] `cargo test -p gestalt`
- [ ] After merge, tag `gestaltd/v*` for gestaltd deploy (step 9 in toolshed)
- [ ] After gestaltd deploy, tag `gestalt/v0.0.2-alpha.17` for the first version-reporting CLI release (step 8b)


Made with [Cursor](https://cursor.com)