### PR TITLE
Replace CLI version allowlist with self-declared semver validation

### DIFF
--- a/gestaltd/internal/semvervalidate/validate.go
+++ b/gestaltd/internal/semvervalidate/validate.go
@@ -1,0 +1,26 @@
+package semvervalidate
+
+import (
+	"strings"
+
+	"golang.org/x/mod/semver"
+)
+
+// Valid reports whether version is a canonical semver without a leading v prefix.
+func Valid(version string) bool {
+	version = strings.TrimSpace(version)
+	if version == "" || strings.HasPrefix(version, "v") {
+		return false
+	}
+
+	canonical := "v" + version
+	if !semver.IsValid(canonical) {
+		return false
+	}
+
+	base := canonical
+	if i := strings.IndexByte(base, '+'); i != -1 {
+		base = base[:i]
+	}
+	return semver.Canonical(canonical) == base
+}

--- a/gestaltd/internal/semvervalidate/validate_test.go
+++ b/gestaltd/internal/semvervalidate/validate_test.go
@@ -1,0 +1,25 @@
+package semvervalidate
+
+import "testing"
+
+func TestValid(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		version string
+		want    bool
+	}{
+		{version: "1.2.3", want: true},
+		{version: "1.0.0-alpha.1", want: true},
+		{version: "0.0.2-alpha.16", want: true},
+		{version: "v1.2.3", want: false},
+		{version: "", want: false},
+		{version: "not-a-version", want: false},
+		{version: "01.02.03", want: false},
+	}
+	for _, tc := range tests {
+		if got := Valid(tc.version); got != tc.want {
+			t.Fatalf("Valid(%q) = %v, want %v", tc.version, got, tc.want)
+		}
+	}
+}

