### PR TITLE
P1b: centralize ingress HTTP duration dim stripping

### DIFF
--- a/docs/content/observability.mdx
+++ b/docs/content/observability.mdx
@@ -547,7 +547,10 @@ when available. Gestalt also attaches stable dimensions for request surfaces it
 can resolve, including `gestaltd.provider.name`,
 `gestaltd.operation.name`, `gestaltd.operation.transport`,
 `gestaltd.connection.mode`, `gestaltd.invocation.surface`,
-`gestaltd.http.binding.name`, and `gestaltd.ui.name`. For hosted HTTP bindings,
+`gestaltd.http.binding.name`, and `gestaltd.ui.name`. Ingress-covered routes
+(those tagged with `gestaltd.ingress.kind`) omit `gestaltd.operation.transport`,
+`gestaltd.connection.mode`, and `gestaltd.invocation.surface` on
+`http.server.request.duration`. For hosted HTTP bindings,
 use `gestaltd.http.binding.name` on `http.server.request.duration` with
 `gestalt.http_binding` on `gestaltd.operation.*` to correlate the accepted HTTP
 delivery with the provider operation it dispatched.

--- a/gestaltd/services/invocation/metrics.go
+++ b/gestaltd/services/invocation/metrics.go
@@ -84,11 +84,6 @@ func recordOperationMetrics(
 		httpDims.HTTPBindingName = binding
 		httpDims.Surface = metricutil.InvocationSurfaceHTTPBinding
 	}
-	if metricutil.HTTPServerHasIngressKind(ctx) {
-		httpDims.Transport = ""
-		httpDims.ConnectionMode = ""
-		httpDims.Surface = ""
-	}
 	metricutil.AddHTTPServerMetricDims(ctx, httpDims)
 
 	metrics.count.Add(ctx, 1, metric.WithAttributes(attrs...))

--- a/gestaltd/services/observability/metricutil/attrs.go
+++ b/gestaltd/services/observability/metricutil/attrs.go
@@ -127,12 +127,15 @@ func HTTPServerAttrs(dims HTTPMetricDims) []attribute.KeyValue {
 }
 
 func AddHTTPServerMetricDims(ctx context.Context, dims HTTPMetricDims) {
+	if httpServerHasIngressKind(ctx) {
+		dims.Transport = ""
+		dims.ConnectionMode = ""
+		dims.Surface = ""
+	}
 	AddHTTPAttributes(ctx, HTTPServerAttrs(dims)...)
 }
 
-// HTTPServerHasIngressKind reports whether P1 ingress telemetry has already
-// tagged the current HTTP request via gestaltd.ingress.kind.
-func HTTPServerHasIngressKind(ctx context.Context) bool {
+func httpServerHasIngressKind(ctx context.Context) bool {
 	labeler, ok := otelhttp.LabelerFromContext(ctx)
 	if !ok {
 		return false

--- a/gestaltd/services/observability/metricutil/attrs_test.go
+++ b/gestaltd/services/observability/metricutil/attrs_test.go
@@ -35,29 +35,46 @@ func TestHTTPServerAttrsIngressAndClientKinds(t *testing.T) {
 	}
 }
 
+func TestHTTPServerAttrsOmitsIngressRedundantDimsWhenIngressKindPresent(t *testing.T) {
+	t.Parallel()
+
+	labeler := &otelhttp.Labeler{}
+	labeler.Add(attribute.String("gestaltd.ingress.kind", metricutil.IngressKindAppInvokeV1))
+	ctx := otelhttp.ContextWithLabeler(context.Background(), labeler)
+
+	metricutil.AddHTTPServerMetricDims(ctx, metricutil.HTTPMetricDims{
+		ProviderName:   "sample",
+		OperationName:  "list",
+		Transport:      "rest",
+		ConnectionMode: "none",
+		Surface:        metricutil.InvocationSurfaceHTTP,
+	})
+
+	attrs := labeler.Get()
+	for _, attr := range attrs {
+		switch string(attr.Key) {
+		case "gestaltd.operation.transport", "gestaltd.connection.mode", "gestaltd.invocation.surface":
+			t.Fatalf("ingress request should omit %s, got %+v", attr.Key, attr)
+		}
+	}
+	if !containsAttr(attrs, "gestaltd.provider.name", "sample") {
+		t.Fatalf("expected provider attr, got %+v", attrs)
+	}
+}
+
+func containsAttr(attrs []attribute.KeyValue, key, value string) bool {
+	for _, attr := range attrs {
+		if string(attr.Key) == key && attr.Value.AsString() == value {
+			return true
+		}
+	}
+	return false
+}
+
 func TestHTTPServerAttrsOmitsUnsetDimensions(t *testing.T) {
 	t.Parallel()
 
 	if attrs := metricutil.HTTPServerAttrs(metricutil.HTTPMetricDims{}); len(attrs) != 0 {
 		t.Fatalf("expected no attrs for empty dims, got %+v", attrs)
-	}
-}
-
-func TestHTTPServerHasIngressKind(t *testing.T) {
-	t.Parallel()
-
-	if metricutil.HTTPServerHasIngressKind(context.Background()) {
-		t.Fatal("expected false without labeler")
-	}
-
-	labeler := &otelhttp.Labeler{}
-	ctx := otelhttp.ContextWithLabeler(context.Background(), labeler)
-	if metricutil.HTTPServerHasIngressKind(ctx) {
-		t.Fatal("expected false before ingress kind is labeled")
-	}
-
-	labeler.Add(attribute.String("gestaltd.ingress.kind", metricutil.IngressKindAppInvokeV1))
-	if !metricutil.HTTPServerHasIngressKind(ctx) {
-		t.Fatal("expected true after ingress kind is labeled")
 	}
 }


### PR DESCRIPTION
## Summary
- Strip `gestaltd.operation.transport`, `gestaltd.connection.mode`, and `gestaltd.invocation.surface` from ingress-covered `http.server.request.duration` series inside `AddHTTPServerMetricDims` when `gestaltd.ingress.kind` is already on the otelhttp labeler.
- Remove the duplicate clear-fields block from `recordOperationMetrics`.
- Document ingress omission rules in observability.mdx.

## Review fixes (thermo-nuclear / code judo)
- Previous implementation cleared redundant dims at the `recordOperationMetrics` call site even though ingress middleware had already labeled the request — a scattered special-case. Centralizing in `AddHTTPServerMetricDims` deletes that branch and covers any future ingress call sites automatically.

## Test plan
- [x] `go test ./services/observability/metricutil/... ./internal/server/... -run TestHTTPServer`
- [ ] Merge and include in next gestaltd deploy if desired (behavior unchanged from gestalt#3148)


Made with [Cursor](https://cursor.com)