### PR TITLE
Attribute gestaltd.subject.label on catalog routes for CLI traffic

### DIFF
--- a/gestaltd/internal/server/ingress_telemetry.go
+++ b/gestaltd/internal/server/ingress_telemetry.go
@@ -96,27 +96,6 @@ func subjectLabelRecorderMiddleware(next http.Handler) http.Handler {
 	})
 }
 
-func (s *Server) catalogCLISubjectLabelMiddleware(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if classifyClientKind(r) != metricutil.ClientKindCLI {
-			next.ServeHTTP(w, r)
-			return
-		}
-
-		r, recorder := withSubjectLabelRecorder(r)
-		defer recorder.flush(r.Context())
-
-		if p, err := s.resolveRequestPrincipal(r); err == nil && p != nil {
-			if enriched, enrichErr := s.resolvePrincipalUserID(r.Context(), p); enrichErr == nil && enriched != nil {
-				p = enriched
-			}
-			addSubjectLabelMetricDims(r.Context(), p)
-		}
-
-		next.ServeHTTP(w, r)
-	})
-}
-
 func (s *Server) classifyClientAppFromReferrer(r *http.Request) string {
 	referer := strings.TrimSpace(r.Referer())
 	if referer == "" || len(referer) > maxReferrerLen {

--- a/gestaltd/internal/server/ingress_telemetry.go
+++ b/gestaltd/internal/server/ingress_telemetry.go
@@ -96,6 +96,27 @@ func subjectLabelRecorderMiddleware(next http.Handler) http.Handler {
 	})
 }
 
+func (s *Server) catalogCLISubjectLabelMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if classifyClientKind(r) != metricutil.ClientKindCLI {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		r, recorder := withSubjectLabelRecorder(r)
+		defer recorder.flush(r.Context())
+
+		if p, err := s.resolveRequestPrincipal(r); err == nil && p != nil {
+			if enriched, enrichErr := s.resolvePrincipalUserID(r.Context(), p); enrichErr == nil && enriched != nil {
+				p = enriched
+			}
+			addSubjectLabelMetricDims(r.Context(), p)
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
 func (s *Server) classifyClientAppFromReferrer(r *http.Request) string {
 	referer := strings.TrimSpace(r.Referer())
 	if referer == "" || len(referer) > maxReferrerLen {

--- a/gestaltd/internal/server/ingress_telemetry_metrics_test.go
+++ b/gestaltd/internal/server/ingress_telemetry_metrics_test.go
@@ -363,12 +363,160 @@ func TestIngressTelemetryRequestMetrics(t *testing.T) {
 			"http.route":              "/api/v1/catalog/apps",
 			"gestaltd.client.kind":    metricutil.ClientKindCLI,
 			"gestaltd.client.version": metricutil.ClientVersionUnknown,
+			"gestaltd.subject.label":  metricutil.SubjectLabelUnknown,
 		}
 		rm := collectMetricsUntil(t, metrics, func(rm metricdata.ResourceMetrics) bool {
 			return metrictest.HasFloat64Histogram(rm, "http.server.request.duration", attrs)
 		})
 		metrictest.RequireFloat64Histogram(t, rm, "http.server.request.duration", attrs)
 		metrictest.RequireFloat64HistogramOmitsAttr(t, rm, "http.server.request.duration", attrs, "gestaltd.ingress.kind")
+	})
+
+	t.Run("catalog route labels authenticated cli subjects", func(t *testing.T) {
+		t.Parallel()
+
+		const providerName = "ingress-catalog-subject"
+		provider := &stubIntegrationWithCatalog{
+			StubIntegration: coretesting.StubIntegration{
+				N:        providerName,
+				ConnMode: core.ConnectionModeNone,
+			},
+			catalog: &catalog.Catalog{
+				Name: providerName,
+				Operations: []catalog.CatalogOperation{
+					{ID: "list", Method: http.MethodGet, Path: "/list"},
+				},
+			},
+		}
+
+		for _, tc := range []struct {
+			name         string
+			path         string
+			route        string
+			auth         core.IdentityProvider
+			token        string
+			subjectLabel string
+		}{
+			{
+				name: "catalog apps user email",
+				path: "/api/v1/catalog/apps",
+				auth: coretesting.NamedIntrospectIdentityStub("stub", func(_ context.Context, token string) (*core.UserIdentity, error) {
+					if token != "user-token" {
+						return nil, core.ErrNotFound
+					}
+					return &core.UserIdentity{Email: "USER@example.com"}, nil
+				}),
+				token:        "user-token",
+				subjectLabel: "user@example.com",
+			},
+			{
+				name: "catalog apps service account",
+				path: "/api/v1/catalog/apps",
+				auth: testAuthStubWithIntrospect(func(_ context.Context, token string) (*core.IntrospectResponse, error) {
+					if token != "sa-token" {
+						return &core.IntrospectResponse{Active: false}, nil
+					}
+					return testIntrospectActive("service_account:oauth-bot", ""), nil
+				}),
+				token:        "sa-token",
+				subjectLabel: "oauth-bot",
+			},
+			{
+				name: "apps list user email",
+				path: "/api/v1/apps",
+				auth: coretesting.NamedIntrospectIdentityStub("stub", func(_ context.Context, token string) (*core.UserIdentity, error) {
+					if token != "user-token" {
+						return nil, core.ErrNotFound
+					}
+					return &core.UserIdentity{Email: "USER@example.com"}, nil
+				}),
+				token:        "user-token",
+				subjectLabel: "user@example.com",
+			},
+			{
+				name:  "app operations service account",
+				path:  "/api/v1/apps/" + providerName + "/operations",
+				route: "/api/v1/apps/{name}/operations",
+				auth: testAuthStubWithIntrospect(func(_ context.Context, token string) (*core.IntrospectResponse, error) {
+					if token != "sa-token" {
+						return &core.IntrospectResponse{Active: false}, nil
+					}
+					return testIntrospectActive("service_account:oauth-bot", ""), nil
+				}),
+				token:        "sa-token",
+				subjectLabel: "oauth-bot",
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				metrics := metrictest.NewManualMeterProvider(t)
+				srv := newTestServer(t, func(cfg *server.Config) {
+					cfg.MeterProvider = metrics.Provider
+					cfg.Auth = tc.auth
+					cfg.StateSecret = []byte("0123456789abcdef0123456789abcdef")
+					cfg.Providers = testutil.NewProviderRegistry(t, provider)
+				})
+				testutil.CloseOnCleanup(t, srv)
+
+				req, _ := http.NewRequest(http.MethodGet, srv.URL+tc.path, nil)
+				req.Header.Set(metricutil.HeaderGestaltClient, metricutil.ClientKindCLI)
+				req.Header.Set("Authorization", "Bearer "+tc.token)
+				resp, err := http.DefaultClient.Do(req)
+				if err != nil {
+					t.Fatalf("request: %v", err)
+				}
+				defer func() { _ = resp.Body.Close() }()
+				if resp.StatusCode != http.StatusOK {
+					t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+				}
+
+				route := tc.path
+				if tc.route != "" {
+					route = tc.route
+				}
+				attrs := map[string]string{
+					"http.route":             route,
+					"gestaltd.client.kind":   metricutil.ClientKindCLI,
+					"gestaltd.subject.label": tc.subjectLabel,
+				}
+				rm := collectMetricsUntil(t, metrics, func(rm metricdata.ResourceMetrics) bool {
+					return metrictest.HasFloat64Histogram(rm, "http.server.request.duration", attrs)
+				})
+				metrictest.RequireFloat64Histogram(t, rm, "http.server.request.duration", attrs)
+				metrictest.RequireFloat64HistogramOmitsAttr(t, rm, "http.server.request.duration", attrs, "gestaltd.ingress.kind")
+			})
+		}
+	})
+
+	t.Run("catalog route omits subject label for web clients", func(t *testing.T) {
+		t.Parallel()
+
+		metrics := metrictest.NewManualMeterProvider(t)
+		srv := newTestServer(t, func(cfg *server.Config) {
+			cfg.MeterProvider = metrics.Provider
+		})
+		testutil.CloseOnCleanup(t, srv)
+
+		req, _ := http.NewRequest(http.MethodGet, srv.URL+"/api/v1/catalog/apps", nil)
+		req.Header.Set("Sec-Fetch-Site", "same-origin")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("request: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+		}
+
+		attrs := map[string]string{
+			"http.route":           "/api/v1/catalog/apps",
+			"gestaltd.client.kind": metricutil.ClientKindWeb,
+		}
+		rm := collectMetricsUntil(t, metrics, func(rm metricdata.ResourceMetrics) bool {
+			return metrictest.HasFloat64Histogram(rm, "http.server.request.duration", attrs)
+		})
+		metrictest.RequireFloat64Histogram(t, rm, "http.server.request.duration", attrs)
 		metrictest.RequireFloat64HistogramOmitsAttr(t, rm, "http.server.request.duration", attrs, "gestaltd.subject.label")
 	})
 

--- a/gestaltd/internal/server/ingress_telemetry_metrics_test.go
+++ b/gestaltd/internal/server/ingress_telemetry_metrics_test.go
@@ -388,6 +388,18 @@ func TestIngressTelemetryRequestMetrics(t *testing.T) {
 				},
 			},
 		}
