### PR TITLE
Add RFC-compliant SCIM Groups

### DIFF
--- a/gestaltd/internal/coredata/schemas.go
+++ b/gestaltd/internal/coredata/schemas.go
@@ -24,6 +24,7 @@ const (
 	StoreAppAccessProfiles              = "app_access_profiles"
 	StoreSCIMUsers                      = "scim_users"
 	StoreSCIMProjectionIntents          = "scim_projection_intents"
+	StoreSCIMGroups                     = "scim_groups"
 )
 
 var SCIMUsersSchema = idb.ObjectStoreOptions{
@@ -83,6 +84,31 @@ var SCIMProjectionIntentsSchema = idb.ObjectStoreOptions{
 		{Name: "attempt_count", Type: idb.TypeInt, NotNull: true},
 		{Name: "next_attempt_at", Type: idb.TypeTime, NotNull: true},
 		{Name: "last_error", Type: idb.TypeString},
+		{Name: "created_at", Type: idb.TypeTime, NotNull: true},
+		{Name: "updated_at", Type: idb.TypeTime, NotNull: true},
+	},
+}
+
+// SCIMGroupsSchema keeps the committed resource and any pending replacement
+// together so projection recovery does not require a separate intent store.
+var SCIMGroupsSchema = idb.ObjectStoreOptions{
+	Indexes: []idb.IndexSchema{
+		{Name: "by_client", KeyPath: []string{"client_id"}},
+	},
+	Columns: []idb.ColumnDef{
+		{Name: "id", Type: idb.TypeString, PrimaryKey: true},
+		{Name: "client_id", Type: idb.TypeString, NotNull: true},
+		{Name: "version", Type: idb.TypeInt, NotNull: true},
+		{Name: "deleted", Type: idb.TypeBool, NotNull: true},
+		{Name: "resource", Type: idb.TypeJSON, NotNull: true},
+		{Name: "pending_resource", Type: idb.TypeJSON},
+		{Name: "pending_deleted", Type: idb.TypeBool},
+		{Name: "pending_version", Type: idb.TypeInt},
+		{Name: "pending_fingerprint", Type: idb.TypeString},
+		{Name: "pending_affected_users", Type: idb.TypeJSON},
+		{Name: "pending_attempt_count", Type: idb.TypeInt},
+		{Name: "pending_next_attempt_at", Type: idb.TypeTime},
+		{Name: "last_operation_fingerprint", Type: idb.TypeString},
 		{Name: "created_at", Type: idb.TypeTime, NotNull: true},
 		{Name: "updated_at", Type: idb.TypeTime, NotNull: true},
 	},

--- a/gestaltd/internal/coredata/services.go
+++ b/gestaltd/internal/coredata/services.go
@@ -101,6 +101,9 @@ func NewWithOptions(ctx context.Context, ds indexeddb.IndexedDB, opts NewOptions
 		if _, err := ds.CreateObjectStore(ctx, StoreSCIMProjectionIntents, SCIMProjectionIntentsSchema); err != nil {
 			return nil, fmt.Errorf("create scim_projection_intents store: %w", err)
 		}
+		if _, err := ds.CreateObjectStore(ctx, StoreSCIMGroups, SCIMGroupsSchema); err != nil {
+			return nil, fmt.Errorf("create scim_groups store: %w", err)
+		}
 	} else if err := ensureDeferredAppRegistryStores(ctx, ds); err != nil {
 		return nil, err
 	} else if err := ensureSCIMStores(ctx, ds); err != nil {
@@ -146,6 +149,9 @@ func ensureSCIMStores(ctx context.Context, ds indexeddb.IndexedDB) error {
 	}
 	if _, err := ds.CreateObjectStore(ctx, StoreSCIMProjectionIntents, SCIMProjectionIntentsSchema); err != nil {
 		return fmt.Errorf("ensure scim_projection_intents store: %w", err)
+	}
+	if _, err := ds.CreateObjectStore(ctx, StoreSCIMGroups, SCIMGroupsSchema); err != nil {
+		return fmt.Errorf("ensure scim_groups store: %w", err)
 	}
 	return nil
 }

--- a/gestaltd/internal/coredata/services_test.go
+++ b/gestaltd/internal/coredata/services_test.go
@@ -258,6 +258,7 @@ func TestNew(t *testing.T) {
 			coredata.StoreAppAccessProfiles,
 			coredata.StoreSCIMUsers,
 			coredata.StoreSCIMProjectionIntents,
+			coredata.StoreSCIMGroups,
 		} {
 			if _, ok := contexts[store]; !ok {
 				t.Fatalf("NewWithContext did not create store %q", store)
@@ -278,8 +279,8 @@ func TestNew(t *testing.T) {
 			t.Fatalf("coredata.NewWithOptions: %v", err)
 		}
 		contexts := db.createdStoreContexts()
-		if len(contexts) != 7 {
-			t.Fatalf("CreateObjectStore calls = %d, want 7", len(contexts))
+		if len(contexts) != 8 {
+			t.Fatalf("CreateObjectStore calls = %d, want 8", len(contexts))
 		}
 		for _, store := range []string{
 			coredata.StoreAppAutoDeploySettings,
@@ -289,6 +290,7 @@ func TestNew(t *testing.T) {
 			coredata.StoreAppAccessProfiles,
 			coredata.StoreSCIMUsers,
 			coredata.StoreSCIMProjectionIntents,
+			coredata.StoreSCIMGroups,
 		} {
 			if _, ok := contexts[store]; !ok {
 				t.Fatalf("CreateObjectStore calls = %v, want %q", contexts, store)

--- a/gestaltd/internal/scim/authorization.go
+++ b/gestaltd/internal/scim/authorization.go
@@ -18,7 +18,7 @@ type authorizationGate struct {
 }
 
 func WrapAuthorization(underlying core.AuthorizationProvider, users *coredata.UserService, service *Service) core.AuthorizationProvider {
-	if underlying == nil || service == nil || len(service.domainOwners) == 0 && len(service.managed) == 0 {
+	if underlying == nil || !service.Enabled() {
 		return underlying
 	}
 	return &authorizationGate{underlying: underlying, users: users, scim: service}
@@ -91,21 +91,35 @@ func (g *authorizationGate) ListRelationships(ctx context.Context, req *proto.Li
 }
 
 func (g *authorizationGate) AddRelationship(ctx context.Context, req *proto.AddRelationshipRequest) (*proto.AddRelationshipResponse, error) {
-	if req != nil && req.Relationship != nil && req.Relationship.Tuple != nil && g.managed(req.Relationship.Tuple) {
-		return nil, fmt.Errorf("relationship is managed by SCIM")
+	if req != nil && req.Relationship != nil {
+		if err := g.checkRelationshipWrite(ctx, req.Relationship.Tuple); err != nil {
+			return nil, err
+		}
 	}
 	return g.underlying.AddRelationship(ctx, req)
 }
 
 func (g *authorizationGate) DeleteRelationship(ctx context.Context, req *proto.DeleteRelationshipRequest) (*proto.DeleteRelationshipResponse, error) {
-	if req != nil && req.RelationshipTuple != nil && g.managed(req.RelationshipTuple) {
-		return nil, fmt.Errorf("relationship is managed by SCIM")
+	if req != nil {
+		if err := g.checkRelationshipWrite(ctx, req.RelationshipTuple); err != nil {
+			return nil, err
+		}
 	}
 	return g.underlying.DeleteRelationship(ctx, req)
 }
 
-func (g *authorizationGate) managed(tuple *proto.RelationshipTuple) bool {
-	return tuple.Resource != nil && g.scim.ManagedRelationship(tuple.Resource.Type, tuple.Resource.Id, tuple.Relation)
+func (g *authorizationGate) checkRelationshipWrite(ctx context.Context, tuple *proto.RelationshipTuple) error {
+	if tuple == nil || tuple.Resource == nil {
+		return nil
+	}
+	managed, err := g.scim.managedRelationship(ctx, tuple.Resource.Type, tuple.Resource.Id, tuple.Relation)
+	if err != nil {
+		return fmt.Errorf("check SCIM relationship ownership: %w", err)
+	}
+	if managed {
+		return fmt.Errorf("relationship is managed by SCIM")
+	}
+	return nil
 }
 
 func (g *authorizationGate) SetAuthorizationState(ctx context.Context, req *proto.SetAuthorizationStateRequest) (*proto.SetAuthorizationStateResponse, error) {

--- a/gestaltd/internal/scim/filter.go
+++ b/gestaltd/internal/scim/filter.go
@@ -12,6 +12,11 @@ type filterClause struct {
 	value     string
 }
 
+type groupFilterClause struct {
+	attribute string
+	value     string
+}
+
 var filterClausePattern = regexp.MustCompile(`(?i)^\s*(externalId|userName|emails\.value|emails\[\s*type\s+eq\s+"work"\s*\]\.value)\s+eq\s+("(?:\\.|[^"\\])*")\s*$`)
 
 func parseFilter(raw string) ([]filterClause, error) {
@@ -98,6 +103,77 @@ func matchesFilter(user persistedUser, clauses []filterClause) bool {
 		default:
 			for _, email := range user.Emails {
 				matched = matched || strings.EqualFold(strings.TrimSpace(email.Type), "work") && normalize(email.Value) == clause.value
+			}
+		}
+		if !matched {
+			return false
+		}
+	}
+	return true
+}
+
+var (
+	groupFilterClausePattern = regexp.MustCompile(`(?i)^\s*(displayName|externalId)\s+eq\s+("(?:\\.|[^"\\])*")\s*$`)
+	groupMemberFilterPattern = regexp.MustCompile(`(?i)^\s*members\[\s*value\s+eq\s+("(?:\\.|[^"\\])*")\s*\]\s*$`)
+)
+
+func parseGroupFilter(raw string) ([]groupFilterClause, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+	parts, err := splitFilterConjunctions(raw)
+	if err != nil {
+		return nil, err
+	}
+	clauses := make([]groupFilterClause, 0, len(parts))
+	for _, part := range parts {
+		matches := groupFilterClausePattern.FindStringSubmatch(part)
+		attribute := ""
+		valueRaw := ""
+		if matches != nil {
+			attribute, valueRaw = strings.ToLower(strings.TrimSpace(matches[1])), matches[2]
+		} else if value, ok := parseGroupMemberFilter(part); ok {
+			clauses = append(clauses, groupFilterClause{attribute: "members.value", value: value})
+			continue
+		} else {
+			return nil, fmt.Errorf("unsupported filter clause %q", strings.TrimSpace(part))
+		}
+		var value string
+		if err := json.Unmarshal([]byte(valueRaw), &value); err != nil {
+			return nil, fmt.Errorf("invalid filter value: %w", err)
+		}
+		clauses = append(clauses, groupFilterClause{attribute: attribute, value: normalize(value)})
+	}
+	return clauses, nil
+}
+
+func parseGroupMemberFilter(raw string) (string, bool) {
+	matches := groupMemberFilterPattern.FindStringSubmatch(raw)
+	if matches == nil {
+		return "", false
+	}
+	var value string
+	if err := json.Unmarshal([]byte(matches[1]), &value); err != nil {
+		return "", false
+	}
+	return strings.TrimSpace(value), true
+}
+
+func matchesGroupFilter(group persistedGroup, clauses []groupFilterClause) bool {
+	for _, clause := range clauses {
+		matched := false
+		switch clause.attribute {
+		case "displayname":
+			matched = normalize(group.DisplayName) == clause.value
+		case "externalid":
+			matched = normalize(group.ExternalID) == clause.value
+		case "members.value":
+			for _, member := range group.Members {
+				if strings.TrimSpace(member.Value) == clause.value {
+					matched = true
+					break
+				}
 			}
 		}
 		if !matched {

--- a/gestaltd/internal/scim/groups.go
+++ b/gestaltd/internal/scim/groups.go
@@ -1,0 +1,1184 @@
+package scim
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	idb "github.com/valon-technologies/gestalt/sdk/go/indexeddb"
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/coredata"
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	gproto "google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+type storedGroup struct {
+	id                   string
+	clientID             string
+	resource             persistedGroup
+	pendingResource      persistedGroup
+	version              int64
+	deleted              bool
+	createdAt            time.Time
+	updatedAt            time.Time
+	lastFingerprint      string
+	pending              bool
+	pendingDeleted       bool
+	pendingVersion       int64
+	pendingFingerprint   string
+	pendingAffectedUsers []string
+	pendingAttemptCount  int64
+	pendingNextAttemptAt time.Time
+}
+
+type groupMutation struct {
+	resource      persistedGroup
+	deleted       bool
+	fingerprint   string
+	affectedUsers []string
+}
+
+func (s *Service) CreateGroup(ctx context.Context, clientID string, input groupInput) (*Group, error) {
+	resource, err := createGroupResource(input)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.validateGroupMembers(ctx, clientID, resource.Members); err != nil {
+		return nil, err
+	}
+	fingerprint := operationFingerprint("create-group", "", resource)
+	unlock := s.lock("create-group\x00" + clientID + "\x00" + fingerprint)
+	defer unlock()
+	if existing, found, findErr := s.findPendingGroup(ctx, clientID, fingerprint); findErr != nil {
+		return nil, findErr
+	} else if found {
+		if err := s.convergeGroup(ctx, existing.id); err != nil {
+			return nil, err
+		}
+		return s.GetGroup(ctx, clientID, existing.id)
+	}
+	id := uuid.NewString()
+	mutation := groupMutation{resource: resource, fingerprint: fingerprint}
+	mutation.affectedUsers = s.affectedUsers(ctx, clientID, nil, resource.Members)
+	if err := s.persistGroupMutation(ctx, id, clientID, storedGroup{resource: persistedGroup{DisplayName: resource.DisplayName}}, mutation, true); err != nil {
+		return nil, err
+	}
+	if err := s.convergeGroup(ctx, id); err != nil {
+		return nil, err
+	}
+	return s.GetGroup(ctx, clientID, id)
+}
+
+func createGroupResource(input groupInput) (persistedGroup, error) {
+	resource := persistedGroup{}
+	if input.ExternalID != nil {
+		resource.ExternalID = *input.ExternalID
+	}
+	if input.DisplayName != nil {
+		resource.DisplayName = *input.DisplayName
+	}
+	if strings.TrimSpace(resource.DisplayName) == "" {
+		return persistedGroup{}, invalid("displayName is required")
+	}
+	if input.Members != nil {
+		resource.Members = append([]Member(nil), (*input.Members)...)
+	}
+	if resource.Members == nil {
+		resource.Members = []Member{}
+	}
+	return resource, nil
+}
+
+func (s *Service) GetGroup(ctx context.Context, clientID, id string) (*Group, error) {
+	row, err := s.loadGroup(ctx, clientID, id, false)
+	if err != nil {
+		return nil, err
+	}
+	if row.pending && row.version == 0 {
+		return nil, unavailable("SCIM Group projection has not converged")
+	}
+	group, err := s.publicGroup(ctx, row)
+	if err != nil {
+		return nil, err
+	}
+	return &group, nil
+}
+
+func (s *Service) listGroups(ctx context.Context, clientID, rawFilter string, startIndex, count int) (listResponse[Group], error) {
+	clauses, err := parseGroupFilter(rawFilter)
+	if err != nil {
+		return listResponse[Group]{}, invalidFilter(err.Error())
+	}
+	records, err := s.db.ObjectStore(coredata.StoreSCIMGroups).Index("by_client").GetAll(ctx, clientID)
+	if err != nil {
+		return listResponse[Group]{}, unavailable("could not list SCIM Groups")
+	}
+	rows := make([]storedGroup, 0, len(records))
+	for _, rec := range records {
+		row, decodeErr := decodeStoredGroup(rec)
+		if decodeErr != nil {
+			return listResponse[Group]{}, unavailable("stored SCIM Group is invalid")
+		}
+		if row.deleted || row.pending && row.version == 0 || !matchesGroupFilter(row.resource, clauses) {
+			continue
+		}
+		rows = append(rows, row)
+	}
+	sort.Slice(rows, func(i, j int) bool { return rows[i].id < rows[j].id })
+	total := len(rows)
+	begin := startIndex - 1
+	if begin > total {
+		begin = total
+	}
+	end := begin + count
+	if end > total {
+		end = total
+	}
+	resources := make([]Group, 0, end-begin)
+	for i := begin; i < end; i++ {
+		group, publicErr := s.publicGroup(ctx, rows[i])
+		if publicErr != nil {
+			return listResponse[Group]{}, publicErr
+		}
+		resources = append(resources, group)
+	}
+	return listResponse[Group]{Schemas: []string{ListSchemaURN}, TotalResults: total, StartIndex: startIndex, ItemsPerPage: len(resources), Resources: resources}, nil
+}
+
+func (s *Service) ReplaceGroup(ctx context.Context, clientID, id, ifMatch string, input groupInput) (*Group, error) {
+	resource, err := createGroupResource(input)
+	if err != nil {
+		return nil, err
+	}
+	fingerprint := operationFingerprint("replace-group", ifMatch, resource)
+	return s.mutateGroup(ctx, clientID, id, ifMatch, fingerprint, func(persistedGroup) (persistedGroup, error) { return resource, nil })
+}
+
+func (s *Service) PatchGroup(ctx context.Context, clientID, id, ifMatch string, request patchRequest) (*Group, error) {
+	fingerprint := patchOperationFingerprint(ifMatch, request)
+	return s.mutateGroup(ctx, clientID, id, ifMatch, fingerprint, func(current persistedGroup) (persistedGroup, error) {
+		return applyGroupPatch(current, request)
+	})
+}
+
+func (s *Service) mutateGroup(ctx context.Context, clientID, id, ifMatch, fingerprint string, propose func(persistedGroup) (persistedGroup, error)) (*Group, error) {
+	unlock := s.lock(userLockKey("group:" + id))
+	defer unlock()
+	if err := s.convergeGroupLocked(ctx, id); err != nil {
+		return nil, err
+	}
+	current, err := s.loadGroup(ctx, clientID, id, false)
+	if err != nil {
+		return nil, err
+	}
+	if current.lastFingerprint == fingerprint {
+		group, publicErr := s.publicGroup(ctx, current)
+		return &group, publicErr
+	}
+	if ifMatch != "" && ifMatch != "*" && ifMatch != etag(current.version) {
+		return nil, &Error{Status: http.StatusPreconditionFailed, Detail: "If-Match does not match the current SCIM Group version"}
+	}
+	resource, err := propose(current.resource)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.validateGroupMembers(ctx, clientID, resource.Members); err != nil {
+		return nil, err
+	}
+	if err := validateImmutableMembers(current.resource.Members, resource.Members); err != nil {
+		return nil, err
+	}
+	mutation := groupMutation{resource: resource, fingerprint: fingerprint}
+	mutation.affectedUsers = s.affectedUsers(ctx, clientID, current.resource.Members, resource.Members)
+	if err := s.persistGroupMutation(ctx, id, clientID, current, mutation, false); err != nil {
+		return nil, err
+	}
+	if err := s.convergeGroupLocked(ctx, id); err != nil {
+		return nil, err
+	}
+	return s.GetGroup(ctx, clientID, id)
+}
+
+func (s *Service) DeleteGroup(ctx context.Context, clientID, id, ifMatch string) error {
+	if err := s.deleteGroup(ctx, clientID, id, ifMatch); err != nil {
+		return err
+	}
+	// Cascade after releasing the deleted Group's lock. Nested Groups may be
+	// cyclic, and concurrent deletes must not acquire locks in opposite order.
+	return s.removeGroupFromParents(ctx, clientID, id)
+}
+
+func (s *Service) deleteGroup(ctx context.Context, clientID, id, ifMatch string) error {
+	fingerprint := operationFingerprint("delete-group", ifMatch, nil)
+	unlock := s.lock(userLockKey("group:" + id))
+	defer unlock()
+	current, err := s.loadGroup(ctx, clientID, id, true)
+	if err != nil {
+		return err
+	}
+	if current.deleted {
+		return notFoundResource("SCIM Group")
+	}
+	if current.pending {
+		pendingFingerprint := current.pendingFingerprint
+		if err := s.convergeGroupLocked(ctx, id); err != nil {
+			return err
+		}
+		current, err = s.loadGroup(ctx, clientID, id, true)
+		if err != nil {
+			return err
+		}
+		if current.deleted {
+			if pendingFingerprint == fingerprint {
+				return nil
+			}
+			return notFoundResource("SCIM Group")
+		}
+	}
+	if ifMatch != "" && ifMatch != "*" && ifMatch != etag(current.version) {
+		return &Error{Status: http.StatusPreconditionFailed, Detail: "If-Match does not match the current SCIM Group version"}
+	}
+	mutation := groupMutation{resource: current.resource, fingerprint: fingerprint, deleted: true}
+	mutation.affectedUsers = s.affectedUsers(ctx, clientID, current.resource.Members, nil)
+	if err := s.persistGroupMutation(ctx, id, clientID, current, mutation, false); err != nil {
+		return err
+	}
+	if err := s.convergeGroupLocked(ctx, id); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *Service) persistGroupMutation(ctx context.Context, id, clientID string, current storedGroup, mutation groupMutation, creating bool) error {
+	now := s.currentTime()
+	tx, err := s.db.Transaction(ctx, []string{coredata.StoreSCIMGroups}, idb.TransactionReadwrite, idb.TransactionOptions{DurabilityHint: idb.TransactionDurabilityStrict})
+	if err != nil {
+		return unavailable("could not begin SCIM Group mutation")
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Abort(context.WithoutCancel(ctx))
+		}
+	}()
+	store := tx.ObjectStore(coredata.StoreSCIMGroups)
+	if creating {
+		if err := store.Add(ctx, groupPendingRecord(id, clientID, mutation, now)); err != nil {
+			return unavailable("could not persist SCIM Group creation")
+		}
+	} else {
+		rec, err := store.Get(ctx, id)
+		if errors.Is(err, idb.ErrNotFound) {
+			return notFoundResource("SCIM Group")
+		}
+		if err != nil {
+			return unavailable("could not verify current SCIM Group")
+		}
+		latest, decodeErr := decodeStoredGroup(rec)
+		if decodeErr != nil || latest.clientID != clientID || latest.deleted || latest.version != current.version || latest.pending {
+			return &Error{Status: http.StatusPreconditionFailed, Detail: "SCIM Group changed during mutation"}
+		}
+		rec["pending_resource"] = jsonMap(mutation.resource)
+		rec["pending_deleted"] = mutation.deleted
+		rec["pending_version"] = current.version + 1
+		rec["pending_fingerprint"] = mutation.fingerprint
+		rec["pending_affected_users"] = jsonSlice(mutation.affectedUsers)
+		rec["pending_attempt_count"] = int64(0)
+		rec["pending_next_attempt_at"] = now
+		if err := store.Put(ctx, rec); err != nil {
+			return unavailable("could not persist SCIM Group mutation")
+		}
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return unavailable("could not commit SCIM Group mutation")
+	}
+	committed = true
+	return nil
+}
+
+func groupPendingRecord(id, clientID string, mutation groupMutation, now time.Time) idb.Record {
+	record := idb.Record{
+		"id": id, "client_id": clientID,
+		"version": int64(0), "deleted": false, "resource": jsonMap(persistedGroup{}),
+		"pending_resource": jsonMap(mutation.resource), "pending_deleted": mutation.deleted, "pending_version": int64(1),
+		"pending_fingerprint": mutation.fingerprint, "pending_affected_users": jsonSlice(mutation.affectedUsers), "pending_attempt_count": int64(0),
+		"pending_next_attempt_at": now, "created_at": now, "updated_at": now,
+	}
+	return record
+}
+
+func (s *Service) convergeGroup(ctx context.Context, id string) error {
+	unlock := s.lock(userLockKey("group:" + id))
+	defer unlock()
+	return s.convergeGroupLocked(ctx, id)
+}
+
+func (s *Service) convergeGroupLocked(ctx context.Context, id string) error {
+	rec, err := s.db.ObjectStore(coredata.StoreSCIMGroups).Get(ctx, id)
+	if errors.Is(err, idb.ErrNotFound) {
+		return notFoundResource("SCIM Group")
+	}
+	if err != nil {
+		return unavailable("could not load pending SCIM Group mutation")
+	}
+	row, err := decodeStoredGroup(rec)
+	if err != nil {
+		return unavailable("pending SCIM Group is invalid")
+	}
+	if !row.pending {
+		return nil
+	}
+	desiredMembers := row.pendingResource.Members
+	if row.pendingDeleted {
+		desiredMembers = nil
+	}
+	if err := s.applyGroupProjections(ctx, row.clientID, row.id, row.resource.Members, desiredMembers); err != nil {
+		_ = s.recordGroupProjectionFailure(ctx, id)
+		return unavailable("authorization Group projection has not converged")
+	}
+	now := s.currentTime()
+	tx, err := s.db.Transaction(ctx, []string{coredata.StoreSCIMGroups}, idb.TransactionReadwrite, idb.TransactionOptions{DurabilityHint: idb.TransactionDurabilityStrict})
+	if err != nil {
+		return unavailable("could not commit SCIM Group mutation")
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Abort(context.WithoutCancel(ctx))
+		}
+	}()
+	latestRec, err := tx.ObjectStore(coredata.StoreSCIMGroups).Get(ctx, id)
+	if err != nil {
+		return unavailable("could not verify pending SCIM Group mutation")
+	}
+	latest, err := decodeStoredGroup(latestRec)
+	if err != nil || !latest.pending || latest.pendingFingerprint != row.pendingFingerprint || latest.pendingVersion != row.pendingVersion {
+		return unavailable("SCIM Group mutation was superseded")
+	}
+	desired := latest.pendingResource
+	latestRec["resource"] = jsonMap(desired)
+	latestRec["version"] = latest.pendingVersion
+	latestRec["deleted"] = latest.pendingDeleted
+	latestRec["updated_at"] = now
+	latestRec["last_operation_fingerprint"] = latest.pendingFingerprint
+	for _, key := range []string{"pending_resource", "pending_deleted", "pending_version", "pending_fingerprint", "pending_affected_users", "pending_attempt_count", "pending_next_attempt_at"} {
+		delete(latestRec, key)
+	}
+	if err := tx.ObjectStore(coredata.StoreSCIMGroups).Put(ctx, latestRec); err != nil {
+		return unavailable("could not commit SCIM Group")
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return unavailable("could not commit SCIM Group")
+	}
+	committed = true
+	return nil
+}
+
+func (s *Service) applyGroupProjections(ctx context.Context, clientID, groupID string, from, to []Member) error {
+	fromTuples, err := s.groupMemberTuples(ctx, clientID, groupID, from)
+	if err != nil {
+		return err
+	}
+	toTuples, err := s.groupMemberTuples(ctx, clientID, groupID, to)
+	if err != nil {
+		return err
+	}
+	fromSet, toSet := make(map[string]*proto.RelationshipTuple), make(map[string]*proto.RelationshipTuple)
+	for _, tuple := range fromTuples {
+		fromSet[relationshipTupleKey(tuple)] = tuple
+	}
+	for _, tuple := range toTuples {
+		toSet[relationshipTupleKey(tuple)] = tuple
+	}
+	if s.authorization == nil {
+		// A deployment without an authorization provider can still act as a
+		// standards-compliant SCIM resource store. There is no projection to
+		// converge in that mode; configuration validation rejects lifecycle
+		// gates and static projections that would require one.
+		return nil
+	}
+	for key, tuple := range fromSet {
+		if _, keep := toSet[key]; keep {
+			continue
+		}
+		existing, err := s.findRelationship(ctx, tuple)
+		if err != nil {
+			return err
+		}
+		if existing == nil || !groupRelationshipOwnedBy(existing, clientID, groupID) {
+			continue
+		}
+		if _, err := s.authorization.DeleteRelationship(ctx, &proto.DeleteRelationshipRequest{RelationshipTuple: tuple}); err != nil && !errors.Is(err, core.ErrNotFound) {
+			return err
+		}
+	}
+	for key, tuple := range toSet {
+		if _, existed := fromSet[key]; existed {
+			continue
+		}
+		existing, err := s.findRelationship(ctx, tuple)
+		if err != nil {
+			return err
+		}
+		if existing != nil {
+			continue
+		}
+		properties, _ := structpb.NewStruct(map[string]any{"managedBy": "scim", "scimClientId": clientID, "scimGroupId": groupID})
+		if _, err := s.authorization.AddRelationship(ctx, &proto.AddRelationshipRequest{Relationship: &proto.Relationship{Tuple: tuple, Properties: properties, SourceLayer: proto.SourceLayer_SOURCE_LAYER_RUNTIME}}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Service) groupMemberTuples(ctx context.Context, clientID, groupID string, members []Member) ([]*proto.RelationshipTuple, error) {
+	out := make([]*proto.RelationshipTuple, 0, len(members))
+	seen := make(map[string]struct{})
+	for _, member := range members {
+		tuple, err := s.groupMemberTuple(ctx, clientID, groupID, member)
+		if err != nil {
+			return nil, err
+		}
+		key := relationshipTupleKey(tuple)
+		if _, duplicate := seen[key]; duplicate {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, tuple)
+	}
+	return out, nil
+}
+
+func (s *Service) groupMemberTuple(ctx context.Context, clientID, groupID string, member Member) (*proto.RelationshipTuple, error) {
+	memberType, err := s.memberType(ctx, clientID, member, true)
+	if err != nil {
+		return nil, err
+	}
+	target := &proto.RelationshipTarget{}
+	if memberType == "User" {
+		row, err := s.loadUserRow(ctx, clientID, member.Value, true)
+		if err != nil {
+			return nil, err
+		}
+		target.Kind = &proto.RelationshipTarget_Subject{Subject: &proto.Subject{Type: "subject", Id: "user:" + row.coreUserID}}
+	} else {
+		target.Kind = &proto.RelationshipTarget_SubjectSet{SubjectSet: &proto.SubjectSet{Resource: &proto.Resource{Type: "group", Id: member.Value}, Relation: "member"}}
+	}
+	return &proto.RelationshipTuple{Target: target, Relation: "member", Resource: &proto.Resource{Type: "group", Id: groupID}}, nil
+}
+
+func (s *Service) memberType(ctx context.Context, clientID string, member Member, includeDeleted bool) (string, error) {
+	requested := strings.ToLower(strings.TrimSpace(member.Type))
+	if requested != "" && requested != "user" && requested != "group" {
+		return "", invalid("members.type must be User or Group")
+	}
+	if _, err := s.loadUserRow(ctx, clientID, member.Value, includeDeleted); err == nil {
+		if requested != "" && requested != "user" {
+			return "", invalid("member type does not match the referenced resource")
+		}
+		return "User", nil
+	} else if isServiceUnavailable(err) {
+		return "", err
+	}
+	if _, err := s.loadGroup(ctx, clientID, member.Value, includeDeleted); err == nil {
+		if requested != "" && requested != "group" {
+			return "", invalid("member type does not match the referenced resource")
+		}
+		return "Group", nil
+	} else if isServiceUnavailable(err) {
+		return "", err
+	}
+	return "", invalid("member value must reference a User or Group in this SCIM client")
+}
+
+func relationshipTupleKey(tuple *proto.RelationshipTuple) string {
+	return tupleKeyTarget(tuple.GetTarget()) + "\x00" + tuple.GetRelation() + "\x00" + tuple.GetResource().GetType() + "\x00" + tuple.GetResource().GetId()
+}
+
+func tupleKeyTarget(target *proto.RelationshipTarget) string {
+	if subject := target.GetSubject(); subject != nil {
+		return "subject\x00" + subject.GetType() + "\x00" + subject.GetId()
+	}
+	set := target.GetSubjectSet()
+	if set == nil {
+		return "empty"
+	}
+	return "set\x00" + set.GetResource().GetType() + "\x00" + set.GetResource().GetId() + "\x00" + set.GetRelation()
+}
+
+func (s *Service) findRelationship(ctx context.Context, tuple *proto.RelationshipTuple) (*proto.Relationship, error) {
+	if s.authorization == nil {
+		return nil, errors.New("authorization provider is unavailable")
+	}
+	response, err := s.authorization.ListRelationships(ctx, &proto.ListRelationshipsRequest{Filter: &proto.RelationshipFilter{Target: tuple.Target, Relation: tuple.Relation, Resource: tuple.Resource}, PageSize: 2})
+	if err != nil {
+		return nil, err
+	}
+	for _, relationship := range response.GetRelationships() {
+		if gproto.Equal(relationship.GetTuple(), tuple) {
+			return relationship, nil
+		}
+	}
+	return nil, nil
+}
+
+func groupRelationshipOwnedBy(relationship *proto.Relationship, clientID, groupID string) bool {
+	return relationshipOwnedBySCIM(relationship, clientID, "scimGroupId", groupID)
+}
+
+func relationshipOwnedBySCIM(relationship *proto.Relationship, clientID, idProperty, id string) bool {
+	if relationship == nil || relationship.GetSourceLayer() != proto.SourceLayer_SOURCE_LAYER_RUNTIME || relationship.GetProperties() == nil {
+		return false
+	}
+	props := relationship.GetProperties().AsMap()
+	return props["managedBy"] == "scim" && props["scimClientId"] == clientID && props[idProperty] == id
+}
+
+func (s *Service) loadGroup(ctx context.Context, clientID, id string, includeDeleted bool) (storedGroup, error) {
+	rec, err := s.db.ObjectStore(coredata.StoreSCIMGroups).Get(ctx, id)
+	if errors.Is(err, idb.ErrNotFound) {
+		return storedGroup{}, notFoundResource("SCIM Group")
+	}
+	if err != nil {
+		return storedGroup{}, unavailable("could not read SCIM Group")
+	}
+	row, err := decodeStoredGroup(rec)
+	if err != nil {
+		return storedGroup{}, unavailable("stored SCIM Group is invalid")
+	}
+	if row.clientID != clientID || row.deleted && !includeDeleted {
+		return storedGroup{}, notFoundResource("SCIM Group")
+	}
+	return row, nil
+}
+
+func (s *Service) publicGroup(ctx context.Context, row storedGroup) (Group, error) {
+	members := append([]Member(nil), row.resource.Members...)
+	for i := range members {
+		members[i].Display = ""
+		memberType, err := s.memberType(ctx, row.clientID, members[i], false)
+		if err != nil {
+			// Deleted references are omitted by cascade, but a historical
+			// resource may contain one during repair. Preserve the value and
+			// leave its vendor-supplied formatting intact.
+			continue
+		}
+		if strings.TrimSpace(members[i].Type) == "" {
+			members[i].Type = memberType
+		}
+		if strings.TrimSpace(members[i].Ref) == "" {
+			if memberType == "User" {
+				members[i].Ref = s.baseURL + "/scim/v2/Users/" + members[i].Value
+			} else {
+				members[i].Ref = s.baseURL + "/scim/v2/Groups/" + members[i].Value
+			}
+		}
+		members[i].Display = s.memberDisplayName(ctx, row.clientID, members[i], memberType)
+	}
+	return Group{Schemas: []string{GroupSchemaURN}, ID: row.id, ExternalID: row.resource.ExternalID, DisplayName: row.resource.DisplayName, Members: members, Meta: Meta{ResourceType: "Group", Created: row.createdAt, LastModified: row.updatedAt, Location: s.baseURL + "/scim/v2/Groups/" + row.id, Version: etag(row.version)}}, nil
+}
+
+func (s *Service) memberDisplayName(ctx context.Context, clientID string, member Member, memberType string) string {
+	if memberType == "User" {
+		row, err := s.loadUserRow(ctx, clientID, member.Value, true)
+		if err == nil {
+			return displayName(row.resource)
+		}
+	} else if row, err := s.loadGroup(ctx, clientID, member.Value, true); err == nil {
+		return row.resource.DisplayName
+	}
+	return ""
+}
+
+func isServiceUnavailable(err error) bool {
+	var scimErr *Error
+	return errors.As(err, &scimErr) && scimErr.Status == 503
+}
+
+func (s *Service) validateGroupMembers(ctx context.Context, clientID string, members []Member) error {
+	seen := make(map[string]struct{}, len(members))
+	for _, member := range members {
+		if strings.TrimSpace(member.Value) == "" {
+			return invalid("members.value is required")
+		}
+		if _, duplicate := seen[member.Value]; duplicate {
+			return invalid("members.value must be unique")
+		}
+		seen[member.Value] = struct{}{}
+		if _, err := s.memberType(ctx, clientID, member, false); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Service) findPendingGroup(ctx context.Context, clientID, fingerprint string) (storedGroup, bool, error) {
+	records, err := s.db.ObjectStore(coredata.StoreSCIMGroups).Index("by_client").GetAll(ctx, clientID)
+	if err != nil {
+		return storedGroup{}, false, unavailable("could not inspect pending SCIM Group creation")
+	}
+	for _, rec := range records {
+		row, decodeErr := decodeStoredGroup(rec)
+		if decodeErr != nil {
+			return storedGroup{}, false, unavailable("stored SCIM Group is invalid")
+		}
+		if row.pending && row.pendingFingerprint == fingerprint {
+			return row, true, nil
+		}
+	}
+	return storedGroup{}, false, nil
+}
+
+func applyGroupPatch(current persistedGroup, request patchRequest) (persistedGroup, error) {
+	if len(request.Operations) == 0 {
+		return persistedGroup{}, invalid("PATCH Operations must not be empty")
+	}
+	result := current
+	for i, operation := range request.Operations {
+		op := strings.ToLower(strings.TrimSpace(operation.Op))
+		if op != "add" && op != "replace" && op != "remove" {
+			return persistedGroup{}, invalid(fmt.Sprintf("Operations[%d].op is unsupported", i))
+		}
+		path := normalizePatchPath(operation.Path)
+		if path == "" {
+			if op == "remove" {
+				return persistedGroup{}, invalid("remove requires a path")
+			}
+			var input groupInput
+			if err := json.Unmarshal(operation.Value, &input); err != nil {
+				return persistedGroup{}, invalid("pathless PATCH value must be an object")
+			}
+			if input.DisplayName != nil {
+				result.DisplayName = *input.DisplayName
+			}
+			if input.ExternalID != nil {
+				result.ExternalID = *input.ExternalID
+			}
+			if input.Members != nil {
+				if op == "add" {
+					result.Members = appendUniqueMembers(result.Members, *input.Members)
+				} else {
+					result.Members = append([]Member(nil), (*input.Members)...)
+				}
+			}
+			continue
+		}
+		if strings.HasPrefix(path, "members[") {
+			value, ok := parseGroupMemberFilter(path)
+			if !ok {
+				return persistedGroup{}, invalid(fmt.Sprintf("Operations[%d] has an invalid members path", i))
+			}
+			switch op {
+			case "remove":
+				filtered := result.Members[:0]
+				found := false
+				for _, member := range result.Members {
+					if member.Value != value {
+						filtered = append(filtered, member)
+					} else {
+						found = true
+					}
+				}
+				if !found {
+					return persistedGroup{}, noTarget(fmt.Sprintf("Operations[%d] member was not found", i))
+				}
+				result.Members = filtered
+			case "replace":
+				var replacement Member
+				if err := json.Unmarshal(operation.Value, &replacement); err != nil || strings.TrimSpace(replacement.Value) == "" {
+					return persistedGroup{}, invalid(fmt.Sprintf("Operations[%d] member replacement is invalid", i))
+				}
+				if replacement.Value != value {
+					return persistedGroup{}, invalid(fmt.Sprintf("Operations[%d] members.value is immutable", i))
+				}
+				found := false
+				for j := range result.Members {
+					if result.Members[j].Value == value {
+						result.Members[j] = replacement
+						found = true
+					}
+				}
+				if !found {
+					return persistedGroup{}, noTarget(fmt.Sprintf("Operations[%d] member was not found", i))
+				}
+			case "add":
+				return persistedGroup{}, invalid("add is not supported for a filtered members path")
+			}
+			continue
+		}
+		switch path {
+		case "displayname":
+			if op == "remove" {
+				return persistedGroup{}, invalid("displayName cannot be removed")
+			}
+			if err := decodePatchValue(operation.Value, &result.DisplayName); err != nil {
+				return persistedGroup{}, invalid(fmt.Sprintf("Operations[%d]: %v", i, err))
+			}
+		case "externalid":
+			if op == "remove" {
+				result.ExternalID = ""
+			} else if err := decodePatchValue(operation.Value, &result.ExternalID); err != nil {
+				return persistedGroup{}, invalid(fmt.Sprintf("Operations[%d]: %v", i, err))
+			}
+		case "members":
+			if op == "remove" {
+				result.Members = []Member{}
+				continue
+			}
+			members, err := decodeMembers(operation.Value)
+			if err != nil {
+				return persistedGroup{}, invalid(fmt.Sprintf("Operations[%d]: %v", i, err))
+			}
+			if op == "add" {
+				result.Members = appendUniqueMembers(result.Members, members)
+			} else {
+				result.Members = members
+			}
+		default:
+			return persistedGroup{}, invalid(fmt.Sprintf("Operations[%d] has unsupported path %q", i, path))
+		}
+	}
+	if strings.TrimSpace(result.DisplayName) == "" {
+		return persistedGroup{}, invalid("displayName is required")
+	}
+	return result, nil
+}
+
+func appendUniqueMembers(existing, additions []Member) []Member {
+	seen := make(map[string]struct{}, len(existing)+len(additions))
+	result := append([]Member(nil), existing...)
+	for _, member := range result {
+		seen[member.Value] = struct{}{}
+	}
+	for _, member := range additions {
+		if _, ok := seen[member.Value]; ok {
+			continue
+		}
+		seen[member.Value] = struct{}{}
+		result = append(result, member)
+	}
+	return result
+}
+
+func validateImmutableMembers(previous, next []Member) error {
+	byValue := make(map[string]Member, len(previous))
+	for _, member := range previous {
+		byValue[member.Value] = member
+	}
+	for _, member := range next {
+		old, ok := byValue[member.Value]
+		if !ok {
+			continue
+		}
+		if old.Ref != "" && member.Ref != "" && old.Ref != member.Ref {
+			return invalid("members.$ref is immutable")
+		}
+		if old.Type != "" && member.Type != "" && !strings.EqualFold(old.Type, member.Type) {
+			return invalid("members.type is immutable")
+		}
+	}
+	return nil
+}
+
+func decodeMembers(raw json.RawMessage) ([]Member, error) {
+	var many []Member
+	if err := json.Unmarshal(raw, &many); err == nil {
+		return many, nil
+	}
+	var one Member
+	if err := json.Unmarshal(raw, &one); err != nil || strings.TrimSpace(one.Value) == "" {
+		return nil, errors.New("members must be an object or array")
+	}
+	return []Member{one}, nil
+}
+
+func decodeStoredGroup(rec idb.Record) (storedGroup, error) {
+	var resource, pendingResource persistedGroup
+	var affected []string
+	if err := decodeJSONValue(rec["resource"], &resource); err != nil {
+		return storedGroup{}, err
+	}
+	if err := decodeJSONValue(rec["pending_resource"], &pendingResource); err != nil {
+		return storedGroup{}, err
+	}
+	if err := decodeJSONValue(rec["pending_affected_users"], &affected); err != nil {
+		return storedGroup{}, err
+	}
+	pendingVersion := recordInt(rec, "pending_version")
+	return storedGroup{id: recordString(rec, "id"), clientID: recordString(rec, "client_id"), resource: resource, pendingResource: pendingResource, version: recordInt(rec, "version"), deleted: recordBool(rec, "deleted"), createdAt: recordTime(rec, "created_at"), updatedAt: recordTime(rec, "updated_at"), lastFingerprint: recordString(rec, "last_operation_fingerprint"), pending: pendingVersion > 0, pendingDeleted: recordBool(rec, "pending_deleted"), pendingVersion: pendingVersion, pendingFingerprint: recordString(rec, "pending_fingerprint"), pendingAffectedUsers: affected, pendingAttemptCount: recordInt(rec, "pending_attempt_count"), pendingNextAttemptAt: recordTime(rec, "pending_next_attempt_at")}, nil
+}
+
+func (s *Service) recordGroupProjectionFailure(ctx context.Context, id string) error {
+	tx, err := s.db.Transaction(ctx, []string{coredata.StoreSCIMGroups}, idb.TransactionReadwrite, idb.TransactionOptions{DurabilityHint: idb.TransactionDurabilityStrict})
+	if err != nil {
+		return err
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Abort(context.WithoutCancel(ctx))
+		}
+	}()
+	rec, err := tx.ObjectStore(coredata.StoreSCIMGroups).Get(ctx, id)
+	if err != nil {
+		return err
+	}
+	row, err := decodeStoredGroup(rec)
+	if err != nil || !row.pending {
+		return err
+	}
+	attempt := row.pendingAttemptCount + 1
+	delay := time.Second << min(attempt-1, 6)
+	if delay > time.Minute {
+		delay = time.Minute
+	}
+	now := s.currentTime()
+	rec["pending_attempt_count"] = attempt
+	rec["pending_next_attempt_at"] = now.Add(delay)
+	if err := tx.ObjectStore(coredata.StoreSCIMGroups).Put(ctx, rec); err != nil {
+		return err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return err
+	}
+	committed = true
+	return nil
+}
+
+func (s *Service) reconcilePendingGroups(ctx context.Context) (int, error) {
+	records, err := s.db.ObjectStore(coredata.StoreSCIMGroups).GetAll(ctx, nil)
+	if err != nil {
+		return 0, err
+	}
+	processed := 0
+	var errs []error
+	now := s.currentTime()
+	for _, rec := range records {
+		row, decodeErr := decodeStoredGroup(rec)
+		if decodeErr != nil {
+			errs = append(errs, decodeErr)
+			continue
+		}
+		if !row.pending || row.pendingNextAttemptAt.After(now) {
+			continue
+		}
+		processed++
+		if err := s.convergeGroup(ctx, row.id); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return processed, errors.Join(errs...)
+}
+
+func (s *Service) reconcileGroupDrift(ctx context.Context) (int, error) {
+	var errs []error
+	if err := s.reconcileDeletedUserReferences(ctx); err != nil {
+		errs = append(errs, err)
+	}
+	records, err := s.db.ObjectStore(coredata.StoreSCIMGroups).GetAll(ctx, nil)
+	if err != nil {
+		return 0, err
+	}
+	for _, rec := range records {
+		row, decodeErr := decodeStoredGroup(rec)
+		if decodeErr != nil {
+			errs = append(errs, decodeErr)
+			continue
+		}
+		if row.deleted {
+			if err := s.removeGroupFromParents(ctx, row.clientID, row.id); err != nil {
+				errs = append(errs, err)
+			}
+		}
+	}
+
+	// Reference cleanup can commit newer parent resources, so reload before
+	// repairing authorization projection drift.
+	records, err = s.db.ObjectStore(coredata.StoreSCIMGroups).GetAll(ctx, nil)
+	if err != nil {
+		errs = append(errs, err)
+		return 0, errors.Join(errs...)
+	}
+	processed := 0
+	for _, rec := range records {
+		row, decodeErr := decodeStoredGroup(rec)
+		if decodeErr != nil {
+			errs = append(errs, decodeErr)
+			continue
+		}
+		if row.deleted || row.pending {
+			continue
+		}
+		processed++
+		if err := s.reconcileGroupProjectionDrift(ctx, row); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return processed, errors.Join(errs...)
+}
+
+func (s *Service) reconcileDeletedUserReferences(ctx context.Context) error {
+	records, err := s.db.ObjectStore(coredata.StoreSCIMUsers).GetAll(ctx, nil)
+	if err != nil {
+		return err
+	}
+	var errs []error
+	for _, rec := range records {
+		row, decodeErr := decodeStoredRow(rec)
+		if decodeErr != nil {
+			errs = append(errs, decodeErr)
+			continue
+		}
+		if !row.deleted {
+			continue
+		}
+		if err := s.removeUserFromGroups(ctx, row.clientID, row.id); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func (s *Service) reconcileGroupProjectionDrift(ctx context.Context, row storedGroup) error {
+	desiredTuples, err := s.groupMemberTuples(ctx, row.clientID, row.id, row.resource.Members)
+	if err != nil {
+		return err
+	}
+	desired := make(map[string]struct{}, len(desiredTuples))
+	for _, tuple := range desiredTuples {
+		desired[relationshipTupleKey(tuple)] = struct{}{}
+	}
+	if s.authorization == nil {
+		return nil
+	}
+	pageToken := ""
+	for {
+		response, err := s.authorization.ListRelationships(ctx, &proto.ListRelationshipsRequest{Filter: &proto.RelationshipFilter{Relation: "member", Resource: &proto.Resource{Type: "group", Id: row.id}}, PageSize: 200, PageToken: pageToken})
+		if err != nil {
+			return err
+		}
+		for _, relationship := range response.GetRelationships() {
+			tuple := relationship.GetTuple()
+			if _, keep := desired[relationshipTupleKey(tuple)]; keep || !groupRelationshipOwnedBy(relationship, row.clientID, row.id) {
+				continue
+			}
+			if _, err := s.authorization.DeleteRelationship(ctx, &proto.DeleteRelationshipRequest{RelationshipTuple: tuple}); err != nil && !errors.Is(err, core.ErrNotFound) {
+				return err
+			}
+		}
+		pageToken = strings.TrimSpace(response.GetNextPageToken())
+		if pageToken == "" {
+			break
+		}
+	}
+	return s.applyGroupProjections(ctx, row.clientID, row.id, nil, row.resource.Members)
+}
+
+func (s *Service) removeGroupFromParents(ctx context.Context, clientID, groupID string) error {
+	return s.removeMemberReferences(ctx, clientID, groupID, "Group")
+}
+
+func (s *Service) removeUserFromGroups(ctx context.Context, clientID, userID string) error {
+	return s.removeMemberReferences(ctx, clientID, userID, "User")
+}
+
+func (s *Service) removeMemberReferences(ctx context.Context, clientID, memberID, expectedType string) error {
+	records, err := s.db.ObjectStore(coredata.StoreSCIMGroups).Index("by_client").GetAll(ctx, clientID)
+	if err != nil {
+		return unavailable("could not find SCIM Group references")
+	}
+	for _, rec := range records {
+		row, decodeErr := decodeStoredGroup(rec)
+		if decodeErr != nil {
+			return unavailable("stored SCIM Group is invalid")
+		}
+		if row.deleted {
+			continue
+		}
+		if row.pending {
+			if err := s.convergeGroup(ctx, row.id); err != nil {
+				return err
+			}
+			row, err = s.loadGroup(ctx, clientID, row.id, false)
+			if err != nil {
+				var scimErr *Error
+				if errors.As(err, &scimErr) && scimErr.Status == http.StatusNotFound {
+					continue
+				}
+				return err
+			}
+		}
+		members := make([]Member, 0, len(row.resource.Members))
+		changed := false
+		for _, member := range row.resource.Members {
+			memberType, typeErr := s.memberType(ctx, clientID, member, false)
+			if isServiceUnavailable(typeErr) {
+				return typeErr
+			}
+			if typeErr != nil {
+				// This was a valid reference when committed and is now a
+				// tombstone. Clean all such references in the same mutation.
+				changed = true
+				continue
+			}
+			if member.Value == memberID && memberType == expectedType {
+				changed = true
+				continue
+			}
+			members = append(members, member)
+		}
+		if changed {
+			if _, err := s.ReplaceGroup(ctx, clientID, row.id, "*", groupInput{DisplayName: &row.resource.DisplayName, ExternalID: &row.resource.ExternalID, Members: &members}); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (s *Service) affectedUsers(ctx context.Context, clientID string, from, to []Member) []string {
+	ids := make(map[string]struct{})
+	for _, member := range append(append([]Member{}, from...), to...) {
+		if typ, err := s.memberType(ctx, clientID, member, true); err == nil && typ == "User" {
+			ids[member.Value] = struct{}{}
+		} else if typ == "Group" {
+			for userID := range s.collectUsersFromMembers(ctx, clientID, []Member{member}, make(map[string]struct{})) {
+				ids[userID] = struct{}{}
+			}
+		}
+	}
+	out := make([]string, 0, len(ids))
+	for id := range ids {
+		out = append(out, id)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func (s *Service) collectUsersFromMembers(ctx context.Context, clientID string, members []Member, seen map[string]struct{}) map[string]struct{} {
+	out := make(map[string]struct{})
+	for _, member := range members {
+		typ, err := s.memberType(ctx, clientID, member, true)
+		if err != nil {
+			continue
+		}
+		if typ == "User" {
+			out[member.Value] = struct{}{}
+			continue
+		}
+		if _, ok := seen[member.Value]; ok {
+			continue
+		}
+		seen[member.Value] = struct{}{}
+		row, err := s.loadGroup(ctx, clientID, member.Value, true)
+		if err != nil {
+			continue
+		}
+		for id := range s.collectUsersFromMembers(ctx, clientID, row.resource.Members, seen) {
+			out[id] = struct{}{}
+		}
+	}
+	return out
+}
+
+func (s *Service) loadGroupGraph(ctx context.Context, clientID string) (map[string]*persistedGroup, error) {
+	records, err := s.db.ObjectStore(coredata.StoreSCIMGroups).Index("by_client").GetAll(ctx, clientID)
+	if err != nil {
+		return nil, unavailable("could not load User groups")
+	}
+	groups := make(map[string]*persistedGroup)
+	for _, rec := range records {
+		row, decodeErr := decodeStoredGroup(rec)
+		if decodeErr != nil {
+			return nil, unavailable("stored SCIM Group is invalid")
+		}
+		if !row.deleted && (!row.pending || row.version > 0) {
+			group := row.resource
+			groups[row.id] = &group
+		}
+	}
+	return groups, nil
+}
+
+func (s *Service) groupRefsForUser(groups map[string]*persistedGroup, userID string) []GroupRef {
+	ids := make([]string, 0)
+	types := make(map[string]string)
+	for id := range groups {
+		if direct, ok := groupMembershipType(id, userID, groups, make(map[string]struct{})); ok {
+			ids = append(ids, id)
+			if direct {
+				types[id] = "direct"
+			} else {
+				types[id] = "indirect"
+			}
+		}
+	}
+	sort.Strings(ids)
+	refs := make([]GroupRef, 0, len(ids))
+	for _, id := range ids {
+		row := groups[id]
+		refs = append(refs, GroupRef{Value: id, Ref: s.baseURL + "/scim/v2/Groups/" + id, Display: row.DisplayName, Type: types[id]})
+	}
+	return refs
+}
+
+// groupMembershipType returns whether the membership is direct (the user is a
+// member of this group) or indirect (the user is reached through a nested
+// group). The visited set makes malformed cyclic graphs terminate safely.
+func groupMembershipType(id, userID string, groups map[string]*persistedGroup, seen map[string]struct{}) (bool, bool) {
+	if _, ok := seen[id]; ok {
+		return false, false
+	}
+	seen[id] = struct{}{}
+	row, ok := groups[id]
+	if !ok {
+		return false, false
+	}
+	indirect := false
+	for _, member := range row.Members {
+		if strings.EqualFold(strings.TrimSpace(member.Type), "group") || strings.TrimSpace(member.Type) == "" && groups[member.Value] != nil {
+			if _, ok := groupMembershipType(member.Value, userID, groups, seen); ok {
+				indirect = true
+			}
+		} else if member.Value == userID {
+			return true, true
+		}
+	}
+	return false, indirect
+}
+
+func (s *Service) decorateUsers(ctx context.Context, clientID string, users []User) error {
+	groups, err := s.loadGroupGraph(ctx, clientID)
+	if err != nil {
+		return err
+	}
+	for i := range users {
+		users[i].Groups = s.groupRefsForUser(groups, users[i].ID)
+	}
+	return nil
+}
+
+func (s *Service) loadUserRow(ctx context.Context, clientID, id string, includeDeleted bool) (storedRow, error) {
+	rec, err := s.db.ObjectStore(coredata.StoreSCIMUsers).Get(ctx, id)
+	if errors.Is(err, idb.ErrNotFound) {
+		return storedRow{}, invalid("member value must reference a User or Group in this SCIM client")
+	}
+	if err != nil {
+		return storedRow{}, unavailable("could not read SCIM User member")
+	}
+	row, err := decodeStoredRow(rec)
+	if err != nil {
+		return storedRow{}, unavailable("stored SCIM User member is invalid")
+	}
+	if row.clientID != clientID || row.deleted && !includeDeleted {
+		return storedRow{}, invalid("member value must reference a User or Group in this SCIM client")
+	}
+	return row, nil
+}

--- a/gestaltd/internal/scim/groups_http_test.go
+++ b/gestaltd/internal/scim/groups_http_test.go
@@ -1,0 +1,306 @@
+package scim_test
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/scim"
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+)
+
+func TestSCIMGroupsCRUDAndUserGroups(t *testing.T) {
+	t.Parallel()
+
+	authorization := newRecordingAuthorization()
+	cfg := testSCIMConfig(map[string]config.SCIMClientConfig{
+		"rippling": ripplingClient(nil),
+	})
+	_, services, handler := newSCIMService(t, nil, authorization, cfg)
+	schemas := scimRequest(t, handler, http.MethodGet, "/scim/v2/Schemas", testCurrentToken, nil)
+	if schemas.Code != http.StatusOK || !bytes.Contains(schemas.Body.Bytes(), []byte(scim.GroupSchemaURN)) {
+		t.Fatalf("Schemas = %d %s", schemas.Code, schemas.Body.String())
+	}
+	alice, response := createUser(t, handler, testCurrentToken, "alice@valon.com", true, nil)
+	if response.Code != http.StatusCreated {
+		t.Fatalf("create Alice = %d %s", response.Code, response.Body.String())
+	}
+	bob, response := createUser(t, handler, testCurrentToken, "bob@valon.com", true, nil)
+	if response.Code != http.StatusCreated {
+		t.Fatalf("create Bob = %d %s", response.Code, response.Body.String())
+	}
+
+	create := map[string]any{
+		"schemas":     []string{scim.GroupSchemaURN},
+		"externalId":  "eng",
+		"displayName": "Engineering",
+		"members":     []map[string]any{{"value": alice.ID, "type": "User", "display": "client-controlled"}},
+	}
+	createdResponse := scimRequest(t, handler, http.MethodPost, "/scim/v2/Groups", testCurrentToken, create)
+	created := decodeResponse[scim.Group](t, createdResponse)
+	if createdResponse.Code != http.StatusCreated || created.ID == "" || created.DisplayName != "Engineering" || len(created.Members) != 1 || created.Members[0].Value != alice.ID || created.Members[0].Type != "User" || created.Members[0].Display == "client-controlled" || created.Meta.Version != `W/"1"` {
+		t.Fatalf("POST Group = %d %#v", createdResponse.Code, created)
+	}
+	if createdResponse.Header().Get("Location") != created.Meta.Location || createdResponse.Header().Get("ETag") != created.Meta.Version {
+		t.Fatalf("Group headers = %#v", createdResponse.Header())
+	}
+	coreAlice, err := services.Users.FindUserByEmail(context.Background(), "alice@valon.com")
+	if err != nil {
+		t.Fatalf("FindUserByEmail: %v", err)
+	}
+	projected := authorization.relationshipForUser(coreAlice.ID)
+	if projected == nil || projected.GetTuple().GetResource().GetType() != "group" || projected.GetTuple().GetResource().GetId() != created.ID || projected.GetTuple().GetRelation() != "member" {
+		t.Fatalf("projected Group membership = %#v", projected)
+	}
+	secondService, _, _ := newSCIMService(t, services.DB, authorization, cfg)
+	if _, err := scim.WrapAuthorization(authorization, services.Users, secondService).AddRelationship(context.Background(), &proto.AddRelationshipRequest{Relationship: projected}); err == nil {
+		t.Fatal("ordinary add to SCIM-managed Group succeeded")
+	}
+	filtered := scimRequest(t, handler, http.MethodGet, "/scim/v2/Groups?filter="+url.QueryEscape(`displayName eq "engineering"`), testCurrentToken, nil)
+	groups := decodeResponse[struct {
+		TotalResults int          `json:"totalResults"`
+		Resources    []scim.Group `json:"Resources"`
+	}](t, filtered)
+	if filtered.Code != http.StatusOK || groups.TotalResults != 1 || groups.Resources[0].ID != created.ID {
+		t.Fatalf("filtered Groups = %d %#v", filtered.Code, groups)
+	}
+
+	aliceRead := decodeResponse[scim.User](t, scimRequest(t, handler, http.MethodGet, "/scim/v2/Users/"+alice.ID, testCurrentToken, nil))
+	if len(aliceRead.Groups) != 1 || aliceRead.Groups[0].Value != created.ID || aliceRead.Groups[0].Display != "Engineering" || aliceRead.Groups[0].Type != "direct" {
+		t.Fatalf("User.groups after create = %#v", aliceRead.Groups)
+	}
+
+	patch := map[string]any{"schemas": []string{scim.PatchSchemaURN}, "Operations": []map[string]any{{"op": "add", "path": "members", "value": map[string]any{"value": bob.ID, "type": "User"}}}}
+	patchedResponse := scimRequest(t, handler, http.MethodPatch, "/scim/v2/Groups/"+created.ID, testCurrentToken, patch, map[string]string{"If-Match": created.Meta.Version})
+	patched := decodeResponse[scim.Group](t, patchedResponse)
+	if patchedResponse.Code != http.StatusOK || len(patched.Members) != 2 || patched.Meta.Version != `W/"2"` {
+		t.Fatalf("PATCH add member = %d %#v", patchedResponse.Code, patched)
+	}
+
+	removeOne := map[string]any{"schemas": []string{scim.PatchSchemaURN}, "Operations": []map[string]any{{"op": "remove", "path": `members[value eq "` + alice.ID + `"]`}}}
+	removedResponse := scimRequest(t, handler, http.MethodPatch, "/scim/v2/Groups/"+created.ID, testCurrentToken, removeOne, map[string]string{"If-Match": patched.Meta.Version})
+	removed := decodeResponse[scim.Group](t, removedResponse)
+	if removedResponse.Code != http.StatusOK || len(removed.Members) != 1 || removed.Members[0].Value != bob.ID {
+		t.Fatalf("PATCH filtered remove = %d %#v", removedResponse.Code, removed)
+	}
+	missing := scimRequest(t, handler, http.MethodPatch, "/scim/v2/Groups/"+created.ID, testCurrentToken, removeOne, map[string]string{"If-Match": removed.Meta.Version})
+	if payload := decodeResponse[testErrorResponse](t, missing); missing.Code != http.StatusBadRequest || payload.SCIMType != "noTarget" {
+		t.Fatalf("PATCH missing member = %d %#v", missing.Code, payload)
+	}
+
+	clear := map[string]any{"schemas": []string{scim.PatchSchemaURN}, "Operations": []map[string]any{{"op": "remove", "path": "members", "value": []map[string]any{{"value": bob.ID}}}}}
+	clearedResponse := scimRequest(t, handler, http.MethodPatch, "/scim/v2/Groups/"+created.ID, testCurrentToken, clear, map[string]string{"If-Match": removed.Meta.Version})
+	cleared := decodeResponse[scim.Group](t, clearedResponse)
+	if clearedResponse.Code != http.StatusOK || len(cleared.Members) != 0 {
+		t.Fatalf("PATCH unfiltered remove = %d %#v", clearedResponse.Code, cleared)
+	}
+
+	stale := scimRequest(t, handler, http.MethodPut, "/scim/v2/Groups/"+created.ID, testCurrentToken, map[string]any{"schemas": []string{scim.GroupSchemaURN}, "displayName": "Renamed"}, map[string]string{"If-Match": created.Meta.Version})
+	if stale.Code != http.StatusPreconditionFailed {
+		t.Fatalf("stale Group PUT = %d %s", stale.Code, stale.Body.String())
+	}
+	readd := map[string]any{"schemas": []string{scim.PatchSchemaURN}, "Operations": []map[string]any{{"op": "add", "path": "members", "value": map[string]any{"value": bob.ID}}}}
+	if response := scimRequest(t, handler, http.MethodPatch, "/scim/v2/Groups/"+created.ID, testCurrentToken, readd, map[string]string{"If-Match": cleared.Meta.Version}); response.Code != http.StatusOK {
+		t.Fatalf("PATCH member before delete = %d %s", response.Code, response.Body.String())
+	}
+
+	authorization.setFailures(false, true)
+	if response := scimRequest(t, handler, http.MethodDelete, "/scim/v2/Groups/"+created.ID, testCurrentToken, nil, map[string]string{"If-Match": "*"}); response.Code != http.StatusServiceUnavailable {
+		t.Fatalf("failed DELETE Group = %d %s", response.Code, response.Body.String())
+	}
+	authorization.setFailures(false, false)
+	if response := scimRequest(t, handler, http.MethodDelete, "/scim/v2/Groups/"+created.ID, testCurrentToken, nil, map[string]string{"If-Match": "*"}); response.Code != http.StatusNoContent {
+		t.Fatalf("DELETE Group = %d %s", response.Code, response.Body.String())
+	}
+	if response := scimRequest(t, handler, http.MethodDelete, "/scim/v2/Groups/"+created.ID, testCurrentToken, nil, map[string]string{"If-Match": "*"}); response.Code != http.StatusNotFound {
+		t.Fatalf("DELETE tombstoned Group = %d %s", response.Code, response.Body.String())
+	}
+	if response := scimRequest(t, handler, http.MethodGet, "/scim/v2/Groups/"+created.ID, testCurrentToken, nil); response.Code != http.StatusNotFound {
+		t.Fatalf("deleted Group GET = %d", response.Code)
+	}
+	if user := decodeResponse[scim.User](t, scimRequest(t, handler, http.MethodGet, "/scim/v2/Users/"+bob.ID, testCurrentToken, nil)); len(user.Groups) != 0 {
+		t.Fatalf("User.groups after Group delete = %#v", user.Groups)
+	}
+	coreBob, err := services.Users.FindUserByEmail(context.Background(), "bob@valon.com")
+	if err != nil {
+		t.Fatalf("FindUserByEmail: %v", err)
+	}
+	if relationship := authorization.relationshipForUser(coreBob.ID); relationship != nil {
+		t.Fatalf("projected membership after Group delete = %#v", relationship)
+	}
+}
+
+func TestSCIMGroupsSupportNestedMembershipAndNamespaceIsolation(t *testing.T) {
+	t.Parallel()
+
+	clients := map[string]config.SCIMClientConfig{
+		"rippling": ripplingClient(nil),
+		"entra": {
+			Credentials: []config.SCIMCredentialConfig{{ID: "current", BearerToken: "entra-token"}},
+		},
+	}
+	_, _, handler := newSCIMService(t, nil, newRecordingAuthorization(), testSCIMConfig(clients))
+	user, response := createUser(t, handler, testCurrentToken, "nested@valon.com", true, nil)
+	if response.Code != http.StatusCreated {
+		t.Fatalf("create nested user = %d %s", response.Code, response.Body.String())
+	}
+	childResponse := scimRequest(t, handler, http.MethodPost, "/scim/v2/Groups", testCurrentToken, map[string]any{"schemas": []string{scim.GroupSchemaURN}, "displayName": "Child"})
+	child := decodeResponse[scim.Group](t, childResponse)
+	if childResponse.Code != http.StatusCreated {
+		t.Fatalf("create child = %d %s", childResponse.Code, childResponse.Body.String())
+	}
+	addUser := map[string]any{"schemas": []string{scim.PatchSchemaURN}, "Operations": []map[string]any{{"op": "add", "path": "members", "value": map[string]any{"value": user.ID}}}}
+	child = decodeResponse[scim.Group](t, scimRequest(t, handler, http.MethodPatch, "/scim/v2/Groups/"+child.ID, testCurrentToken, addUser, map[string]string{"If-Match": child.Meta.Version}))
+	parentResponse := scimRequest(t, handler, http.MethodPost, "/scim/v2/Groups", testCurrentToken, map[string]any{"schemas": []string{scim.GroupSchemaURN}, "displayName": "Parent", "members": []map[string]any{{"value": child.ID, "type": "Group"}}})
+	parent := decodeResponse[scim.Group](t, parentResponse)
+	if parentResponse.Code != http.StatusCreated {
+		t.Fatalf("create parent = %d %s", parentResponse.Code, parentResponse.Body.String())
+	}
+	if len(parent.Members) != 1 || parent.Members[0].Value != child.ID {
+		t.Fatalf("parent members = %#v", parent.Members)
+	}
+	readUser := decodeResponse[scim.User](t, scimRequest(t, handler, http.MethodGet, "/scim/v2/Users/"+user.ID, testCurrentToken, nil))
+	if len(readUser.Groups) != 2 {
+		t.Fatalf("nested User.groups = %#v", readUser.Groups)
+	}
+	for _, group := range readUser.Groups {
+		if group.Value == child.ID && group.Type != "direct" || group.Value == parent.ID && group.Type != "indirect" {
+			t.Fatalf("nested User.groups types = %#v", readUser.Groups)
+		}
+	}
+	addDirect := map[string]any{"schemas": []string{scim.PatchSchemaURN}, "Operations": []map[string]any{{"op": "add", "path": "members", "value": map[string]any{"value": user.ID}}}}
+	parent = decodeResponse[scim.Group](t, scimRequest(t, handler, http.MethodPatch, "/scim/v2/Groups/"+parent.ID, testCurrentToken, addDirect, map[string]string{"If-Match": parent.Meta.Version}))
+	readUser = decodeResponse[scim.User](t, scimRequest(t, handler, http.MethodGet, "/scim/v2/Users/"+user.ID, testCurrentToken, nil))
+	for _, group := range readUser.Groups {
+		if group.Value == parent.ID && group.Type != "direct" {
+			t.Fatalf("direct membership did not override indirect membership: %#v", readUser.Groups)
+		}
+	}
+	removeDirect := map[string]any{"schemas": []string{scim.PatchSchemaURN}, "Operations": []map[string]any{{"op": "remove", "path": `members[value eq "` + user.ID + `"]`}}}
+	parent = decodeResponse[scim.Group](t, scimRequest(t, handler, http.MethodPatch, "/scim/v2/Groups/"+parent.ID, testCurrentToken, removeDirect, map[string]string{"If-Match": parent.Meta.Version}))
+	if response := scimRequest(t, handler, http.MethodDelete, "/scim/v2/Groups/"+child.ID, testCurrentToken, nil, map[string]string{"If-Match": "*"}); response.Code != http.StatusNoContent {
+		t.Fatalf("DELETE nested child = %d %s", response.Code, response.Body.String())
+	}
+	parentAfterDelete := decodeResponse[scim.Group](t, scimRequest(t, handler, http.MethodGet, "/scim/v2/Groups/"+parent.ID, testCurrentToken, nil))
+	if len(parentAfterDelete.Members) != 0 {
+		t.Fatalf("parent members after child delete = %#v", parentAfterDelete.Members)
+	}
+
+	otherUser, response := createUser(t, handler, "entra-token", "other@example.com", true, nil)
+	if response.Code != http.StatusCreated {
+		t.Fatalf("create other namespace user = %d %s", response.Code, response.Body.String())
+	}
+	foreign := scimRequest(t, handler, http.MethodGet, "/scim/v2/Users/"+user.ID, "entra-token", nil)
+	if foreign.Code != http.StatusNotFound {
+		t.Fatalf("cross-client User GET = %d", foreign.Code)
+	}
+	foreignGroup := scimRequest(t, handler, http.MethodPost, "/scim/v2/Groups", "entra-token", map[string]any{"schemas": []string{scim.GroupSchemaURN}, "displayName": "Foreign", "members": []map[string]any{{"value": user.ID}}})
+	if foreignGroup.Code != http.StatusBadRequest {
+		t.Fatalf("cross-client Group member = %d %s", foreignGroup.Code, foreignGroup.Body.String())
+	}
+	_ = otherUser
+}
+
+func TestSCIMUserDeleteRemovesGroupMembership(t *testing.T) {
+	t.Parallel()
+
+	_, _, handler := newSCIMService(t, nil, newRecordingAuthorization(), testSCIMConfig(map[string]config.SCIMClientConfig{
+		"rippling": ripplingClient(nil),
+	}))
+	user, response := createUser(t, handler, testCurrentToken, "remove-me@valon.com", true, nil)
+	if response.Code != http.StatusCreated {
+		t.Fatalf("create user = %d %s", response.Code, response.Body.String())
+	}
+	groupResponse := scimRequest(t, handler, http.MethodPost, "/scim/v2/Groups", testCurrentToken, map[string]any{"schemas": []string{scim.GroupSchemaURN}, "displayName": "Cleanup", "members": []map[string]any{{"value": user.ID}}})
+	group := decodeResponse[scim.Group](t, groupResponse)
+	if groupResponse.Code != http.StatusCreated {
+		t.Fatalf("create group = %d %s", groupResponse.Code, groupResponse.Body.String())
+	}
+	if response := scimRequest(t, handler, http.MethodDelete, "/scim/v2/Users/"+user.ID, testCurrentToken, nil, map[string]string{"If-Match": "*"}); response.Code != http.StatusNoContent {
+		t.Fatalf("delete user = %d %s", response.Code, response.Body.String())
+	}
+	updated := decodeResponse[scim.Group](t, scimRequest(t, handler, http.MethodGet, "/scim/v2/Groups/"+group.ID, testCurrentToken, nil))
+	if len(updated.Members) != 0 {
+		t.Fatalf("group members after user delete = %#v", updated.Members)
+	}
+}
+
+func TestSCIMGroupProjectionRecoversAfterRestart(t *testing.T) {
+	t.Parallel()
+
+	authorization := newRecordingAuthorization()
+	cfg := testSCIMConfig(map[string]config.SCIMClientConfig{
+		"rippling": ripplingClient([]string{"valon.com"}),
+	})
+	service, services, handler := newSCIMService(t, nil, authorization, cfg)
+	user, response := createUser(t, handler, testCurrentToken, "recover@valon.com", true, nil)
+	if response.Code != http.StatusCreated {
+		t.Fatalf("create user = %d %s", response.Code, response.Body.String())
+	}
+	coreUser, err := services.Users.FindUserByEmail(context.Background(), user.UserName)
+	if err != nil {
+		t.Fatalf("FindUserByEmail: %v", err)
+	}
+
+	authorization.setFailures(true, false)
+	response = scimRequest(t, handler, http.MethodPost, "/scim/v2/Groups", testCurrentToken, map[string]any{
+		"schemas": []string{scim.GroupSchemaURN}, "displayName": "Recovery", "members": []map[string]any{{"value": user.ID}},
+	})
+	if response.Code != http.StatusServiceUnavailable || response.Header().Get("Retry-After") != "1" {
+		t.Fatalf("failed Group projection = %d %s", response.Code, response.Body.String())
+	}
+	if decision, err := scim.WrapAuthorization(authorization, services.Users, service).CheckAccess(context.Background(), accessRequest(coreUser.ID)); err != nil || decision.Allowed {
+		t.Fatalf("pending Group access = %#v, %v", decision, err)
+	}
+
+	authorization.setFailures(false, false)
+	restarted, _, restartedHandler := newSCIMService(t, services.DB, authorization, cfg)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	restarted.Start(ctx)
+	eventually(t, func() bool {
+		response := scimRequest(t, restartedHandler, http.MethodGet, "/scim/v2/Groups?filter="+url.QueryEscape(`displayName eq "Recovery"`), testCurrentToken, nil)
+		if response.Code != http.StatusOK {
+			return false
+		}
+		return decodeResponse[struct {
+			TotalResults int `json:"totalResults"`
+		}](t, response).TotalResults == 1
+	})
+	listed := decodeResponse[struct {
+		Resources []scim.Group `json:"Resources"`
+	}](t, scimRequest(t, restartedHandler, http.MethodGet, "/scim/v2/Groups?filter="+url.QueryEscape(`displayName eq "Recovery"`), testCurrentToken, nil))
+	group := listed.Resources[0]
+	cancel()
+	second, response := createUser(t, restartedHandler, testCurrentToken, "recover-second@valon.com", true, nil)
+	if response.Code != http.StatusCreated {
+		t.Fatalf("create second user = %d %s", response.Code, response.Body.String())
+	}
+	authorization.setFailures(true, false)
+	addSecond := map[string]any{"schemas": []string{scim.PatchSchemaURN}, "Operations": []map[string]any{{"op": "add", "path": "members", "value": map[string]any{"value": second.ID}}}}
+	response = scimRequest(t, restartedHandler, http.MethodPatch, "/scim/v2/Groups/"+group.ID, testCurrentToken, addSecond, map[string]string{"If-Match": group.Meta.Version})
+	if response.Code != http.StatusServiceUnavailable {
+		t.Fatalf("failed Group update = %d %s", response.Code, response.Body.String())
+	}
+	visible := decodeResponse[struct {
+		TotalResults int          `json:"totalResults"`
+		Resources    []scim.Group `json:"Resources"`
+	}](t, scimRequest(t, restartedHandler, http.MethodGet, "/scim/v2/Groups?filter="+url.QueryEscape(`displayName eq "Recovery"`), testCurrentToken, nil))
+	if visible.TotalResults != 1 || len(visible.Resources) != 1 || len(visible.Resources[0].Members) != 1 || visible.Resources[0].Meta.Version != group.Meta.Version {
+		t.Fatalf("committed Group hidden during pending update: %#v", visible)
+	}
+	if decision, err := scim.WrapAuthorization(authorization, services.Users, restarted).CheckAccess(context.Background(), accessRequest(coreUser.ID)); err != nil || decision.Allowed {
+		t.Fatalf("pending Group update access = %#v, %v", decision, err)
+	}
+	authorization.setFailures(false, false)
+	retried := scimRequest(t, restartedHandler, http.MethodPatch, "/scim/v2/Groups/"+group.ID, testCurrentToken, addSecond, map[string]string{"If-Match": group.Meta.Version})
+	if updated := decodeResponse[scim.Group](t, retried); retried.Code != http.StatusOK || len(updated.Members) != 2 {
+		t.Fatalf("retried Group update = %d %#v", retried.Code, updated)
+	}
+	if decision, err := scim.WrapAuthorization(authorization, services.Users, restarted).CheckAccess(context.Background(), accessRequest(coreUser.ID)); err != nil || !decision.Allowed {
+		t.Fatalf("recovered Group access = %#v, %v", decision, err)
+	}
+}

--- a/gestaltd/internal/scim/handler.go
+++ b/gestaltd/internal/scim/handler.go
@@ -30,8 +30,14 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.listUsers(w, r, clientID)
 	case path == "/scim/v2/Users" && r.Method == http.MethodPost:
 		h.createUser(w, r, clientID)
+	case path == "/scim/v2/Groups" && r.Method == http.MethodGet:
+		h.listGroups(w, r, clientID)
+	case path == "/scim/v2/Groups" && r.Method == http.MethodPost:
+		h.createGroup(w, r, clientID)
 	case strings.HasPrefix(path, "/scim/v2/Users/"):
 		h.user(w, r, clientID, strings.TrimPrefix(path, "/scim/v2/Users/"))
+	case strings.HasPrefix(path, "/scim/v2/Groups/"):
+		h.group(w, r, clientID, strings.TrimPrefix(path, "/scim/v2/Groups/"))
 	default:
 		writeError(w, notFound())
 	}
@@ -46,7 +52,7 @@ func (h *Handler) authenticate(r *http.Request) (string, bool) {
 }
 
 func (h *Handler) schemas(w http.ResponseWriter) {
-	schema := map[string]any{
+	userSchema := map[string]any{
 		"schemas": []string{"urn:ietf:params:scim:schemas:core:2.0:Schema"}, "id": UserSchemaURN, "name": "User", "description": "Gestalt provisioned user",
 		"attributes": []map[string]any{
 			{"name": "externalId", "type": "string", "multiValued": false, "required": false, "caseExact": false, "mutability": "readWrite", "returned": "default", "uniqueness": "server"},
@@ -55,29 +61,34 @@ func (h *Handler) schemas(w http.ResponseWriter) {
 			{"name": "displayName", "type": "string", "multiValued": false, "required": false, "mutability": "readWrite", "returned": "default"},
 			{"name": "name", "type": "complex", "multiValued": false, "required": false, "mutability": "readWrite", "returned": "default", "subAttributes": []map[string]any{{"name": "formatted", "type": "string"}, {"name": "familyName", "type": "string"}, {"name": "givenName", "type": "string"}}},
 			{"name": "emails", "type": "complex", "multiValued": true, "required": false, "mutability": "readWrite", "returned": "default", "subAttributes": []map[string]any{{"name": "value", "type": "string"}, {"name": "type", "type": "string", "canonicalValues": []string{"work"}}, {"name": "primary", "type": "boolean"}}},
+			{"name": "groups", "type": "complex", "multiValued": true, "required": false, "mutability": "readOnly", "returned": "default", "subAttributes": []map[string]any{{"name": "value", "type": "string"}, {"name": "$ref", "type": "reference"}, {"name": "display", "type": "string"}, {"name": "type", "type": "string", "canonicalValues": []string{"direct", "indirect"}}}},
 		},
 		"meta": map[string]any{"resourceType": "Schema", "location": h.service.baseURL + "/scim/v2/Schemas"},
 	}
-	writeJSON(w, http.StatusOK, map[string]any{"schemas": []string{ListSchemaURN}, "totalResults": 1, "startIndex": 1, "itemsPerPage": 1, "Resources": []any{schema}})
+	groupSchema := map[string]any{
+		"schemas": []string{"urn:ietf:params:scim:schemas:core:2.0:Schema"}, "id": GroupSchemaURN, "name": "Group", "description": "Gestalt provisioned group",
+		"attributes": []map[string]any{
+			{"name": "displayName", "type": "string", "multiValued": false, "required": true, "caseExact": false, "mutability": "readWrite", "returned": "always", "uniqueness": "none"},
+			{"name": "members", "type": "complex", "multiValued": true, "required": false, "mutability": "readWrite", "returned": "default", "subAttributes": []map[string]any{{"name": "value", "type": "string", "required": true, "mutability": "immutable"}, {"name": "$ref", "type": "reference", "mutability": "immutable"}, {"name": "display", "type": "string", "mutability": "readOnly"}, {"name": "type", "type": "string", "mutability": "immutable"}}},
+		},
+		"meta": map[string]any{"resourceType": "Schema", "location": h.service.baseURL + "/scim/v2/Schemas"},
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"schemas": []string{ListSchemaURN}, "totalResults": 2, "startIndex": 1, "itemsPerPage": 2, "Resources": []any{userSchema, groupSchema}})
 }
 
 func (h *Handler) listUsers(w http.ResponseWriter, r *http.Request, clientID string) {
-	startIndex, err := paginationQueryInt(r, "startIndex", 1, 1)
+	startIndex, count, err := pagination(r)
 	if err != nil {
 		writeError(w, err)
 		return
-	}
-	count, err := paginationQueryInt(r, "count", 100, 0)
-	if err != nil {
-		writeError(w, err)
-		return
-	}
-	if count > 200 {
-		count = 200
 	}
 	response, serviceErr := h.service.list(r.Context(), clientID, r.URL.Query().Get("filter"), startIndex, count)
 	if serviceErr != nil {
 		writeError(w, serviceErr)
+		return
+	}
+	if err := h.service.decorateUsers(r.Context(), clientID, response.Resources); err != nil {
+		writeError(w, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, response)
@@ -98,9 +109,26 @@ func paginationQueryInt(r *http.Request, name string, defaultValue, minimum int)
 	return value, nil
 }
 
+func pagination(r *http.Request) (int, int, error) {
+	startIndex, err := paginationQueryInt(r, "startIndex", 1, 1)
+	if err != nil {
+		return 0, 0, err
+	}
+	count, err := paginationQueryInt(r, "count", 100, 0)
+	if err != nil {
+		return 0, 0, err
+	}
+	return startIndex, min(count, 200), nil
+}
+
 func (h *Handler) createUser(w http.ResponseWriter, r *http.Request, clientID string) {
 	var input userInput
 	if err := decodeBody(r, &input); err != nil {
+		writeError(w, err)
+		return
+	}
+	groups, err := h.service.loadGroupGraph(r.Context(), clientID)
+	if err != nil {
 		writeError(w, err)
 		return
 	}
@@ -109,15 +137,22 @@ func (h *Handler) createUser(w http.ResponseWriter, r *http.Request, clientID st
 		writeError(w, err)
 		return
 	}
-	w.Header().Set("Location", user.Meta.Location)
-	w.Header().Set("ETag", user.Meta.Version)
-	writeJSON(w, http.StatusCreated, user)
+	h.writeUser(w, http.StatusCreated, user, groups)
 }
 
 func (h *Handler) user(w http.ResponseWriter, r *http.Request, clientID, id string) {
 	if id == "" || strings.Contains(id, "/") {
 		writeError(w, notFound())
 		return
+	}
+	var groups map[string]*persistedGroup
+	if r.Method == http.MethodGet || r.Method == http.MethodPut || r.Method == http.MethodPatch {
+		var err error
+		groups, err = h.service.loadGroupGraph(r.Context(), clientID)
+		if err != nil {
+			writeError(w, err)
+			return
+		}
 	}
 	switch r.Method {
 	case http.MethodGet:
@@ -126,7 +161,7 @@ func (h *Handler) user(w http.ResponseWriter, r *http.Request, clientID, id stri
 			writeError(w, err)
 			return
 		}
-		writeUser(w, http.StatusOK, user)
+		h.writeUser(w, http.StatusOK, user, groups)
 	case http.MethodPut:
 		var input userInput
 		if err := decodeBody(r, &input); err != nil {
@@ -138,7 +173,7 @@ func (h *Handler) user(w http.ResponseWriter, r *http.Request, clientID, id stri
 			writeError(w, err)
 			return
 		}
-		writeUser(w, http.StatusOK, user)
+		h.writeUser(w, http.StatusOK, user, groups)
 	case http.MethodPatch:
 		var request patchRequest
 		if err := decodeBody(r, &request); err != nil {
@@ -150,7 +185,7 @@ func (h *Handler) user(w http.ResponseWriter, r *http.Request, clientID, id stri
 			writeError(w, err)
 			return
 		}
-		writeUser(w, http.StatusOK, user)
+		h.writeUser(w, http.StatusOK, user, groups)
 	case http.MethodDelete:
 		if err := h.service.Delete(r.Context(), clientID, id, strings.TrimSpace(r.Header.Get("If-Match"))); err != nil {
 			writeError(w, err)
@@ -159,6 +194,84 @@ func (h *Handler) user(w http.ResponseWriter, r *http.Request, clientID, id stri
 		w.WriteHeader(http.StatusNoContent)
 	default:
 		writeError(w, notFound())
+	}
+}
+
+func (h *Handler) listGroups(w http.ResponseWriter, r *http.Request, clientID string) {
+	startIndex, count, err := pagination(r)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	response, serviceErr := h.service.listGroups(r.Context(), clientID, r.URL.Query().Get("filter"), startIndex, count)
+	if serviceErr != nil {
+		writeError(w, serviceErr)
+		return
+	}
+	writeJSON(w, http.StatusOK, response)
+}
+
+func (h *Handler) createGroup(w http.ResponseWriter, r *http.Request, clientID string) {
+	var input groupInput
+	if err := decodeBody(r, &input); err != nil {
+		writeError(w, err)
+		return
+	}
+	group, err := h.service.CreateGroup(r.Context(), clientID, input)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	w.Header().Set("Location", group.Meta.Location)
+	w.Header().Set("ETag", group.Meta.Version)
+	writeJSON(w, http.StatusCreated, group)
+}
+
+func (h *Handler) group(w http.ResponseWriter, r *http.Request, clientID, id string) {
+	if id == "" || strings.Contains(id, "/") {
+		writeError(w, notFoundResource("SCIM Group"))
+		return
+	}
+	switch r.Method {
+	case http.MethodGet:
+		group, err := h.service.GetGroup(r.Context(), clientID, id)
+		if err != nil {
+			writeError(w, err)
+			return
+		}
+		writeGroup(w, http.StatusOK, group)
+	case http.MethodPut:
+		var input groupInput
+		if err := decodeBody(r, &input); err != nil {
+			writeError(w, err)
+			return
+		}
+		group, err := h.service.ReplaceGroup(r.Context(), clientID, id, strings.TrimSpace(r.Header.Get("If-Match")), input)
+		if err != nil {
+			writeError(w, err)
+			return
+		}
+		writeGroup(w, http.StatusOK, group)
+	case http.MethodPatch:
+		var request patchRequest
+		if err := decodeBody(r, &request); err != nil {
+			writeError(w, err)
+			return
+		}
+		group, err := h.service.PatchGroup(r.Context(), clientID, id, strings.TrimSpace(r.Header.Get("If-Match")), request)
+		if err != nil {
+			writeError(w, err)
+			return
+		}
+		writeGroup(w, http.StatusOK, group)
+	case http.MethodDelete:
+		if err := h.service.DeleteGroup(r.Context(), clientID, id, strings.TrimSpace(r.Header.Get("If-Match"))); err != nil {
+			writeError(w, err)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	default:
+		writeError(w, notFoundResource("SCIM Group"))
 	}
 }
 
@@ -178,10 +291,17 @@ func decodeBody(r *http.Request, target any) error {
 	return nil
 }
 
-func writeUser(w http.ResponseWriter, status int, user *User) {
+func (h *Handler) writeUser(w http.ResponseWriter, status int, user *User, groups map[string]*persistedGroup) {
+	user.Groups = h.service.groupRefsForUser(groups, user.ID)
 	w.Header().Set("Location", user.Meta.Location)
 	w.Header().Set("ETag", user.Meta.Version)
 	writeJSON(w, status, user)
+}
+
+func writeGroup(w http.ResponseWriter, status int, group *Group) {
+	w.Header().Set("Location", group.Meta.Location)
+	w.Header().Set("ETag", group.Meta.Version)
+	writeJSON(w, status, group)
 }
 
 func writeError(w http.ResponseWriter, err error) {

--- a/gestaltd/internal/scim/service.go
+++ b/gestaltd/internal/scim/service.go
@@ -26,7 +26,6 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/observability/metricutil"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
-	gproto "google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -188,7 +187,9 @@ func (s *Service) Start(ctx context.Context) {
 	}
 	go func() {
 		s.runReconciliation(ctx, "retry", s.reconcileDueIntents)
+		s.runReconciliation(ctx, "retry-groups", s.reconcilePendingGroups)
 		s.runReconciliation(ctx, "drift", s.reconcileDrift)
+		s.runReconciliation(ctx, "drift-groups", s.reconcileGroupDrift)
 		retryTicks, stopRetry := s.ticker(s.retryInterval)
 		defer stopRetry()
 		driftTicks, stopDrift := s.ticker(s.driftInterval)
@@ -199,8 +200,10 @@ func (s *Service) Start(ctx context.Context) {
 				return
 			case <-retryTicks:
 				s.runReconciliation(ctx, "retry", s.reconcileDueIntents)
+				s.runReconciliation(ctx, "retry-groups", s.reconcilePendingGroups)
 			case <-driftTicks:
 				s.runReconciliation(ctx, "drift", s.reconcileDrift)
+				s.runReconciliation(ctx, "drift-groups", s.reconcileGroupDrift)
 			}
 		}
 	}()
@@ -437,20 +440,20 @@ func (s *Service) Get(ctx context.Context, clientID, id string) (*User, error) {
 	return &user, nil
 }
 
-func (s *Service) list(ctx context.Context, clientID, rawFilter string, startIndex, count int) (listResponse, error) {
+func (s *Service) list(ctx context.Context, clientID, rawFilter string, startIndex, count int) (listResponse[User], error) {
 	clauses, err := parseFilter(rawFilter)
 	if err != nil {
-		return listResponse{}, invalid(err.Error())
+		return listResponse[User]{}, invalid(err.Error())
 	}
 	records, err := s.db.ObjectStore(coredata.StoreSCIMUsers).Index("by_client").GetAll(ctx, clientID)
 	if err != nil {
-		return listResponse{}, unavailable("could not list SCIM Users")
+		return listResponse[User]{}, unavailable("could not list SCIM Users")
 	}
 	rows := make([]storedRow, 0, len(records))
 	for _, rec := range records {
 		row, decodeErr := decodeStoredRow(rec)
 		if decodeErr != nil {
-			return listResponse{}, unavailable("stored SCIM User is invalid")
+			return listResponse[User]{}, unavailable("stored SCIM User is invalid")
 		}
 		if !row.deleted && matchesFilter(row.resource, clauses) {
 			rows = append(rows, row)
@@ -470,7 +473,7 @@ func (s *Service) list(ctx context.Context, clientID, rawFilter string, startInd
 	for i := begin; i < end; i++ {
 		resources = append(resources, s.publicUser(rows[i]))
 	}
-	return listResponse{Schemas: []string{ListSchemaURN}, TotalResults: total, StartIndex: startIndex, ItemsPerPage: len(resources), Resources: resources}, nil
+	return listResponse[User]{Schemas: []string{ListSchemaURN}, TotalResults: total, StartIndex: startIndex, ItemsPerPage: len(resources), Resources: resources}, nil
 }
 
 func (s *Service) Replace(ctx context.Context, clientID, id, ifMatch string, input userInput) (*User, error) {
@@ -520,12 +523,15 @@ func (s *Service) Delete(ctx context.Context, clientID, id, ifMatch string) erro
 	}
 	if current.deleted {
 		if current.lastFingerprint == fingerprint {
-			return nil
+			return s.removeUserFromGroups(ctx, clientID, id)
 		}
 		return notFound()
 	}
 	_, err = s.commitMutationLocked(ctx, clientID, id, ifMatch, current, current.resource, mustLoginEmail(current.resource), true, fingerprint)
-	return err
+	if err != nil {
+		return err
+	}
+	return s.removeUserFromGroups(ctx, clientID, id)
 }
 
 func (s *Service) mutate(ctx context.Context, clientID, id, ifMatch string, proposed persistedUser, email string, deleted bool, fingerprint string) (*User, error) {
@@ -973,28 +979,11 @@ func (s *Service) applyProjections(ctx context.Context, intent intentRow) ([]pro
 }
 
 func (s *Service) findProjection(ctx context.Context, coreUserID string, value projection) (*proto.Relationship, error) {
-	tuple := projectionTuple(coreUserID, value)
-	response, err := s.authorization.ListRelationships(ctx, &proto.ListRelationshipsRequest{
-		Filter:   &proto.RelationshipFilter{Target: tuple.Target, Relation: tuple.Relation, Resource: tuple.Resource},
-		PageSize: 2,
-	})
-	if err != nil {
-		return nil, err
-	}
-	for _, relationship := range response.GetRelationships() {
-		if gproto.Equal(relationship.GetTuple(), tuple) {
-			return relationship, nil
-		}
-	}
-	return nil, nil
+	return s.findRelationship(ctx, projectionTuple(coreUserID, value))
 }
 
 func relationshipOwnedBy(relationship *proto.Relationship, clientID, userID string) bool {
-	if relationship == nil || relationship.GetSourceLayer() != proto.SourceLayer_SOURCE_LAYER_RUNTIME || relationship.GetProperties() == nil {
-		return false
-	}
-	properties := relationship.GetProperties().AsMap()
-	return properties["managedBy"] == "scim" && properties["scimClientId"] == clientID && properties["scimUserId"] == userID
+	return relationshipOwnedBySCIM(relationship, clientID, "scimUserId", userID)
 }
 
 func projectionTuple(coreUserID string, value projection) *proto.RelationshipTuple {
@@ -1329,7 +1318,37 @@ func (s *Service) IsEligible(ctx context.Context, coreUserID, email string) (boo
 			return false, nil
 		}
 	}
+	if pending, err := s.pendingGroupAffectsUser(ctx, clientID, activeUsers); err != nil {
+		return false, err
+	} else if pending {
+		return false, nil
+	}
 	return true, nil
+}
+
+func (s *Service) pendingGroupAffectsUser(ctx context.Context, clientID string, activeUsers map[string]storedRow) (bool, error) {
+	if clientID == "" {
+		return false, nil
+	}
+	records, err := s.db.ObjectStore(coredata.StoreSCIMGroups).Index("by_client").GetAll(ctx, clientID)
+	if err != nil {
+		return false, err
+	}
+	for _, rec := range records {
+		row, decodeErr := decodeStoredGroup(rec)
+		if decodeErr != nil {
+			return false, decodeErr
+		}
+		if !row.pending {
+			continue
+		}
+		for _, userID := range row.pendingAffectedUsers {
+			if _, ok := activeUsers[userID]; ok {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
 }
 
 func intentPreservesEligibility(intent intentRow, committed storedRow) bool {
@@ -1367,7 +1386,19 @@ func (s *Service) clientOwnsDomain(clientID, domain string) bool {
 	return ok
 }
 
-func (s *Service) ManagedRelationship(resourceType, resourceID, relation string) bool {
-	_, ok := s.managed[(projection{ResourceType: resourceType, ResourceID: resourceID, Relation: relation}).key()]
-	return ok
+func (s *Service) managedRelationship(ctx context.Context, resourceType, resourceID, relation string) (bool, error) {
+	if _, ok := s.managed[(projection{ResourceType: resourceType, ResourceID: resourceID, Relation: relation}).key()]; ok {
+		return true, nil
+	}
+	if resourceType != "group" || relation != "member" {
+		return false, nil
+	}
+	rec, err := s.db.ObjectStore(coredata.StoreSCIMGroups).Get(ctx, resourceID)
+	if errors.Is(err, idb.ErrNotFound) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return !recordBool(rec, "deleted"), nil
 }

--- a/gestaltd/internal/scim/types.go
+++ b/gestaltd/internal/scim/types.go
@@ -10,6 +10,7 @@ import (
 
 const (
 	UserSchemaURN  = "urn:ietf:params:scim:schemas:core:2.0:User"
+	GroupSchemaURN = "urn:ietf:params:scim:schemas:core:2.0:Group"
 	PatchSchemaURN = "urn:ietf:params:scim:api:messages:2.0:PatchOp"
 	ListSchemaURN  = "urn:ietf:params:scim:api:messages:2.0:ListResponse"
 	ErrorSchemaURN = "urn:ietf:params:scim:api:messages:2.0:Error"
@@ -36,14 +37,39 @@ type Meta struct {
 }
 
 type User struct {
+	Schemas     []string   `json:"schemas"`
+	ID          string     `json:"id"`
+	ExternalID  string     `json:"externalId,omitempty"`
+	UserName    string     `json:"userName"`
+	Active      bool       `json:"active"`
+	DisplayName string     `json:"displayName,omitempty"`
+	Name        Name       `json:"name,omitempty"`
+	Emails      []Email    `json:"emails,omitempty"`
+	Groups      []GroupRef `json:"groups,omitempty"`
+	Meta        Meta       `json:"meta"`
+}
+
+// GroupRef is the read-only User.groups representation defined by RFC 7643.
+type GroupRef struct {
+	Value   string `json:"value"`
+	Ref     string `json:"$ref,omitempty"`
+	Display string `json:"display,omitempty"`
+	Type    string `json:"type,omitempty"`
+}
+
+type Member struct {
+	Value   string `json:"value"`
+	Ref     string `json:"$ref,omitempty"`
+	Display string `json:"display,omitempty"`
+	Type    string `json:"type,omitempty"`
+}
+
+type Group struct {
 	Schemas     []string `json:"schemas"`
 	ID          string   `json:"id"`
 	ExternalID  string   `json:"externalId,omitempty"`
-	UserName    string   `json:"userName"`
-	Active      bool     `json:"active"`
-	DisplayName string   `json:"displayName,omitempty"`
-	Name        Name     `json:"name,omitempty"`
-	Emails      []Email  `json:"emails,omitempty"`
+	DisplayName string   `json:"displayName"`
+	Members     []Member `json:"members,omitempty"`
 	Meta        Meta     `json:"meta"`
 }
 
@@ -57,6 +83,13 @@ type userInput struct {
 	Emails      *[]Email `json:"emails,omitempty"`
 }
 
+type groupInput struct {
+	Schemas     []string  `json:"schemas"`
+	ExternalID  *string   `json:"externalId,omitempty"`
+	DisplayName *string   `json:"displayName,omitempty"`
+	Members     *[]Member `json:"members,omitempty"`
+}
+
 type persistedUser struct {
 	ExternalID  string  `json:"externalId,omitempty"`
 	UserName    string  `json:"userName"`
@@ -66,12 +99,18 @@ type persistedUser struct {
 	Emails      []Email `json:"emails,omitempty"`
 }
 
-type listResponse struct {
+type persistedGroup struct {
+	ExternalID  string   `json:"externalId,omitempty"`
+	DisplayName string   `json:"displayName"`
+	Members     []Member `json:"members,omitempty"`
+}
+
+type listResponse[T any] struct {
 	Schemas      []string `json:"schemas"`
 	TotalResults int      `json:"totalResults"`
 	StartIndex   int      `json:"startIndex"`
 	ItemsPerPage int      `json:"itemsPerPage"`
-	Resources    []User   `json:"Resources"`
+	Resources    []T      `json:"Resources"`
 }
 
 type patchRequest struct {
@@ -98,8 +137,20 @@ func invalid(detail string) *Error {
 	return &Error{Status: http.StatusBadRequest, SCIMType: "invalidValue", Detail: detail}
 }
 
+func invalidFilter(detail string) *Error {
+	return &Error{Status: http.StatusBadRequest, SCIMType: "invalidFilter", Detail: detail}
+}
+
+func noTarget(detail string) *Error {
+	return &Error{Status: http.StatusBadRequest, SCIMType: "noTarget", Detail: detail}
+}
+
 func notFound() *Error {
 	return &Error{Status: http.StatusNotFound, Detail: "SCIM User was not found"}
+}
+
+func notFoundResource(resource string) *Error {
+	return &Error{Status: http.StatusNotFound, Detail: resource + " was not found"}
 }
 
 func conflict(detail string) *Error {

--- a/gestaltd/internal/scim/users_http_test.go
+++ b/gestaltd/internal/scim/users_http_test.go
@@ -1047,8 +1047,12 @@ func projectedRelationship(coreUserID string, source proto.SourceLayer) *proto.R
 }
 
 func relationshipKey(tuple *proto.RelationshipTuple) string {
-	subject := tuple.GetTarget().GetSubject()
-	return subject.GetType() + "\x00" + subject.GetId() + "\x00" + tuple.GetRelation() + "\x00" + tuple.GetResource().GetType() + "\x00" + tuple.GetResource().GetId()
+	target := tuple.GetTarget()
+	targetKey := "subject\x00" + target.GetSubject().GetType() + "\x00" + target.GetSubject().GetId()
+	if subjectSet := target.GetSubjectSet(); subjectSet != nil {
+		targetKey = "subject-set\x00" + subjectSet.GetResource().GetType() + "\x00" + subjectSet.GetResource().GetId() + "\x00" + subjectSet.GetRelation()
+	}
+	return targetKey + "\x00" + tuple.GetRelation() + "\x00" + tuple.GetResource().GetType() + "\x00" + tuple.GetResource().GetId()
 }
 
 var _ core.AuthorizationProvider = (*recordingAuthorization)(nil)


### PR DESCRIPTION
## Summary

Adds RFC 7643/7644 SCIM Group provisioning alongside the existing Users implementation. Groups are durable SCIM resources whose memberships project into Gestalt authorization. No documentation or deployment configuration changes are included.

## Endpoints

All requests use `Authorization: Bearer <client-token>` and `application/scim+json` under `https://<gestalt-base-url>/scim/v2`.

- `GET /Schemas`
- `GET, POST /Users`
- `GET, PUT, PATCH, DELETE /Users/{id}`
- `GET, POST /Groups`
- `GET, PUT, PATCH, DELETE /Groups/{id}`

Contract: [RFC 7643](https://www.rfc-editor.org/rfc/rfc7643.html) and [RFC 7644](https://www.rfc-editor.org/rfc/rfc7644.html).

## Behavior

- Supports Group filters, one-based pagination, weak ETags, optional `If-Match`, and SCIM error payloads.
- Supports case-insensitive PATCH add, replace, and remove, including filtered member paths and `noTarget` errors.
- User `groups` is read-only and reports direct and indirect memberships. Groups may contain Users or nested Groups.
- Memberships project to runtime authorization relationships with SCIM ownership metadata. Pending projections survive restart, retry with backoff, and deny affected authoritative users until convergence.
- Authorization ownership is checked from shared storage, so multiple gestaltd replicas behave consistently.
- Deleting a User or Group removes containing-Group references and projected memberships; tombstones return 404.

## Verification

- `golangci-lint run ./internal/coredata ./internal/scim`
- `go test ./gestaltd/...`
- `go test -race ./gestaltd/internal/scim`
