### PR TITLE
Authenticate private GCS snapshots with ADC

### DIFF
--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -138,12 +138,14 @@ that set `artifactRepository`.
 providerSnapshotRepositories:
   valon:
     url: https://storage.googleapis.com/valon-gestalt-provider-snapshots
+    auth: gcpADC
     gestaltRef: 651a5c30feb995c9364c38f63d0d5c3880bc2055
 ```
 
 | Field | Description |
 | --- | --- |
 | `providerSnapshotRepositories.<name>.url` | HTTP(S) root containing deterministic snapshot `provider-release.yaml` files and archives. |
+| `providerSnapshotRepositories.<name>.auth` | Optional. `gcpADC` uses Application Default Credentials for `storage.googleapis.com` requests. Omit it for unauthenticated fetching. |
 | `providerSnapshotRepositories.<name>.gestaltRef` | Optional full Gestalt commit SHA expected for snapshots from this repository. |
 
 ## `server`

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -69,8 +69,13 @@ type ProviderRepositoryConfig struct {
 type ProviderSnapshotRepositoryConfig struct {
 	URL        string                                  `yaml:"url,omitempty"`
 	GestaltRef string                                  `yaml:"gestaltRef,omitempty"`
+	Auth       ProviderSnapshotRepositoryAuth          `yaml:"auth,omitempty"`
 	Publish    ProviderSnapshotRepositoryPublishConfig `yaml:"publish,omitempty"`
 }
+
+type ProviderSnapshotRepositoryAuth string
+
+const ProviderSnapshotRepositoryAuthGCPADC ProviderSnapshotRepositoryAuth = "gcpADC"
 
 type ProviderSnapshotRepositoryPublishConfig struct {
 	PathLayout string                                  `yaml:"pathLayout,omitempty"`

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -304,6 +304,15 @@ func validateProviderSnapshotRepositories(cfg *Config) error {
 		if ref := strings.TrimSpace(repo.GestaltRef); ref != "" && !isFullGitSHA(ref) {
 			return fmt.Errorf("config validation: providerSnapshotRepositories.%s.gestaltRef must be a 40-character commit SHA", name)
 		}
+		switch repo.Auth {
+		case "":
+		case ProviderSnapshotRepositoryAuthGCPADC:
+			if parsed.Scheme != "https" || !strings.EqualFold(parsed.Hostname(), "storage.googleapis.com") || parsed.Port() != "" || parsed.User != nil {
+				return fmt.Errorf("config validation: providerSnapshotRepositories.%s.auth %q requires an https://storage.googleapis.com URL", name, repo.Auth)
+			}
+		default:
+			return fmt.Errorf("config validation: providerSnapshotRepositories.%s.auth must be %q when set", name, ProviderSnapshotRepositoryAuthGCPADC)
+		}
 		if err := validateProviderSnapshotRepositoryPublish(name, repo.Publish); err != nil {
 			return err
 		}

--- a/gestaltd/internal/config/provider_snapshot_repository_auth_test.go
+++ b/gestaltd/internal/config/provider_snapshot_repository_auth_test.go
@@ -1,0 +1,61 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateProviderSnapshotRepositoryAuth(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		repo    ProviderSnapshotRepositoryConfig
+		wantErr string
+	}{
+		{
+			name: "GCP ADC on Google Cloud Storage",
+			repo: ProviderSnapshotRepositoryConfig{
+				URL:  "https://storage.googleapis.com/private-snapshots",
+				Auth: ProviderSnapshotRepositoryAuthGCPADC,
+			},
+		},
+		{
+			name: "legacy unauthenticated HTTP repository",
+			repo: ProviderSnapshotRepositoryConfig{URL: "http://snapshots.example.test"},
+		},
+		{
+			name: "unsupported auth",
+			repo: ProviderSnapshotRepositoryConfig{
+				URL:  "https://storage.googleapis.com/private-snapshots",
+				Auth: "other",
+			},
+			wantErr: `auth must be "gcpADC" when set`,
+		},
+		{
+			name: "GCP ADC on another host",
+			repo: ProviderSnapshotRepositoryConfig{
+				URL:  "https://snapshots.example.test",
+				Auth: ProviderSnapshotRepositoryAuthGCPADC,
+			},
+			wantErr: `requires an https://storage.googleapis.com URL`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := &Config{ProviderSnapshotRepositories: map[string]ProviderSnapshotRepositoryConfig{"valon": test.repo}}
+			err := validateProviderSnapshotRepositories(cfg)
+			if test.wantErr == "" {
+				if err != nil {
+					t.Fatalf("validateProviderSnapshotRepositories() error = %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+				t.Fatalf("validateProviderSnapshotRepositories() error = %v, want %q", err, test.wantErr)
+			}
+		})
+	}
+}

