### PR TITLE
Deploy downtime step 1: authorization viewer/admin public API gates

### DIFF
--- a/gestaltd/internal/server/handlers_admin_auth_test.go
+++ b/gestaltd/internal/server/handlers_admin_auth_test.go
@@ -73,6 +73,53 @@ func TestAdminAPIAllowsAuthorizedAdminSession(t *testing.T) {
 	}
 }
 
+func TestAdminAPIAllowsLegacyGestaltAdminSession(t *testing.T) {
+	t.Parallel()
+
+	svc := testutil.NewStubServices(t)
+	user := seedUserRecord(t, svc, "legacy-admin-user", "legacy-admin-user@example.test", time.Now())
+	authz := &serverTestAuthorizationProvider{
+		resourceTypes: []*proto.AuthorizationModelResourceType{{
+			Name: "gestaltAdmin",
+		}},
+		relationships: []*proto.Relationship{
+			testAuthorizationRelationship(
+				principal.UserSubjectID(user.ID),
+				"admin",
+				"gestaltAdmin",
+				"gestaltAdmin",
+			),
+		},
+	}
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = coretesting.NamedIntrospectIdentityStub("test", func(_ context.Context, token string) (*core.UserIdentity, error) {
+			if token != "session-token" {
+				return nil, core.ErrNotFound
+			}
+			return &core.UserIdentity{Email: user.Email}, nil
+		})
+		cfg.Services = svc
+		cfg.Authorization = authz
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, err := http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/runtime/providers", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "session-token"})
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET admin API: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, body)
+	}
+}
+
 func TestAdminAPIRejectsAuthenticatedUserWithoutAdminRole(t *testing.T) {
 	t.Parallel()
 
@@ -107,14 +154,14 @@ func newAuthorizedAdminTestServer(t *testing.T, grantAdmin bool) *httptest.Serve
 		relationships = append(relationships, testAuthorizationRelationship(
 			principal.UserSubjectID(user.ID),
 			"admin",
-			"gestaltAdmin",
-			"gestaltAdmin",
+			"gestalt",
+			"gestalt",
 		))
 	}
 
 	authz := &serverTestAuthorizationProvider{
 		resourceTypes: []*proto.AuthorizationModelResourceType{{
-			Name: "gestaltAdmin",
+			Name: "gestalt",
 		}},
 		relationships: relationships,
 	}

