### PR TITLE
Fix SCIM profile IndexedDB wire encoding

### DIFF
--- a/gestaltd/internal/scim/compact_groups.go
+++ b/gestaltd/internal/scim/compact_groups.go
@@ -154,7 +154,11 @@ func (s *CompactService) CreateGroup(ctx context.Context, cid string, in groupIn
 	if e != nil {
 		return nil, e
 	}
-	if e = s.db.ObjectStore("scim_resources").Add(ctx, resourceRecord(g)); e != nil {
+	record, e := resourceRecord(g)
+	if e != nil {
+		return nil, unavailable("could not encode SCIM group")
+	}
+	if e = s.db.ObjectStore("scim_resources").Add(ctx, record); e != nil {
 		if errors.Is(e, idb.ErrAlreadyExists) {
 			return nil, conflict("SCIM group already exists")
 		}
@@ -294,7 +298,11 @@ func (s *CompactService) mutateGroupLocked(ctx context.Context, cid, id, ifm str
 	if ifm != "" && ifm != "*" && ifm != old.Meta.Version {
 		return nil, &Error{Status: 412, Detail: "SCIM resource version does not match"}
 	}
-	if !sameResourceContent(txRow, resourceRecord(snapshot)) {
+	snapshotRecord, e := resourceRecord(snapshot)
+	if e != nil {
+		return nil, unavailable("could not encode SCIM group")
+	}
+	if !sameResourceContent(txRow, snapshotRecord) {
 		if ifm == "" {
 			return nil, unavailable("SCIM resource changed concurrently; retry the request")
 		}
@@ -304,7 +312,11 @@ func (s *CompactService) mutateGroupLocked(ctx context.Context, cid, id, ifm str
 		return &old, nil
 	}
 	r.ExternalID, r.DisplayName, r.UpdatedAt = next.ExternalID, next.DisplayName, s.nowUTC()
-	if e = tx.ObjectStore(coredata.StoreSCIMResources).Put(ctx, resourceRecord(r)); e != nil {
+	record, e := resourceRecord(r)
+	if e != nil {
+		return nil, unavailable("could not encode SCIM group")
+	}
+	if e = tx.ObjectStore(coredata.StoreSCIMResources).Put(ctx, record); e != nil {
 		return nil, unavailable("could not persist SCIM group")
 	}
 	if e = tx.Commit(ctx); e != nil {
@@ -394,7 +406,11 @@ func (s *CompactService) DeleteGroup(ctx context.Context, cid, id, ifm string) e
 		}
 		return unavailable("could not revalidate SCIM group")
 	}
-	if !sameResourceContent(current, resourceRecord(r)) {
+	snapshotRecord, e := resourceRecord(r)
+	if e != nil {
+		return unavailable("could not encode SCIM group")
+	}
+	if !sameResourceContent(current, snapshotRecord) {
 		if ifm == "" {
 			return unavailable("SCIM resource changed concurrently; retry the request")
 		}

--- a/gestaltd/internal/scim/compact_http_test.go
+++ b/gestaltd/internal/scim/compact_http_test.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"testing"
 
+	sdkidb "github.com/valon-technologies/gestalt/sdk/go/indexeddb"
 	"github.com/valon-technologies/gestalt/server/core"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	"github.com/valon-technologies/gestalt/server/internal/config"
@@ -193,6 +194,47 @@ func TestSCIMResourcesStoreDoesNotDuplicateLiveAuthorizationState(t *testing.T) 
 				t.Fatalf("SCIM metadata row stores live state %q: %#v", forbidden, row)
 			}
 		}
+	}
+}
+
+func TestSCIMUserProfileUsesIndexedDBWireCodec(t *testing.T) {
+	t.Parallel()
+	h, _, services := setup(t)
+	response := req(t, h, "POST", "/scim/v2/Users", map[string]any{
+		"schemas":  []string{scim.UserSchemaURN},
+		"userName": "codec@valon.com",
+		"active":   true,
+		"name":     map[string]any{"givenName": "Codec", "familyName": "User"},
+		"emails":   []map[string]any{{"value": "codec@valon.com", "type": "work", "primary": true}},
+	})
+	if response.Code != http.StatusCreated {
+		t.Fatal(response.Code, response.Body.String())
+	}
+	rows, err := services.DB.ObjectStore(coredata.StoreSCIMResources).GetAll(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var userRow map[string]any
+	for _, row := range rows {
+		if row["resource_type"] == "User" {
+			userRow = row
+			break
+		}
+	}
+	if userRow == nil {
+		t.Fatal("created User row not found")
+	}
+	encoded, err := sdkidb.EncodeIndexedDBRecord(userRow)
+	if err != nil {
+		t.Fatalf("SCIM User row is not accepted by the IndexedDB wire codec: %v", err)
+	}
+	decoded, err := sdkidb.DecodeIndexedDBRecord(encoded)
+	if err != nil {
+		t.Fatalf("decode encoded SCIM User row: %v", err)
+	}
+	profile, ok := decoded["profile"].(map[string]any)
+	if !ok || profile["name"].(map[string]any)["givenName"] != "Codec" {
+		t.Fatalf("decoded profile = %#v", decoded["profile"])
 	}
 }
 

--- a/gestaltd/internal/scim/compact_http_test.go
+++ b/gestaltd/internal/scim/compact_http_test.go
@@ -9,7 +9,6 @@ import (
 	"sync"
 	"testing"
 
-	sdkidb "github.com/valon-technologies/gestalt/sdk/go/indexeddb"
 	"github.com/valon-technologies/gestalt/server/core"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	"github.com/valon-technologies/gestalt/server/internal/config"
@@ -194,47 +193,6 @@ func TestSCIMResourcesStoreDoesNotDuplicateLiveAuthorizationState(t *testing.T) 
 				t.Fatalf("SCIM metadata row stores live state %q: %#v", forbidden, row)
 			}
 		}
-	}
-}
-
-func TestSCIMUserProfileUsesIndexedDBWireCodec(t *testing.T) {
-	t.Parallel()
-	h, _, services := setup(t)
-	response := req(t, h, "POST", "/scim/v2/Users", map[string]any{
-		"schemas":  []string{scim.UserSchemaURN},
-		"userName": "codec@valon.com",
-		"active":   true,
-		"name":     map[string]any{"givenName": "Codec", "familyName": "User"},
-		"emails":   []map[string]any{{"value": "codec@valon.com", "type": "work", "primary": true}},
-	})
-	if response.Code != http.StatusCreated {
-		t.Fatal(response.Code, response.Body.String())
-	}
-	rows, err := services.DB.ObjectStore(coredata.StoreSCIMResources).GetAll(context.Background(), nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	var userRow map[string]any
-	for _, row := range rows {
-		if row["resource_type"] == "User" {
-			userRow = row
-			break
-		}
-	}
-	if userRow == nil {
-		t.Fatal("created User row not found")
-	}
-	encoded, err := sdkidb.EncodeIndexedDBRecord(userRow)
-	if err != nil {
-		t.Fatalf("SCIM User row is not accepted by the IndexedDB wire codec: %v", err)
-	}
-	decoded, err := sdkidb.DecodeIndexedDBRecord(encoded)
-	if err != nil {
-		t.Fatalf("decode encoded SCIM User row: %v", err)
-	}
-	profile, ok := decoded["profile"].(map[string]any)
-	if !ok || profile["name"].(map[string]any)["givenName"] != "Codec" {
-		t.Fatalf("decoded profile = %#v", decoded["profile"])
 	}
 }
 

--- a/gestaltd/internal/scim/compact_migration.go
+++ b/gestaltd/internal/scim/compact_migration.go
@@ -130,7 +130,11 @@ func (s *CompactService) putMigratedUser(ctx context.Context, row idb.Record, u 
 		updated = created
 	}
 	r := storedResource{ID: id, ClientID: cid, ResourceType: "User", ExternalID: u.ExternalID, CoreUserID: coreID, UserName: normalize(u.UserName), Profile: userProfile{Name: u.Name, Emails: u.Emails}, CreatedAt: created, UpdatedAt: updated}
-	return s.db.ObjectStore(coredata.StoreSCIMResources).Put(ctx, resourceRecord(r))
+	record, err := resourceRecord(r)
+	if err != nil {
+		return fmt.Errorf("encode migrated User: %w", err)
+	}
+	return s.db.ObjectStore(coredata.StoreSCIMResources).Put(ctx, record)
 }
 func (s *CompactService) migrateLegacyGroups(ctx context.Context) error {
 	rows, err := s.db.ObjectStore(coredata.StoreSCIMGroups).GetAll(ctx, nil)
@@ -171,7 +175,11 @@ func (s *CompactService) migrateLegacyGroups(ctx context.Context) error {
 			updated = created
 		}
 		r := storedResource{ID: id, ClientID: cid, ResourceType: "Group", ExternalID: g.ExternalID, DisplayName: g.DisplayName, CreatedAt: created, UpdatedAt: updated}
-		if err := s.db.ObjectStore(coredata.StoreSCIMResources).Put(ctx, resourceRecord(r)); err != nil {
+		record, err := resourceRecord(r)
+		if err != nil {
+			return fmt.Errorf("encode migrated Group: %w", err)
+		}
+		if err := s.db.ObjectStore(coredata.StoreSCIMResources).Put(ctx, record); err != nil {
 			return err
 		}
 	}

--- a/gestaltd/internal/scim/compact_migration_test.go
+++ b/gestaltd/internal/scim/compact_migration_test.go
@@ -105,7 +105,12 @@ func TestSCIMMigrationPreservesCommittedAndCreateOnlyResources(t *testing.T) {
 		}
 	}
 	now := time.Now().UTC().Truncate(time.Millisecond)
-	resource, _ := json.Marshal(map[string]any{"userName": "Migrated@Valon.com", "active": true})
+	resource, _ := json.Marshal(map[string]any{
+		"userName": "Migrated@Valon.com",
+		"active":   true,
+		"name":     map[string]any{"givenName": "Migrated", "familyName": "User"},
+		"emails":   []map[string]any{{"value": "migrated@valon.com", "type": "work", "primary": true}},
+	})
 	// Simulate a crash after the compact row was created but before the legacy
 	// migration completed. The rerunnable migration must replace this partial
 	// row with the complete legacy representation.
@@ -147,8 +152,16 @@ func TestSCIMMigrationPreservesCommittedAndCreateOnlyResources(t *testing.T) {
 	authorization.setRelationship(&proto.Relationship{Tuple: legacyTuple, Properties: props, SourceLayer: proto.SourceLayer_SOURCE_LAYER_RUNTIME})
 	cfg := testSCIMConfig(map[string]config.SCIMClientConfig{"rippling": ripplingClient(nil)})
 	_, _, handler := newSCIMService(t, db, authorization, cfg)
-	if response := scimRequest(t, handler, http.MethodGet, "/scim/v2/Users/legacy-user", testCurrentToken, nil); response.Code != http.StatusOK {
+	response := scimRequest(t, handler, http.MethodGet, "/scim/v2/Users/legacy-user", testCurrentToken, nil)
+	if response.Code != http.StatusOK {
 		t.Fatalf("migrated User GET = %d %s", response.Code, response.Body.String())
+	}
+	var migratedUser scim.User
+	if err := json.Unmarshal(response.Body.Bytes(), &migratedUser); err != nil {
+		t.Fatalf("decode migrated User: %v", err)
+	}
+	if migratedUser.Name.GivenName != "Migrated" || migratedUser.Name.FamilyName != "User" || len(migratedUser.Emails) != 1 || migratedUser.Emails[0].Value != "migrated@valon.com" {
+		t.Fatalf("migrated User profile = %#v", migratedUser)
 	}
 	if response := scimRequest(t, handler, http.MethodGet, "/scim/v2/Groups/legacy-group", testCurrentToken, nil); response.Code != http.StatusOK {
 		t.Fatalf("migrated Group GET = %d %s", response.Code, response.Body.String())

--- a/gestaltd/internal/scim/compact_migration_test.go
+++ b/gestaltd/internal/scim/compact_migration_test.go
@@ -163,6 +163,36 @@ func TestSCIMMigrationPreservesCommittedAndCreateOnlyResources(t *testing.T) {
 	if migratedUser.Name.GivenName != "Migrated" || migratedUser.Name.FamilyName != "User" || len(migratedUser.Emails) != 1 || migratedUser.Emails[0].Value != "migrated@valon.com" {
 		t.Fatalf("migrated User profile = %#v", migratedUser)
 	}
+	rows, err := services.DB.ObjectStore(coredata.StoreSCIMResources).GetAll(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var migratedRow idb.Record
+	for _, row := range rows {
+		if row["id"] == "legacy-user" {
+			migratedRow = row
+			break
+		}
+	}
+	if migratedRow == nil {
+		t.Fatal("migrated User row not found")
+	}
+	encoded, err := idb.EncodeIndexedDBRecord(migratedRow)
+	if err != nil {
+		t.Fatalf("migrated User row is not accepted by the IndexedDB wire codec: %v", err)
+	}
+	decoded, err := idb.DecodeIndexedDBRecord(encoded)
+	if err != nil {
+		t.Fatalf("decode migrated User row: %v", err)
+	}
+	profile, ok := decoded["profile"].(map[string]any)
+	if !ok {
+		t.Fatalf("decoded migrated profile = %#v", decoded["profile"])
+	}
+	name, ok := profile["name"].(map[string]any)
+	if !ok || name["givenName"] != "Migrated" {
+		t.Fatalf("decoded migrated profile name = %#v", profile["name"])
+	}
 	if response := scimRequest(t, handler, http.MethodGet, "/scim/v2/Groups/legacy-group", testCurrentToken, nil); response.Code != http.StatusOK {
 		t.Fatalf("migrated Group GET = %d %s", response.Code, response.Body.String())
 	}

--- a/gestaltd/internal/scim/compact_migration_test.go
+++ b/gestaltd/internal/scim/compact_migration_test.go
@@ -106,6 +106,15 @@ func TestSCIMMigrationPreservesCommittedAndCreateOnlyResources(t *testing.T) {
 	}
 	now := time.Now().UTC().Truncate(time.Millisecond)
 	resource, _ := json.Marshal(map[string]any{"userName": "Migrated@Valon.com", "active": true})
+	// Simulate a crash after the compact row was created but before the legacy
+	// migration completed. The rerunnable migration must replace this partial
+	// row with the complete legacy representation.
+	if err := db.ObjectStore(coredata.StoreSCIMResources).Put(context.Background(), idb.Record{
+		"id": "legacy-user", "client_id": "rippling", "resource_type": "User", "core_user_id": coreUser.ID,
+		"user_name": "partial@valon.com", "created_at": now, "updated_at": now,
+	}); err != nil {
+		t.Fatal(err)
+	}
 	if err := db.ObjectStore(coredata.StoreSCIMUsers).Add(context.Background(), idb.Record{
 		"id": "legacy-user", "client_id": "rippling", "core_user_id": coreUser.ID, "version": int64(1), "deleted": false,
 		"resource": json.RawMessage(resource), "created_at": now, "updated_at": now,
@@ -154,6 +163,9 @@ func TestSCIMMigrationPreservesCommittedAndCreateOnlyResources(t *testing.T) {
 		if db.HasObjectStore(name) {
 			t.Fatalf("legacy store %q remains", name)
 		}
+	}
+	if _, err := scim.NewService(services.DB, authorization, "https://gestalt.example", cfg); err != nil {
+		t.Fatalf("rerunning completed migration: %v", err)
 	}
 }
 

--- a/gestaltd/internal/scim/compact_service.go
+++ b/gestaltd/internal/scim/compact_service.go
@@ -152,15 +152,25 @@ func stored(r idb.Record) storedResource {
 	_ = decodeJSONValue(r["profile"], &p)
 	return storedResource{ID: recordString(r, "id"), ClientID: recordString(r, "client_id"), ResourceType: recordString(r, "resource_type"), ExternalID: recordString(r, "external_id"), CoreUserID: recordString(r, "core_user_id"), UserName: recordString(r, "user_name"), Profile: p, DisplayName: recordString(r, "display_name"), CreatedAt: recordTime(r, "created_at"), UpdatedAt: recordTime(r, "updated_at")}
 }
-func resourceRecord(x storedResource) idb.Record {
+func resourceRecord(x storedResource) (idb.Record, error) {
 	r := idb.Record{"id": x.ID, "client_id": x.ClientID, "resource_type": x.ResourceType, "created_at": x.CreatedAt, "updated_at": x.UpdatedAt}
 	if x.ExternalID != "" {
 		r["external_id"] = x.ExternalID
 	}
 	if x.ResourceType == "User" {
 		if x.Profile.Name != (Name{}) || len(x.Profile.Emails) > 0 {
-			p, _ := json.Marshal(x.Profile)
-			r["profile"] = json.RawMessage(p)
+			// IndexedDB's wire codec accepts JSON-native maps/slices, not
+			// json.RawMessage. Round-trip the profile through JSON so the
+			// stored value has the same shape while remaining codec-compatible.
+			p, err := json.Marshal(x.Profile)
+			if err != nil {
+				return nil, fmt.Errorf("marshal profile: %w", err)
+			}
+			var native any
+			if err := json.Unmarshal(p, &native); err != nil {
+				return nil, fmt.Errorf("normalize profile: %w", err)
+			}
+			r["profile"] = native
 		}
 	}
 	if x.ResourceType == "Group" {
@@ -172,7 +182,7 @@ func resourceRecord(x storedResource) idb.Record {
 	if x.UserName != "" {
 		r["user_name"] = x.UserName
 	}
-	return r
+	return r, nil
 }
 
 // sameResourceContent compares the compact fields represented by SCIM. The
@@ -791,7 +801,11 @@ func (s *CompactService) Create(ctx context.Context, clientID string, input user
 		return nil, unavailable("could not link core user")
 	}
 	row := storedResource{ID: id, ClientID: clientID, ResourceType: "User", ExternalID: u.ExternalID, CoreUserID: cu.ID, UserName: normalize(u.UserName), Profile: userProfile{Name: u.Name, Emails: u.Emails}, CreatedAt: now, UpdatedAt: now}
-	if e = tx.ObjectStore(coredata.StoreSCIMResources).Add(ctx, resourceRecord(row)); e != nil {
+	record, e := resourceRecord(row)
+	if e != nil {
+		return nil, unavailable("could not encode SCIM user")
+	}
+	if e = tx.ObjectStore(coredata.StoreSCIMResources).Add(ctx, record); e != nil {
 		_ = tx.Abort(ctx)
 		if errors.Is(e, idb.ErrAlreadyExists) {
 			return nil, conflict("SCIM user already exists")
@@ -932,7 +946,11 @@ func (s *CompactService) mutateUser(ctx context.Context, clientID, id, ifMatch s
 	if ifMatch != "" && ifMatch != "*" && ifMatch != old.Meta.Version {
 		return nil, &Error{Status: 412, Detail: "SCIM resource version does not match"}
 	}
-	if !sameResourceContent(txRow, resourceRecord(r)) {
+	snapshotRecord, e := resourceRecord(r)
+	if e != nil {
+		return nil, unavailable("could not encode SCIM user")
+	}
+	if !sameResourceContent(txRow, snapshotRecord) {
 		if ifMatch == "" {
 			return nil, unavailable("SCIM resource changed concurrently; retry the request")
 		}
@@ -958,7 +976,11 @@ func (s *CompactService) mutateUser(ctx context.Context, clientID, id, ifMatch s
 	r.UserName = normalize(u.UserName)
 	r.Profile = userProfile{Name: u.Name, Emails: u.Emails}
 	r.UpdatedAt = now
-	if e = tx.ObjectStore(coredata.StoreSCIMResources).Put(ctx, resourceRecord(r)); e != nil {
+	record, e := resourceRecord(r)
+	if e != nil {
+		return nil, unavailable("could not encode SCIM user")
+	}
+	if e = tx.ObjectStore(coredata.StoreSCIMResources).Put(ctx, record); e != nil {
 		if errors.Is(e, idb.ErrAlreadyExists) {
 			return nil, conflict("userName must be unique")
 		}
@@ -1052,7 +1074,11 @@ func (s *CompactService) Delete(ctx context.Context, clientID, id, ifMatch strin
 		}
 		return unavailable("could not revalidate SCIM user")
 	}
-	if !sameResourceContent(current, resourceRecord(r)) {
+	snapshotRecord, e := resourceRecord(r)
+	if e != nil {
+		return unavailable("could not encode SCIM user")
+	}
+	if !sameResourceContent(current, snapshotRecord) {
 		if ifMatch == "" {
 			return unavailable("SCIM resource changed concurrently; retry the request")
 		}


### PR DESCRIPTION
## Summary
- Store compact SCIM User profiles as JSON-native maps instead of `json.RawMessage`, which the production IndexedDB wire codec rejects.
- Surface profile encoding failures during User/Group writes and legacy migration.
- Keep one focused migration test covering production-shaped profiles, partial copies, reruns, and real IndexedDB wire encode/decode.

Legacy SCIM migration code remains intact pending a successful production deploy and smoke test.

## Test plan
- `go test ./gestaltd/internal/scim -count=1 -timeout=60s`
- `go test ./gestaltd/internal/scim ./gestaltd/internal/coredata ./gestaltd/internal/indexeddbcodec ./sdk/go/indexeddb`
- `go test ./internal/bootstrap ./services/providerdev -count=1 -timeout=120s` (rerun of unrelated full-suite timing failures)
- `go test ./...` (SCIM and relevant packages passed; initial run had unrelated hosted-agent/providerdev timing failures, which passed on isolated rerun)
- `git diff --check`