### PR TITLE
P1b: stop redundant HTTP duration tags on ingress routes

### DIFF
--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -824,10 +824,8 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 		ctx = invocation.WithConnection(ctx, connection)
 	}
 	metricutil.AddHTTPServerMetricDims(r.Context(), metricutil.HTTPMetricDims{
-		ProviderName:   providerName,
-		OperationName:  opMeta.ID,
-		ConnectionMode: metricutil.NormalizeConnectionMode(s.invocationConnectionMode(prov, providerName, connection)),
-		Surface:        metricutil.InvocationSurfaceHTTP,
+		ProviderName:  providerName,
+		OperationName: opMeta.ID,
 	})
 	ctx = invocation.WithInvocationSurface(ctx, invocation.InvocationSurfaceHTTP)
 	ctx = invocation.WithEntry(ctx, invocation.EntryHTTP)

--- a/gestaltd/internal/server/ingress_telemetry_metrics_test.go
+++ b/gestaltd/internal/server/ingress_telemetry_metrics_test.go
@@ -95,6 +95,9 @@ func TestIngressTelemetryRequestMetrics(t *testing.T) {
 		})
 		metrictest.RequireFloat64Histogram(t, rm, "http.server.request.duration", attrs)
 		metrictest.RequireFloat64HistogramOmitsAttr(t, rm, "http.server.request.duration", attrs, "gestaltd.client.app")