+		userAuth := coretesting.NamedIntrospectIdentityStub("stub", func(_ context.Context, token string) (*core.UserIdentity, error) {
+			if token != "user-token" {
+				return nil, core.ErrNotFound
+			}
+			return &core.UserIdentity{Email: "USER@example.com"}, nil
+		})
+		saAuth := testAuthStubWithIntrospect(func(_ context.Context, token string) (*core.IntrospectResponse, error) {
+			if token != "sa-token" {
+				return &core.IntrospectResponse{Active: false}, nil
+			}
+			return testIntrospectActive("service_account:oauth-bot", ""), nil
+		})
 
 		for _, tc := range []struct {
 			name         string
@@ -398,51 +410,31 @@ func TestIngressTelemetryRequestMetrics(t *testing.T) {
 			subjectLabel string
 		}{
 			{
-				name: "catalog apps user email",
-				path: "/api/v1/catalog/apps",
-				auth: coretesting.NamedIntrospectIdentityStub("stub", func(_ context.Context, token string) (*core.UserIdentity, error) {
-					if token != "user-token" {
-						return nil, core.ErrNotFound
-					}
-					return &core.UserIdentity{Email: "USER@example.com"}, nil
-				}),
+				name:         "catalog apps user email",
+				path:         "/api/v1/catalog/apps",
+				auth:         userAuth,
 				token:        "user-token",
 				subjectLabel: "user@example.com",
 			},
 			{
-				name: "catalog apps service account",
-				path: "/api/v1/catalog/apps",
-				auth: testAuthStubWithIntrospect(func(_ context.Context, token string) (*core.IntrospectResponse, error) {
-					if token != "sa-token" {
-						return &core.IntrospectResponse{Active: false}, nil
-					}
-					return testIntrospectActive("service_account:oauth-bot", ""), nil
-				}),
+				name:         "catalog apps service account",
+				path:         "/api/v1/catalog/apps",
+				auth:         saAuth,
 				token:        "sa-token",
 				subjectLabel: "oauth-bot",
 			},
 			{
-				name: "apps list user email",
-				path: "/api/v1/apps",
-				auth: coretesting.NamedIntrospectIdentityStub("stub", func(_ context.Context, token string) (*core.UserIdentity, error) {
-					if token != "user-token" {
-						return nil, core.ErrNotFound
-					}
-					return &core.UserIdentity{Email: "USER@example.com"}, nil
-				}),
+				name:         "apps list user email",
+				path:         "/api/v1/apps",
+				auth:         userAuth,
 				token:        "user-token",
 				subjectLabel: "user@example.com",
 			},
 			{
-				name:  "app operations service account",
-				path:  "/api/v1/apps/" + providerName + "/operations",
-				route: "/api/v1/apps/{name}/operations",
-				auth: testAuthStubWithIntrospect(func(_ context.Context, token string) (*core.IntrospectResponse, error) {
-					if token != "sa-token" {
-						return &core.IntrospectResponse{Active: false}, nil
-					}
-					return testIntrospectActive("service_account:oauth-bot", ""), nil
-				}),
+				name:         "app operations service account",
+				path:         "/api/v1/apps/" + providerName + "/operations",
+				route:        "/api/v1/apps/{name}/operations",
+				auth:         saAuth,
 				token:        "sa-token",
 				subjectLabel: "oauth-bot",
 			},
@@ -487,6 +479,46 @@ func TestIngressTelemetryRequestMetrics(t *testing.T) {
 				metrictest.RequireFloat64HistogramOmitsAttr(t, rm, "http.server.request.duration", attrs, "gestaltd.ingress.kind")
 			})
 		}
