### PR TITLE
analytics: expose completed request details to app admins

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -265,6 +265,7 @@ type Result struct {
 	ManualConnectionAuth    func() map[string]map[string]ManualTokenExchanger
 	Invoker                 invocation.Invoker
 	AppInvocation           invocation.Invoker
+	InvocationRecords       observability.InvocationRecordReader
 	CapabilityLister        invocation.CapabilityLister
 	AuditSink               core.AuditSink
 	SecretManager           core.SecretManager
@@ -1336,6 +1337,7 @@ func BootstrapWithOptions(ctx context.Context, cfg *config.Config, factories *Fa
 	}
 	kinds := ProviderAuthorizationKinds(cfg)
 	authorizationPolicies := ProviderAuthorizationPolicies(cfg)
+	invocationRecords := observability.NewInvocationRecordStore(observability.DefaultInvocationRecordCapacity)
 	sharedInvoker := invocation.NewBroker(providers, prepared.Services.Users, prepared.Services.ExternalCredentials,
 		invocation.WithConnectionMapper(invocation.ConnectionMap(connMaps.APIConnection)),
 		invocation.WithMCPConnectionMapper(invocation.ConnectionMap(connMaps.MCPConnection)),
@@ -1345,6 +1347,7 @@ func BootstrapWithOptions(ctx context.Context, cfg *config.Config, factories *Fa
 		invocation.WithAuthorizationProvider(authorizationProvider),
 		invocation.WithProviderKinds(kinds),
 		invocation.WithAuthorizationPolicies(authorizationPolicies),
+		invocation.WithInvocationRecorder(invocationRecords),
 	)
 	audit, auditClose, err := buildAuditSink(ctx, cfg, factories, prepared.Telemetry)
 	if err != nil {
@@ -1588,6 +1591,7 @@ func BootstrapWithOptions(ctx context.Context, cfg *config.Config, factories *Fa
 		ManualConnectionAuth:           manualConnAuthResolver,
 		Invoker:                        sharedInvoker,
 		AppInvocation:                  pluginInvoker,
+		InvocationRecords:              invocationRecords,
 		CapabilityLister:               sharedInvoker,
 		AuditSink:                      audit,
 		SecretManager:                  prepared.SecretManager,

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -1630,6 +1630,9 @@ func TestBootstrap(t *testing.T) {
 	if result.Invoker == nil {
 		t.Fatal("Invoker is nil")
 	}
+	if result.InvocationRecords == nil {
+		t.Fatal("InvocationRecords is nil")
+	}
 	if result.CapabilityLister == nil {
 		t.Fatal("CapabilityLister is nil")
 	}

--- a/gestaltd/internal/server/handlers_admin_metrics.go
+++ b/gestaltd/internal/server/handlers_admin_metrics.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 )
@@ -106,5 +107,18 @@ func (s *Server) getAppAdminMetrics(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	samples := samplesForProvider(parsed, appName)
-	writeJSON(w, http.StatusOK, summarizeAppMetrics(appName, samples))
+	response := summarizeAppMetrics(appName, samples)
+	if s.invocationRecords != nil {
+		for _, record := range s.invocationRecords.RecentInvocations(appName, 32) {
+			response.RecentRequests = append(response.RecentRequests, appAdminRequestSample{
+				ID:         record.ID,
+				Operation:  record.Operation,
+				Outcome:    record.Outcome,
+				Status:     record.Status,
+				DurationMs: float64(record.Duration) / float64(time.Millisecond),
+				Timestamp:  record.Timestamp,
+			})
+		}
+	}
+	writeJSON(w, http.StatusOK, response)
 }

--- a/gestaltd/internal/server/handlers_admin_metrics_test.go
+++ b/gestaltd/internal/server/handlers_admin_metrics_test.go
@@ -7,12 +7,25 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/valon-technologies/gestalt/server/internal/server"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
+	"github.com/valon-technologies/gestalt/server/services/observability"
 )
+
+type adminMetricsSampleReader struct {
+	samples []observability.InvocationRecord
+}
+
+func (r adminMetricsSampleReader) RecentInvocations(_ string, limit int) []observability.InvocationRecord {
+	if limit > len(r.samples) {
+		limit = len(r.samples)
+	}
+	return r.samples[:limit]
+}
 
 func TestAppAdminMetricsFiltersByProvider(t *testing.T) {
 	t.Parallel()
@@ -68,6 +81,76 @@ gestaltd_operation_error_count_total{gestalt_provider="g-issues",gestalt_operati
 	}
 	if len(payload.Operations) != 1 || payload.Operations[0].Operation != "list" {
 		t.Fatalf("operations = %#v", payload.Operations)
+	}
+}
+
+func TestAppAdminMetricsIncludesRecentRequestSamples(t *testing.T) {
+	t.Parallel()
+
+	adminID := principal.UserSubjectID(testCanonicalAdminUserID)
+	authz := &serverTestAuthorizationProvider{
+		relationships: []*proto.Relationship{
+			testAuthorizationRelationship(adminID, "admin", "app", "g-issues"),
+		},
+	}
+	startedAt := time.Date(2026, time.September, 3, 12, 0, 0, 0, time.UTC)
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = authStubWithSessionTokenIntrospect("alice-token", adminID, "")
+		cfg.Authorization = authz
+		cfg.AppDefs = appAdminTestAppDefs()
+		cfg.PrometheusMetrics = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte("gestaltd_operation_count_total{gestalt_provider=\"g-issues\",gestalt_operation=\"list\"} 4\n"))
+		})
+		cfg.InvocationRecords = adminMetricsSampleReader{samples: []observability.InvocationRecord{
+			{
+				ID:        1,
+				Operation: "list",
+				Outcome:   observability.InvocationPassed,
+				Status:    http.StatusOK,
+				Duration:  125 * time.Millisecond,
+				Timestamp: startedAt,
+			},
+			{
+				ID:        2,
+				Operation: "update",
+				Outcome:   observability.InvocationFailed,
+				Status:    http.StatusInternalServerError,
+				Duration:  2500 * time.Millisecond,
+				Timestamp: startedAt.Add(time.Second),
+			},
+		}}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	request, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/apps/g-issues/admin/metrics", nil)
+	request.Header.Set("Authorization", "Bearer alice-token")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("GET metrics: %v", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	body, _ := io.ReadAll(response.Body)
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d: %s", response.StatusCode, body)
+	}
+	var payload struct {
+		RecentRequests []struct {
+			ID         uint64  `json:"id"`
+			Operation  string  `json:"operation"`
+			Outcome    string  `json:"outcome"`
+			Status     int     `json:"status"`
+			DurationMs float64 `json:"durationMs"`
+			Timestamp  string  `json:"timestamp"`
+		} `json:"recentRequests"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(payload.RecentRequests) != 2 {
+		t.Fatalf("recentRequests = %#v", payload.RecentRequests)
+	}
+	if got := payload.RecentRequests[1]; got.ID != 2 || got.Operation != "update" || got.Outcome != "failed" || got.Status != http.StatusInternalServerError || got.DurationMs != 2500 || got.Timestamp != startedAt.Add(time.Second).Format(time.RFC3339Nano) {
+		t.Fatalf("recentRequests[1] = %#v", got)
 	}
 }
 

--- a/gestaltd/internal/server/http_binding_streaming_test.go
+++ b/gestaltd/internal/server/http_binding_streaming_test.go
@@ -129,6 +129,40 @@ func TestHTTPBindingStreaming(t *testing.T) {
 		}
 	})
 
+	t.Run("preserves trailing error body", func(t *testing.T) {
+		t.Parallel()
+
+		provider := streamingProvider(func(_ context.Context, _ string, _ map[string]any, _ string) (core.StreamReader, error) {
+			return frameReader(
+				&core.InvokeFrame{Metadata: &core.InvokeMetadata{Status: http.StatusOK, MediaType: "text/event-stream"}},
+				&core.InvokeFrame{Data: []byte("data: before\n\n")},
+				&core.InvokeFrame{Metadata: &core.InvokeMetadata{Status: http.StatusBadGateway}},
+				&core.InvokeFrame{Data: []byte(`{"error":"boom"}`)},
+			), nil
+		})
+
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.Providers = testutil.NewProviderRegistry(t, provider)
+			cfg.AppDefs = map[string]*config.ProviderEntry{"streamer": streamingAppEntry(provider)}
+		})
+
+		resp, err := http.Post(ts.URL+"/api/v1/streamer/webhooks/hooks/echo", "application/json", bytes.NewReader([]byte(`{}`)))
+		if err != nil {
+			t.Fatalf("POST: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("ReadAll: %v", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, want 200 after headers commit; body=%s", resp.StatusCode, string(body))
+		}
+		if !bytes.Contains(body, []byte(`{"error":"boom"}`)) {
+			t.Fatalf("body = %q, want trailing error body", string(body))
+		}
+	})
+
 	// Non-streaming bindings still take the unary path and return a buffered result.
 	t.Run("unary binding unchanged", func(t *testing.T) {
 		t.Parallel()

--- a/gestaltd/internal/server/prometheus_filter.go
+++ b/gestaltd/internal/server/prometheus_filter.go
@@ -5,10 +5,12 @@ import (
 	"math"
 	"sort"
 	"strings"
+	"time"
 
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
 	"github.com/prometheus/common/model"
+	"github.com/valon-technologies/gestalt/server/services/observability"
 )
 
 const (
@@ -43,6 +45,16 @@ type appAdminMetricsResponse struct {
 	DurationSecondsSum   float64                   `json:"durationSecondsSum"`
 	DurationSecondsCount float64                   `json:"durationSecondsCount"`
 	Operations           []appAdminOperationMetric `json:"operations"`
+	RecentRequests       []appAdminRequestSample   `json:"recentRequests"`
+}
+
+type appAdminRequestSample struct {
+	ID         uint64                          `json:"id"`
+	Operation  string                          `json:"operation"`
+	Outcome    observability.InvocationOutcome `json:"outcome"`
+	Status     int                             `json:"status"`
+	DurationMs float64                         `json:"durationMs"`
+	Timestamp  time.Time                       `json:"timestamp"`
 }
 
 func parsePrometheus(text string) ([]prometheusSample, error) {
@@ -154,8 +166,9 @@ func samplesForProvider(samples []prometheusSample, provider string) []prometheu
 func summarizeAppMetrics(app string, samples []prometheusSample) appAdminMetricsResponse {
 	byOp := map[string]*appAdminOperationMetric{}
 	response := appAdminMetricsResponse{
-		App:       app,
-		Available: true,
+		App:            app,
+		Available:      true,
+		RecentRequests: make([]appAdminRequestSample, 0),
 	}
 	for _, sample := range samples {
 		if math.IsNaN(sample.value) || !isAppOperationMetric(sample.name) {

--- a/gestaltd/internal/server/response.go
+++ b/gestaltd/internal/server/response.go
@@ -63,6 +63,7 @@ func writeStreamingOperationResult(w http.ResponseWriter, r *http.Request, reade
 	}
 
 	headersWritten := false
+	terminalMetadataSeen := false
 	writeHeaders := func(meta *core.InvokeMetadata) {
 		mediaType := strings.TrimSpace(meta.MediaType)
 		if mediaType == "" {
@@ -125,8 +126,8 @@ func writeStreamingOperationResult(w http.ResponseWriter, r *http.Request, reade
 					_, _ = w.Write(frame.Data)
 					flusher.Flush()
 				}
-				finalizeStreamReader(reader, nil)
-				return
+				terminalMetadataSeen = true
+				continue
 			}
 			continue
 		}
@@ -136,6 +137,10 @@ func writeStreamingOperationResult(w http.ResponseWriter, r *http.Request, reade
 		if len(frame.Data) > 0 {
 			_, _ = w.Write(frame.Data)
 			flusher.Flush()
+		}
+		if terminalMetadataSeen {
+			finalizeStreamReader(reader, nil)
+			return
 		}
 	}
 }

--- a/gestaltd/internal/server/response.go
+++ b/gestaltd/internal/server/response.go
@@ -57,6 +57,7 @@ func writeStreamingOperationResult(w http.ResponseWriter, r *http.Request, reade
 	}
 	flusher, ok := w.(http.Flusher)
 	if !ok {
+		finalizeStreamReader(reader, errors.New("streaming is not supported"))
 		writeError(w, http.StatusInternalServerError, "streaming is not supported")
 		return
 	}
@@ -87,11 +88,13 @@ func writeStreamingOperationResult(w http.ResponseWriter, r *http.Request, reade
 	for {
 		select {
 		case <-ctx.Done():
+			finalizeStreamReader(reader, ctx.Err())
 			return
 		default:
 		}
 		frame, err := reader.Recv()
 		if err != nil {
+			finalizeStreamReader(reader, err)
 			if errors.Is(err, io.EOF) {
 				if !headersWritten {
 					writeError(w, http.StatusInternalServerError, "internal error")
@@ -104,6 +107,7 @@ func writeStreamingOperationResult(w http.ResponseWriter, r *http.Request, reade
 			return
 		}
 		if frame == nil {
+			finalizeStreamReader(reader, nil)
 			if !headersWritten {
 				writeError(w, http.StatusInternalServerError, "internal error")
 			}
@@ -132,6 +136,12 @@ func writeStreamingOperationResult(w http.ResponseWriter, r *http.Request, reade
 			_, _ = w.Write(frame.Data)
 			flusher.Flush()
 		}
+	}
+}
+
+func finalizeStreamReader(reader core.StreamReader, err error) {
+	if finalizer, ok := reader.(invocation.StreamFinalizer); ok {
+		finalizer.FinalizeStream(err)
 	}
 }
 

--- a/gestaltd/internal/server/response.go
+++ b/gestaltd/internal/server/response.go
@@ -125,6 +125,7 @@ func writeStreamingOperationResult(w http.ResponseWriter, r *http.Request, reade
 					_, _ = w.Write(frame.Data)
 					flusher.Flush()
 				}
+				finalizeStreamReader(reader, nil)
 				return
 			}
 			continue

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -110,6 +110,7 @@ func run(ctx context.Context, cfg *config.Config, result *bootstrap.Result, gest
 		Runtimes:              result.Runtimes,
 		Invoker:               httpInvoker,
 		AppInvocation:         result.AppInvocation,
+		InvocationRecords:     result.InvocationRecords,
 		DefaultConnection:     connMaps.DefaultConnection,
 		// HTTP routes expose REST-visible operations via the API surface catalog map.
 		// Dynamic session/MCP operation resolution uses MCPConnection below.

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -141,6 +141,7 @@ type Server struct {
 	authResolvers                 map[string]*principal.Resolver
 	invoker                       invocation.Invoker
 	pluginInvoker                 invocation.Invoker
+	invocationRecords             observability.InvocationRecordReader
 	appPrompts                    map[string][]appPromptInfo
 	apiRouteTimeout               time.Duration
 	defaultConnection             map[string]string
@@ -238,6 +239,7 @@ type Config struct {
 	Runtimes                      bootstrap.RuntimeInspector
 	Invoker                       invocation.Invoker
 	AppInvocation                 invocation.Invoker
+	InvocationRecords             observability.InvocationRecordReader
 	DefaultConnection             map[string]string
 	CatalogConnection             map[string]string
 	MCPConnection                 map[string]string
@@ -480,6 +482,7 @@ func New(cfg Config) (*Server, error) {
 		authResolvers:                 authResolvers,
 		invoker:                       cfg.Invoker,
 		pluginInvoker:                 pluginInvoker,
+		invocationRecords:             cfg.InvocationRecords,
 		appPrompts:                    appPrompts,
 		apiRouteTimeout:               apiRouteTimeout,
 		defaultConnection:             cfg.DefaultConnection,

--- a/gestaltd/services/appaccess/app_server.go
+++ b/gestaltd/services/appaccess/app_server.go
@@ -146,6 +146,7 @@ func (s *AppServer) InvokeStream(req *proto.AppInvokeRequest, stream proto.App_I
 	for {
 		frame, err := reader.Recv()
 		if err != nil {
+			finalizeStreamReader(reader, err)
 			if errors.Is(err, io.EOF) {
 				return nil
 			}
@@ -153,9 +154,16 @@ func (s *AppServer) InvokeStream(req *proto.AppInvokeRequest, stream proto.App_I
 		}
 		for _, pf := range invokeFrameToProto(frame) {
 			if err := stream.Send(pf); err != nil {
+				finalizeStreamReader(reader, err)
 				return err
 			}
 		}
+	}
+}
+
+func finalizeStreamReader(reader core.StreamReader, err error) {
+	if finalizer, ok := reader.(invocation.StreamFinalizer); ok {
+		finalizer.FinalizeStream(err)
 	}
 }
 

--- a/gestaltd/services/invocation/broker.go
+++ b/gestaltd/services/invocation/broker.go
@@ -619,9 +619,9 @@ func (b *Broker) InvokeStream(ctx context.Context, p *principal.Principal, provi
 	// *OperationResult, so the observation happens on the first Recv.
 	spanOwned = true
 	return newObservingStreamReader(
+		ctx,
 		reader,
 		b,
-		ctx,
 		span,
 		startedAt,
 		p,
@@ -798,9 +798,9 @@ func (b *Broker) InvokeMaybeStream(ctx context.Context, p *principal.Principal, 
 		}
 		spanOwned = true
 		return &InvokeOutcome{Stream: newObservingStreamReader(
+			ctx,
 			reader,
 			b,
-			ctx,
 			span,
 			startedAt,
 			p,
@@ -846,9 +846,9 @@ type observingStreamReader struct {
 }
 
 func newObservingStreamReader(
+	ctx context.Context,
 	inner core.StreamReader,
 	broker *Broker,
-	ctx context.Context,
 	span trace.Span,
 	startedAt time.Time,
 	p *principal.Principal,

--- a/gestaltd/services/invocation/broker.go
+++ b/gestaltd/services/invocation/broker.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/valon-technologies/gestalt/server/core"
@@ -14,6 +16,7 @@ import (
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	"github.com/valon-technologies/gestalt/server/services/apps/registry"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
+	"github.com/valon-technologies/gestalt/server/services/observability"
 	"github.com/valon-technologies/gestalt/server/services/observability/metricutil"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -127,6 +130,7 @@ type Broker struct {
 	providers                     *registry.ProviderMap[core.Provider]
 	users                         UserStore
 	externalCreds                 core.ExternalCredentialProvider
+	invocationRecorder            observability.InvocationRecordRecorder
 	connectionInstancePreferences ConnectionInstancePreferenceStore
 	connMapper                    ConnectionMapper
 	mcpMapper                     ConnectionMapper
@@ -188,12 +192,54 @@ func WithTracerProvider(provider trace.TracerProvider) BrokerOption {
 	return func(b *Broker) { b.tracerProvider = provider }
 }
 
+func WithInvocationRecorder(recorder observability.InvocationRecordRecorder) BrokerOption {
+	return func(b *Broker) { b.invocationRecorder = recorder }
+}
+
 func NewBroker(providers *registry.ProviderMap[core.Provider], users UserStore, externalCreds core.ExternalCredentialProvider, opts ...BrokerOption) *Broker {
 	b := &Broker{providers: providers, users: users, externalCreds: externalCreds}
 	for _, o := range opts {
 		o(b)
 	}
 	return b
+}
+
+func (b *Broker) recordCompletedInvocation(
+	ctx context.Context,
+	startedAt time.Time,
+	provider string,
+	operation string,
+	transport string,
+	connectionMode string,
+	resultStatus int,
+	failed bool,
+) {
+	recordOperationMetrics(ctx, startedAt, provider, operation, transport, connectionMode, resultStatus, failed)
+	b.recordInvocationRecord(startedAt, provider, operation, resultStatus, failed)
+}
+
+func (b *Broker) recordInvocationRecord(
+	startedAt time.Time,
+	provider string,
+	operation string,
+	resultStatus int,
+	failed bool,
+) {
+	if b == nil || b.invocationRecorder == nil {
+		return
+	}
+	outcome := observability.InvocationPassed
+	if failed {
+		outcome = observability.InvocationFailed
+	}
+	b.invocationRecorder.RecordInvocation(observability.InvocationRecord{
+		Provider:  provider,
+		Operation: operation,
+		Outcome:   outcome,
+		Status:    resultStatus,
+		Duration:  time.Since(startedAt),
+		Timestamp: startedAt.UTC(),
+	})
 }
 
 func (b *Broker) log() *slog.Logger {
@@ -243,7 +289,7 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 	defer span.End()
 	defer func() {
 		resultStatus := operationResultStatus(result, err)
-		recordOperationMetrics(
+		b.recordCompletedInvocation(
 			ctx,
 			startedAt,
 			metricProvider,
@@ -550,6 +596,7 @@ func (b *Broker) InvokeStream(ctx context.Context, p *principal.Principal, provi
 		broker:       b,
 		ctx:          ctx,
 		span:         span,
+		startedAt:    startedAt,
 		principal:    p,
 		providerName: providerName,
 		operation:    opMeta.ID,
@@ -727,6 +774,7 @@ func (b *Broker) InvokeMaybeStream(ctx context.Context, p *principal.Principal, 
 			broker:       b,
 			ctx:          ctx,
 			span:         span,
+			startedAt:    startedAt,
 			principal:    p,
 			providerName: providerName,
 			operation:    opMeta.ID,
@@ -744,25 +792,30 @@ func (b *Broker) InvokeMaybeStream(ctx context.Context, p *principal.Principal, 
 	return &InvokeOutcome{Unary: result}, nil
 }
 
-// observingStreamReader wraps a StreamReader and inspects the first metadata
-// frame for 5xx status, calling observePlugin5xxResult for telemetry parity
-// with the unary Invoke path.
+// observingStreamReader wraps a StreamReader, inspects the first metadata frame
+// for 5xx status, and records the invocation when the stream terminates.
 type observingStreamReader struct {
 	inner        core.StreamReader
 	broker       *Broker
 	ctx          context.Context
 	span         trace.Span
+	startedAt    time.Time
 	principal    *principal.Principal
 	providerName string
 	operation    string
 	transport    string
 	observed     bool
-	ended        bool
+	endOnce      sync.Once
+	resultStatus int
+	resultErr    error
 }
 
 func (r *observingStreamReader) Recv() (*core.InvokeFrame, error) {
 	frame, err := r.inner.Recv()
 	if err != nil {
+		if !errors.Is(err, io.EOF) {
+			r.resultErr = err
+		}
 		r.endSpan()
 		return nil, err
 	}
@@ -773,6 +826,7 @@ func (r *observingStreamReader) Recv() (*core.InvokeFrame, error) {
 			Headers: frame.Metadata.Headers,
 			Body:    frame.Data,
 		}
+		r.resultStatus = result.Status
 		r.broker.observePlugin5xxResult(r.ctx, r.span, r.principal, r.providerName, r.operation, r.transport, result)
 	}
 	if frame == nil {
@@ -785,10 +839,16 @@ func (r *observingStreamReader) Recv() (*core.InvokeFrame, error) {
 // a nil frame so the span stays open long enough for observePlugin5xxResult
 // to set status and attributes on a streaming 5xx.
 func (r *observingStreamReader) endSpan() {
-	if !r.ended {
-		r.ended = true
+	r.endOnce.Do(func() {
+		r.broker.recordInvocationRecord(
+			r.startedAt,
+			r.providerName,
+			r.operation,
+			r.resultStatus,
+			operationResultFailed(r.resultStatus, r.resultErr),
+		)
 		r.span.End()
-	}
+	})
 }
 
 func (b *Broker) observePlugin5xxResult(ctx context.Context, span trace.Span, p *principal.Principal, providerName, operation, transport string, result *core.OperationResult) {
@@ -852,7 +912,7 @@ func (b *Broker) InvokeGraphQL(ctx context.Context, p *principal.Principal, prov
 	defer span.End()
 	defer func() {
 		resultStatus := operationResultStatus(result, err)
-		recordOperationMetrics(
+		b.recordCompletedInvocation(
 			ctx,
 			startedAt,
 			metricProvider,

--- a/gestaltd/services/invocation/broker.go
+++ b/gestaltd/services/invocation/broker.go
@@ -885,8 +885,8 @@ func (r *observingStreamReader) Recv() (*core.InvokeFrame, error) {
 		return nil, nil
 	}
 	r.mu.Lock()
+	terminalMetadata := frame.Metadata != nil && r.frameSeen
 	r.frameSeen = true
-	terminalMetadata := frame.Metadata != nil && r.metadataSeen
 	if frame.Metadata != nil {
 		r.metadataSeen = true
 		result := &core.OperationResult{

--- a/gestaltd/services/invocation/broker.go
+++ b/gestaltd/services/invocation/broker.go
@@ -218,6 +218,28 @@ func (b *Broker) recordCompletedInvocation(
 	b.recordInvocationRecord(startedAt, provider, operation, resultStatus, failed)
 }
 
+// recordInvocationOutcome keeps dispatch-time stream metrics separate from
+// completed invocation records. A stream owns its final record until the
+// observing reader sees the terminal frame or error; every other outcome is
+// finalized here so all non-stream paths share the same recorder wiring.
+func (b *Broker) recordInvocationOutcome(
+	ctx context.Context,
+	startedAt time.Time,
+	provider string,
+	operation string,
+	transport string,
+	connectionMode string,
+	resultStatus int,
+	failed bool,
+	streamPending bool,
+) {
+	if streamPending {
+		recordOperationMetrics(ctx, startedAt, provider, operation, transport, connectionMode, resultStatus, failed)
+		return
+	}
+	b.recordCompletedInvocation(ctx, startedAt, provider, operation, transport, connectionMode, resultStatus, failed)
+}
+
 func (b *Broker) recordInvocationRecord(
 	startedAt time.Time,
 	provider string,
@@ -443,13 +465,11 @@ func (b *Broker) InvokeStream(ctx context.Context, p *principal.Principal, provi
 		if !spanOwned {
 			span.End()
 		}
-		// Record dispatch-phase metrics. If the stream was successfully
-		// dispatched (dispatchErr is nil), the final stream status is not
-		// known here — it is observed by observingStreamReader on the first
-		// Recv. Dispatch failures (auth, resolve, token, etc.) are recorded
-		// as failed operations, mirroring unary Invoke.
+		// Record dispatch-phase metrics while a successfully dispatched stream
+		// owns its final outcome. Dispatch failures (auth, resolve, token, etc.)
+		// are completed here, mirroring unary Invoke.
 		resultStatus := operationResultStatus(nil, dispatchErr)
-		recordOperationMetrics(
+		b.recordInvocationOutcome(
 			ctx,
 			startedAt,
 			metricProvider,
@@ -458,6 +478,7 @@ func (b *Broker) InvokeStream(ctx context.Context, p *principal.Principal, provi
 			metricConnectionMode,
 			resultStatus,
 			operationResultFailed(resultStatus, dispatchErr),
+			spanOwned && dispatchErr == nil,
 		)
 	}()
 
@@ -634,7 +655,7 @@ func (b *Broker) InvokeMaybeStream(ctx context.Context, p *principal.Principal, 
 			span.End()
 		}
 		resultStatus := operationResultStatus(unaryResult, dispatchErr)
-		recordOperationMetrics(
+		b.recordInvocationOutcome(
 			ctx,
 			startedAt,
 			metricProvider,
@@ -643,6 +664,7 @@ func (b *Broker) InvokeMaybeStream(ctx context.Context, p *principal.Principal, 
 			metricConnectionMode,
 			resultStatus,
 			operationResultFailed(resultStatus, dispatchErr),
+			spanOwned && dispatchErr == nil,
 		)
 	}()
 
@@ -792,8 +814,10 @@ func (b *Broker) InvokeMaybeStream(ctx context.Context, p *principal.Principal, 
 	return &InvokeOutcome{Unary: result}, nil
 }
 
-// observingStreamReader wraps a StreamReader, inspects the first metadata frame
-// for 5xx status, and records the invocation when the stream terminates.
+// observingStreamReader wraps a StreamReader, inspects metadata frames for 5xx
+// status, and records the invocation when the stream reaches its terminal
+// frame or error. A second metadata frame is the protocol's terminal error
+// frame, so it must finalize the record before the caller returns it.
 type observingStreamReader struct {
 	inner        core.StreamReader
 	broker       *Broker
@@ -804,7 +828,8 @@ type observingStreamReader struct {
 	providerName string
 	operation    string
 	transport    string
-	observed     bool
+	metadataSeen bool
+	frameSeen    bool
 	endOnce      sync.Once
 	resultStatus int
 	resultErr    error
@@ -819,8 +844,14 @@ func (r *observingStreamReader) Recv() (*core.InvokeFrame, error) {
 		r.endSpan()
 		return nil, err
 	}
-	if !r.observed && frame != nil && frame.Metadata != nil {
-		r.observed = true
+	if frame == nil {
+		r.endSpan()
+		return nil, nil
+	}
+	r.frameSeen = true
+	if frame.Metadata != nil {
+		terminalMetadata := r.metadataSeen
+		r.metadataSeen = true
 		result := &core.OperationResult{
 			Status:  frame.Metadata.Status,
 			Headers: frame.Metadata.Headers,
@@ -828,24 +859,40 @@ func (r *observingStreamReader) Recv() (*core.InvokeFrame, error) {
 		}
 		r.resultStatus = result.Status
 		r.broker.observePlugin5xxResult(r.ctx, r.span, r.principal, r.providerName, r.operation, r.transport, result)
-	}
-	if frame == nil {
-		r.endSpan()
+		if terminalMetadata {
+			r.endSpan()
+		}
 	}
 	return frame, nil
 }
 
-// endSpan ends the tracing span exactly once. It is called on EOF, error, or
-// a nil frame so the span stays open long enough for observePlugin5xxResult
-// to set status and attributes on a streaming 5xx.
+func (r *observingStreamReader) terminalResultStatus() int {
+	if validHTTPStatus(r.resultStatus) {
+		return r.resultStatus
+	}
+	if r.metadataSeen || r.frameSeen {
+		// The HTTP streaming writer commits 200 when a frame has arrived but
+		// carries no explicit status.
+		return http.StatusOK
+	}
+	if r.resultErr != nil {
+		return operationResultStatus(nil, r.resultErr)
+	}
+	return http.StatusInternalServerError
+}
+
+// endSpan ends the tracing span and records the invocation exactly once. It is
+// called on EOF, error, nil frames, and terminal metadata frames so callers
+// that stop after an error frame cannot leave the request unrecorded.
 func (r *observingStreamReader) endSpan() {
 	r.endOnce.Do(func() {
+		resultStatus := r.terminalResultStatus()
 		r.broker.recordInvocationRecord(
 			r.startedAt,
 			r.providerName,
 			r.operation,
-			r.resultStatus,
-			operationResultFailed(r.resultStatus, r.resultErr),
+			resultStatus,
+			operationResultFailed(resultStatus, r.resultErr),
 		)
 		r.span.End()
 	})

--- a/gestaltd/services/invocation/broker.go
+++ b/gestaltd/services/invocation/broker.go
@@ -86,6 +86,12 @@ type StreamingInvoker interface {
 	InvokeStream(ctx context.Context, p *principal.Principal, providerName, instance, operation string, params map[string]any) (core.StreamReader, error)
 }
 
+// StreamFinalizer lets a transport report that it stopped consuming a stream
+// before the reader could observe its terminal frame or error.
+type StreamFinalizer interface {
+	FinalizeStream(error)
+}
+
 // MaybeStreamingInvoker is implemented by invokers that resolve unary-vs-stream
 // in a single catalog lookup.
 type MaybeStreamingInvoker interface {
@@ -612,17 +618,17 @@ func (b *Broker) InvokeStream(ctx context.Context, p *principal.Principal, provi
 	// arrives as a metadata frame with status >= 500, not a terminal
 	// *OperationResult, so the observation happens on the first Recv.
 	spanOwned = true
-	return &observingStreamReader{
-		inner:        reader,
-		broker:       b,
-		ctx:          ctx,
-		span:         span,
-		startedAt:    startedAt,
-		principal:    p,
-		providerName: providerName,
-		operation:    opMeta.ID,
-		transport:    metricutil.AttrValue(transport),
-	}, nil
+	return newObservingStreamReader(
+		reader,
+		b,
+		ctx,
+		span,
+		startedAt,
+		p,
+		providerName,
+		opMeta.ID,
+		metricutil.AttrValue(transport),
+	), nil
 }
 
 // InvokeOutcome is the discriminated result of InvokeMaybeStream. Exactly one
@@ -791,17 +797,17 @@ func (b *Broker) InvokeMaybeStream(ctx context.Context, p *principal.Principal, 
 			return fail(err)
 		}
 		spanOwned = true
-		return &InvokeOutcome{Stream: &observingStreamReader{
-			inner:        reader,
-			broker:       b,
-			ctx:          ctx,
-			span:         span,
-			startedAt:    startedAt,
-			principal:    p,
-			providerName: providerName,
-			operation:    opMeta.ID,
-			transport:    metricutil.AttrValue(transport),
-		}}, nil
+		return &InvokeOutcome{Stream: newObservingStreamReader(
+			reader,
+			b,
+			ctx,
+			span,
+			startedAt,
+			p,
+			providerName,
+			opMeta.ID,
+			metricutil.AttrValue(transport),
+		)}, nil
 	}
 
 	result, err := prov.Execute(ctx, operation, params, accessToken)
@@ -817,7 +823,9 @@ func (b *Broker) InvokeMaybeStream(ctx context.Context, p *principal.Principal, 
 // observingStreamReader wraps a StreamReader, inspects metadata frames for 5xx
 // status, and records the invocation when the stream reaches its terminal
 // frame or error. A second metadata frame is the protocol's terminal error
-// frame, so it must finalize the record before the caller returns it.
+// frame, so it must finalize the record before the caller returns it. The
+// context watcher and StreamFinalizer hook cover consumers that stop reading
+// because the client disconnected or the transport failed to send a frame.
 type observingStreamReader struct {
 	inner        core.StreamReader
 	broker       *Broker
@@ -828,18 +836,50 @@ type observingStreamReader struct {
 	providerName string
 	operation    string
 	transport    string
+	mu           sync.Mutex
 	metadataSeen bool
 	frameSeen    bool
 	endOnce      sync.Once
+	stopWatch    func() bool
 	resultStatus int
 	resultErr    error
+}
+
+func newObservingStreamReader(
+	inner core.StreamReader,
+	broker *Broker,
+	ctx context.Context,
+	span trace.Span,
+	startedAt time.Time,
+	p *principal.Principal,
+	providerName, operation, transport string,
+) *observingStreamReader {
+	reader := &observingStreamReader{
+		inner:        inner,
+		broker:       broker,
+		ctx:          ctx,
+		span:         span,
+		startedAt:    startedAt,
+		principal:    p,
+		providerName: providerName,
+		operation:    operation,
+		transport:    transport,
+	}
+	reader.stopWatch = context.AfterFunc(ctx, func() {
+		reader.FinalizeStream(ctx.Err())
+	})
+	return reader
 }
 
 func (r *observingStreamReader) Recv() (*core.InvokeFrame, error) {
 	frame, err := r.inner.Recv()
 	if err != nil {
 		if !errors.Is(err, io.EOF) {
-			r.resultErr = err
+			r.mu.Lock()
+			if r.resultErr == nil {
+				r.resultErr = err
+			}
+			r.mu.Unlock()
 		}
 		r.endSpan()
 		return nil, err
@@ -848,9 +888,10 @@ func (r *observingStreamReader) Recv() (*core.InvokeFrame, error) {
 		r.endSpan()
 		return nil, nil
 	}
+	r.mu.Lock()
 	r.frameSeen = true
+	terminalMetadata := frame.Metadata != nil && r.metadataSeen
 	if frame.Metadata != nil {
-		terminalMetadata := r.metadataSeen
 		r.metadataSeen = true
 		result := &core.OperationResult{
 			Status:  frame.Metadata.Status,
@@ -858,15 +899,32 @@ func (r *observingStreamReader) Recv() (*core.InvokeFrame, error) {
 			Body:    frame.Data,
 		}
 		r.resultStatus = result.Status
+		r.mu.Unlock()
 		r.broker.observePlugin5xxResult(r.ctx, r.span, r.principal, r.providerName, r.operation, r.transport, result)
 		if terminalMetadata {
 			r.endSpan()
 		}
+		return frame, nil
 	}
+	r.mu.Unlock()
 	return frame, nil
 }
 
-func (r *observingStreamReader) terminalResultStatus() int {
+// FinalizeStream records an invocation when its transport stops consuming the
+// reader before Recv can observe a terminal frame. It is safe to call more
+// than once; only the first completion records the request.
+func (r *observingStreamReader) FinalizeStream(err error) {
+	if err != nil && !errors.Is(err, io.EOF) {
+		r.mu.Lock()
+		if r.resultErr == nil {
+			r.resultErr = err
+		}
+		r.mu.Unlock()
+	}
+	r.endSpan()
+}
+
+func (r *observingStreamReader) terminalResultStatusLocked() int {
 	if validHTTPStatus(r.resultStatus) {
 		return r.resultStatus
 	}
@@ -886,13 +944,19 @@ func (r *observingStreamReader) terminalResultStatus() int {
 // that stop after an error frame cannot leave the request unrecorded.
 func (r *observingStreamReader) endSpan() {
 	r.endOnce.Do(func() {
-		resultStatus := r.terminalResultStatus()
+		if r.stopWatch != nil {
+			r.stopWatch()
+		}
+		r.mu.Lock()
+		resultStatus := r.terminalResultStatusLocked()
+		resultErr := r.resultErr
+		r.mu.Unlock()
 		r.broker.recordInvocationRecord(
 			r.startedAt,
 			r.providerName,
 			r.operation,
 			resultStatus,
-			operationResultFailed(resultStatus, r.resultErr),
+			operationResultFailed(resultStatus, resultErr),
 		)
 		r.span.End()
 	})

--- a/gestaltd/services/invocation/broker.go
+++ b/gestaltd/services/invocation/broker.go
@@ -307,7 +307,7 @@ func (b *Broker) ListCapabilities() []core.Capability {
 func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerName, instance, operation string, params map[string]any) (result *core.OperationResult, err error) {
 	startedAt := time.Now()
 	metricProvider := metricutil.UnknownAttrValue
-	metricOperation := metricutil.UnknownAttrValue
+	metricOperation := metricutil.AttrValue(operation)
 	metricTransport := metricutil.UnknownAttrValue
 	metricConnectionMode := metricutil.UnknownAttrValue
 
@@ -458,7 +458,7 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 func (b *Broker) InvokeStream(ctx context.Context, p *principal.Principal, providerName, instance, operation string, params map[string]any) (core.StreamReader, error) {
 	startedAt := time.Now()
 	metricProvider := metricutil.UnknownAttrValue
-	metricOperation := metricutil.UnknownAttrValue
+	metricOperation := metricutil.AttrValue(operation)
 	metricTransport := metricutil.UnknownAttrValue
 	metricConnectionMode := metricutil.UnknownAttrValue
 	var dispatchErr error
@@ -646,7 +646,7 @@ func (o *InvokeOutcome) IsStream() bool { return o != nil && o.Stream != nil }
 func (b *Broker) InvokeMaybeStream(ctx context.Context, p *principal.Principal, providerName, instance, operation string, params map[string]any) (*InvokeOutcome, error) {
 	startedAt := time.Now()
 	metricProvider := metricutil.UnknownAttrValue
-	metricOperation := metricutil.UnknownAttrValue
+	metricOperation := metricutil.AttrValue(operation)
 	metricTransport := metricutil.UnknownAttrValue
 	metricConnectionMode := metricutil.UnknownAttrValue
 	var dispatchErr error
@@ -827,22 +827,23 @@ func (b *Broker) InvokeMaybeStream(ctx context.Context, p *principal.Principal, 
 // context watcher and StreamFinalizer hook cover consumers that stop reading
 // because the client disconnected or the transport failed to send a frame.
 type observingStreamReader struct {
-	inner        core.StreamReader
-	broker       *Broker
-	ctx          context.Context
-	span         trace.Span
-	startedAt    time.Time
-	principal    *principal.Principal
-	providerName string
-	operation    string
-	transport    string
-	mu           sync.Mutex
-	metadataSeen bool
-	frameSeen    bool
-	endOnce      sync.Once
-	stopWatch    func() bool
-	resultStatus int
-	resultErr    error
+	inner           core.StreamReader
+	broker          *Broker
+	ctx             context.Context
+	span            trace.Span
+	startedAt       time.Time
+	principal       *principal.Principal
+	providerName    string
+	operation       string
+	transport       string
+	mu              sync.Mutex
+	metadataSeen    bool
+	frameSeen       bool
+	terminalPending bool
+	finished        bool
+	stopWatch       func() bool
+	resultStatus    int
+	resultErr       error
 }
 
 func newObservingStreamReader(
@@ -866,7 +867,7 @@ func newObservingStreamReader(
 		transport:    transport,
 	}
 	reader.stopWatch = context.AfterFunc(ctx, func() {
-		reader.FinalizeStream(ctx.Err())
+		reader.finish(ctx.Err(), false, false)
 	})
 	return reader
 }
@@ -874,17 +875,12 @@ func newObservingStreamReader(
 func (r *observingStreamReader) Recv() (*core.InvokeFrame, error) {
 	frame, err := r.inner.Recv()
 	if err != nil {
-		if !errors.Is(err, io.EOF) {
-			r.mu.Lock()
-			if r.resultErr == nil {
-				r.resultErr = err
-			}
-			r.mu.Unlock()
-		}
+		r.markTerminal(err)
 		r.endSpan()
 		return nil, err
 	}
 	if frame == nil {
+		r.markTerminal(nil)
 		r.endSpan()
 		return nil, nil
 	}
@@ -900,6 +896,9 @@ func (r *observingStreamReader) Recv() (*core.InvokeFrame, error) {
 		}
 		r.resultStatus = result.Status
 		r.mu.Unlock()
+		if terminalMetadata {
+			r.markTerminal(nil)
+		}
 		r.broker.observePlugin5xxResult(r.ctx, r.span, r.principal, r.providerName, r.operation, r.transport, result)
 		if terminalMetadata {
 			r.endSpan()
@@ -910,18 +909,27 @@ func (r *observingStreamReader) Recv() (*core.InvokeFrame, error) {
 	return frame, nil
 }
 
+func (r *observingStreamReader) markTerminal(err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.finished {
+		return
+	}
+	r.terminalPending = true
+	if err != nil && !errors.Is(err, io.EOF) && r.resultErr == nil {
+		r.resultErr = err
+	}
+}
+
 // FinalizeStream records an invocation when its transport stops consuming the
 // reader before Recv can observe a terminal frame. It is safe to call more
 // than once; only the first completion records the request.
 func (r *observingStreamReader) FinalizeStream(err error) {
-	if err != nil && !errors.Is(err, io.EOF) {
-		r.mu.Lock()
-		if r.resultErr == nil {
-			r.resultErr = err
-		}
-		r.mu.Unlock()
+	if errors.Is(err, io.EOF) {
+		r.endSpan()
+		return
 	}
-	r.endSpan()
+	r.finish(err, false, true)
 }
 
 func (r *observingStreamReader) terminalResultStatusLocked() int {
@@ -943,23 +951,35 @@ func (r *observingStreamReader) terminalResultStatusLocked() int {
 // called on EOF, error, nil frames, and terminal metadata frames so callers
 // that stop after an error frame cannot leave the request unrecorded.
 func (r *observingStreamReader) endSpan() {
-	r.endOnce.Do(func() {
-		if r.stopWatch != nil {
-			r.stopWatch()
-		}
-		r.mu.Lock()
-		resultStatus := r.terminalResultStatusLocked()
-		resultErr := r.resultErr
+	r.finish(nil, true, true)
+}
+
+func (r *observingStreamReader) finish(err error, natural, stopWatch bool) {
+	r.mu.Lock()
+	if r.finished || (!natural && r.terminalPending) {
 		r.mu.Unlock()
-		r.broker.recordInvocationRecord(
-			r.startedAt,
-			r.providerName,
-			r.operation,
-			resultStatus,
-			operationResultFailed(resultStatus, resultErr),
-		)
-		r.span.End()
-	})
+		return
+	}
+	if err != nil && !errors.Is(err, io.EOF) && r.resultErr == nil {
+		r.resultErr = err
+	}
+	r.finished = true
+	resultStatus := r.terminalResultStatusLocked()
+	resultErr := r.resultErr
+	contextStop := r.stopWatch
+	r.mu.Unlock()
+
+	if stopWatch && contextStop != nil {
+		contextStop()
+	}
+	r.broker.recordInvocationRecord(
+		r.startedAt,
+		r.providerName,
+		r.operation,
+		resultStatus,
+		operationResultFailed(resultStatus, resultErr),
+	)
+	r.span.End()
 }
 
 func (b *Broker) observePlugin5xxResult(ctx context.Context, span trace.Span, p *principal.Principal, providerName, operation, transport string, result *core.OperationResult) {

--- a/gestaltd/services/invocation/broker_test.go
+++ b/gestaltd/services/invocation/broker_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/apps/apiexec"
 	"github.com/valon-technologies/gestalt/server/services/egress"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
+	"github.com/valon-technologies/gestalt/server/services/observability"
 )
 
 func TestBrokerResolveToken_ConnectionModeNoneDoesNotCanonicalizeUserSubject(t *testing.T) {
@@ -683,6 +684,7 @@ func TestBrokerInvokeStreamDispatchesToStreamingExecutor(t *testing.T) {
 	t.Parallel()
 
 	svc := testutil.NewStubServices(t)
+	recorder := &recordingInvocationRecorder{}
 	cat := &catalog.Catalog{
 		Name: "events",
 		Operations: []catalog.CatalogOperation{{
@@ -725,6 +727,7 @@ func TestBrokerInvokeStreamDispatchesToStreamingExecutor(t *testing.T) {
 			matchedRelations: []string{"admin"},
 		}),
 		WithProviderKinds(map[string]ProviderKind{"events": ProviderKindApp}),
+		WithInvocationRecorder(recorder),
 	)
 
 	reader, err := broker.InvokeStream(
@@ -765,12 +768,19 @@ func TestBrokerInvokeStreamDispatchesToStreamingExecutor(t *testing.T) {
 	if _, err := reader.Recv(); err != io.EOF {
 		t.Fatalf("Recv after end = %v, want io.EOF", err)
 	}
+	if len(recorder.records) != 1 {
+		t.Fatalf("got %d invocation records, want one", len(recorder.records))
+	}
+	if got := recorder.records[0]; got.Provider != "events" || got.Operation != "events.watch" || got.Outcome != observability.InvocationPassed || got.Status != http.StatusOK {
+		t.Fatalf("record = %#v", got)
+	}
 }
 
 func TestBrokerInvokeStreamRejectsNonStreamingProvider(t *testing.T) {
 	t.Parallel()
 
 	svc := testutil.NewStubServices(t)
+	recorder := &recordingInvocationRecorder{}
 	cat := &catalog.Catalog{
 		Name: "plain",
 		Operations: []catalog.CatalogOperation{{
@@ -790,6 +800,7 @@ func TestBrokerInvokeStreamRejectsNonStreamingProvider(t *testing.T) {
 		testutil.NewProviderRegistry(t, provider),
 		svc.Users,
 		svc.ExternalCredentials,
+		WithInvocationRecorder(recorder),
 	)
 
 	_, err := broker.InvokeStream(
@@ -805,6 +816,12 @@ func TestBrokerInvokeStreamRejectsNonStreamingProvider(t *testing.T) {
 	}
 	if !errors.Is(err, ErrStreamingUnsupported) {
 		t.Fatalf("InvokeStream error = %v, want ErrStreamingUnsupported", err)
+	}
+	if len(recorder.records) != 1 {
+		t.Fatalf("got %d invocation records, want one", len(recorder.records))
+	}
+	if got := recorder.records[0]; got.Provider != "plain" || got.Outcome != observability.InvocationFailed {
+		t.Fatalf("record = %#v, want failed dispatch record", got)
 	}
 }
 
@@ -838,6 +855,7 @@ func TestBrokerInvokeMaybeStreamDispatchesStreaming(t *testing.T) {
 	t.Parallel()
 
 	svc := testutil.NewStubServices(t)
+	recorder := &recordingInvocationRecorder{}
 	cat := &catalog.Catalog{
 		Name: "events",
 		Operations: []catalog.CatalogOperation{{
@@ -876,6 +894,7 @@ func TestBrokerInvokeMaybeStreamDispatchesStreaming(t *testing.T) {
 			matchedRelations: []string{"admin"},
 		}),
 		WithProviderKinds(map[string]ProviderKind{"events": ProviderKindApp}),
+		WithInvocationRecorder(recorder),
 	)
 
 	outcome, err := broker.InvokeMaybeStream(
@@ -909,12 +928,22 @@ func TestBrokerInvokeMaybeStreamDispatchesStreaming(t *testing.T) {
 	if string(data.Data) != `{"event":"start"}`+"\n" {
 		t.Fatalf("data = %q", string(data.Data))
 	}
+	if _, err := outcome.Stream.Recv(); err != io.EOF {
+		t.Fatalf("Recv EOF error = %v, want EOF", err)
+	}
+	if len(recorder.records) != 1 {
+		t.Fatalf("got %d invocation records, want one", len(recorder.records))
+	}
+	if got := recorder.records[0]; got.Provider != "events" || got.Operation != "events.watch" || got.Outcome != observability.InvocationPassed || got.Status != http.StatusOK {
+		t.Fatalf("record = %#v", got)
+	}
 }
 
 func TestBrokerInvokeMaybeStreamDispatchesUnary(t *testing.T) {
 	t.Parallel()
 
 	svc := testutil.NewStubServices(t)
+	recorder := &recordingInvocationRecorder{}
 	cat := &catalog.Catalog{
 		Name: "sync",
 		Operations: []catalog.CatalogOperation{{
@@ -937,6 +966,7 @@ func TestBrokerInvokeMaybeStreamDispatchesUnary(t *testing.T) {
 		testutil.NewProviderRegistry(t, provider),
 		svc.Users,
 		svc.ExternalCredentials,
+		WithInvocationRecorder(recorder),
 	)
 
 	outcome, err := broker.InvokeMaybeStream(
@@ -959,12 +989,19 @@ func TestBrokerInvokeMaybeStreamDispatchesUnary(t *testing.T) {
 	if string(outcome.Unary.Body) != `{"ok":true}` {
 		t.Fatalf("unary body = %q, want %q", string(outcome.Unary.Body), `{"ok":true}`)
 	}
+	if len(recorder.records) != 1 {
+		t.Fatalf("got %d invocation records, want one", len(recorder.records))
+	}
+	if got := recorder.records[0]; got.Provider != "sync" || got.Operation != "sync.op" || got.Outcome != observability.InvocationPassed || got.Status != http.StatusOK {
+		t.Fatalf("record = %#v", got)
+	}
 }
 
 func TestBrokerInvokeMaybeStreamRejectsNonStreamingProvider(t *testing.T) {
 	t.Parallel()
 
 	svc := testutil.NewStubServices(t)
+	recorder := &recordingInvocationRecorder{}
 	cat := &catalog.Catalog{
 		Name: "broken-stream",
 		Operations: []catalog.CatalogOperation{{
@@ -985,6 +1022,7 @@ func TestBrokerInvokeMaybeStreamRejectsNonStreamingProvider(t *testing.T) {
 		testutil.NewProviderRegistry(t, provider),
 		svc.Users,
 		svc.ExternalCredentials,
+		WithInvocationRecorder(recorder),
 	)
 
 	_, err := broker.InvokeMaybeStream(
@@ -1000,6 +1038,12 @@ func TestBrokerInvokeMaybeStreamRejectsNonStreamingProvider(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "streaming unsupported") && !errors.Is(err, ErrStreamingUnsupported) {
 		t.Fatalf("error = %v, want streaming unsupported", err)
+	}
+	if len(recorder.records) != 1 {
+		t.Fatalf("got %d invocation records, want one", len(recorder.records))
+	}
+	if got := recorder.records[0]; got.Provider != "broken-stream" || got.Outcome != observability.InvocationFailed {
+		t.Fatalf("record = %#v, want failed dispatch record", got)
 	}
 }
 

--- a/gestaltd/services/invocation/broker_test.go
+++ b/gestaltd/services/invocation/broker_test.go
@@ -820,7 +820,7 @@ func TestBrokerInvokeStreamRejectsNonStreamingProvider(t *testing.T) {
 	if len(recorder.records) != 1 {
 		t.Fatalf("got %d invocation records, want one", len(recorder.records))
 	}
-	if got := recorder.records[0]; got.Provider != "plain" || got.Outcome != observability.InvocationFailed {
+	if got := recorder.records[0]; got.Provider != "plain" || got.Operation != "plain.op" || got.Outcome != observability.InvocationFailed {
 		t.Fatalf("record = %#v, want failed dispatch record", got)
 	}
 }
@@ -1042,7 +1042,7 @@ func TestBrokerInvokeMaybeStreamRejectsNonStreamingProvider(t *testing.T) {
 	if len(recorder.records) != 1 {
 		t.Fatalf("got %d invocation records, want one", len(recorder.records))
 	}
-	if got := recorder.records[0]; got.Provider != "broken-stream" || got.Outcome != observability.InvocationFailed {
+	if got := recorder.records[0]; got.Provider != "broken-stream" || got.Operation != "events.watch" || got.Outcome != observability.InvocationFailed {
 		t.Fatalf("record = %#v, want failed dispatch record", got)
 	}
 }

--- a/gestaltd/services/invocation/invocation_records_test.go
+++ b/gestaltd/services/invocation/invocation_records_test.go
@@ -80,6 +80,39 @@ func TestObservingStreamReaderRecordsOnceAtTerminalCompletion(t *testing.T) {
 	}
 }
 
+func TestObservingStreamReaderRecordsMetadataAfterData(t *testing.T) {
+	t.Parallel()
+
+	recorder := &recordingInvocationRecorder{}
+	broker := &Broker{invocationRecorder: recorder}
+	_, span := broker.tracer().Start(context.Background(), "test")
+	reader := &observingStreamReader{
+		inner: core.StreamReaderFunc(streamFrames([]*core.InvokeFrame{
+			{Data: []byte("chunk")},
+			{Metadata: &core.InvokeMetadata{Status: http.StatusOK}},
+		})),
+		broker:       broker,
+		ctx:          context.Background(),
+		span:         span,
+		startedAt:    time.Now().Add(-time.Millisecond),
+		providerName: "g-issues",
+		operation:    "stream",
+	}
+
+	if _, err := reader.Recv(); err != nil {
+		t.Fatalf("Recv data: %v", err)
+	}
+	if _, err := reader.Recv(); err != nil {
+		t.Fatalf("Recv terminal metadata: %v", err)
+	}
+	if len(recorder.records) != 1 {
+		t.Fatalf("got %d records, want exactly 1", len(recorder.records))
+	}
+	if got := recorder.records[0]; got.Outcome != observability.InvocationPassed || got.Status != http.StatusOK {
+		t.Fatalf("record = %#v, want passed 200", got)
+	}
+}
+
 func TestObservingStreamReaderRecordsTrailingFailureBeforeReturn(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/services/invocation/invocation_records_test.go
+++ b/gestaltd/services/invocation/invocation_records_test.go
@@ -1,0 +1,85 @@
+package invocation
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/services/observability"
+)
+
+type recordingInvocationRecorder struct {
+	records []observability.InvocationRecord
+}
+
+func (r *recordingInvocationRecorder) RecordInvocation(record observability.InvocationRecord) {
+	r.records = append(r.records, record)
+}
+
+func TestBrokerRecordsCompletedInvocation(t *testing.T) {
+	t.Parallel()
+
+	recorder := &recordingInvocationRecorder{}
+	broker := &Broker{invocationRecorder: recorder}
+	startedAt := time.Now().Add(-time.Millisecond)
+	broker.recordCompletedInvocation(context.Background(), startedAt, "g-issues", "list", "http", "subject", 200, false)
+
+	if len(recorder.records) != 1 {
+		t.Fatalf("got %d records, want 1", len(recorder.records))
+	}
+	record := recorder.records[0]
+	if record.Provider != "g-issues" || record.Operation != "list" || record.Outcome != observability.InvocationPassed || record.Status != 200 {
+		t.Fatalf("record = %#v", record)
+	}
+	if record.Duration <= 0 || record.Timestamp.IsZero() {
+		t.Fatalf("record timing = %#v", record)
+	}
+}
+
+func TestObservingStreamReaderRecordsOnceAtTerminalCompletion(t *testing.T) {
+	t.Parallel()
+
+	recorder := &recordingInvocationRecorder{}
+	broker := &Broker{invocationRecorder: recorder}
+	startedAt := time.Now().Add(-time.Millisecond)
+	_, span := broker.tracer().Start(context.Background(), "test")
+	reader := &observingStreamReader{
+		inner:        core.StreamReaderFunc(streamFrames([]*core.InvokeFrame{{Metadata: &core.InvokeMetadata{Status: 200}}})),
+		broker:       broker,
+		ctx:          context.Background(),
+		span:         span,
+		startedAt:    startedAt,
+		providerName: "g-issues",
+		operation:    "stream",
+	}
+
+	if _, err := reader.Recv(); err != nil {
+		t.Fatalf("first Recv: %v", err)
+	}
+	if _, err := reader.Recv(); err != io.EOF {
+		t.Fatalf("second Recv error = %v, want EOF", err)
+	}
+	if _, err := reader.Recv(); err != io.EOF {
+		t.Fatalf("third Recv error = %v, want EOF", err)
+	}
+	if len(recorder.records) != 1 {
+		t.Fatalf("got %d records, want exactly 1", len(recorder.records))
+	}
+	if recorder.records[0].Outcome != observability.InvocationPassed || recorder.records[0].Status != 200 {
+		t.Fatalf("record = %#v", recorder.records[0])
+	}
+}
+
+func streamFrames(frames []*core.InvokeFrame) func() (*core.InvokeFrame, error) {
+	index := 0
+	return func() (*core.InvokeFrame, error) {
+		if index == len(frames) {
+			return nil, io.EOF
+		}
+		frame := frames[index]
+		index++
+		return frame, nil
+	}
+}

--- a/gestaltd/services/invocation/invocation_records_test.go
+++ b/gestaltd/services/invocation/invocation_records_test.go
@@ -16,6 +16,12 @@ type recordingInvocationRecorder struct {
 	records []observability.InvocationRecord
 }
 
+type invocationRecordChannel chan observability.InvocationRecord
+
+func (r invocationRecordChannel) RecordInvocation(record observability.InvocationRecord) {
+	r <- record
+}
+
 func (r *recordingInvocationRecorder) RecordInvocation(record observability.InvocationRecord) {
 	r.records = append(r.records, record)
 }
@@ -75,6 +81,8 @@ func TestObservingStreamReaderRecordsOnceAtTerminalCompletion(t *testing.T) {
 }
 
 func TestObservingStreamReaderRecordsTrailingFailureBeforeReturn(t *testing.T) {
+	t.Parallel()
+
 	recorder := &recordingInvocationRecorder{}
 	broker := &Broker{invocationRecorder: recorder}
 	_, span := broker.tracer().Start(context.Background(), "test")
@@ -106,6 +114,8 @@ func TestObservingStreamReaderRecordsTrailingFailureBeforeReturn(t *testing.T) {
 }
 
 func TestObservingStreamReaderMapsPreMetadataErrorStatus(t *testing.T) {
+	t.Parallel()
+
 	recorder := &recordingInvocationRecorder{}
 	broker := &Broker{invocationRecorder: recorder}
 	_, span := broker.tracer().Start(context.Background(), "test")
@@ -130,6 +140,75 @@ func TestObservingStreamReaderMapsPreMetadataErrorStatus(t *testing.T) {
 	}
 	if got := recorder.records[0]; got.Outcome != observability.InvocationFailed || got.Status != http.StatusBadGateway {
 		t.Fatalf("record = %#v, want failed 502", got)
+	}
+}
+
+func TestObservingStreamReaderFinalizesOnContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	records := make(chan observability.InvocationRecord, 1)
+	recorder := invocationRecordChannel(records)
+	broker := &Broker{invocationRecorder: recorder}
+	_, span := broker.tracer().Start(ctx, "test")
+	newObservingStreamReader(
+		core.StreamReaderFunc(func() (*core.InvokeFrame, error) { return nil, io.EOF }),
+		broker,
+		ctx,
+		span,
+		time.Now().Add(-time.Millisecond),
+		nil,
+		"g-issues",
+		"stream",
+		"http",
+	)
+
+	cancel()
+	select {
+	case got := <-records:
+		if got.Outcome != observability.InvocationFailed || got.Status != http.StatusBadGateway {
+			t.Fatalf("record = %#v, want failed 502", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("context cancellation did not finalize the stream")
+	}
+
+	select {
+	case got := <-records:
+		t.Fatalf("got duplicate record: %#v", got)
+	default:
+	}
+}
+
+func TestObservingStreamReaderFinalizesExplicitly(t *testing.T) {
+	t.Parallel()
+
+	records := make(chan observability.InvocationRecord, 1)
+	recorder := invocationRecordChannel(records)
+	broker := &Broker{invocationRecorder: recorder}
+	ctx := context.Background()
+	_, span := broker.tracer().Start(ctx, "test")
+	reader := newObservingStreamReader(
+		core.StreamReaderFunc(func() (*core.InvokeFrame, error) { return nil, io.EOF }),
+		broker,
+		ctx,
+		span,
+		time.Now().Add(-time.Millisecond),
+		nil,
+		"g-issues",
+		"stream",
+		"grpc",
+	)
+
+	reader.FinalizeStream(errors.New("client send failed"))
+	select {
+	case got := <-records:
+		if got.Outcome != observability.InvocationFailed || got.Status != http.StatusBadGateway {
+			t.Fatalf("record = %#v, want failed 502", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("explicit finalization did not record the stream")
 	}
 }
 

--- a/gestaltd/services/invocation/invocation_records_test.go
+++ b/gestaltd/services/invocation/invocation_records_test.go
@@ -2,7 +2,9 @@ package invocation
 
 import (
 	"context"
+	"errors"
 	"io"
+	"net/http"
 	"testing"
 	"time"
 
@@ -69,6 +71,65 @@ func TestObservingStreamReaderRecordsOnceAtTerminalCompletion(t *testing.T) {
 	}
 	if recorder.records[0].Outcome != observability.InvocationPassed || recorder.records[0].Status != 200 {
 		t.Fatalf("record = %#v", recorder.records[0])
+	}
+}
+
+func TestObservingStreamReaderRecordsTrailingFailureBeforeReturn(t *testing.T) {
+	recorder := &recordingInvocationRecorder{}
+	broker := &Broker{invocationRecorder: recorder}
+	_, span := broker.tracer().Start(context.Background(), "test")
+	reader := &observingStreamReader{
+		inner: core.StreamReaderFunc(streamFrames([]*core.InvokeFrame{
+			{Metadata: &core.InvokeMetadata{Status: http.StatusOK}},
+			{Data: []byte("chunk")},
+			{Metadata: &core.InvokeMetadata{Status: http.StatusBadGateway}, Data: []byte("error")},
+		})),
+		broker:       broker,
+		ctx:          context.Background(),
+		span:         span,
+		startedAt:    time.Now().Add(-time.Millisecond),
+		providerName: "g-issues",
+		operation:    "stream",
+	}
+
+	for i := 0; i < 3; i++ {
+		if _, err := reader.Recv(); err != nil {
+			t.Fatalf("Recv %d: %v", i, err)
+		}
+	}
+	if len(recorder.records) != 1 {
+		t.Fatalf("got %d records, want exactly 1", len(recorder.records))
+	}
+	if got := recorder.records[0]; got.Outcome != observability.InvocationFailed || got.Status != http.StatusBadGateway {
+		t.Fatalf("record = %#v, want failed 502", got)
+	}
+}
+
+func TestObservingStreamReaderMapsPreMetadataErrorStatus(t *testing.T) {
+	recorder := &recordingInvocationRecorder{}
+	broker := &Broker{invocationRecorder: recorder}
+	_, span := broker.tracer().Start(context.Background(), "test")
+	streamErr := errors.New("upstream stream failed")
+	reader := &observingStreamReader{
+		inner: core.StreamReaderFunc(func() (*core.InvokeFrame, error) {
+			return nil, streamErr
+		}),
+		broker:       broker,
+		ctx:          context.Background(),
+		span:         span,
+		startedAt:    time.Now().Add(-time.Millisecond),
+		providerName: "g-issues",
+		operation:    "stream",
+	}
+
+	if _, err := reader.Recv(); !errors.Is(err, streamErr) {
+		t.Fatalf("Recv error = %v, want %v", err, streamErr)
+	}
+	if len(recorder.records) != 1 {
+		t.Fatalf("got %d records, want exactly 1", len(recorder.records))
+	}
+	if got := recorder.records[0]; got.Outcome != observability.InvocationFailed || got.Status != http.StatusBadGateway {
+		t.Fatalf("record = %#v, want failed 502", got)
 	}
 }
 

--- a/gestaltd/services/invocation/invocation_records_test.go
+++ b/gestaltd/services/invocation/invocation_records_test.go
@@ -153,9 +153,9 @@ func TestObservingStreamReaderFinalizesOnContextCancellation(t *testing.T) {
 	broker := &Broker{invocationRecorder: recorder}
 	_, span := broker.tracer().Start(ctx, "test")
 	newObservingStreamReader(
+		ctx,
 		core.StreamReaderFunc(func() (*core.InvokeFrame, error) { return nil, io.EOF }),
 		broker,
-		ctx,
 		span,
 		time.Now().Add(-time.Millisecond),
 		nil,
@@ -190,9 +190,9 @@ func TestObservingStreamReaderFinalizesExplicitly(t *testing.T) {
 	ctx := context.Background()
 	_, span := broker.tracer().Start(ctx, "test")
 	reader := newObservingStreamReader(
+		ctx,
 		core.StreamReaderFunc(func() (*core.InvokeFrame, error) { return nil, io.EOF }),
 		broker,
-		ctx,
 		span,
 		time.Now().Add(-time.Millisecond),
 		nil,

--- a/gestaltd/services/observability/invocation_records.go
+++ b/gestaltd/services/observability/invocation_records.go
@@ -68,10 +68,16 @@ func (s *InvocationRecordStore) RecordInvocation(record InvocationRecord) {
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if s.capacity <= 0 {
+		s.capacity = DefaultInvocationRecordCapacity
+	}
+	if s.records == nil {
+		s.records = make(map[string][]InvocationRecord)
+	}
 	s.nextID++
 	record.ID = s.nextID
 	records := s.records[record.Provider]
-	if len(records) == s.capacity {
+	if len(records) >= s.capacity {
 		copy(records, records[1:])
 		records = records[:len(records)-1]
 	}

--- a/gestaltd/services/observability/invocation_records.go
+++ b/gestaltd/services/observability/invocation_records.go
@@ -1,0 +1,98 @@
+package observability
+
+import (
+	"strings"
+	"sync"
+	"time"
+)
+
+// DefaultInvocationRecordCapacity bounds each provider's process-local history.
+const DefaultInvocationRecordCapacity = 256
+
+type InvocationOutcome string
+
+const (
+	InvocationPassed InvocationOutcome = "passed"
+	InvocationFailed InvocationOutcome = "failed"
+)
+
+// InvocationRecord is the privacy-safe summary of one completed operation.
+// It intentionally excludes invocation parameters, response bodies, caller
+// identity, and error payloads.
+type InvocationRecord struct {
+	ID        uint64
+	Provider  string
+	Operation string
+	Outcome   InvocationOutcome
+	Status    int
+	Duration  time.Duration
+	Timestamp time.Time
+}
+
+// InvocationRecordRecorder accepts completed invocation records.
+type InvocationRecordRecorder interface {
+	RecordInvocation(InvocationRecord)
+}
+
+// InvocationRecordReader reads recent records for one provider.
+type InvocationRecordReader interface {
+	RecentInvocations(provider string, limit int) []InvocationRecord
+}
+
+// InvocationRecordStore retains recent records in memory for the lifetime of
+// one gestaltd process. Capacity is applied independently to each provider so
+// traffic from one app cannot evict another app's recent history.
+type InvocationRecordStore struct {
+	mu       sync.RWMutex
+	capacity int
+	nextID   uint64
+	records  map[string][]InvocationRecord
+}
+
+func NewInvocationRecordStore(capacity int) *InvocationRecordStore {
+	if capacity <= 0 {
+		capacity = DefaultInvocationRecordCapacity
+	}
+	return &InvocationRecordStore{
+		capacity: capacity,
+		records:  make(map[string][]InvocationRecord),
+	}
+}
+
+func (s *InvocationRecordStore) RecordInvocation(record InvocationRecord) {
+	if s == nil {
+		return
+	}
+	record.Provider = strings.TrimSpace(record.Provider)
+	record.Operation = strings.TrimSpace(record.Operation)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.nextID++
+	record.ID = s.nextID
+	records := s.records[record.Provider]
+	if len(records) == s.capacity {
+		copy(records, records[1:])
+		records = records[:len(records)-1]
+	}
+	s.records[record.Provider] = append(records, record)
+}
+
+func (s *InvocationRecordStore) RecentInvocations(provider string, limit int) []InvocationRecord {
+	if s == nil || limit <= 0 {
+		return nil
+	}
+	provider = strings.TrimSpace(provider)
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	records := s.records[provider]
+	result := make([]InvocationRecord, 0, min(limit, len(records)))
+	for i := len(records) - 1; i >= 0 && len(result) < limit; i-- {
+		result = append(result, records[i])
+	}
+	return result
+}
+
+var _ InvocationRecordRecorder = (*InvocationRecordStore)(nil)
+var _ InvocationRecordReader = (*InvocationRecordStore)(nil)

--- a/gestaltd/services/observability/invocation_records_test.go
+++ b/gestaltd/services/observability/invocation_records_test.go
@@ -1,0 +1,31 @@
+package observability
+
+import (
+	"testing"
+	"time"
+)
+
+func TestInvocationRecordStoreReturnsNewestRecordsPerProvider(t *testing.T) {
+	t.Parallel()
+
+	store := NewInvocationRecordStore(2)
+	startedAt := time.Date(2026, time.September, 3, 12, 0, 0, 123000000, time.UTC)
+	store.RecordInvocation(InvocationRecord{Provider: "g-issues", Operation: "list", Outcome: InvocationPassed, Timestamp: startedAt})
+	store.RecordInvocation(InvocationRecord{Provider: "slack", Operation: "post", Outcome: InvocationFailed, Timestamp: startedAt.Add(time.Second)})
+	store.RecordInvocation(InvocationRecord{Provider: "g-issues", Operation: "update", Outcome: InvocationFailed, Timestamp: startedAt.Add(2 * time.Second)})
+	store.RecordInvocation(InvocationRecord{Provider: "g-issues", Operation: "delete", Outcome: InvocationPassed, Timestamp: startedAt.Add(3 * time.Second)})
+
+	got := store.RecentInvocations("g-issues", 32)
+	if len(got) != 2 {
+		t.Fatalf("got %d records, want 2: %#v", len(got), got)
+	}
+	if got[0].Operation != "delete" || got[0].Outcome != InvocationPassed || got[0].ID != 4 {
+		t.Fatalf("newest record = %#v", got[0])
+	}
+	if got[1].Operation != "update" || got[1].ID != 3 {
+		t.Fatalf("oldest retained record = %#v", got[1])
+	}
+	if len(store.RecentInvocations("slack", 32)) != 1 {
+		t.Fatal("records from another provider were evicted")
+	}
+}

--- a/gestaltd/services/observability/invocation_records_test.go
+++ b/gestaltd/services/observability/invocation_records_test.go
@@ -5,6 +5,24 @@ import (
 	"time"
 )
 
+func TestInvocationRecordStoreZeroValueIsUsable(t *testing.T) {
+	var store InvocationRecordStore
+
+	store.RecordInvocation(InvocationRecord{
+		Provider:  "g-issues",
+		Operation: "list",
+		Outcome:   InvocationPassed,
+	})
+
+	records := store.RecentInvocations("g-issues", 1)
+	if len(records) != 1 {
+		t.Fatalf("records = %#v, want one record", records)
+	}
+	if records[0].ID != 1 || records[0].Provider != "g-issues" || records[0].Operation != "list" {
+		t.Fatalf("record = %#v", records[0])
+	}
+}
+
 func TestInvocationRecordStoreReturnsNewestRecordsPerProvider(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/services/observability/invocation_records_test.go
+++ b/gestaltd/services/observability/invocation_records_test.go
@@ -6,6 +6,8 @@ import (
 )
 
 func TestInvocationRecordStoreZeroValueIsUsable(t *testing.T) {
+	t.Parallel()
+
 	var store InvocationRecordStore
 
 	store.RecordInvocation(InvocationRecord{


### PR DESCRIPTION
## Summary

- App admins can receive recent completed request records alongside the existing aggregate analytics.
- Each record includes a stable id, operation name, outcome, status, duration in milliseconds, and start timestamp.

## Why / context

The analytics UI currently has aggregate counts, so its Health squares cannot explain which operation each square represents or how long it took. The request record is now a first-class observability concern, rather than state owned by the invocation broker or inferred from Prometheus counters.

## What changed

- Added a process-local `InvocationRecordStore` under observability with bounded retention per provider.
- Bootstrap creates the store and explicitly injects its recorder into the shared invocation broker and its reader into the server.
- Unary and GraphQL invocations record once at completion.
- Streaming invocations record once when the stream reaches EOF or an error, while preserving the existing dispatch metrics.
- The app admin metrics response adds a `recentRequests` array with the newest 32 records for that app.
- Records exclude parameters, response bodies, caller identity, and error payloads.

## Test plan

- [x] `go test ./services/observability ./services/invocation ./internal/server ./internal/bootstrap`
- [x] Store retention is isolated per provider.
- [x] Unary completion and streaming terminal completion are covered, including exactly-once stream recording.
- [x] App admin metrics JSON includes the recent request contract.
- [x] `git diff --check`
- [ ] The full suite has an unrelated `server/internal/operator` failure because the environment uses Python 3.9.6 while the SDK requires Python 3.10 or newer.

## Reviewer focus

Please review whether the invocation record belongs in observability as modeled, whether per-provider process-local retention matches the current server-session product requirement, and whether the streaming terminal status behavior is sufficient.

## Rollout / compatibility

No migration or configuration change is required. The endpoint remains protected by the existing app-admin authorization. `recentRequests` is additive, so older clients can ignore it. Records are intentionally ephemeral and are lost on process restart.

## Follow-up

Toolshed can render Health squares directly from `recentRequests`, using the aggregate totals only when older records have rotated out of the retained window.