+		metrictest.RequireFloat64HistogramOmitsAttr(t, rm, "http.server.request.duration", attrs, "gestaltd.invocation.surface")
+		metrictest.RequireFloat64HistogramOmitsAttr(t, rm, "http.server.request.duration", attrs, "gestaltd.operation.transport")
+		metrictest.RequireFloat64HistogramOmitsAttr(t, rm, "http.server.request.duration", attrs, "gestaltd.connection.mode")
 	})
 
 	t.Run("app invoke v1 labels authenticated user and service account subjects", func(t *testing.T) {
@@ -585,6 +588,7 @@ func TestIngressTelemetryRequestMetrics(t *testing.T) {
 		})
 		metrictest.RequireFloat64Histogram(t, rm, "http.server.request.duration", attrs)
 		metrictest.RequireFloat64HistogramOmitsAttr(t, rm, "http.server.request.duration", attrs, "gestaltd.subject.label")
+		metrictest.RequireFloat64HistogramOmitsAttr(t, rm, "http.server.request.duration", attrs, "gestaltd.invocation.surface")
 	})
 
 	t.Run("public rest labels cli client and ingress kind", func(t *testing.T) {

--- a/gestaltd/internal/server/metrics_test.go
+++ b/gestaltd/internal/server/metrics_test.go
@@ -443,12 +443,9 @@ func TestOperationMetricsDefaultRESTTransportFromCatalogContext(t *testing.T) {
 		"gestalt.result_status_class": "4xx",
 	})
 	httpAttrs := map[string]string{
-		"http.route":                   "/api/v1/{integration}/{operation}",
-		"gestaltd.provider.name":       providerName,
-		"gestaltd.operation.name":      "list",
-		"gestaltd.operation.transport": "rest",
-		"gestaltd.connection.mode":     "none",
-		"gestaltd.invocation.surface":  "http",
+		"http.route":               "/api/v1/{integration}/{operation}",
+		"gestaltd.provider.name":   providerName,
+		"gestaltd.operation.name":  "list",
 	}
 	metrictest.RequireFloat64Histogram(t, rm, "http.server.request.duration", httpAttrs)
 	metrictest.RequireFloat64HistogramOmitsAttr(t, rm, "http.server.request.duration", httpAttrs, "gestalt.provider")

--- a/gestaltd/internal/server/mounted_ui.go
+++ b/gestaltd/internal/server/mounted_ui.go
@@ -244,9 +244,7 @@ func (s *Server) writeMountedUnauthenticated(w http.ResponseWriter, r *http.Requ
 func mountedUITelemetryHandler(mounted MountedUI, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		metricutil.AddHTTPServerMetricDims(r.Context(), metricutil.HTTPMetricDims{
-			ProviderName: mounted.AppName,
-			Surface:      metricutil.InvocationSurfaceUI,
-			UIName:       mounted.Name,
+			UIName: mounted.Name,
 		})
 		next.ServeHTTP(w, r)
 	})

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -7744,13 +7744,11 @@ func TestExecuteOperation_DeclarativeRESTConnectionSelectorRoutesCredentialAndOm
 
 	rm := metrictest.CollectMetrics(t, metrics.Reader)
 	httpOperationAttrs := map[string]string{
-		"http.route":                  "/api/v1/{integration}/{operation}",
-		"gestaltd.provider.name":      "messaging",
-		"gestaltd.operation.name":     "messages.send",
-		"gestaltd.invocation.surface": "http",
+		"http.route":              "/api/v1/{integration}/{operation}",
+		"gestaltd.provider.name":  "messaging",
+		"gestaltd.operation.name": "messages.send",
 	}
 	subjectAttrs := maps.Clone(httpOperationAttrs)
-	subjectAttrs["gestaltd.connection.mode"] = "subject"
 	metrictest.RequireFloat64Histogram(t, rm, "http.server.request.duration", subjectAttrs)
 
 	mu.Lock()

--- a/gestaltd/internal/server/tracing_test.go
+++ b/gestaltd/internal/server/tracing_test.go
@@ -98,8 +98,8 @@ func TestTracing_HTTPAndBrokerSpans(t *testing.T) {
 	}
 	assertSpanHasAttr(t, httpSpan, "gestaltd.provider.name", "tracer-prov")
 	assertSpanHasAttr(t, httpSpan, "gestaltd.operation.name", "ping")
-	assertSpanHasAttr(t, httpSpan, "gestaltd.connection.mode", "none")
-	assertSpanHasAttr(t, httpSpan, "gestaltd.invocation.surface", "http")
+	assertSpanLacksAttr(t, httpSpan, "gestaltd.connection.mode")
+	assertSpanLacksAttr(t, httpSpan, "gestaltd.invocation.surface")
 	assertSpanLacksAttr(t, httpSpan, "gestalt.provider")
 	assertSpanLacksAttr(t, httpSpan, "gestalt.operation")
 

--- a/gestaltd/services/invocation/metrics.go
+++ b/gestaltd/services/invocation/metrics.go
@@ -84,6 +84,11 @@ func recordOperationMetrics(
 		httpDims.HTTPBindingName = binding
 		httpDims.Surface = metricutil.InvocationSurfaceHTTPBinding
 	}
+	if metricutil.HTTPServerHasIngressKind(ctx) {
+		httpDims.Transport = ""
+		httpDims.ConnectionMode = ""
+		httpDims.Surface = ""
+	}
 	metricutil.AddHTTPServerMetricDims(ctx, httpDims)
 
 	metrics.count.Add(ctx, 1, metric.WithAttributes(attrs...))

--- a/gestaltd/services/observability/metricutil/attrs.go
+++ b/gestaltd/services/observability/metricutil/attrs.go
@@ -130,6 +130,21 @@ func AddHTTPServerMetricDims(ctx context.Context, dims HTTPMetricDims) {
 	AddHTTPAttributes(ctx, HTTPServerAttrs(dims)...)
 }
 
+// HTTPServerHasIngressKind reports whether P1 ingress telemetry has already
+// tagged the current HTTP request via gestaltd.ingress.kind.
+func HTTPServerHasIngressKind(ctx context.Context) bool {
+	labeler, ok := otelhttp.LabelerFromContext(ctx)
+	if !ok {
+		return false
+	}
+	for _, attr := range labeler.Get() {
+		if attr.Key == attrGestaltdIngressKind {
+			return true
+		}
+	}
+	return false
+}
+
 func RPCAttrs(dims RPCMetricDims) []attribute.KeyValue {
 	attrs := make([]attribute.KeyValue, 0, 3)
 	attrs = appendStringAttr(attrs, attrGestaltdRPCRole, dims.Role)

--- a/gestaltd/services/observability/metricutil/attrs_test.go
+++ b/gestaltd/services/observability/metricutil/attrs_test.go
@@ -1,9 +1,11 @@
 package metricutil_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/valon-technologies/gestalt/server/services/observability/metricutil"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel/attribute"
 )
 
@@ -38,5 +40,24 @@ func TestHTTPServerAttrsOmitsUnsetDimensions(t *testing.T) {
 
 	if attrs := metricutil.HTTPServerAttrs(metricutil.HTTPMetricDims{}); len(attrs) != 0 {
 		t.Fatalf("expected no attrs for empty dims, got %+v", attrs)
+	}
+}
+
+func TestHTTPServerHasIngressKind(t *testing.T) {
+	t.Parallel()
+
+	if metricutil.HTTPServerHasIngressKind(context.Background()) {
+		t.Fatal("expected false without labeler")
+	}
+
+	labeler := &otelhttp.Labeler{}
+	ctx := otelhttp.ContextWithLabeler(context.Background(), labeler)
+	if metricutil.HTTPServerHasIngressKind(ctx) {
+		t.Fatal("expected false before ingress kind is labeled")
+	}
+
+	labeler.Add(attribute.String("gestaltd.ingress.kind", metricutil.IngressKindAppInvokeV1))
+	if !metricutil.HTTPServerHasIngressKind(ctx) {
+		t.Fatal("expected true after ingress kind is labeled")
 	}
 }


### PR DESCRIPTION
## Summary
- Stop emitting `gestaltd.invocation.surface`, `gestaltd.operation.transport`, and `gestaltd.connection.mode` on ingress-covered `http.server.request.duration` series (`mounted_ui`, `app_invoke_v1`, `public_rest`).
- Keep provider/operation names on app invoke for CLI hierarchy dashboards; keep webhook `gestaltd.invocation.surface:http_binding` and catalog/auth tagging unchanged.
- Mounted UI HTTP duration now tags only `gestaltd.ui.name` (drops redundant `gestaltd.provider.name` and `ui` surface).

Implements gestalt step 1 of toolshed `valon-tools/docs/plans/3b_telemetry-cleanup.md`.

## Test plan
- [x] `go test ./services/observability/metricutil/... ./internal/server/...`
- [ ] Release gestaltd and deploy via toolshed (step 2)
- [ ] Post-deploy: ingress matrix `all_satisfied: true`; spot-check UI and CLI dashboards


Made with [Cursor](https://cursor.com)