--- a/gestaltd/internal/server/ingress_telemetry.go
+++ b/gestaltd/internal/server/ingress_telemetry.go
@@ -37,7 +37,7 @@ func classifyClientMetricDims(r *http.Request) metricutil.HTTPMetricDims {
 	kind := classifyClientKind(r)
 	dims := metricutil.HTTPMetricDims{ClientKind: kind}
 	if kind == metricutil.ClientKindCLI {
-		dims.ClientVersion = metricutil.ClassifyKnownCLIVersion(
+		dims.ClientVersion = metricutil.NormalizeCLIVersion(
 			r.Header.Get(metricutil.HeaderGestaltClientVersion),
 		)
 	}

--- a/gestaltd/internal/server/ingress_telemetry_test.go
+++ b/gestaltd/internal/server/ingress_telemetry_test.go
@@ -71,7 +71,7 @@ func TestClassifyClientMetricDims(t *testing.T) {
 		want   metricutil.HTTPMetricDims
 	}{
 		{
-			name: "cli with allowlisted version",
+			name: "cli with declared version",
 			header: func(r *http.Request) {
 				r.Header.Set(metricutil.HeaderGestaltClient, metricutil.ClientKindCLI)
 				r.Header.Set(metricutil.HeaderGestaltClientVersion, "0.0.2-alpha.17")

--- a/gestaltd/services/apps/source/version.go
+++ b/gestaltd/services/apps/source/version.go
@@ -2,21 +2,12 @@ package source
 
 import (
 	"fmt"
-	"strings"
 
-	"golang.org/x/mod/semver"
+	"github.com/valon-technologies/gestalt/server/internal/semvervalidate"
 )
 
 func ValidateVersion(version string) error {
-	canonical := versionPrefix + version
-	if !semver.IsValid(canonical) {
-		return fmt.Errorf("plugin source: invalid semver %q", version)
-	}
-	base := canonical
-	if i := strings.IndexByte(base, '+'); i != -1 {
-		base = base[:i]
-	}
-	if semver.Canonical(canonical) != base {
+	if !semvervalidate.Valid(version) {
 		return fmt.Errorf("plugin source: invalid semver %q", version)
 	}
 	return nil

--- a/gestaltd/services/observability/metricutil/cli_version.go
+++ b/gestaltd/services/observability/metricutil/cli_version.go
@@ -1,6 +1,10 @@
 package metricutil
 
-import "strings"
+import (
+	"strings"
+
+	"golang.org/x/mod/semver"
+)
 
 const (
 	HeaderGestaltClientVersion = "X-Gestalt-Client-Version"
@@ -8,49 +12,29 @@ const (
 	ClientVersionUnknown = "unknown"
 
 	maxCLIVersionHeaderLen = 64
-	maxKnownCLIVersions    = 20
 )
 
-var knownCLIVersions = []string{
-	"0.0.2-alpha.17",
-}
-
-func ClassifyKnownCLIVersion(raw string) string {
-	return classifyKnownCLIVersion(knownCLIVersions, raw)
-}
-
-func classifyKnownCLIVersion(versions []string, raw string) string {
+func NormalizeCLIVersion(raw string) string {
 	raw = strings.TrimSpace(raw)
 	if raw == "" || len(raw) > maxCLIVersionHeaderLen {
 		return ClientVersionUnknown
 	}
-	for _, known := range effectiveKnownCLIVersions(versions) {
-		if raw == known {
-			return known
-		}
-	}
-	return ClientVersionUnknown
-}
 
-func effectiveKnownCLIVersions(versions []string) []string {
-	if len(versions) <= maxKnownCLIVersions {
-		return versions
+	canonical := raw
+	if !strings.HasPrefix(canonical, "v") {
+		canonical = "v" + canonical
 	}
-	return versions[len(versions)-maxKnownCLIVersions:]
-}
+	if !semver.IsValid(canonical) {
+		return ClientVersionUnknown
+	}
 
-func appendKnownCLIVersion(versions []string, version string, max int) []string {
-	version = strings.TrimSpace(version)
-	if version == "" || max <= 0 {
-		return versions
+	base := canonical
+	if i := strings.IndexByte(base, '+'); i != -1 {
+		base = base[:i]
 	}
-	for _, known := range versions {
-		if known == version {
-			return versions
-		}
+	if semver.Canonical(canonical) != base {
+		return ClientVersionUnknown
 	}
-	if len(versions) < max {
-		return append(versions, version)
-	}
-	return append(versions[1:], version)
+
+	return raw
 }

--- a/gestaltd/services/observability/metricutil/cli_version.go
+++ b/gestaltd/services/observability/metricutil/cli_version.go
@@ -3,7 +3,7 @@ package metricutil
 import (
 	"strings"
 
-	"golang.org/x/mod/semver"
+	"github.com/valon-technologies/gestalt/server/internal/semvervalidate"
 )
 
 const (
@@ -19,22 +19,8 @@ func NormalizeCLIVersion(raw string) string {
 	if raw == "" || len(raw) > maxCLIVersionHeaderLen {
 		return ClientVersionUnknown
 	}
-
-	canonical := raw
-	if !strings.HasPrefix(canonical, "v") {
-		canonical = "v" + canonical
-	}
-	if !semver.IsValid(canonical) {
+	if !semvervalidate.Valid(strings.TrimPrefix(raw, "v")) {
 		return ClientVersionUnknown
 	}
-
-	base := canonical
-	if i := strings.IndexByte(base, '+'); i != -1 {
-		base = base[:i]
-	}
-	if semver.Canonical(canonical) != base {
-		return ClientVersionUnknown
-	}
-
 	return raw
 }

--- a/gestaltd/services/observability/metricutil/cli_version_test.go
+++ b/gestaltd/services/observability/metricutil/cli_version_test.go
@@ -1,80 +1,42 @@
 package metricutil
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 )
 
-func TestClassifyKnownCLIVersionRecognizesAllowlistedRelease(t *testing.T) {
+func TestNormalizeCLIVersionAcceptsDeclaredSemver(t *testing.T) {
 	t.Parallel()
 
-	for _, raw := range []string{"0.0.2-alpha.17", " 0.0.2-alpha.17 "} {
-		if got := ClassifyKnownCLIVersion(raw); got != "0.0.2-alpha.17" {
-			t.Fatalf("ClassifyKnownCLIVersion(%q) = %q, want %q", raw, got, "0.0.2-alpha.17")
+	tests := []struct {
+		raw  string
+		want string
+	}{
+		{raw: "0.0.2-alpha.17", want: "0.0.2-alpha.17"},
+		{raw: " 0.0.2-alpha.17 ", want: "0.0.2-alpha.17"},
+		{raw: "0.0.2-alpha.16", want: "0.0.2-alpha.16"},
+		{raw: "1.2.3", want: "1.2.3"},
+		{raw: "v1.2.3", want: "v1.2.3"},
+	}
+	for _, tc := range tests {
+		if got := NormalizeCLIVersion(tc.raw); got != tc.want {
+			t.Fatalf("NormalizeCLIVersion(%q) = %q, want %q", tc.raw, got, tc.want)
 		}
 	}
 }
 
-func TestClassifyKnownCLIVersionRejectsInvalidHeaders(t *testing.T) {
+func TestNormalizeCLIVersionRejectsInvalidHeaders(t *testing.T) {
 	t.Parallel()
 
 	for _, raw := range []string{
 		"",
 		"   ",
 		"not-a-version",
-		"0.0.2-alpha.16",
-		"0.0.2-alpha.17-extra",
+		"01.02.03",
 		strings.Repeat("0", maxCLIVersionHeaderLen+1),
 	} {
-		if got := ClassifyKnownCLIVersion(raw); got != ClientVersionUnknown {
-			t.Fatalf("ClassifyKnownCLIVersion(%q) = %q, want %q", raw, got, ClientVersionUnknown)
+		if got := NormalizeCLIVersion(raw); got != ClientVersionUnknown {
+			t.Fatalf("NormalizeCLIVersion(%q) = %q, want %q", raw, got, ClientVersionUnknown)
 		}
 	}
-}
-
-func TestAppendKnownCLIVersionEvictsOldestAtCapacity(t *testing.T) {
-	t.Parallel()
-
-	versions := make([]string, 0, maxKnownCLIVersions)
-	for i := 1; i <= maxKnownCLIVersions; i++ {
-		versions = appendKnownCLIVersion(versions, versionForIndex(i), maxKnownCLIVersions)
-	}
-	if len(versions) != maxKnownCLIVersions {
-		t.Fatalf("len(versions) = %d, want %d", len(versions), maxKnownCLIVersions)
-	}
-	if versions[0] != versionForIndex(1) {
-		t.Fatalf("oldest version = %q, want %q", versions[0], versionForIndex(1))
-	}
-
-	versions = appendKnownCLIVersion(versions, versionForIndex(maxKnownCLIVersions+1), maxKnownCLIVersions)
-	if len(versions) != maxKnownCLIVersions {
-		t.Fatalf("len(versions) after eviction = %d, want %d", len(versions), maxKnownCLIVersions)
-	}
-	if versions[0] != versionForIndex(2) {
-		t.Fatalf("oldest version after eviction = %q, want %q", versions[0], versionForIndex(2))
-	}
-	if versions[len(versions)-1] != versionForIndex(maxKnownCLIVersions+1) {
-		t.Fatalf("newest version = %q, want %q", versions[len(versions)-1], versionForIndex(maxKnownCLIVersions+1))
-	}
-	if got := classifyKnownCLIVersion(versions, versionForIndex(1)); got != ClientVersionUnknown {
-		t.Fatalf("classifyKnownCLIVersion(evicted) = %q, want %q", got, ClientVersionUnknown)
-	}
-	if got := classifyKnownCLIVersion(versions, versionForIndex(maxKnownCLIVersions+1)); got != versionForIndex(maxKnownCLIVersions+1) {
-		t.Fatalf("classifyKnownCLIVersion(newest) = %q, want %q", got, versionForIndex(maxKnownCLIVersions+1))
-	}
-}
-
-func TestAppendKnownCLIVersionIsIdempotent(t *testing.T) {
-	t.Parallel()
-
-	versions := []string{"0.0.2-alpha.1"}
-	got := appendKnownCLIVersion(versions, "0.0.2-alpha.1", maxKnownCLIVersions)
-	if len(got) != 1 || got[0] != "0.0.2-alpha.1" {
-		t.Fatalf("appendKnownCLIVersion() = %#v, want unchanged slice", got)
-	}
-}
-
-func versionForIndex(i int) string {
-	return fmt.Sprintf("0.0.2-alpha.%d", i)
 }

--- a/gestaltd/services/observability/metricutil/cli_version_test.go
+++ b/gestaltd/services/observability/metricutil/cli_version_test.go
@@ -19,9 +19,12 @@ func TestNormalizeCLIVersionAcceptsDeclaredSemver(t *testing.T) {
 		{raw: "v1.2.3", want: "v1.2.3"},
 	}
 	for _, tc := range tests {
-		if got := NormalizeCLIVersion(tc.raw); got != tc.want {
-			t.Fatalf("NormalizeCLIVersion(%q) = %q, want %q", tc.raw, got, tc.want)
-		}
+		t.Run(tc.raw, func(t *testing.T) {
+			t.Parallel()
+			if got := NormalizeCLIVersion(tc.raw); got != tc.want {
+				t.Fatalf("NormalizeCLIVersion(%q) = %q, want %q", tc.raw, got, tc.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- Replace `ClassifyKnownCLIVersion` with `NormalizeCLIVersion`: trim, max 64 chars, and `golang.org/x/mod/semver` validation before pass-through.
- Remove the capped allowlist and eviction helpers from `metricutil`.
- Update ingress client classification tests for declared-version semantics.

Implements ingress refactor step **12** ([toolshed#4660](https://github.com/valon-technologies/toolshed/pull/4660)).

## Test plan
- [x] `go test ./services/observability/metricutil/...`
- [x] `go test ./internal/server/... -run ClassifyClientMetricDims`
- [ ] Release gestaltd; toolshed step **12b** deploys and verifies declared/unknown probes


Made with [Cursor](https://cursor.com)