### PR TITLE
Deploy downtime steps 5–6: authz mutations and idempotent state apply

### DIFF
--- a/gestalt/cli/src/cli.rs
+++ b/gestalt/cli/src/cli.rs
@@ -228,11 +228,29 @@ pub enum AuthorizationCommands {
         #[command(subcommand)]
         command: AuthorizationModelCommands,
     },
+    /// Manage authorization state snapshots
+    State {
+        #[command(subcommand)]
+        command: AuthorizationStateCommands,
+    },
     /// Manage service-account subjects
     Subjects {
         #[command(subcommand)]
         command: AuthorizationSubjectCommands,
     },
+}
+
+#[derive(Subcommand)]
+pub enum AuthorizationStateCommands {
+    /// Idempotently apply a model and relationship snapshot
+    Apply(AuthorizationStateApplyArgs),
+}
+
+#[derive(Args)]
+pub struct AuthorizationStateApplyArgs {
+    /// JSON file containing model and relationships in SetAuthorizationStateRequest shape
+    #[arg(long = "input-file")]
+    pub input_file: String,
 }
 
 #[derive(Args)]
@@ -258,6 +276,29 @@ pub struct AuthorizationCheckAccessArgs {
 pub enum AuthorizationRelationshipCommands {
     /// List relationships
     List(AuthorizationRelationshipListArgs),
+    /// Add a relationship tuple
+    Add(AuthorizationRelationshipMutationArgs),
+    /// Delete a relationship tuple
+    Delete(AuthorizationRelationshipMutationArgs),
+}
+
+#[derive(Args)]
+pub struct AuthorizationRelationshipMutationArgs {
+    /// Resource type on the relationship tuple
+    #[arg(long = "resource-type")]
+    pub resource_type: String,
+    /// Resource id on the relationship tuple
+    #[arg(long = "resource-id")]
+    pub resource_id: String,
+    /// Relationship relation, such as admin or viewer
+    #[arg(long)]
+    pub relation: String,
+    /// Direct subject id target, such as user:abc
+    #[arg(long = "subject-id", conflicts_with_all = ["subject_set"])]
+    pub subject_id: Option<String>,
+    /// Subject set target, such as group:valon-employees#member
+    #[arg(long = "subject-set", conflicts_with = "subject_id")]
+    pub subject_set: Option<String>,
 }
 
 #[derive(Args)]

--- a/gestalt/cli/src/commands/authorization.rs
+++ b/gestalt/cli/src/commands/authorization.rs
@@ -17,10 +17,10 @@ use gestalt_sdk::authorization::source_layer::{
     SOURCE_LAYER_RUNTIME, SOURCE_LAYER_STATIC_CONFIG, SOURCE_LAYER_UNSPECIFIED,
 };
 use gestalt_sdk::authorization::{
-    Action, AddRelationshipRequest, AuthorizationModelResourceTypeFilter,
-    CheckAccessRequest, DeleteRelationshipRequest, ListActiveModelResourceTypesRequest,
-    ListRelationshipsRequest, Relationship, RelationshipFilter, RelationshipTarget,
-    RelationshipTargetKind, Resource, Subject,
+    Action, AddRelationshipRequest, AuthorizationModelResourceTypeFilter, CheckAccessRequest,
+    DeleteRelationshipRequest, ListActiveModelResourceTypesRequest, ListRelationshipsRequest,
+    Relationship, RelationshipFilter, RelationshipTarget, RelationshipTargetKind, Resource,
+    Subject,
 };
 use gestalt_sdk::public::generated::app_client::AuthorizationClient;
 use gestalt_sdk::public::rest_transport::SyncRestTransport;
@@ -136,10 +136,14 @@ pub fn dispatch(
     }
 }
 