+	})
+
+	t.Run("catalog cli subject label ignores session cookie", func(t *testing.T) {
+		t.Parallel()
+
+		metrics := metrictest.NewManualMeterProvider(t)
+		srv := newTestServer(t, func(cfg *server.Config) {
+			cfg.MeterProvider = metrics.Provider
+			cfg.Auth = coretesting.NamedIntrospectIdentityStub("stub", func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "session-token" {
+					return nil, core.ErrNotFound
+				}
+				return &core.UserIdentity{Email: "cookie@example.com"}, nil
+			})
+		})
+		testutil.CloseOnCleanup(t, srv)
+
+		req, _ := http.NewRequest(http.MethodGet, srv.URL+"/api/v1/catalog/apps", nil)
+		req.Header.Set(metricutil.HeaderGestaltClient, metricutil.ClientKindCLI)
+		req.AddCookie(&http.Cookie{Name: "session_token", Value: "session-token"})
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("request: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+		}
+
+		attrs := map[string]string{
+			"http.route":              "/api/v1/catalog/apps",
+			"gestaltd.client.kind":    metricutil.ClientKindCLI,
+			"gestaltd.client.version": metricutil.ClientVersionUnknown,
+			"gestaltd.subject.label":  metricutil.SubjectLabelUnknown,
+		}
+		rm := collectMetricsUntil(t, metrics, func(rm metricdata.ResourceMetrics) bool {
+			return metrictest.HasFloat64Histogram(rm, "http.server.request.duration", attrs)
+		})
+		metrictest.RequireFloat64Histogram(t, rm, "http.server.request.duration", attrs)
+		metrictest.RequireFloat64HistogramOmitsAttr(t, rm, "http.server.request.duration", attrs, "gestaltd.ingress.kind")
 	})
 
 	t.Run("catalog route omits subject label for web clients", func(t *testing.T) {

--- a/gestaltd/internal/server/middleware.go
+++ b/gestaltd/internal/server/middleware.go
@@ -327,3 +327,45 @@ func (s *Server) pluginRouteAuthWithSubjectLabelMiddleware(pluginParam string) f
 		})
 	}
 }