--- a/gestaltd/internal/server/handlers_admin_platform_admins_test.go
+++ b/gestaltd/internal/server/handlers_admin_platform_admins_test.go
@@ -18,7 +18,7 @@ func TestAdminPlatformAdminsList(t *testing.T) {
 	adminID := principal.UserSubjectID(testCanonicalAdminUserID)
 	authz := &serverTestAuthorizationProvider{
 		relationships: []*proto.Relationship{
-			testAuthorizationRelationship(adminID, "admin", "gestaltAdmin", "gestaltAdmin"),
+			testAuthorizationRelationship(adminID, "admin", "gestalt", "gestalt"),
 			{
 				Tuple: &proto.RelationshipTuple{
 					Target: &proto.RelationshipTarget{
@@ -30,7 +30,7 @@ func TestAdminPlatformAdminsList(t *testing.T) {
 						},
 					},
 					Relation: "admin",
-					Resource: &proto.Resource{Type: "gestaltAdmin", Id: "gestaltAdmin"},
+					Resource: &proto.Resource{Type: "gestalt", Id: "gestalt"},
 				},
 				SourceLayer: proto.SourceLayer_SOURCE_LAYER_STATIC_CONFIG,
 			},
@@ -69,7 +69,7 @@ func TestAdminPlatformAdminsList(t *testing.T) {
 	if err := json.Unmarshal(body, &payload); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if payload.Resource.Type != "gestaltAdmin" || payload.Resource.ID != "gestaltAdmin" {
+	if payload.Resource.Type != "gestalt" || payload.Resource.ID != "gestalt" {
 		t.Fatalf("resource = %#v", payload.Resource)
 	}
 	if payload.Role != "admin" {

--- a/gestaltd/internal/server/mounted_ui.go
+++ b/gestaltd/internal/server/mounted_ui.go
@@ -18,7 +18,6 @@ import (
 )
 
 const browserLoginPath = "/api/v1/auth/login"
-const defaultAdminAuthorizationResource = "gestaltAdmin"
 
 type protectedUILoginRedirect func(http.ResponseWriter, *http.Request) error
 
@@ -261,7 +260,7 @@ func (s *Server) authorizeMountedAppAccess(ctx context.Context, p *principal.Pri
 	if err != nil || !ok {
 		return invocation.AccessContext{}, false, err
 	}
-	return s.authorizeMountedResourceRoles(ctx, mountedResourceAccess{
+	return s.authorizeMountedResourceRolesWithLegacy(ctx, mountedResourceAccess{
 		appKey:       strings.TrimSpace(mounted.AppName),
 		resourceName: resourceName,
 		subjectID:    subjectID,

--- a/gestaltd/internal/server/platform_admin.go
+++ b/gestaltd/internal/server/platform_admin.go
@@ -32,7 +32,6 @@ func (s *Server) authorizeMountedResourceRolesWithLegacy(
 		return s.authorizeMountedResourceRoles(ctx, access)
 	}
 
-	var last invocation.AccessContext
 	for _, name := range names {
 		candidate := access
 		candidate.resourceName = name
@@ -43,7 +42,6 @@ func (s *Server) authorizeMountedResourceRolesWithLegacy(
 		if allowed {
 			return decision, true, nil
 		}
-		last = decision
 	}
-	return last, false, nil
+	return invocation.AccessContext{}, false, nil
 }

--- a/gestaltd/internal/server/platform_admin.go
+++ b/gestaltd/internal/server/platform_admin.go
@@ -1,0 +1,49 @@
+package server
+
+import (
+	"context"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/services/invocation"
+)
+
+const (
+	defaultAdminAuthorizationResource = "gestalt"
+	legacyAdminAuthorizationResource  = "gestaltAdmin"
+)
+
+func platformAdminResourceNames(primary string) []string {
+	primary = strings.TrimSpace(primary)
+	if primary == "" {
+		primary = defaultAdminAuthorizationResource
+	}
+	if primary == defaultAdminAuthorizationResource {
+		return []string{defaultAdminAuthorizationResource, legacyAdminAuthorizationResource}
+	}
+	return []string{primary}
+}
+
+func (s *Server) authorizeMountedResourceRolesWithLegacy(
+	ctx context.Context,
+	access mountedResourceAccess,
+) (invocation.AccessContext, bool, error) {
+	names := platformAdminResourceNames(access.resourceName)
+	if len(names) == 1 {
+		return s.authorizeMountedResourceRoles(ctx, access)
+	}
+
+	var last invocation.AccessContext
+	for _, name := range names {
+		candidate := access
+		candidate.resourceName = name
+		decision, allowed, err := s.authorizeMountedResourceRoles(ctx, candidate)
+		if err != nil {
+			return invocation.AccessContext{}, false, err
+		}
+		if allowed {
+			return decision, true, nil
+		}
+		last = decision
+	}
+	return last, false, nil
+}

--- a/gestaltd/internal/server/platform_admin_test.go
+++ b/gestaltd/internal/server/platform_admin_test.go
@@ -1,0 +1,17 @@
+package server
+
+import "testing"
+
+func TestPlatformAdminResourceNames(t *testing.T) {
+	t.Parallel()
+
+	if got := platformAdminResourceNames(""); len(got) != 2 || got[0] != "gestalt" || got[1] != "gestaltAdmin" {
+		t.Fatalf("default names = %#v", got)
+	}
+	if got := platformAdminResourceNames("gestalt"); len(got) != 2 {
+		t.Fatalf("gestalt names = %#v", got)
+	}
+	if got := platformAdminResourceNames("customPolicy"); len(got) != 1 || got[0] != "customPolicy" {
+		t.Fatalf("custom names = %#v", got)
+	}
+}

--- a/gestaltd/services/providergateway/authorization_access.go
+++ b/gestaltd/services/providergateway/authorization_access.go
@@ -1,0 +1,75 @@
+package providergateway
+
+import (
+	"context"
+
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"github.com/valon-technologies/gestalt/server/services/invocation"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	authorizationResourceType = "authorization"
+	authorizationResourceID   = "authorization"
+	legacyAuthorizationAction = "authorization"
+)
+
+func authorizationMethodAccessClass(fullMethod string) (read bool, write bool, ok bool) {
+	_, method := splitFullMethod(fullMethod)
+	switch method {
+	case "GetActiveModelRef",
+		"ListActiveModelResourceTypes",
+		"ListRelationships",
+		"CheckAccess",
+		"CheckAccessMany":
+		return true, false, true
+	case "SetActiveModel",
+		"SetAuthorizationState",
+		"AddRelationship",
+		"DeleteRelationship":
+		return false, true, true
+	default:
+		return false, false, false
+	}
+}
+
+func (t *ProviderGatewayTransport) enforceAuthorizationPublicAccess(
+	ctx context.Context,
+	subjectID, fullMethod string,
+) error {
+	read, write, ok := authorizationMethodAccessClass(fullMethod)
+	if !ok {
+		return status.Error(codes.Internal, "provider gateway: unsupported authorization method")
+	}
+
+	resource := &proto.Resource{Type: authorizationResourceType, Id: authorizationResourceID}
+	actions := authorizationPublicActions(read, write)
+	for _, action := range actions {
+		req := invocation.SubjectAccessRequest(subjectID, action, resource)
+		allowed, err := invocation.CheckSubjectAccess(ctx, t.authorization, req)
+		if err != nil {
+			return status.Error(codes.Unavailable, "authorization provider unavailable")
+		}
+		if allowed {
+			return nil
+		}
+	}
+	return status.Error(codes.PermissionDenied, "access denied")
+}
+
+func authorizationPublicActions(read, write bool) []string {
+	switch {
+	case write:
+		return []string{"admin", legacyAuthorizationAction}
+	case read:
+		return []string{"viewer", "admin", legacyAuthorizationAction}
+	default:
+		return nil
+	}
+}
+
+func isAuthorizationServiceMethod(fullMethod string) bool {
+	service, _ := splitFullMethod(fullMethod)
+	return service == proto.Authorization_ServiceDesc.ServiceName
+}

--- a/gestaltd/services/providergateway/authorization_access.go
+++ b/gestaltd/services/providergateway/authorization_access.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	authorizationResourceType = "authorization"
+	authorizationResourceType = string(ProviderKindAuthorization)
 	authorizationResourceID   = "authorization"
 	legacyAuthorizationAction = "authorization"
 )

--- a/gestaltd/services/providergateway/authorization_access_test.go
+++ b/gestaltd/services/providergateway/authorization_access_test.go
@@ -1,0 +1,48 @@
+package providergateway
+
+import "testing"
+
+func TestAuthorizationMethodAccessClass(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		method string
+		read   bool
+		write  bool
+		ok     bool
+	}{
+		{method: "GetActiveModelRef", read: true, ok: true},
+		{method: "ListActiveModelResourceTypes", read: true, ok: true},
+		{method: "ListRelationships", read: true, ok: true},
+		{method: "CheckAccess", read: true, ok: true},
+		{method: "CheckAccessMany", read: true, ok: true},
+		{method: "SetActiveModel", write: true, ok: true},
+		{method: "SetAuthorizationState", write: true, ok: true},
+		{method: "AddRelationship", write: true, ok: true},
+		{method: "DeleteRelationship", write: true, ok: true},
+		{method: "Ping", ok: false},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.method, func(t *testing.T) {
+			t.Parallel()
+			fullMethod := "/gestalt.provider.v1.Authorization/" + tc.method
+			read, write, ok := authorizationMethodAccessClass(fullMethod)
+			if read != tc.read || write != tc.write || ok != tc.ok {
+				t.Fatalf("authorizationMethodAccessClass(%q) = (%v, %v, %v), want (%v, %v, %v)", fullMethod, read, write, ok, tc.read, tc.write, tc.ok)
+			}
+		})
+	}
+}
+
+func TestAuthorizationPublicActions(t *testing.T) {
+	t.Parallel()
+
+	if got := authorizationPublicActions(true, false); len(got) != 3 || got[0] != "viewer" || got[1] != "admin" || got[2] != legacyAuthorizationAction {
+		t.Fatalf("read actions = %#v", got)
+	}
+	if got := authorizationPublicActions(false, true); len(got) != 2 || got[0] != "admin" || got[1] != legacyAuthorizationAction {
+		t.Fatalf("write actions = %#v", got)
+	}
+}

--- a/gestaltd/services/providergateway/gateway_test.go
+++ b/gestaltd/services/providergateway/gateway_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/valon-technologies/gestalt/server/core"
@@ -25,23 +26,34 @@ func boolPtr(value bool) *bool {
 }
 
 type stubAuthorizationProvider struct {
-	called        bool
-	allowedResult *bool
-	fail          bool
-	ctx           context.Context
-	request       *proto.CheckAccessRequest
+	called         bool
+	allowedResult  *bool
+	allowedActions map[string]bool
+	fail           bool
+	ctx            context.Context
+	request        *proto.CheckAccessRequest
+	requests       []*proto.CheckAccessRequest
 }
 
 func (p *stubAuthorizationProvider) CheckAccess(ctx context.Context, req *proto.CheckAccessRequest) (*proto.CheckAccessResponse, error) {
 	p.called = true
 	p.ctx = ctx
 	p.request = req
+	p.requests = append(p.requests, req)
 	if p.fail {
 		return nil, errors.New("authorization provider down")
 	}
 	allowed := true
 	if p.allowedResult != nil {
 		allowed = *p.allowedResult
+	}
+	if p.allowedActions != nil {
+		action := strings.TrimSpace(req.GetAction().GetName())
+		allowed, ok := p.allowedActions[action]
+		if !ok {
+			allowed = false
+		}
+		return &proto.CheckAccessResponse{Allowed: allowed}, nil
 	}
 	return &proto.CheckAccessResponse{Allowed: allowed}, nil
 }
@@ -186,7 +198,7 @@ func TestPreparePublicRequest(t *testing.T) {
 			wantCode:   codes.InvalidArgument,
 		},
 		{
-			name:       "authorization check uses stable provider resource type",
+			name:       "authorization read checks viewer before admin",
 			fullMethod: proto.Authorization_CheckAccess_FullMethodName,
 			withOrigin: true,
 			introspect: activeAlice,
@@ -197,15 +209,41 @@ func TestPreparePublicRequest(t *testing.T) {
 			},
 			checkAuth: func(t *testing.T, auth *stubAuthorizationProvider) {
 				t.Helper()
-				if got := auth.request.GetResource().GetType(); got != string(ProviderKindAuthorization) {
-					t.Fatalf("authorization resource type = %q, want %q", got, ProviderKindAuthorization)
+				if got := auth.request.GetResource().GetType(); got != authorizationResourceType {
+					t.Fatalf("authorization resource type = %q, want %q", got, authorizationResourceType)
 				}
-				if got := auth.request.GetResource().GetId(); got != "authorization" {
-					t.Fatalf("authorization resource id = %q, want authorization", got)
+				if got := auth.request.GetResource().GetId(); got != authorizationResourceID {
+					t.Fatalf("authorization resource id = %q, want %q", got, authorizationResourceID)
 				}
-				if got := auth.request.GetAction().GetName(); got != "authorization" {
-					t.Fatalf("authorization action = %q, want authorization", got)
+				if got := auth.request.GetAction().GetName(); got != "viewer" {
+					t.Fatalf("authorization action = %q, want viewer", got)
 				}
+			},
+		},
+		{
+			name:       "authorization write requires admin",
+			fullMethod: proto.Authorization_SetActiveModel_FullMethodName,
+			withOrigin: true,
+			introspect: activeAlice,
+			authAllow:  &denied,
+			req:        &proto.SetActiveModelRequest{},
+			wantCode:   codes.PermissionDenied,
+			setup: func(transport *ProviderGatewayTransport) {
+				transport.SetAuthorizationProvider(&stubAuthorizationProvider{
+					allowedActions: map[string]bool{"viewer": true},
+				})
+			},
+		},
+		{
+			name:       "authorization write allows admin",
+			fullMethod: proto.Authorization_SetActiveModel_FullMethodName,
+			withOrigin: true,
+			introspect: activeAlice,
+			req:        &proto.SetActiveModelRequest{},
+			setup: func(transport *ProviderGatewayTransport) {
+				transport.SetAuthorizationProvider(&stubAuthorizationProvider{
+					allowedActions: map[string]bool{"admin": true},
+				})
 			},
 		},
 		{

--- a/gestaltd/services/providergateway/public_request.go
+++ b/gestaltd/services/providergateway/public_request.go
@@ -116,6 +116,9 @@ func (t *ProviderGatewayTransport) enforcePublicAuthorization(
 	if err != nil {
 		return status.Error(codes.Unauthenticated, "authenticated subject is required")
 	}
+	if isAuthorizationServiceMethod(fullMethod) {
+		return t.enforceAuthorizationPublicAccess(ctx, subjectID, fullMethod)
+	}
 	target := ProviderTarget{Kind: providerKindFromFullMethod(fullMethod), Name: providerID}
 	resource := &proto.Resource{Type: string(target.Kind), Id: strings.TrimSpace(target.Name)}
 	action := &proto.Action{Name: strings.TrimSpace(target.Name)}


### PR DESCRIPTION
## Summary
- Gate Authorization public RPCs with method-aware viewer/admin checks instead of the coarse provider-name action.
- Default built-in platform admin authorization to the `gestalt` resource while preserving `gestaltAdmin` access during config migration.

## Test plan
- [x] `go test ./services/providergateway/... ./internal/server/... -run 'TestAuthorization|TestPreparePublicRequest|TestPlatformAdmin|TestAdminAPI'`
- [ ] Merge after [toolshed#4724](https://github.com/valon-technologies/toolshed/pull/4724) lands
- [ ] Publish gestaltd-ci artifacts for this commit before toolshed step 2 deploy


Made with [Cursor](https://cursor.com)