-fn apply_state(api: &ApiClient, args: &crate::cli::AuthorizationStateApplyArgs, format: Format) -> Result<()> {
+fn apply_state(
+    api: &ApiClient,
+    args: &crate::cli::AuthorizationStateApplyArgs,
+    format: Format,
+) -> Result<()> {
     let path = Path::new(args.input_file.trim());
-    let body = fs::read_to_string(path)
-        .with_context(|| format!("failed to read {}", path.display()))?;
+    let body =
+        fs::read_to_string(path).with_context(|| format!("failed to read {}", path.display()))?;
     let payload: Value = serde_json::from_str(&body)
         .with_context(|| format!("failed to parse JSON from {}", path.display()))?;
     let resp = api

--- a/gestalt/cli/src/commands/authorization.rs
+++ b/gestalt/cli/src/commands/authorization.rs
@@ -1,9 +1,12 @@
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use serde_json::Value;
+use std::fs;
+use std::path::Path;
 
 use crate::cli::{
     AuthorizationActiveModelCommands, AuthorizationActiveModelResourceTypeCommands,
     AuthorizationCommands, AuthorizationModelCommands, AuthorizationRelationshipCommands,
+    AuthorizationStateCommands,
 };
 use crate::output::{self, Format};
 
@@ -14,9 +17,10 @@ use gestalt_sdk::authorization::source_layer::{
     SOURCE_LAYER_RUNTIME, SOURCE_LAYER_STATIC_CONFIG, SOURCE_LAYER_UNSPECIFIED,
 };
 use gestalt_sdk::authorization::{
-    Action, AuthorizationModelResourceTypeFilter, CheckAccessRequest,
-    ListActiveModelResourceTypesRequest, ListRelationshipsRequest, RelationshipFilter,
-    RelationshipTarget, RelationshipTargetKind, Resource, Subject,
+    Action, AddRelationshipRequest, AuthorizationModelResourceTypeFilter,
+    CheckAccessRequest, DeleteRelationshipRequest, ListActiveModelResourceTypesRequest,
+    ListRelationshipsRequest, Relationship, RelationshipFilter, RelationshipTarget,
+    RelationshipTargetKind, Resource, Subject,
 };
 use gestalt_sdk::public::generated::app_client::AuthorizationClient;
 use gestalt_sdk::public::rest_transport::SyncRestTransport;
@@ -60,6 +64,35 @@ pub fn dispatch(
                 print_value(&serde_json::to_value(&resp)?, format);
                 Ok(())
             }
+            AuthorizationRelationshipCommands::Add(args) => {
+                let relationship = build_relationship_from_args(&args)?;
+                let resp = authz
+                    .add_relationship_sync(AddRelationshipRequest {
+                        relationship: Some(relationship),
+                    })
+                    .context("failed to add authorization relationship")?;
+                print_value(&serde_json::to_value(&resp)?, format);
+                Ok(())
+            }
+            AuthorizationRelationshipCommands::Delete(args) => {
+                let tuple = relationship_tuple_from_parts(
+                    &args.resource_type,
+                    &args.resource_id,
+                    &args.relation,
+                    args.subject_id.as_deref(),
+                    args.subject_set.as_deref(),
+                )?;
+                authz
+                    .delete_relationship_sync(DeleteRelationshipRequest {
+                        relationship_tuple: Some(tuple),
+                    })
+                    .context("failed to delete authorization relationship")?;
+                match format {
+                    Format::Json => output::print_json(&serde_json::json!({})),
+                    Format::Table => output::print_success("Deleted authorization relationship."),
+                }
+                Ok(())
+            }
         },
         AuthorizationCommands::Models { command } => match command {
             AuthorizationModelCommands::Active { command } => match command {
@@ -97,7 +130,111 @@ pub fn dispatch(
         AuthorizationCommands::Subjects { command } => {
             authorization_subjects::dispatch(api, command, format)
         }
+        AuthorizationCommands::State { command } => match command {
+            AuthorizationStateCommands::Apply(args) => apply_state(api, &args, format),
+        },
     }
+}
+
+fn apply_state(api: &ApiClient, args: &crate::cli::AuthorizationStateApplyArgs, format: Format) -> Result<()> {
+    let path = Path::new(args.input_file.trim());
+    let body = fs::read_to_string(path)
+        .with_context(|| format!("failed to read {}", path.display()))?;
+    let payload: Value = serde_json::from_str(&body)
+        .with_context(|| format!("failed to parse JSON from {}", path.display()))?;
+    let resp = api
+        .post("/api/v2/authorization/state:apply", &payload)
+        .context("failed to apply authorization state")?;
+    match format {
+        Format::Json => output::print_json(&resp),
+        Format::Table => output::print_success("Applied authorization state."),
+    }
+    Ok(())
+}
+
+fn build_relationship_from_args(
+    args: &crate::cli::AuthorizationRelationshipMutationArgs,
+) -> Result<Relationship> {
+    Ok(Relationship {
+        tuple: Some(relationship_tuple_from_parts(
+            &args.resource_type,
+            &args.resource_id,
+            &args.relation,
+            args.subject_id.as_deref(),
+            args.subject_set.as_deref(),
+        )?),
+        properties: None,
+        source_layer: SOURCE_LAYER_RUNTIME,
+    })
+}
+
+fn relationship_tuple_from_parts(
+    resource_type: &str,
+    resource_id: &str,
+    relation: &str,
+    subject_id: Option<&str>,
+    subject_set: Option<&str>,
+) -> Result<gestalt_sdk::authorization::RelationshipTuple> {
+    let target = build_relationship_target(subject_id, subject_set)?;
+    Ok(gestalt_sdk::authorization::RelationshipTuple {
+        resource: Some(Resource {
+            r#type: resource_type.trim().to_string(),
+            id: resource_id.trim().to_string(),
+            properties: None,
+        }),
+        relation: relation.trim().to_string(),
+        target: Some(target),
+    })
+}
+
+fn build_relationship_target(
+    subject_id: Option<&str>,
+    subject_set: Option<&str>,
+) -> Result<RelationshipTarget> {
+    if let Some(subject_id) = subject_id.map(str::trim).filter(|value| !value.is_empty()) {
+        return Ok(RelationshipTarget {
+            kind: Some(RelationshipTargetKind::Subject(Subject {
+                r#type: "subject".to_string(),
+                id: subject_id.to_string(),
+                properties: None,
+            })),
+        });
+    }
+    if let Some(subject_set) = subject_set.map(str::trim).filter(|value| !value.is_empty()) {
+        let (resource, relation) = parse_subject_set(subject_set)?;
+        return Ok(RelationshipTarget {
+            kind: Some(RelationshipTargetKind::SubjectSet(
+                gestalt_sdk::authorization::SubjectSet {
+                    resource: Some(resource),
+                    relation,
+                },
+            )),
+        });
+    }
+    bail!("either --subject-id or --subject-set is required")
+}
+
+fn parse_subject_set(value: &str) -> Result<(Resource, String)> {
+    let (head, relation) = value
+        .split_once('#')
+        .map(|(head, relation)| (head, relation.trim().to_string()))
+        .unwrap_or((value, String::new()));
+    let (resource_type, resource_id) = head
+        .split_once(':')
+        .context("subject set must look like group:valon-employees#member")?;
+    let resource_type = resource_type.trim();
+    let resource_id = resource_id.trim();
+    if resource_type.is_empty() || resource_id.is_empty() {
+        bail!("subject set must look like group:valon-employees#member");
+    }
+    Ok((
+        Resource {
+            r#type: resource_type.to_string(),
+            id: resource_id.to_string(),
+            properties: None,
+        },
+        relation,
+    ))
 }
 
 fn build_list_relationships_request(

--- a/gestaltd/internal/authorizationstate/apply.go
+++ b/gestaltd/internal/authorizationstate/apply.go
@@ -12,6 +12,8 @@ import (
 	"github.com/valon-technologies/gestalt/server/core"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	gproto "google.golang.org/protobuf/proto"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // Apply merges the requested model and relationships into the active runtime
@@ -114,6 +116,9 @@ func listRuntimeModelResourceTypes(ctx context.Context, provider core.Authorizat
 			PageToken: pageToken,
 		})
 		if err != nil {
+			if status.Code(err) == codes.NotFound {
+				return out, nil
+			}
 			return nil, fmt.Errorf("list runtime model resource types: %w", err)
 		}
 		for _, resourceType := range resp.GetResourceTypes() {

--- a/gestaltd/internal/authorizationstate/apply.go
+++ b/gestaltd/internal/authorizationstate/apply.go
@@ -1,0 +1,182 @@
+package authorizationstate
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	gproto "google.golang.org/protobuf/proto"
+)
+
+// Apply merges the requested model and relationships into the active runtime
+// authorization store without replacing unrelated runtime-only state.
+func Apply(
+	ctx context.Context,
+	provider core.AuthorizationProvider,
+	req *proto.SetAuthorizationStateRequest,
+) (*proto.SetAuthorizationStateResponse, error) {
+	if provider == nil {
+		return nil, fmt.Errorf("authorization provider is required")
+	}
+	if req == nil {
+		return nil, fmt.Errorf("request is required")
+	}
+	model := gproto.Clone(req.GetModel()).(*proto.AuthorizationModel)
+	if model == nil {
+		model = &proto.AuthorizationModel{}
+	}
+	runtimeResourceTypes, err := listRuntimeModelResourceTypes(ctx, provider)
+	if err != nil {
+		return nil, err
+	}
+	model.ResourceTypes = mergeModelResourceTypes(model.GetResourceTypes(), runtimeResourceTypes)
+	if err := stampModel(model, time.Now()); err != nil {
+		return nil, err
+	}
+	if err := ensureRelationships(ctx, provider, req.GetRelationships()); err != nil {
+		return nil, err
+	}
+	resp, err := provider.SetActiveModel(ctx, &proto.SetActiveModelRequest{Model: model})
+	if err != nil {
+		return nil, fmt.Errorf("set active model: %w", err)
+	}
+	return &proto.SetAuthorizationStateResponse{ActiveModel: resp.GetModel()}, nil
+}
+
+func ensureRelationships(ctx context.Context, provider core.AuthorizationProvider, desired []*proto.Relationship) error {
+	existing, err := listAllRelationships(ctx, provider)
+	if err != nil {
+		return err
+	}
+	existingKeys := make(map[string]struct{}, len(existing))
+	for _, relationship := range existing {
+		key, err := relationshipTupleKey(relationship.GetTuple())
+		if err != nil {
+			return err
+		}
+		existingKeys[key] = struct{}{}
+	}
+	for _, relationship := range desired {
+		if relationship == nil || relationship.GetTuple() == nil {
+			continue
+		}
+		key, err := relationshipTupleKey(relationship.GetTuple())
+		if err != nil {
+			return err
+		}
+		if _, ok := existingKeys[key]; ok {
+			continue
+		}
+		if _, err := provider.AddRelationship(ctx, &proto.AddRelationshipRequest{
+			Relationship: gproto.Clone(relationship).(*proto.Relationship),
+		}); err != nil {
+			return fmt.Errorf("add relationship %q: %w", key, err)
+		}
+		existingKeys[key] = struct{}{}
+	}
+	return nil
+}
+
+func listAllRelationships(ctx context.Context, provider core.AuthorizationProvider) ([]*proto.Relationship, error) {
+	var out []*proto.Relationship
+	pageToken := ""
+	for {
+		resp, err := provider.ListRelationships(ctx, &proto.ListRelationshipsRequest{
+			PageSize:  500,
+			PageToken: pageToken,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("list relationships: %w", err)
+		}
+		out = append(out, resp.GetRelationships()...)
+		pageToken = strings.TrimSpace(resp.GetNextPageToken())
+		if pageToken == "" {
+			return out, nil
+		}
+	}
+}
+
+func listRuntimeModelResourceTypes(ctx context.Context, provider core.AuthorizationProvider) ([]*proto.AuthorizationModelResourceType, error) {
+	var out []*proto.AuthorizationModelResourceType
+	pageToken := ""
+	for {
+		resp, err := provider.ListActiveModelResourceTypes(ctx, &proto.ListActiveModelResourceTypesRequest{
+			Filter: &proto.AuthorizationModelResourceTypeFilter{
+				SourceLayer: proto.SourceLayer_SOURCE_LAYER_RUNTIME,
+			},
+			PageSize:  500,
+			PageToken: pageToken,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("list runtime model resource types: %w", err)
+		}
+		for _, resourceType := range resp.GetResourceTypes() {
+			if resourceType.GetSourceLayer() != proto.SourceLayer_SOURCE_LAYER_RUNTIME {
+				continue
+			}
+			out = append(out, gproto.Clone(resourceType).(*proto.AuthorizationModelResourceType))
+		}
+		pageToken = strings.TrimSpace(resp.GetNextPageToken())
+		if pageToken == "" {
+			return out, nil
+		}
+	}
+}
+
+func mergeModelResourceTypes(static, runtime []*proto.AuthorizationModelResourceType) []*proto.AuthorizationModelResourceType {
+	out := make([]*proto.AuthorizationModelResourceType, 0, len(static)+len(runtime))
+	staticNames := make(map[string]struct{}, len(static))
+	for _, resourceType := range static {
+		name := strings.TrimSpace(resourceType.GetName())
+		staticNames[name] = struct{}{}
+		out = append(out, resourceType)
+	}
+	for _, resourceType := range runtime {
+		name := strings.TrimSpace(resourceType.GetName())
+		if _, ok := staticNames[name]; ok {
+			continue
+		}
+		out = append(out, resourceType)
+	}
+	return out
+}
+
+func stampModel(model *proto.AuthorizationModel, now time.Time) error {
+	id, err := modelContentHash(model)
+	if err != nil {
+		return err
+	}
+	model.Id = id
+	model.Version = strconv.FormatInt(now.Unix(), 10)
+	return nil
+}
+
+func modelContentHash(model *proto.AuthorizationModel) (string, error) {
+	content := gproto.Clone(model).(*proto.AuthorizationModel)
+	content.Id = ""
+	content.Version = ""
+	data, err := gproto.MarshalOptions{Deterministic: true}.Marshal(content)
+	if err != nil {
+		return "", fmt.Errorf("hash authorization model content: %w", err)
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func relationshipTupleKey(tuple *proto.RelationshipTuple) (string, error) {
+	if tuple == nil {
+		return "", fmt.Errorf("relationship tuple is required")
+	}
+	data, err := gproto.MarshalOptions{Deterministic: true}.Marshal(tuple)
+	if err != nil {
+		return "", fmt.Errorf("marshal relationship tuple: %w", err)
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:]), nil
+}

--- a/gestaltd/internal/authorizationstate/apply.go
+++ b/gestaltd/internal/authorizationstate/apply.go
@@ -11,9 +11,9 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/core"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
-	gproto "google.golang.org/protobuf/proto"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	gproto "google.golang.org/protobuf/proto"
 )
 
 // Apply merges the requested model and relationships into the active runtime

--- a/gestaltd/internal/authorizationstate/apply_test.go
+++ b/gestaltd/internal/authorizationstate/apply_test.go
@@ -1,0 +1,154 @@
+package authorizationstate
+
+import (
+	"context"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+)
+
+type recordingProvider struct {
+	relationships []*proto.Relationship
+	resourceTypes []*proto.AuthorizationModelResourceType
+	activeModel   *proto.AuthorizationModelRef
+	addCalls      int
+	setModelCalls int
+}
+
+func (p *recordingProvider) CheckAccess(context.Context, *proto.CheckAccessRequest) (*proto.CheckAccessResponse, error) {
+	return &proto.CheckAccessResponse{}, nil
+}
+
+func (p *recordingProvider) CheckAccessMany(context.Context, *proto.CheckAccessManyRequest) (*proto.CheckAccessManyResponse, error) {
+	return &proto.CheckAccessManyResponse{}, nil
+}
+
+func (p *recordingProvider) ListRelationships(_ context.Context, req *proto.ListRelationshipsRequest) (*proto.ListRelationshipsResponse, error) {
+	if req.GetPageToken() != "" {
+		return &proto.ListRelationshipsResponse{}, nil
+	}
+	return &proto.ListRelationshipsResponse{Relationships: append([]*proto.Relationship(nil), p.relationships...)}, nil
+}
+
+func (p *recordingProvider) AddRelationship(_ context.Context, req *proto.AddRelationshipRequest) (*proto.AddRelationshipResponse, error) {
+	p.addCalls++
+	p.relationships = append(p.relationships, req.GetRelationship())
+	return &proto.AddRelationshipResponse{Relationship: req.GetRelationship()}, nil
+}
+
+func (p *recordingProvider) DeleteRelationship(context.Context, *proto.DeleteRelationshipRequest) (*proto.DeleteRelationshipResponse, error) {
+	return &proto.DeleteRelationshipResponse{}, nil
+}
+
+func (p *recordingProvider) SetAuthorizationState(context.Context, *proto.SetAuthorizationStateRequest) (*proto.SetAuthorizationStateResponse, error) {
+	return &proto.SetAuthorizationStateResponse{}, nil
+}
+
+func (p *recordingProvider) GetActiveModelRef(context.Context) (*proto.GetActiveModelRefResponse, error) {
+	return &proto.GetActiveModelRefResponse{Model: p.activeModel}, nil
+}
+
+func (p *recordingProvider) SetActiveModel(_ context.Context, req *proto.SetActiveModelRequest) (*proto.SetActiveModelResponse, error) {
+	p.setModelCalls++
+	p.activeModel = &proto.AuthorizationModelRef{
+		Id:      req.GetModel().GetId(),
+		Version: req.GetModel().GetVersion(),
+	}
+	return &proto.SetActiveModelResponse{Model: p.activeModel}, nil
+}
+
+func (p *recordingProvider) ListActiveModelResourceTypes(_ context.Context, req *proto.ListActiveModelResourceTypesRequest) (*proto.ListActiveModelResourceTypesResponse, error) {
+	if req.GetPageToken() != "" {
+		return &proto.ListActiveModelResourceTypesResponse{}, nil
+	}
+	return &proto.ListActiveModelResourceTypesResponse{
+		ResourceTypes: append([]*proto.AuthorizationModelResourceType(nil), p.resourceTypes...),
+	}, nil
+}
+
+func (p *recordingProvider) Ping(context.Context) error { return nil }
+func (p *recordingProvider) Close() error               { return nil }
+
+var _ core.AuthorizationProvider = (*recordingProvider)(nil)
+
+func TestApplyIsIdempotentForExistingRelationships(t *testing.T) {
+	t.Parallel()
+
+	existing := &proto.Relationship{
+		Tuple: &proto.RelationshipTuple{
+			Resource: &proto.Resource{Type: "app", Id: "home"},
+			Relation: "admin",
+			Target: &proto.RelationshipTarget{
+				Kind: &proto.RelationshipTarget_Subject{
+					Subject: &proto.Subject{Type: "subject", Id: "user:alice"},
+				},
+			},
+		},
+	}
+	provider := &recordingProvider{relationships: []*proto.Relationship{existing}}
+	req := &proto.SetAuthorizationStateRequest{
+		Model: &proto.AuthorizationModel{
+			ResourceTypes: []*proto.AuthorizationModelResourceType{{
+				Name:        "app",
+				SourceLayer: proto.SourceLayer_SOURCE_LAYER_STATIC_CONFIG,
+			}},
+		},
+		Relationships: []*proto.Relationship{existing},
+	}
+
+	if _, err := Apply(context.Background(), provider, req); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if provider.addCalls != 0 {
+		t.Fatalf("add calls = %d, want 0 for existing relationship", provider.addCalls)
+	}
+	if provider.setModelCalls != 1 {
+		t.Fatalf("set model calls = %d, want 1", provider.setModelCalls)
+	}
+
+	if _, err := Apply(context.Background(), provider, req); err != nil {
+		t.Fatalf("Apply second time: %v", err)
+	}
+	if provider.addCalls != 0 {
+		t.Fatalf("add calls after second apply = %d, want 0", provider.addCalls)
+	}
+}
+
+func TestApplyAddsMissingRelationships(t *testing.T) {
+	t.Parallel()
+
+	provider := &recordingProvider{}
+	req := &proto.SetAuthorizationStateRequest{
+		Model: &proto.AuthorizationModel{
+			ResourceTypes: []*proto.AuthorizationModelResourceType{{
+				Name:        "app",
+				SourceLayer: proto.SourceLayer_SOURCE_LAYER_STATIC_CONFIG,
+			}},
+		},
+		Relationships: []*proto.Relationship{{
+			Tuple: &proto.RelationshipTuple{
+				Resource: &proto.Resource{Type: "app", Id: "home"},
+				Relation: "viewer",
+				Target: &proto.RelationshipTarget{
+					Kind: &proto.RelationshipTarget_SubjectSet{
+						SubjectSet: &proto.SubjectSet{
+							Resource: &proto.Resource{Type: "group", Id: "valon-employees"},
+							Relation: "member",
+						},
+					},
+				},
+			},
+		}},
+	}
+
+	if _, err := Apply(context.Background(), provider, req); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if provider.addCalls != 1 {
+		t.Fatalf("add calls = %d, want 1", provider.addCalls)
+	}
+	if len(provider.relationships) != 1 {
+		t.Fatalf("relationships = %d, want 1", len(provider.relationships))
+	}
+}

--- a/gestaltd/internal/authorizationstate/apply_test.go
+++ b/gestaltd/internal/authorizationstate/apply_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/core"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type recordingProvider struct {
@@ -71,6 +73,35 @@ func (p *recordingProvider) Ping(context.Context) error { return nil }
 func (p *recordingProvider) Close() error               { return nil }
 
 var _ core.AuthorizationProvider = (*recordingProvider)(nil)
+
+type notFoundResourceTypesProvider struct {
+	recordingProvider
+}
+
+func (p *notFoundResourceTypesProvider) ListActiveModelResourceTypes(context.Context, *proto.ListActiveModelResourceTypesRequest) (*proto.ListActiveModelResourceTypesResponse, error) {
+	return nil, status.Error(codes.NotFound, "no active model")
+}
+
+func TestApplySeedsStateWhenRuntimeModelResourceTypesAreMissing(t *testing.T) {
+	t.Parallel()
+
+	provider := &notFoundResourceTypesProvider{}
+	req := &proto.SetAuthorizationStateRequest{
+		Model: &proto.AuthorizationModel{
+			ResourceTypes: []*proto.AuthorizationModelResourceType{{
+				Name:        "app",
+				SourceLayer: proto.SourceLayer_SOURCE_LAYER_STATIC_CONFIG,
+			}},
+		},
+	}
+
+	if _, err := Apply(context.Background(), provider, req); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if provider.setModelCalls != 1 {
+		t.Fatalf("set model calls = %d, want 1", provider.setModelCalls)
+	}
+}
 
 func TestApplyIsIdempotentForExistingRelationships(t *testing.T) {
 	t.Parallel()

--- a/gestaltd/internal/server/handlers_authorization_apply.go
+++ b/gestaltd/internal/server/handlers_authorization_apply.go
@@ -14,6 +14,7 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
+// applyAuthorizationStateFullMethod reuses SetAuthorizationState policy until generated bindings include ApplyAuthorizationState.
 const applyAuthorizationStateFullMethod = proto.Authorization_SetAuthorizationState_FullMethodName
 
 func handleRESTApplyAuthorizationState(

--- a/gestaltd/internal/server/handlers_authorization_apply.go
+++ b/gestaltd/internal/server/handlers_authorization_apply.go
@@ -10,6 +10,7 @@ import (
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	"github.com/valon-technologies/gestalt/server/services/providergateway"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
 )
@@ -37,6 +38,12 @@ func handleRESTApplyAuthorizationState(
 	}
 
 	ctx := publicrpc.WithPublicOrigin(r.Context(), applyAuthorizationStateFullMethod)
+	existingMD, _ := metadata.FromIncomingContext(r.Context())
+	ctx = metadata.NewIncomingContext(ctx, metadata.Join(
+		existingMD,
+		httpHeadersToGRPCMetadata(r.Header),
+	))
+	ctx = stripInternalIdentityMetadata(ctx)
 	if _, _, err := transport.PreparePublicRequest(ctx, applyAuthorizationStateFullMethod, &protoReq); err != nil {
 		publicRESTErrorHandler(ctx, nil, nil, w, r, err)
 		return

--- a/gestaltd/internal/server/handlers_authorization_apply.go
+++ b/gestaltd/internal/server/handlers_authorization_apply.go
@@ -1,0 +1,60 @@
+package server
+
+import (
+	"io"
+	"net/http"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/authorizationstate"
+	"github.com/valon-technologies/gestalt/server/internal/publicrpc"
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"github.com/valon-technologies/gestalt/server/services/providergateway"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+const applyAuthorizationStateFullMethod = proto.Authorization_SetAuthorizationState_FullMethodName
+
+func handleRESTApplyAuthorizationState(
+	w http.ResponseWriter,
+	r *http.Request,
+	transport *providergateway.ProviderGatewayTransport,
+	provider core.AuthorizationProvider,
+) {
+	var protoReq proto.SetAuthorizationStateRequest
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		publicRESTErrorHandler(r.Context(), nil, nil, w, r, status.Errorf(codes.InvalidArgument, "%v", err))
+		return
+	}
+	if len(body) > 0 {
+		if err := protojson.Unmarshal(body, &protoReq); err != nil {
+			publicRESTErrorHandler(r.Context(), nil, nil, w, r, status.Errorf(codes.InvalidArgument, "%v", err))
+			return
+		}
+	}
+
+	ctx := publicrpc.WithPublicOrigin(r.Context(), applyAuthorizationStateFullMethod)
+	if _, _, err := transport.PreparePublicRequest(ctx, applyAuthorizationStateFullMethod, &protoReq); err != nil {
+		publicRESTErrorHandler(ctx, nil, nil, w, r, err)
+		return
+	}
+	if provider == nil {
+		publicRESTErrorHandler(ctx, nil, nil, w, r, status.Error(codes.FailedPrecondition, "authorization provider is not configured"))
+		return
+	}
+	resp, err := authorizationstate.Apply(ctx, provider, &protoReq)
+	if err != nil {
+		publicRESTErrorHandler(ctx, nil, nil, w, r, status.Errorf(codes.Internal, "%v", err))
+		return
+	}
+	data, err := protojson.Marshal(resp)
+	if err != nil {
+		publicRESTErrorHandler(ctx, nil, nil, w, r, status.Error(codes.Internal, "internal error"))
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(data)
+}

--- a/gestaltd/internal/server/public_rest.go
+++ b/gestaltd/internal/server/public_rest.go
@@ -64,6 +64,12 @@ func buildPublicGateway(cfg publicGRPCConfig) (*publicrpc.InProcessConn, http.Ha
 		conn.Close()
 		return nil, nil, err
 	}
+	if err := mux.HandlePath(http.MethodPost, "/api/v2/authorization/state:apply", func(w http.ResponseWriter, r *http.Request, _ map[string]string) {
+		handleRESTApplyAuthorizationState(w, r, cfg.Transport, cfg.Authorization)
+	}); err != nil {
+		conn.Close()
+		return nil, nil, err
+	}
 	return conn, subjectLabelRecorderMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		token, err := requestBearerTokenPreferringHeader(r)
 		if err == nil && token != "" {

--- a/sdk/proto/v1/authorization.proto
+++ b/sdk/proto/v1/authorization.proto
@@ -278,6 +278,17 @@ service Authorization {
     option (signature) = "relationships";
     option (signature) = "model";
   }
+  rpc ApplyAuthorizationState(SetAuthorizationStateRequest) returns (SetAuthorizationStateResponse) {
+    option (google.api.http) = {
+      post: "/api/v2/authorization/state:apply"
+      body: "*"
+    };
+    option (google.api.method_visibility) = {
+      restriction: "PUBLIC"
+    };
+    option (signature) = "relationships";
+    option (signature) = "model";
+  }
 
   rpc GetActiveModelRef(google.protobuf.Empty) returns (GetActiveModelRefResponse) {
     option (google.api.http) = {get: "/api/v2/authorization/models/active"};

--- a/sdk/proto/v1/authorization.proto
+++ b/sdk/proto/v1/authorization.proto
@@ -278,17 +278,6 @@ service Authorization {
     option (signature) = "relationships";
     option (signature) = "model";
   }
-  rpc ApplyAuthorizationState(SetAuthorizationStateRequest) returns (SetAuthorizationStateResponse) {
-    option (google.api.http) = {
-      post: "/api/v2/authorization/state:apply"
-      body: "*"
-    };
-    option (google.api.method_visibility) = {
-      restriction: "PUBLIC"
-    };
-    option (signature) = "relationships";
-    option (signature) = "model";
-  }
 
   rpc GetActiveModelRef(google.protobuf.Empty) returns (GetActiveModelRefResponse) {
     option (google.api.http) = {get: "/api/v2/authorization/models/active"};


### PR DESCRIPTION
## Summary
- Add `gestalt authorization relationships add|delete` for `authorization:admin` callers.
- Add idempotent `POST /api/v2/authorization/state:apply` and `gestalt authorization state apply --input-file` to merge model and relationship snapshots without wiping unrelated runtime state.
- Document `ApplyAuthorizationState` in `authorization.proto` (generated bindings to follow when buf regen is available).

## Test plan
- [x] `go test ./internal/authorizationstate/...`
- [x] `cargo test` (gestalt CLI compiles)
- [ ] `gestalt authorization relationships add` and `delete` against a dev gestaltd instance
- [ ] `gestalt authorization state apply --input-file snapshot.json` is idempotent on repeat
- [ ] Non-admin callers receive 403 on `state:apply`


Made with [Cursor](https://cursor.com)