+
+func (s *Server) subjectLabelFromOptionalRequest(r *http.Request, resolver *principal.Resolver) {
+	token, err := requestBearerToken(r)
+	if err != nil || token == "" {
+		return
+	}
+	p, err := resolver.ResolveToken(r.Context(), token)
+	if err != nil || p == nil {
+		return
+	}
+	enriched, enrichErr := s.resolvePrincipalUserID(r.Context(), p)
+	if enrichErr == nil && enriched != nil {
+		p = enriched
+	}
+	addSubjectLabelMetricDims(r.Context(), p)
+}
+
+func (s *Server) cliOptionalSubjectLabelMiddleware(pluginParam string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if classifyClientKind(r) != metricutil.ClientKindCLI {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			r, recorder := withSubjectLabelRecorder(r)
+			defer recorder.flush(r.Context())
+
+			resolver := s.resolver
+			if pluginParam != "" {
+				if pluginName := strings.TrimSpace(chi.URLParam(r, pluginParam)); pluginName != "" {
+					if auth, err := s.pluginAuthRuntime(pluginName); err == nil {
+						resolver = auth.resolver
+					}
+				}
+			}
+			s.subjectLabelFromOptionalRequest(r, resolver)
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/gestaltd/internal/server/routes_user.go
+++ b/gestaltd/internal/server/routes_user.go
@@ -11,14 +11,8 @@ func (s *Server) mountAuthenticatedRoutes(r chi.Router) {
 	s.mountAppAdminIdentitiesRoutes(r)
 	s.mountAppAdminMetricsRoutes(r)
 
-	r.Group(func(r chi.Router) {
-		r.Use(s.catalogCLISubjectLabelMiddleware)
-		r.Use(s.authMiddleware)
+	s.mountCatalogCLIRoutes(r)
 
-		r.Get("/catalog/apps", s.listAppCatalog)
-		r.Get("/catalog/apps/{name}/icon", s.serveAppCatalogIcon)
-		r.Get("/apps", s.listIntegrations)
-	})
 	r.Group(func(r chi.Router) {
 		r.Use(s.authMiddleware)
 
@@ -44,12 +38,23 @@ func (s *Server) mountAuthenticatedRoutes(r chi.Router) {
 
 	})
 
-	r.With(s.catalogCLISubjectLabelMiddleware, s.pluginRouteAuthMiddleware("name")).Get("/apps/{name}/operations", s.listOperations)
+	r.With(s.cliOptionalSubjectLabelMiddleware("name"), s.pluginRouteAuthMiddleware("name")).Get("/apps/{name}/operations", s.listOperations)
 	r.Group(func(r chi.Router) {
 		r.Use(s.uiAPIIngressTelemetryMiddleware(metricutil.IngressKindAppInvokeV1))
 		r.Use(subjectLabelRecorderMiddleware)
 		r.Use(s.pluginRouteAuthWithSubjectLabelMiddleware("integration"))
 		r.Get("/{integration}/{operation}", s.executeOperation)
 		r.Post("/{integration}/{operation}", s.executeOperation)
+	})
+}
+
+func (s *Server) mountCatalogCLIRoutes(r chi.Router) {
+	r.Group(func(r chi.Router) {
+		r.Use(s.cliOptionalSubjectLabelMiddleware(""))
+		r.Use(s.authMiddleware)
+
+		r.Get("/catalog/apps", s.listAppCatalog)
+		r.Get("/catalog/apps/{name}/icon", s.serveAppCatalogIcon)
+		r.Get("/apps", s.listIntegrations)
 	})
 }

--- a/gestaltd/internal/server/routes_user.go
+++ b/gestaltd/internal/server/routes_user.go
@@ -12,13 +12,18 @@ func (s *Server) mountAuthenticatedRoutes(r chi.Router) {
 	s.mountAppAdminMetricsRoutes(r)
 
 	r.Group(func(r chi.Router) {
+		r.Use(s.catalogCLISubjectLabelMiddleware)
 		r.Use(s.authMiddleware)
 
 		r.Get("/catalog/apps", s.listAppCatalog)
 		r.Get("/catalog/apps/{name}/icon", s.serveAppCatalogIcon)
+		r.Get("/apps", s.listIntegrations)
+	})
+	r.Group(func(r chi.Router) {
+		r.Use(s.authMiddleware)
+
 		r.Get("/me/app-connections", s.listAppConnections)
 
-		r.Get("/apps", s.listIntegrations)
 		r.Delete("/apps/{name}", s.disconnectIntegration)
 		r.Put("/apps/{name}/preferred-instance", s.selectPreferredInstance)
 		r.Get("/apps/{name}/access", s.getAppAccess)
@@ -39,7 +44,7 @@ func (s *Server) mountAuthenticatedRoutes(r chi.Router) {
 
 	})
 
-	r.With(s.pluginRouteAuthMiddleware("name")).Get("/apps/{name}/operations", s.listOperations)
+	r.With(s.catalogCLISubjectLabelMiddleware, s.pluginRouteAuthMiddleware("name")).Get("/apps/{name}/operations", s.listOperations)
 	r.Group(func(r chi.Router) {
 		r.Use(s.uiAPIIngressTelemetryMiddleware(metricutil.IngressKindAppInvokeV1))
 		r.Use(subjectLabelRecorderMiddleware)


### PR DESCRIPTION
## Summary
- Add `catalogCLISubjectLabelMiddleware` to emit `gestaltd.subject.label` on `/api/v1/catalog/*`, `/api/v1/apps`, and `/api/v1/apps/{name}/operations` for identified CLI requests
- Resolve bearer tokens to normalized user emails or service-account names when present; emit `unknown` when the CLI sends no credentials
- Keep catalog routes out of `gestaltd.ingress.kind`; web catalog traffic still omits the subject tag
- Extend request-to-metric tests for unauthenticated CLI, authenticated user/SA, and web omission cases

Ingress refactor step **11** in [toolshed#4654](https://github.com/valon-technologies/toolshed/pull/4654).

## Test plan
- [x] `go test ./internal/server -run TestIngressTelemetryRequestMetrics`
- [x] `go test ./internal/server`


Made with [Cursor](https://cursor.com)