--- a/gestaltd/internal/operator/git_source.go
+++ b/gestaltd/internal/operator/git_source.go
@@ -249,7 +249,11 @@ func (l *Lifecycle) lockGitSnapshotSource(ctx context.Context, cfg *config.Confi
 	metadataProvider := *app
 	metadataProvider.Source = config.NewMetadataSource(snapshot.MetadataURL)
 	metadataProvider.Source.Auth = app.Source.Auth
-	installed, entry, err := l.installMetadataSourcePackage(ctx, expectedKind, name, subject, destDir, &metadataProvider, paths.configDir, mode)
+	client, err := l.snapshotRepositoryHTTPClient(ctx, cfg, app)
+	if err != nil {
+		return LockEntry{}, nil, fmt.Errorf("%s source.git snapshot authentication: %w", subject, err)
+	}
+	installed, entry, err := l.installMetadataSourcePackage(ctx, client, expectedKind, name, subject, destDir, &metadataProvider, paths.configDir, mode)
 	if err != nil {
 		return LockEntry{}, nil, fmt.Errorf("%s source.git snapshot %s: %w", subject, snapshot.MetadataURL, err)
 	}

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -28,6 +28,7 @@ import (
 	appservice "github.com/valon-technologies/gestalt/server/services/apps"
 	"github.com/valon-technologies/gestalt/server/services/apps/packageio"
 	"github.com/valon-technologies/gestalt/server/services/apps/providerpkg"
+	"golang.org/x/oauth2"
 	"gopkg.in/yaml.v3"
 )
 
@@ -96,6 +97,7 @@ type StaticValidationOptions struct {
 type Lifecycle struct {
 	configSecretResolver     func(context.Context, *config.Config) error
 	sourceAuthSecretResolver func(context.Context, *config.Config) error
+	snapshotGCSTokenSource   func(context.Context) (oauth2.TokenSource, error)
 	sourceCommandOutput      providerpkg.CommandOutput
 	progress                 LifecycleProgress
 	httpClient               *http.Client
@@ -1668,6 +1670,7 @@ func (l *Lifecycle) primeSecretsProviderForConfigResolution(ctx context.Context,
 }
 
 type lifecyclePaths struct {
+	config                 *config.Config
 	configPaths            []string
 	configFlags            string
 	lockFlags              string
@@ -1967,6 +1970,7 @@ func resolveLifecyclePaths(configPaths []string, cfg *config.Config, lockfilePat
 	resolvedArtifactsDir := resolveArtifactsDir(configPath, cfg, artifactsDir)
 	resolvedLockfilePath := resolveLockfilePath(lockfilePath)
 	return lifecyclePaths{
+		config:                 cfg,
 		configPaths:            append([]string(nil), configPaths...),
 		configFlags:            formatConfigStateFlags(configPaths, artifactsDir, lockfilePath),
 		lockFlags:              formatLockFlags(configPaths, lockfilePath),
@@ -2965,9 +2969,9 @@ func localLockEntryFromPreparedInstall(paths lifecyclePaths, kind, name string, 
 	return entry, nil
 }
 
-func (l *Lifecycle) installMetadataSourcePackage(ctx context.Context, expectedKind, name, subject, destDir string, app *config.ProviderEntry, configDir string, mode artifactMode) (*installedPackage, LockEntry, error) {
+func (l *Lifecycle) installMetadataSourcePackage(ctx context.Context, client *http.Client, expectedKind, name, subject, destDir string, app *config.ProviderEntry, configDir string, mode artifactMode) (*installedPackage, LockEntry, error) {
 	sourceLocation := app.SourceReleaseLocation()
-	bundle, resolvedMetadataLocation, gitHubReleaseAssets, err := fetchProviderReleaseBundle(ctx, l.metadataHTTPClient(), sourceLocation, sourceAuthToken(app))
+	bundle, resolvedMetadataLocation, gitHubReleaseAssets, err := fetchProviderReleaseBundle(ctx, client, sourceLocation, sourceAuthToken(app))
 	if err != nil {
 		return nil, LockEntry{}, fmt.Errorf("%s fetch metadata %q: %w", subject, sourceLocation, err)
 	}
@@ -3012,7 +3016,7 @@ func (l *Lifecycle) installMetadataSourcePackage(ctx context.Context, expectedKi
 	if err != nil {
 		return nil, LockEntry{}, fmt.Errorf("resolve archive for %s: %w", subject, err)
 	}
-	download, err := downloadArchiveForSource(ctx, l.metadataHTTPClient(), sourceAuthToken(app), archiveLocation)
+	download, err := downloadArchiveForSource(ctx, client, sourceAuthToken(app), archiveLocation)
 	if err != nil {
 		return nil, LockEntry{}, fmt.Errorf("download metadata source package for %s: %w", subject, err)
 	}
@@ -3114,7 +3118,7 @@ func (l *Lifecycle) resolveLockedProvider(ctx context.Context, cfg *config.Confi
 	if !provider.HasReleaseMetadataSource() {
 		return LockEntry{}, fmt.Errorf("%s source %q: only provider-release metadata sources and local manifest paths are supported", subject, sourceLocation)
 	}
-	installed, entry, err := l.installMetadataSourcePackage(ctx, kind, name, subject, destDir, provider, paths.configDir, mode)
+	installed, entry, err := l.installMetadataSourcePackage(ctx, l.metadataHTTPClient(), kind, name, subject, destDir, provider, paths.configDir, mode)
 	if err != nil {
 		return LockEntry{}, err
 	}
@@ -4532,7 +4536,11 @@ func (l *Lifecycle) materializeLockedArchive(ctx context.Context, paths lifecycl
 	}
 
 	downloadStart := time.Now()
-	download, err := downloadArchiveForSource(ctx, l.metadataHTTPClient(), sourceAuthToken(app), archiveLocation)
+	client, err := l.snapshotRepositoryHTTPClient(ctx, paths.config, app)
+	if err != nil {
+		return lockedArchiveDownloadError{err: fmt.Errorf("authenticate locked source archive for %s: %w", subject, err)}
+	}
+	download, err := downloadArchiveForSource(ctx, client, sourceAuthToken(app), archiveLocation)
 	if err != nil {
 		return lockedArchiveDownloadError{err: fmt.Errorf("download locked source archive for %s: %w", subject, err)}
 	}

--- a/gestaltd/internal/operator/snapshot_repository_auth.go
+++ b/gestaltd/internal/operator/snapshot_repository_auth.go
@@ -1,0 +1,79 @@
+package operator
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+)
+
+const snapshotGCSReadOnlyScope = "https://www.googleapis.com/auth/devstorage.read_only"
+
+func (l *Lifecycle) snapshotRepositoryHTTPClient(ctx context.Context, cfg *config.Config, entry *config.ProviderEntry) (*http.Client, error) {
+	client := l.metadataHTTPClient()
+	git := gitSourceDef(entry)
+	if cfg == nil || git == nil || gitSourceMaterialization(git) != gitMaterializationSnapshot {
+		return client, nil
+	}
+	repo, ok := cfg.ProviderSnapshotRepositories[strings.TrimSpace(git.ArtifactRepository)]
+	if !ok || repo.Auth == "" {
+		return client, nil
+	}
+	if repo.Auth != config.ProviderSnapshotRepositoryAuthGCPADC {
+		return nil, fmt.Errorf("unsupported provider snapshot repository auth %q", repo.Auth)
+	}
+
+	newTokenSource := googleSnapshotTokenSource
+	if l != nil && l.snapshotGCSTokenSource != nil {
+		newTokenSource = l.snapshotGCSTokenSource
+	}
+	tokenSource, err := newTokenSource(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("create provider snapshot GCS ADC token source: %w", err)
+	}
+	clone := *client
+	clone.Transport = &gcsADCRoundTripper{
+		base:        client.Transport,
+		tokenSource: oauth2.ReuseTokenSource(nil, tokenSource),
+	}
+	return &clone, nil
+}
+
+func googleSnapshotTokenSource(ctx context.Context) (oauth2.TokenSource, error) {
+	return google.DefaultTokenSource(ctx, snapshotGCSReadOnlyScope)
+}
+
+type gcsADCRoundTripper struct {
+	base        http.RoundTripper
+	tokenSource oauth2.TokenSource
+}
+
+func (t *gcsADCRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	base := t.base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	if !isGoogleCloudStorageURL(req.URL) {
+		return base.RoundTrip(req)
+	}
+	token, err := t.tokenSource.Token()
+	if err != nil {
+		return nil, fmt.Errorf("get provider snapshot GCS ADC token: %w", err)
+	}
+	clone := req.Clone(req.Context())
+	clone.Header = req.Header.Clone()
+	token.SetAuthHeader(clone)
+	return base.RoundTrip(clone)
+}
+
+func isGoogleCloudStorageURL(u *url.URL) bool {
+	if u == nil || u.Scheme != "https" || !strings.EqualFold(u.Hostname(), "storage.googleapis.com") {
+		return false
+	}
+	return u.Port() == "" || u.Port() == "443"
+}

--- a/gestaltd/internal/operator/snapshot_repository_auth_test.go
+++ b/gestaltd/internal/operator/snapshot_repository_auth_test.go
@@ -1,0 +1,105 @@
+package operator
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"golang.org/x/oauth2"
+)
+
+func TestSnapshotRepositoryHTTPClientUsesADCOnlyForGCS(t *testing.T) {
+	t.Parallel()
+
+	authorizationByHost := map[string]string{}
+	lifecycle := &Lifecycle{
+		httpClient: &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			authorizationByHost[req.URL.Host] = req.Header.Get("Authorization")
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader("ok")),
+				Request:    req,
+			}, nil
+		})},
+		snapshotGCSTokenSource: func(context.Context) (oauth2.TokenSource, error) {
+			return oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "adc-token"}), nil
+		},
+	}
+	cfg := &config.Config{ProviderSnapshotRepositories: map[string]config.ProviderSnapshotRepositoryConfig{
+		"valon": {
+			URL:  "https://storage.googleapis.com/private-snapshots",
+			Auth: config.ProviderSnapshotRepositoryAuthGCPADC,
+		},
+	}}
+	entry := &config.ProviderEntry{Source: config.NewGitSource(config.GitSourceDef{
+		ArtifactRepository: "valon",
+		Materialization:    gitMaterializationSnapshot,
+	})}
+
+	client, err := lifecycle.snapshotRepositoryHTTPClient(context.Background(), cfg, entry)
+	if err != nil {
+		t.Fatalf("snapshotRepositoryHTTPClient() error = %v", err)
+	}
+	for _, rawURL := range []string{
+		"https://storage.googleapis.com/private-snapshots/provider-release.yaml",
+		"https://archives.example.test/provider.tar.gz",
+	} {
+		response, err := client.Get(rawURL)
+		if err != nil {
+			t.Fatalf("GET %s: %v", rawURL, err)
+		}
+		_ = response.Body.Close()
+	}
+
+	if got := authorizationByHost["storage.googleapis.com"]; got != "Bearer adc-token" {
+		t.Fatalf("GCS Authorization = %q", got)
+	}
+	if got := authorizationByHost["archives.example.test"]; got != "" {
+		t.Fatalf("non-GCS Authorization = %q, want empty", got)
+	}
+}
+
+func TestSnapshotRepositoryHTTPClientLeavesLegacyRepositoriesUnauthenticated(t *testing.T) {
+	t.Parallel()
+
+	var authorization string
+	lifecycle := &Lifecycle{
+		httpClient: &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			authorization = req.Header.Get("Authorization")
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader("ok")),
+				Request:    req,
+			}, nil
+		})},
+		snapshotGCSTokenSource: func(context.Context) (oauth2.TokenSource, error) {
+			return nil, fmt.Errorf("ADC must not be loaded")
+		},
+	}
+	cfg := &config.Config{ProviderSnapshotRepositories: map[string]config.ProviderSnapshotRepositoryConfig{
+		"valon": {URL: "https://storage.googleapis.com/public-snapshots"},
+	}}
+	entry := &config.ProviderEntry{Source: config.NewGitSource(config.GitSourceDef{
+		ArtifactRepository: "valon",
+		Materialization:    gitMaterializationSnapshot,
+	})}
+
+	client, err := lifecycle.snapshotRepositoryHTTPClient(context.Background(), cfg, entry)
+	if err != nil {
+		t.Fatalf("snapshotRepositoryHTTPClient() error = %v", err)
+	}
+	response, err := client.Get("https://storage.googleapis.com/public-snapshots/provider-release.yaml")
+	if err != nil {
+		t.Fatalf("GET legacy snapshot: %v", err)
+	}
+	_ = response.Body.Close()
+	if authorization != "" {
+		t.Fatalf("Authorization = %q, want empty", authorization)
+	}
+}


### PR DESCRIPTION
Adds opt-in ADC authentication for GCS provider snapshots; existing repositories remain unauthenticated.