### PR TITLE
Index SCIM relationship traffic and batch writes

### DIFF
--- a/gestaltd/internal/scim/authorization.go
+++ b/gestaltd/internal/scim/authorization.go
@@ -10,6 +10,8 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/coredata"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type authorizationGate struct {
@@ -97,8 +99,77 @@ func (g *authorizationGate) ListRelationships(ctx context.Context, req *proto.Li
 	return g.underlying.ListRelationships(ctx, req)
 }
 
+func (g *authorizationGate) WriteRelationships(ctx context.Context, req *proto.WriteRelationshipsRequest) (*proto.WriteRelationshipsResponse, error) {
+	writer, ok := g.underlying.(core.AuthorizationRelationshipWriter)
+	if !ok {
+		return nil, status.Error(codes.Unimplemented, "authorization relationship writes are not implemented")
+	}
+	if req == nil {
+		return writer.WriteRelationships(ctx, req)
+	}
+	affected := map[string]map[string]struct{}{}
+	runtimeChanges := map[string]struct{}{}
+	for _, update := range req.Updates {
+		if update == nil || update.Relationship == nil {
+			continue
+		}
+		relationship := update.Relationship
+		affectsRuntime := relationship.GetSourceLayer() == proto.SourceLayer_SOURCE_LAYER_RUNTIME
+		if update.Operation == proto.RelationshipUpdate_OPERATION_DELETE && relationship.GetSourceLayer() == proto.SourceLayer_SOURCE_LAYER_UNSPECIFIED {
+			var err error
+			affectsRuntime, err = g.scim.compact.relationshipPresent(ctx, relationship.GetTuple())
+			if err != nil {
+				return nil, err
+			}
+		}
+		if !affectsRuntime {
+			continue
+		}
+		runtimeChanges[tupleKey(relationship.GetTuple())] = struct{}{}
+		if update.Operation == proto.RelationshipUpdate_OPERATION_DELETE {
+			if err := g.scim.compact.captureRelationshipAffectedUsers(ctx, relationship.GetTuple(), affected); err != nil {
+				return nil, err
+			}
+		}
+	}
+	response, err := writer.WriteRelationships(ctx, req)
+	if err != nil {
+		return response, err
+	}
+	ids := map[string]struct{}{}
+	seen := map[string]struct{}{}
+	for _, update := range req.Updates {
+		if update == nil || update.Relationship == nil {
+			continue
+		}
+		tuple := update.Relationship.GetTuple()
+		key := tupleKey(tuple)
+		if _, affectsRuntime := runtimeChanges[key]; !affectsRuntime {
+			continue
+		}
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		touch, err := g.scim.compact.relationshipTouchIDs(ctx, tuple)
+		if err != nil {
+			return response, err
+		}
+		for id := range touch {
+			ids[id] = struct{}{}
+		}
+	}
+	if err := g.scim.compact.collectClientCoreUserTouchIDs(ctx, affected, ids); err != nil {
+		return response, err
+	}
+	if err := g.scim.compact.touchRows(ctx, ids); err != nil {
+		return response, err
+	}
+	return response, nil
+}
+
 func (g *authorizationGate) AddRelationship(ctx context.Context, req *proto.AddRelationshipRequest) (*proto.AddRelationshipResponse, error) {
-	if req == nil || req.Relationship == nil || req.Relationship.Tuple == nil {
+	if req == nil || req.Relationship == nil || req.Relationship.Tuple == nil || req.Relationship.GetSourceLayer() != proto.SourceLayer_SOURCE_LAYER_RUNTIME {
 		return g.underlying.AddRelationship(ctx, req)
 	}
 	before, beforeErr := g.scim.compact.relationshipPresent(ctx, req.Relationship.Tuple)
@@ -133,12 +204,20 @@ func (g *authorizationGate) DeleteRelationship(ctx context.Context, req *proto.D
 		return response, err
 	}
 	after, afterErr := g.scim.compact.relationshipPresent(ctx, req.RelationshipTuple)
+	ids := map[string]struct{}{}
 	if idempotent || beforeErr != nil || afterErr != nil || before != after {
-		if touchErr := g.scim.compact.touchRelationship(ctx, req.RelationshipTuple); touchErr != nil {
+		touch, touchErr := g.scim.compact.relationshipTouchIDs(ctx, req.RelationshipTuple)
+		if touchErr != nil {
 			return response, touchErr
 		}
+		for id := range touch {
+			ids[id] = struct{}{}
+		}
 	}
-	if err := g.scim.compact.touchCoreUsersByClient(ctx, affected); err != nil {
+	if err := g.scim.compact.collectClientCoreUserTouchIDs(ctx, affected, ids); err != nil {
+		return response, err
+	}
+	if err := g.scim.compact.touchRows(ctx, ids); err != nil {
 		return response, err
 	}
 	return response, nil
@@ -167,17 +246,29 @@ func (g *authorizationGate) SetAuthorizationState(ctx context.Context, req *prot
 		return response, err
 	}
 	if g.scim != nil && g.scim.compact != nil {
+		ids := map[string]struct{}{}
 		for _, relationship := range changed.added {
-			if touchErr := g.scim.compact.touchRelationship(ctx, relationship.GetTuple()); touchErr != nil {
+			touch, touchErr := g.scim.compact.relationshipTouchIDs(ctx, relationship.GetTuple())
+			if touchErr != nil {
 				return response, touchErr
+			}
+			for id := range touch {
+				ids[id] = struct{}{}
 			}
 		}
 		for _, relationship := range changed.removed {
-			if touchErr := g.scim.compact.touchRelationship(ctx, relationship.GetTuple()); touchErr != nil {
+			touch, touchErr := g.scim.compact.relationshipTouchIDs(ctx, relationship.GetTuple())
+			if touchErr != nil {
 				return response, touchErr
 			}
+			for id := range touch {
+				ids[id] = struct{}{}
+			}
 		}
-		if touchErr := g.scim.compact.touchCoreUsersByClient(ctx, affected); touchErr != nil {
+		if touchErr := g.scim.compact.collectClientCoreUserTouchIDs(ctx, affected, ids); touchErr != nil {
+			return response, touchErr
+		}
+		if touchErr := g.scim.compact.touchRows(ctx, ids); touchErr != nil {
 			return response, touchErr
 		}
 	}

--- a/gestaltd/internal/scim/compact_groups.go
+++ b/gestaltd/internal/scim/compact_groups.go
@@ -55,23 +55,29 @@ func (s *CompactService) liveMembers(ctx context.Context, cid, gid string) ([]Me
 	if e != nil {
 		return nil, e
 	}
-	users, err := s.listRecords(ctx, cid, "User")
-	if err != nil {
-		return nil, err
-	}
-	byCore := map[string]idb.Record{}
-	for _, u := range users {
-		byCore[recordString(u, "core_user_id")] = u
-	}
 	out := []Member{}
+	seen := map[string]struct{}{}
 	for _, x := range rs {
+		if x.GetSourceLayer() != proto.SourceLayer_SOURCE_LAYER_RUNTIME {
+			continue
+		}
 		t := x.GetTuple().GetTarget()
 		if sub := t.GetSubject(); sub != nil && strings.HasPrefix(sub.Id, "user:") {
-			u, ok := byCore[strings.TrimPrefix(sub.Id, "user:")]
-			if !ok {
+			users, err := s.db.ObjectStore(coredata.StoreSCIMResources).Index("by_client_core_user").GetAll(ctx, []any{cid, "User", strings.TrimPrefix(sub.Id, "user:")})
+			if err != nil {
+				return nil, err
+			}
+			if len(users) != 1 {
 				continue
 			}
-			out = append(out, Member{Value: recordString(u, "id"), Ref: s.baseURL + "/scim/v2/Users/" + recordString(u, "id"), Type: "User"})
+			u := users[0]
+			member := Member{Value: recordString(u, "id"), Ref: s.baseURL + "/scim/v2/Users/" + recordString(u, "id"), Type: "User"}
+			key := member.Type + "\x00" + member.Value
+			if _, exists := seen[key]; exists {
+				continue
+			}
+			seen[key] = struct{}{}
+			out = append(out, member)
 		} else if ss := t.GetSubjectSet(); ss != nil && ss.Resource != nil {
 			gr, e := s.findGroup(ctx, cid, ss.Resource.Id)
 			if e != nil {
@@ -80,7 +86,13 @@ func (s *CompactService) liveMembers(ctx context.Context, cid, gid string) ([]Me
 				}
 				continue
 			}
-			out = append(out, Member{Value: gr.ID, Ref: s.baseURL + "/scim/v2/Groups/" + gr.ID, Type: "Group"})
+			member := Member{Value: gr.ID, Ref: s.baseURL + "/scim/v2/Groups/" + gr.ID, Type: "Group"}
+			key := member.Type + "\x00" + member.Value
+			if _, exists := seen[key]; exists {
+				continue
+			}
+			seen[key] = struct{}{}
+			out = append(out, member)
 		}
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Value < out[j].Value })
@@ -134,6 +146,35 @@ func (s *CompactService) tuplesForMembers(ctx context.Context, cid, gid string, 
 	sort.Slice(out, func(i, j int) bool { return tupleKey(out[i]) < tupleKey(out[j]) })
 	return out, nil
 }
+
+func (s *CompactService) actualGroupTuples(ctx context.Context, cid, gid string, members []Member) ([]*proto.RelationshipTuple, error) {
+	desired, err := s.tuplesForMembers(ctx, cid, gid, members)
+	if err != nil {
+		return nil, err
+	}
+	logical := make(map[string]struct{}, len(desired))
+	for _, tuple := range desired {
+		logical[tupleKey(tuple)] = struct{}{}
+	}
+	relationships, err := s.listRelationships(ctx, &proto.RelationshipFilter{
+		Resource: &proto.Resource{Type: "group", Id: gid}, Relation: "member", SourceLayer: proto.SourceLayer_SOURCE_LAYER_RUNTIME,
+	}, 100)
+	if err != nil {
+		return nil, err
+	}
+	actual := make([]*proto.RelationshipTuple, 0, len(relationships))
+	for _, relationship := range relationships {
+		if relationship.GetSourceLayer() != proto.SourceLayer_SOURCE_LAYER_RUNTIME {
+			continue
+		}
+		if _, ok := logical[tupleKey(relationship.GetTuple())]; ok {
+			actual = append(actual, relationship.GetTuple())
+		}
+	}
+	sort.SliceStable(actual, func(i, j int) bool { return physicalTupleKey(actual[i]) < physicalTupleKey(actual[j]) })
+	return actual, nil
+}
+
 func (s *CompactService) CreateGroup(ctx context.Context, cid string, in groupInput) (*Group, error) {
 	if err := validateResourceSchemas(in.Schemas, GroupSchemaURN); err != nil {
 		return nil, err
@@ -201,29 +242,116 @@ func (s *CompactService) listGroups(ctx context.Context, cid, raw string, start,
 		return listResponse[Group]{}, unavailable("could not list SCIM groups")
 	}
 	sort.Slice(rs, func(i, j int) bool { return recordString(rs[i], "id") < recordString(rs[j], "id") })
-	all := []Group{}
+	storedClauses := make([]groupFilterClause, 0, len(clauses))
+	memberClauses := make([]groupFilterClause, 0, len(clauses))
+	for _, clause := range clauses {
+		if clause.attribute == "members.value" {
+			memberClauses = append(memberClauses, clause)
+		} else {
+			storedClauses = append(storedClauses, clause)
+		}
+	}
+	knownGroupIDs := make(map[string]struct{}, len(rs))
+	for _, row := range rs {
+		knownGroupIDs[recordString(row, "id")] = struct{}{}
+	}
+	allowedGroups := map[string]struct{}{}
+	if len(memberClauses) > 0 {
+		for i, clause := range memberClauses {
+			target, ok, err := s.groupMemberTarget(ctx, cid, clause.value)
+			if err != nil {
+				return listResponse[Group]{}, unavailable("could not validate group member")
+			}
+			if !ok {
+				return listResponse[Group]{Schemas: []string{ListSchemaURN}, TotalResults: 0, StartIndex: 1, ItemsPerPage: 0, Resources: []Group{}}, nil
+			}
+			relations, err := s.listRelationships(ctx, &proto.RelationshipFilter{Target: target, Relation: "member", SourceLayer: proto.SourceLayer_SOURCE_LAYER_RUNTIME}, 100)
+			if err != nil {
+				return listResponse[Group]{}, unavailable("could not read group membership")
+			}
+			current := map[string]struct{}{}
+			for _, relationship := range relations {
+				if relationship.GetSourceLayer() != proto.SourceLayer_SOURCE_LAYER_RUNTIME || !sameRelationshipTarget(relationship.GetTuple().GetTarget(), target) {
+					continue
+				}
+				resource := relationship.GetTuple().GetResource()
+				if resource.GetType() == "group" {
+					if _, exists := knownGroupIDs[resource.GetId()]; exists {
+						current[resource.GetId()] = struct{}{}
+					}
+				}
+			}
+			if i == 0 {
+				allowedGroups = current
+			} else {
+				for groupID := range allowedGroups {
+					if _, exists := current[groupID]; !exists {
+						delete(allowedGroups, groupID)
+					}
+				}
+			}
+		}
+	}
+	matching := make([]idb.Record, 0, len(rs))
 	for _, rr := range rs {
 		g := stored(rr)
-		v, e := s.groupValue(ctx, g)
-		if e != nil {
-			return listResponse[Group]{}, e
+		if !matchesStoredGroupFilter(persistedGroup{ExternalID: g.ExternalID, DisplayName: g.DisplayName}, storedClauses) {
+			continue
 		}
-		if matchesGroupFilter(persistedGroup{ExternalID: g.ExternalID, DisplayName: g.DisplayName, Members: v.Members}, clauses) {
-			all = append(all, v)
+		if len(memberClauses) > 0 {
+			if _, ok := allowedGroups[g.ID]; !ok {
+				continue
+			}
 		}
+		matching = append(matching, rr)
 	}
-	if start > len(all)+1 {
-		start = len(all) + 1
+	if start > len(matching)+1 {
+		start = len(matching) + 1
 	}
-	end := pageMin(start-1+count, len(all))
+	end := pageMin(start-1+count, len(matching))
 	if end < start-1 {
 		end = start - 1
 	}
-	n := end - start + 1
-	if n < 0 {
-		n = 0
+	page := matching[start-1 : end]
+	all := make([]Group, 0, len(page))
+	for _, rr := range page {
+		v, err := s.groupValue(ctx, stored(rr))
+		if err != nil {
+			return listResponse[Group]{}, err
+		}
+		all = append(all, v)
 	}
-	return listResponse[Group]{Schemas: []string{ListSchemaURN}, TotalResults: len(all), StartIndex: start, ItemsPerPage: n, Resources: all[start-1 : end]}, nil
+	return listResponse[Group]{Schemas: []string{ListSchemaURN}, TotalResults: len(matching), StartIndex: start, ItemsPerPage: len(all), Resources: all}, nil
+}
+
+func matchesStoredGroupFilter(group persistedGroup, clauses []groupFilterClause) bool {
+	for _, clause := range clauses {
+		switch clause.attribute {
+		case "displayname":
+			if normalize(group.DisplayName) != clause.value {
+				return false
+			}
+		case "externalid":
+			if group.ExternalID != clause.value {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func (s *CompactService) groupMemberTarget(ctx context.Context, cid, value string) (*proto.RelationshipTarget, bool, error) {
+	if user, err := s.findUser(ctx, cid, value); err == nil {
+		return &proto.RelationshipTarget{Kind: &proto.RelationshipTarget_Subject{Subject: &proto.Subject{Type: "subject", Id: "user:" + user.CoreUserID}}}, true, nil
+	} else if !errors.Is(err, idb.ErrNotFound) {
+		return nil, false, err
+	}
+	if group, err := s.findGroup(ctx, cid, value); err == nil {
+		return &proto.RelationshipTarget{Kind: &proto.RelationshipTarget_SubjectSet{SubjectSet: &proto.SubjectSet{Resource: &proto.Resource{Type: "group", Id: group.ID}, Relation: "member"}}}, true, nil
+	} else if !errors.Is(err, idb.ErrNotFound) {
+		return nil, false, err
+	}
+	return nil, false, nil
 }
 func (s *CompactService) mutateGroup(ctx context.Context, cid, id, ifm string, in groupInput) (*Group, error) {
 	unlock := s.lock(id)
@@ -262,7 +390,7 @@ func (s *CompactService) mutateGroupLocked(ctx context.Context, cid, id, ifm str
 	if e := validateRetainedMemberAttributes(old.Members, next.Members); e != nil {
 		return nil, e
 	}
-	from, e := s.tuplesForMembers(ctx, cid, id, old.Members)
+	from, e := s.actualGroupTuples(ctx, cid, id, old.Members)
 	if e != nil {
 		return nil, e
 	}
@@ -338,15 +466,19 @@ func (s *CompactService) mutateGroupLocked(ctx context.Context, cid, id, ifm str
 }
 
 func sameTuples(a, b []*proto.RelationshipTuple) bool {
-	if len(a) != len(b) {
+	left := make(map[string]struct{}, len(a))
+	for _, tuple := range a {
+		left[tupleKey(tuple)] = struct{}{}
+	}
+	right := make(map[string]struct{}, len(b))
+	for _, tuple := range b {
+		right[tupleKey(tuple)] = struct{}{}
+	}
+	if len(left) != len(right) {
 		return false
 	}
-	seen := make(map[string]struct{}, len(a))
-	for _, tuple := range a {
-		seen[tupleKey(tuple)] = struct{}{}
-	}
-	for _, tuple := range b {
-		if _, ok := seen[tupleKey(tuple)]; !ok {
+	for key := range left {
+		if _, ok := right[key]; !ok {
 			return false
 		}
 	}
@@ -433,19 +565,6 @@ func (s *CompactService) DeleteGroup(ctx context.Context, cid, id, ifm string) e
 // references for exactly the group being deleted. Deleting the group makes
 // both kinds of references invalid; unrelated resources are not inspected.
 func (s *CompactService) removeGroupRelationships(ctx context.Context, clientID, groupID string) error {
-	outgoing, err := s.listRelationships(ctx, &proto.RelationshipFilter{Resource: &proto.Resource{Type: "group", Id: groupID}, Relation: "member", SourceLayer: proto.SourceLayer_SOURCE_LAYER_RUNTIME}, 100)
-	if err != nil {
-		return err
-	}
-	for _, relationship := range outgoing {
-		if err := s.deleteRelationship(ctx, relationship.GetTuple()); err != nil {
-			return err
-		}
-	}
-	incoming, err := s.listRelationships(ctx, &proto.RelationshipFilter{Relation: "member", SourceLayer: proto.SourceLayer_SOURCE_LAYER_RUNTIME}, 100)
-	if err != nil {
-		return err
-	}
 	groups, err := s.listRecords(ctx, clientID, "Group")
 	if err != nil {
 		return err
@@ -454,18 +573,39 @@ func (s *CompactService) removeGroupRelationships(ctx context.Context, clientID,
 	for _, row := range groups {
 		knownGroups[recordString(row, "id")] = struct{}{}
 	}
+	outgoing, err := s.listRelationships(ctx, &proto.RelationshipFilter{Resource: &proto.Resource{Type: "group", Id: groupID}, Relation: "member", SourceLayer: proto.SourceLayer_SOURCE_LAYER_RUNTIME}, 100)
+	if err != nil {
+		return err
+	}
+	target := &proto.RelationshipTarget{Kind: &proto.RelationshipTarget_SubjectSet{SubjectSet: &proto.SubjectSet{Resource: &proto.Resource{Type: "group", Id: groupID}, Relation: "member"}}}
+	incoming, err := s.listRelationships(ctx, &proto.RelationshipFilter{Target: target, Relation: "member", SourceLayer: proto.SourceLayer_SOURCE_LAYER_RUNTIME}, 100)
+	if err != nil {
+		return err
+	}
+	seen := map[string]*proto.RelationshipTuple{}
+	for _, relationship := range outgoing {
+		if relationship.GetSourceLayer() == proto.SourceLayer_SOURCE_LAYER_RUNTIME && relationship.GetTuple().GetResource().GetType() == "group" && relationship.GetTuple().GetResource().GetId() == groupID {
+			seen[physicalTupleKey(relationship.GetTuple())] = relationship.GetTuple()
+		}
+	}
 	for _, relationship := range incoming {
+		if relationship.GetSourceLayer() != proto.SourceLayer_SOURCE_LAYER_RUNTIME || !sameRelationshipTarget(relationship.GetTuple().GetTarget(), target) {
+			continue
+		}
 		tuple := relationship.GetTuple()
 		if _, ok := knownGroups[tuple.GetResource().GetId()]; !ok {
 			continue
 		}
-		set := tuple.GetTarget().GetSubjectSet()
-		if set == nil || set.GetResource().GetType() != "group" || set.GetResource().GetId() != groupID || set.GetRelation() != "member" {
-			continue
-		}
-		if err := s.deleteRelationship(ctx, tuple); err != nil {
-			return err
-		}
+		seen[physicalTupleKey(tuple)] = tuple
 	}
-	return nil
+	keys := make([]string, 0, len(seen))
+	for key := range seen {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	tuples := make([]*proto.RelationshipTuple, 0, len(keys))
+	for _, key := range keys {
+		tuples = append(tuples, seen[key])
+	}
+	return s.apply(ctx, tuples, nil)
 }

--- a/gestaltd/internal/scim/compact_relationships_test.go
+++ b/gestaltd/internal/scim/compact_relationships_test.go
@@ -1,0 +1,386 @@
+package scim_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/scim"
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	gproto "google.golang.org/protobuf/proto"
+)
+
+type relationshipWriterMode int
+
+const (
+	relationshipWriterWorks relationshipWriterMode = iota
+	relationshipWriterUnimplemented
+	relationshipWriterFails
+)
+
+type batchRecordingAuthorization struct {
+	*recordingAuthorization
+	mode   relationshipWriterMode
+	writes [][]*proto.RelationshipUpdate
+}
+
+func (a *batchRecordingAuthorization) WriteRelationships(_ context.Context, req *proto.WriteRelationshipsRequest) (*proto.WriteRelationshipsResponse, error) {
+	a.mu.Lock()
+	updates := make([]*proto.RelationshipUpdate, 0, len(req.GetUpdates()))
+	for _, update := range req.GetUpdates() {
+		updates = append(updates, gproto.Clone(update).(*proto.RelationshipUpdate))
+	}
+	a.writes = append(a.writes, updates)
+	mode := a.mode
+	a.mu.Unlock()
+	if mode == relationshipWriterUnimplemented {
+		return nil, status.Error(codes.Unimplemented, "writer unavailable")
+	}
+	if mode == relationshipWriterFails {
+		return nil, errors.New("injected writer failure")
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	for _, update := range req.GetUpdates() {
+		if update.GetOperation() == proto.RelationshipUpdate_OPERATION_DELETE {
+			delete(a.relations, relationshipKey(update.GetRelationship().GetTuple()))
+			continue
+		}
+		a.relations[relationshipKey(update.GetRelationship().GetTuple())] = gproto.Clone(update.GetRelationship()).(*proto.Relationship)
+	}
+	return &proto.WriteRelationshipsResponse{}, nil
+}
+
+func TestSCIMAtomicRelationshipBatchUsesOneWriter(t *testing.T) {
+	t.Parallel()
+
+	authorization := &batchRecordingAuthorization{recordingAuthorization: newRecordingAuthorization()}
+	cfg := testSCIMConfig(map[string]config.SCIMClientConfig{"rippling": ripplingClient(nil)})
+	_, _, handler := newSCIMService(t, nil, authorization, cfg)
+	alice, response := createUser(t, handler, testCurrentToken, "batch-alice@valon.com", true, nil)
+	if response.Code != 201 {
+		t.Fatalf("create Alice = %d %s", response.Code, response.Body.String())
+	}
+	bob, response := createUser(t, handler, testCurrentToken, "batch-bob@valon.com", true, nil)
+	if response.Code != 201 {
+		t.Fatalf("create Bob = %d %s", response.Code, response.Body.String())
+	}
+	authorization.mu.Lock()
+	writesBefore := len(authorization.writes)
+	authorization.mu.Unlock()
+	groupResponse := scimRequest(t, handler, "POST", "/scim/v2/Groups", testCurrentToken, map[string]any{
+		"schemas": []string{scim.GroupSchemaURN}, "displayName": "Batch group", "members": []map[string]any{{"value": alice.ID}, {"value": bob.ID}},
+	})
+	if groupResponse.Code != 201 {
+		t.Fatalf("create group = %d %s", groupResponse.Code, groupResponse.Body.String())
+	}
+	authorization.mu.Lock()
+	if len(authorization.writes) == writesBefore {
+		authorization.mu.Unlock()
+		t.Fatal("group batch did not invoke the relationship writer")
+	}
+	lastWrite := authorization.writes[len(authorization.writes)-1]
+	writeCalls := len(authorization.writes) - writesBefore
+	authorization.mu.Unlock()
+	if writeCalls != 1 || len(lastWrite) != 2 {
+		t.Fatalf("group batch writes = %d calls, %#v updates", writeCalls, lastWrite)
+	}
+	for _, update := range lastWrite {
+		if update.GetRelationship().GetSourceLayer() != proto.SourceLayer_SOURCE_LAYER_RUNTIME {
+			t.Fatalf("batch source layer = %v, want runtime", update.GetRelationship().GetSourceLayer())
+		}
+		if update.GetOperation() != proto.RelationshipUpdate_OPERATION_TOUCH {
+			t.Fatalf("group create operation = %v, want TOUCH", update.GetOperation())
+		}
+	}
+}
+
+func TestSCIMRelationshipBatchOrderAndEmptyDiff(t *testing.T) {
+	t.Parallel()
+
+	authorization := &batchRecordingAuthorization{recordingAuthorization: newRecordingAuthorization()}
+	cfg := testSCIMConfig(map[string]config.SCIMClientConfig{"rippling": ripplingClient(nil)})
+	_, _, handler := newSCIMService(t, nil, authorization, cfg)
+	alice, response := createUser(t, handler, testCurrentToken, "order-alice@valon.com", true, nil)
+	if response.Code != http.StatusCreated {
+		t.Fatalf("create Alice = %d %s", response.Code, response.Body.String())
+	}
+	bob, response := createUser(t, handler, testCurrentToken, "order-bob@valon.com", true, nil)
+	if response.Code != http.StatusCreated {
+		t.Fatalf("create Bob = %d %s", response.Code, response.Body.String())
+	}
+	groupResponse := scimRequest(t, handler, http.MethodPost, "/scim/v2/Groups", testCurrentToken, map[string]any{
+		"schemas": []string{scim.GroupSchemaURN}, "displayName": "Order group", "members": []map[string]any{{"value": alice.ID}},
+	})
+	group := decodeResponse[scim.Group](t, groupResponse)
+	if groupResponse.Code != http.StatusCreated {
+		t.Fatalf("create order group = %d %s", groupResponse.Code, groupResponse.Body.String())
+	}
+	if response = scimRequest(t, handler, http.MethodPut, "/scim/v2/Groups/"+group.ID, testCurrentToken, map[string]any{
+		"schemas": []string{scim.GroupSchemaURN}, "displayName": group.DisplayName, "members": []map[string]any{{"value": bob.ID}},
+	}, map[string]string{"If-Match": group.Meta.Version}); response.Code != http.StatusOK {
+		t.Fatalf("replace order group = %d %s", response.Code, response.Body.String())
+	}
+	authorization.mu.Lock()
+	updates := authorization.writes[len(authorization.writes)-1]
+	writes := len(authorization.writes)
+	authorization.mu.Unlock()
+	if len(updates) != 2 || updates[0].GetOperation() != proto.RelationshipUpdate_OPERATION_DELETE || updates[1].GetOperation() != proto.RelationshipUpdate_OPERATION_TOUCH {
+		t.Fatalf("replacement updates = %#v, want DELETE then TOUCH", updates)
+	}
+	current := decodeResponse[scim.Group](t, response)
+	if response = scimRequest(t, handler, http.MethodPut, "/scim/v2/Groups/"+current.ID, testCurrentToken, map[string]any{
+		"schemas": []string{scim.GroupSchemaURN}, "displayName": current.DisplayName, "members": []map[string]any{{"value": bob.ID}},
+	}, map[string]string{"If-Match": current.Meta.Version}); response.Code != http.StatusOK {
+		t.Fatalf("empty-diff group replacement = %d %s", response.Code, response.Body.String())
+	}
+	authorization.mu.Lock()
+	defer authorization.mu.Unlock()
+	if len(authorization.writes) != writes {
+		t.Fatalf("empty diff writer calls = %d, want %d", len(authorization.writes), writes)
+	}
+}
+
+func TestSCIMRelationshipWriterFallsBackOnlyForUnimplemented(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		mode       relationshipWriterMode
+		wantStatus int
+		wantAdds   int
+	}{
+		{name: "supported", mode: relationshipWriterWorks, wantStatus: http.StatusCreated},
+		{name: "unimplemented", mode: relationshipWriterUnimplemented, wantStatus: http.StatusCreated, wantAdds: 1},
+		{name: "other error", mode: relationshipWriterFails, wantStatus: http.StatusServiceUnavailable},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			authorization := &batchRecordingAuthorization{recordingAuthorization: newRecordingAuthorization(), mode: test.mode}
+			cfg := testSCIMConfig(map[string]config.SCIMClientConfig{"rippling": ripplingClient(nil)})
+			_, _, handler := newSCIMService(t, nil, authorization, cfg)
+			user, response := createUser(t, handler, testCurrentToken, "fallback-"+test.name+"@valon.com", true, nil)
+			if response.Code != http.StatusCreated {
+				t.Fatalf("create user = %d %s", response.Code, response.Body.String())
+			}
+			groupResponse := scimRequest(t, handler, http.MethodPost, "/scim/v2/Groups", testCurrentToken, map[string]any{
+				"schemas": []string{scim.GroupSchemaURN}, "displayName": "Fallback " + test.name, "members": []map[string]any{{"value": user.ID}},
+			})
+			if groupResponse.Code != test.wantStatus {
+				t.Fatalf("create group = %d %s, want %d", groupResponse.Code, groupResponse.Body.String(), test.wantStatus)
+			}
+			authorization.mu.Lock()
+			writeCalls := len(authorization.writes)
+			authorization.mu.Unlock()
+			if writeCalls != 1 {
+				t.Fatalf("writer calls = %d, want 1", writeCalls)
+			}
+			if got := authorization.additionCount(); got != test.wantAdds {
+				t.Fatalf("legacy additions = %d, want %d", got, test.wantAdds)
+			}
+		})
+	}
+}
+
+func TestSCIMLegacyFallbackTouchesSuccessfulPrefixOnFailure(t *testing.T) {
+	t.Parallel()
+
+	authorization := &batchRecordingAuthorization{
+		recordingAuthorization: newRecordingAuthorization(),
+		mode:                   relationshipWriterUnimplemented,
+	}
+	cfg := testSCIMConfig(map[string]config.SCIMClientConfig{"rippling": ripplingClient(nil)})
+	_, _, handler := newSCIMService(t, nil, authorization, cfg)
+	alice, response := createUser(t, handler, testCurrentToken, "prefix-alice@valon.com", true, nil)
+	if response.Code != http.StatusCreated {
+		t.Fatalf("create Alice = %d %s", response.Code, response.Body.String())
+	}
+	bob, response := createUser(t, handler, testCurrentToken, "prefix-bob@valon.com", true, nil)
+	if response.Code != http.StatusCreated {
+		t.Fatalf("create Bob = %d %s", response.Code, response.Body.String())
+	}
+	groupResponse := scimRequest(t, handler, http.MethodPost, "/scim/v2/Groups", testCurrentToken, map[string]any{
+		"schemas": []string{scim.GroupSchemaURN}, "displayName": "Fallback prefix",
+	})
+	group := decodeResponse[scim.Group](t, groupResponse)
+	if groupResponse.Code != http.StatusCreated {
+		t.Fatalf("create empty group = %d %s", groupResponse.Code, groupResponse.Body.String())
+	}
+	before := map[string]scim.Meta{}
+	for _, user := range []*scim.User{alice, bob} {
+		read := decodeResponse[scim.User](t, scimRequest(t, handler, http.MethodGet, "/scim/v2/Users/"+user.ID, testCurrentToken, nil))
+		before[user.ID] = read.Meta
+	}
+	authorization.setFailureAt(2, 0)
+	authorization.mu.Lock()
+	writesBefore := len(authorization.writes)
+	authorization.mu.Unlock()
+
+	replacement := scimRequest(t, handler, http.MethodPut, "/scim/v2/Groups/"+group.ID, testCurrentToken, map[string]any{
+		"schemas": []string{scim.GroupSchemaURN}, "displayName": group.DisplayName, "members": []map[string]any{{"value": alice.ID}, {"value": bob.ID}},
+	}, map[string]string{"If-Match": group.Meta.Version})
+	if replacement.Code != http.StatusServiceUnavailable {
+		t.Fatalf("partial fallback group replacement = %d %s, want 503", replacement.Code, replacement.Body.String())
+	}
+	authorization.mu.Lock()
+	writeCalls := len(authorization.writes) - writesBefore
+	authorization.mu.Unlock()
+	if writeCalls != 1 {
+		t.Fatalf("fallback writer calls = %d, want 1", writeCalls)
+	}
+	groupAfter := decodeResponse[scim.Group](t, scimRequest(t, handler, http.MethodGet, "/scim/v2/Groups/"+group.ID, testCurrentToken, nil))
+	if groupAfter.Meta.Version == group.Meta.Version || len(groupAfter.Members) != 1 {
+		t.Fatalf("successful legacy prefix group projection = %#v", groupAfter)
+	}
+	memberID := groupAfter.Members[0].Value
+	memberAfter := decodeResponse[scim.User](t, scimRequest(t, handler, http.MethodGet, "/scim/v2/Users/"+memberID, testCurrentToken, nil))
+	if !memberAfter.Meta.LastModified.After(before[memberID].LastModified) {
+		t.Fatalf("successful legacy prefix did not advance affected user metadata = before %#v after %#v", before[memberID], memberAfter.Meta)
+	}
+	if len(memberAfter.Groups) != 1 || memberAfter.Groups[0].Value != group.ID {
+		t.Fatalf("successful legacy prefix was not visible through the affected user = %#v", memberAfter.Groups)
+	}
+}
+
+func TestSCIMSupportedRelationshipWriterDowngradesAfterUnimplemented(t *testing.T) {
+	t.Parallel()
+
+	authorization := &batchRecordingAuthorization{recordingAuthorization: newRecordingAuthorization(), mode: relationshipWriterWorks}
+	cfg := testSCIMConfig(map[string]config.SCIMClientConfig{"rippling": ripplingClient(nil)})
+	_, _, handler := newSCIMService(t, nil, authorization, cfg)
+	user, response := createUser(t, handler, testCurrentToken, "downgrade@valon.com", true, nil)
+	if response.Code != http.StatusCreated {
+		t.Fatalf("create user = %d %s", response.Code, response.Body.String())
+	}
+	createGroup := func(name string) {
+		t.Helper()
+		response := scimRequest(t, handler, http.MethodPost, "/scim/v2/Groups", testCurrentToken, map[string]any{
+			"schemas": []string{scim.GroupSchemaURN}, "displayName": name, "members": []map[string]any{{"value": user.ID}},
+		})
+		if response.Code != http.StatusCreated {
+			t.Fatalf("create %s = %d %s", name, response.Code, response.Body.String())
+		}
+	}
+	createGroup("Supported")
+	authorization.mu.Lock()
+	authorization.mode = relationshipWriterUnimplemented
+	authorization.mu.Unlock()
+	createGroup("Downgrade")
+	authorization.mu.Lock()
+	writerCalls := len(authorization.writes)
+	authorization.mu.Unlock()
+	if writerCalls != 2 {
+		t.Fatalf("writer calls after downgrade = %d, want 2", writerCalls)
+	}
+	createGroup("Cached fallback")
+	authorization.mu.Lock()
+	writerCalls = len(authorization.writes)
+	authorization.mu.Unlock()
+	if writerCalls != 2 {
+		t.Fatalf("cached unsupported writer calls = %d, want 2", writerCalls)
+	}
+	if got := authorization.additionCount(); got != 2 {
+		t.Fatalf("legacy additions after downgrade = %d, want 2", got)
+	}
+}
+
+func TestSCIMExternalRelationshipBatchUsesOneWriterAndUpdatesSCIMResources(t *testing.T) {
+	t.Parallel()
+
+	authorization := &batchRecordingAuthorization{recordingAuthorization: newRecordingAuthorization()}
+	cfg := testSCIMConfig(map[string]config.SCIMClientConfig{"rippling": ripplingClient(nil)})
+	service, services, handler := newSCIMService(t, nil, authorization, cfg)
+	alice, response := createUser(t, handler, testCurrentToken, "external-batch-alice@valon.com", true, nil)
+	if response.Code != http.StatusCreated {
+		t.Fatalf("create Alice = %d %s", response.Code, response.Body.String())
+	}
+	bob, response := createUser(t, handler, testCurrentToken, "external-batch-bob@valon.com", true, nil)
+	if response.Code != http.StatusCreated {
+		t.Fatalf("create Bob = %d %s", response.Code, response.Body.String())
+	}
+	groupResponse := scimRequest(t, handler, http.MethodPost, "/scim/v2/Groups", testCurrentToken, map[string]any{
+		"schemas": []string{scim.GroupSchemaURN}, "displayName": "External batch",
+	})
+	group := decodeResponse[scim.Group](t, groupResponse)
+	if groupResponse.Code != http.StatusCreated {
+		t.Fatalf("create group = %d %s", groupResponse.Code, groupResponse.Body.String())
+	}
+	groupBefore := decodeResponse[scim.Group](t, scimRequest(t, handler, http.MethodGet, "/scim/v2/Groups/"+group.ID, testCurrentToken, nil))
+	aliceCore, err := services.Users.FindUserByEmail(context.Background(), "external-batch-alice@valon.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	bobCore, err := services.Users.FindUserByEmail(context.Background(), "external-batch-bob@valon.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	aliceBefore := decodeResponse[scim.User](t, scimRequest(t, handler, http.MethodGet, "/scim/v2/Users/"+alice.ID, testCurrentToken, nil))
+	bobBefore := decodeResponse[scim.User](t, scimRequest(t, handler, http.MethodGet, "/scim/v2/Users/"+bob.ID, testCurrentToken, nil))
+	updates := []*proto.RelationshipUpdate{
+		{Operation: proto.RelationshipUpdate_OPERATION_TOUCH, Relationship: runtimeGroupMember(aliceCore.ID, group.ID)},
+		{Operation: proto.RelationshipUpdate_OPERATION_TOUCH, Relationship: runtimeGroupMember(bobCore.ID, group.ID)},
+	}
+	authorization.mu.Lock()
+	writesBefore := len(authorization.writes)
+	authorization.mu.Unlock()
+	gate, ok := scim.WrapAuthorization(authorization, services.Users, service).(core.AuthorizationRelationshipWriter)
+	if !ok {
+		t.Fatal("wrapped authorization does not implement relationship writer")
+	}
+	if _, err := gate.WriteRelationships(context.Background(), &proto.WriteRelationshipsRequest{Updates: updates}); err != nil {
+		t.Fatalf("external WriteRelationships = %v", err)
+	}
+	authorization.mu.Lock()
+	writeCalls := len(authorization.writes) - writesBefore
+	authorization.mu.Unlock()
+	if writeCalls != 1 {
+		t.Fatalf("external writer calls = %d, want 1", writeCalls)
+	}
+	groupAfter := decodeResponse[scim.Group](t, scimRequest(t, handler, http.MethodGet, "/scim/v2/Groups/"+group.ID, testCurrentToken, nil))
+	aliceAfter := decodeResponse[scim.User](t, scimRequest(t, handler, http.MethodGet, "/scim/v2/Users/"+alice.ID, testCurrentToken, nil))
+	bobAfter := decodeResponse[scim.User](t, scimRequest(t, handler, http.MethodGet, "/scim/v2/Users/"+bob.ID, testCurrentToken, nil))
+	if len(groupAfter.Members) != 2 || groupAfter.Meta.Version == groupBefore.Meta.Version || !groupAfter.Meta.LastModified.After(groupBefore.Meta.LastModified) {
+		t.Fatalf("external group membership was not reflected = before %#v after %#v", groupBefore, groupAfter)
+	}
+	if len(aliceAfter.Groups) != 1 || aliceAfter.Groups[0].Value != group.ID || aliceAfter.Meta.Version == aliceBefore.Meta.Version || !aliceAfter.Meta.LastModified.After(aliceBefore.Meta.LastModified) {
+		t.Fatalf("external Alice membership was not reflected = before %#v after %#v", aliceBefore, aliceAfter)
+	}
+	if len(bobAfter.Groups) != 1 || bobAfter.Groups[0].Value != group.ID || bobAfter.Meta.Version == bobBefore.Meta.Version || !bobAfter.Meta.LastModified.After(bobBefore.Meta.LastModified) {
+		t.Fatalf("external Bob membership was not reflected = before %#v after %#v", bobBefore, bobAfter)
+	}
+
+	unspecifiedDelete := runtimeGroupMember(aliceCore.ID, group.ID)
+	unspecifiedDelete.SourceLayer = proto.SourceLayer_SOURCE_LAYER_UNSPECIFIED
+	if _, err := gate.WriteRelationships(context.Background(), &proto.WriteRelationshipsRequest{Updates: []*proto.RelationshipUpdate{{
+		Operation:    proto.RelationshipUpdate_OPERATION_DELETE,
+		Relationship: unspecifiedDelete,
+	}}}); err != nil {
+		t.Fatalf("external unspecified-source delete = %v", err)
+	}
+	groupAfterDelete := decodeResponse[scim.Group](t, scimRequest(t, handler, http.MethodGet, "/scim/v2/Groups/"+group.ID, testCurrentToken, nil))
+	aliceAfterDelete := decodeResponse[scim.User](t, scimRequest(t, handler, http.MethodGet, "/scim/v2/Users/"+alice.ID, testCurrentToken, nil))
+	if len(groupAfterDelete.Members) != 1 || groupAfterDelete.Members[0].Value != bob.ID || groupAfterDelete.Meta.Version == groupAfter.Meta.Version || !groupAfterDelete.Meta.LastModified.After(groupAfter.Meta.LastModified) {
+		t.Fatalf("unspecified-source delete was not reflected in group = before %#v after %#v", groupAfter, groupAfterDelete)
+	}
+	if len(aliceAfterDelete.Groups) != 0 || aliceAfterDelete.Meta.Version == aliceAfter.Meta.Version || !aliceAfterDelete.Meta.LastModified.After(aliceAfter.Meta.LastModified) {
+		t.Fatalf("unspecified-source delete was not reflected for Alice = before %#v after %#v", aliceAfter, aliceAfterDelete)
+	}
+}
+
+func runtimeGroupMember(coreID, groupID string) *proto.Relationship {
+	return &proto.Relationship{
+		Tuple: &proto.RelationshipTuple{
+			Target:   &proto.RelationshipTarget{Kind: &proto.RelationshipTarget_Subject{Subject: &proto.Subject{Type: "subject", Id: "user:" + coreID}}},
+			Relation: "member",
+			Resource: &proto.Resource{Type: "group", Id: groupID},
+		},
+		SourceLayer: proto.SourceLayer_SOURCE_LAYER_RUNTIME,
+	}
+}

--- a/gestaltd/internal/scim/compact_service.go
+++ b/gestaltd/internal/scim/compact_service.go
@@ -15,6 +15,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -26,6 +27,7 @@ import (
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	gproto "google.golang.org/protobuf/proto"
 )
 
 type compactProjection struct{ relation, resourceType, resourceID string }
@@ -53,13 +55,14 @@ type userProfile struct {
 }
 
 type CompactService struct {
-	db            coredb.IndexedDB
-	authorization core.AuthorizationProvider
-	baseURL       string
-	clients       map[string]*compactClient
-	credentials   []compactCredential
-	domainOwners  map[string]string
-	now           func() time.Time
+	db                coredb.IndexedDB
+	authorization     core.AuthorizationProvider
+	baseURL           string
+	clients           map[string]*compactClient
+	credentials       []compactCredential
+	domainOwners      map[string]string
+	now               func() time.Time
+	writerUnsupported atomic.Bool
 }
 
 func NewService(db coredb.IndexedDB, authorization core.AuthorizationProvider, baseURL string, cfg config.ServerSCIMConfig) (*Service, error) {
@@ -125,6 +128,13 @@ func (s *CompactService) get(ctx context.Context, clientID, id, typ string) (idb
 }
 func (s *CompactService) listRecords(ctx context.Context, clientID, typ string) ([]idb.Record, error) {
 	return s.db.ObjectStore(coredata.StoreSCIMResources).Index("by_client_type").GetAll(ctx, []any{clientID, typ})
+}
+
+func (s *CompactService) listUserRecords(ctx context.Context, clientID string, clauses []filterClause) ([]idb.Record, error) {
+	if username, ok := usernameFilterValue(clauses); ok {
+		return s.db.ObjectStore(coredata.StoreSCIMResources).Index("by_client_user_name").GetAll(ctx, []any{clientID, "User", username})
+	}
+	return s.listRecords(ctx, clientID, "User")
 }
 
 type recordStore interface {
@@ -244,6 +254,73 @@ func (s *CompactService) emailFor(u persistedUser) (string, error) {
 	return "", invalid("user must include an email address")
 }
 func (s *CompactService) userValue(ctx context.Context, r storedResource) (User, error) {
+	hydration, err := s.newHydration(ctx, r.ClientID)
+	if err != nil {
+		return User{}, unavailable("could not load SCIM group map")
+	}
+	return s.userValueWithHydration(ctx, r, hydration)
+}
+
+type scimHydration struct {
+	service    *CompactService
+	groups     map[string]storedResource
+	parentRels map[string][]*proto.Relationship
+}
+
+func (s *CompactService) newHydration(ctx context.Context, clientID string) (*scimHydration, error) {
+	rows, err := s.listRecords(ctx, clientID, "Group")
+	if err != nil {
+		return nil, err
+	}
+	groups := make(map[string]storedResource, len(rows))
+	for _, row := range rows {
+		group := stored(row)
+		groups[group.ID] = group
+	}
+	return &scimHydration{service: s, groups: groups, parentRels: map[string][]*proto.Relationship{}}, nil
+}
+
+func (h *scimHydration) userRelationships(ctx context.Context, coreID string) ([]*proto.Relationship, error) {
+	target := &proto.RelationshipTarget{Kind: &proto.RelationshipTarget_Subject{Subject: &proto.Subject{Type: "subject", Id: "user:" + coreID}}}
+	relationships, err := h.service.listRelationships(ctx, &proto.RelationshipFilter{Target: target, SourceLayer: proto.SourceLayer_SOURCE_LAYER_RUNTIME}, 100)
+	if err != nil {
+		return nil, err
+	}
+	filtered := make([]*proto.Relationship, 0, len(relationships))
+	for _, relationship := range relationships {
+		if relationship.GetSourceLayer() != proto.SourceLayer_SOURCE_LAYER_RUNTIME || !sameRelationshipTarget(relationship.GetTuple().GetTarget(), target) {
+			continue
+		}
+		filtered = append(filtered, relationship)
+	}
+	return filtered, nil
+}
+
+func (h *scimHydration) parentRelationships(ctx context.Context, groupID string) ([]*proto.Relationship, error) {
+	if relationships, ok := h.parentRels[groupID]; ok {
+		return relationships, nil
+	}
+	target := &proto.RelationshipTarget{Kind: &proto.RelationshipTarget_SubjectSet{SubjectSet: &proto.SubjectSet{Resource: &proto.Resource{Type: "group", Id: groupID}, Relation: "member"}}}
+	relationships, err := h.service.listRelationships(ctx, &proto.RelationshipFilter{Target: target, Relation: "member", SourceLayer: proto.SourceLayer_SOURCE_LAYER_RUNTIME}, 100)
+	if err != nil {
+		return nil, err
+	}
+	filtered := make([]*proto.Relationship, 0, len(relationships))
+	for _, relationship := range relationships {
+		if relationship.GetSourceLayer() != proto.SourceLayer_SOURCE_LAYER_RUNTIME || relationship.GetTuple().GetRelation() != "member" || !sameRelationshipTarget(relationship.GetTuple().GetTarget(), target) {
+			continue
+		}
+		filtered = append(filtered, relationship)
+	}
+	h.parentRels[groupID] = filtered
+	return filtered, nil
+}
+
+func sameRelationshipTarget(a, b *proto.RelationshipTarget) bool {
+	return relationshipTargetKey(a) == relationshipTargetKey(b)
+}
+
+func (s *CompactService) userValueWithHydration(ctx context.Context, r storedResource, hydration *scimHydration) (User, error) {
 	cu, e := coredata.NewUserService(s.db).GetUser(ctx, r.CoreUserID)
 	if e != nil {
 		return User{}, unavailable("could not load linked user")
@@ -253,11 +330,16 @@ func (s *CompactService) userValue(ctx context.Context, r storedResource) (User,
 		lastModified = cu.UpdatedAt
 	}
 	u := User{Schemas: []string{UserSchemaURN}, ID: r.ID, ExternalID: r.ExternalID, UserName: r.UserName, DisplayName: cu.DisplayName, Name: r.Profile.Name, Emails: r.Profile.Emails, Meta: Meta{ResourceType: "User", Created: r.CreatedAt, LastModified: lastModified, Location: s.baseURL + "/scim/v2/Users/" + r.ID}}
-	u.Active, e = s.userActive(ctx, r)
-	if e != nil {
-		return User{}, unavailable("could not read authorization state")
+	var relationships []*proto.Relationship
+	client := s.clients[r.ClientID]
+	if (client != nil && len(client.projections) > 0) || len(hydration.groups) > 0 {
+		relationships, e = hydration.userRelationships(ctx, r.CoreUserID)
+		if e != nil {
+			return User{}, unavailable("could not read authorization state")
+		}
 	}
-	u.Groups, e = s.userGroupsNested(ctx, r.ClientID, r.CoreUserID)
+	u.Active = activeFromRelationships(r.CoreUserID, relationships, client)
+	u.Groups, e = s.userGroupsNestedWithHydration(ctx, r.ClientID, r.CoreUserID, hydration, relationships)
 	if e != nil {
 		return User{}, unavailable("could not read group membership")
 	}
@@ -275,34 +357,27 @@ func (s *CompactService) userValue(ctx context.Context, r storedResource) (User,
 	u.Meta.Version = etag(canon)
 	return u, nil
 }
-func (s *CompactService) userActive(ctx context.Context, r storedResource) (bool, error) {
-	if r.CoreUserID == "" {
-		return false, nil
+
+func activeFromRelationships(coreUserID string, relationships []*proto.Relationship, client *compactClient) bool {
+	if coreUserID == "" || client == nil || len(client.projections) == 0 {
+		return false
 	}
-	c := s.clients[r.ClientID]
-	if c == nil {
-		return false, nil
-	}
-	for _, p := range c.projections {
-		ok, e := s.hasTuple(ctx, userTuple(r.CoreUserID, p))
-		if e != nil {
-			return false, e
+	present := make(map[string]struct{}, len(relationships))
+	for _, relationship := range relationships {
+		if relationship.GetSourceLayer() != proto.SourceLayer_SOURCE_LAYER_RUNTIME {
+			continue
 		}
-		if !ok {
-			return false, nil
+		present[tupleKey(relationship.GetTuple())] = struct{}{}
+	}
+	for _, projection := range client.projections {
+		if _, ok := present[tupleKey(userTuple(coreUserID, projection))]; !ok {
+			return false
 		}
 	}
-	return len(c.projections) > 0, nil
+	return true
 }
 func userTuple(uid string, p compactProjection) *proto.RelationshipTuple {
 	return &proto.RelationshipTuple{Target: &proto.RelationshipTarget{Kind: &proto.RelationshipTarget_Subject{Subject: &proto.Subject{Type: "subject", Id: "user:" + uid}}}, Relation: p.relation, Resource: &proto.Resource{Type: p.resourceType, Id: p.resourceID}}
-}
-func (s *CompactService) hasTuple(ctx context.Context, t *proto.RelationshipTuple) (bool, error) {
-	r, e := s.listRelationships(ctx, &proto.RelationshipFilter{Target: t.Target, Relation: t.Relation, Resource: t.Resource, SourceLayer: proto.SourceLayer_SOURCE_LAYER_RUNTIME}, 2)
-	if e != nil {
-		return false, e
-	}
-	return len(r) > 0, nil
 }
 
 func (s *CompactService) listRelationships(ctx context.Context, filter *proto.RelationshipFilter, pageSize int32) ([]*proto.Relationship, error) {
@@ -345,57 +420,62 @@ func (s *CompactService) relationshipPresent(ctx context.Context, tuple *proto.R
 // affected by a successful shared authorization write. The provider remains
 // canonical; this timestamp is informational and is never used for ETags.
 func (s *CompactService) touchRelationship(ctx context.Context, tuple *proto.RelationshipTuple) error {
-	if tuple == nil || tuple.GetTarget() == nil {
-		return nil
-	}
-	rows, err := s.db.ObjectStore(coredata.StoreSCIMResources).GetAll(ctx, nil)
+	touch, err := s.relationshipTouchIDs(ctx, tuple)
 	if err != nil {
 		return err
 	}
+	return s.touchRows(ctx, touch)
+}
+
+func (s *CompactService) relationshipTouchIDs(ctx context.Context, tuple *proto.RelationshipTuple) (map[string]struct{}, error) {
 	touch := map[string]struct{}{}
-	for _, row := range rows {
-		if recordString(row, "resource_type") != "User" || recordString(row, "core_user_id") == "" {
-			continue
-		}
-		clientID := recordString(row, "client_id")
-		if subject := tuple.GetTarget().GetSubject(); subject != nil && subject.GetId() == "user:"+recordString(row, "core_user_id") {
+	if tuple == nil || tuple.GetTarget() == nil {
+		return touch, nil
+	}
+	if subject := tuple.GetTarget().GetSubject(); subject != nil && strings.HasPrefix(subject.GetId(), "user:") {
+		coreID := strings.TrimPrefix(subject.GetId(), "user:")
+		for clientID := range s.clients {
+			rows, err := s.db.ObjectStore(coredata.StoreSCIMResources).Index("by_client_core_user").GetAll(ctx, []any{clientID, "User", coreID})
+			if err != nil {
+				return nil, err
+			}
 			inGroup, err := s.clientHasGroup(ctx, clientID, tuple.GetResource().GetType(), tuple.GetResource().GetId())
 			if err != nil {
-				return err
+				return nil, err
 			}
 			if s.isConfiguredProjection(clientID, tuple) || inGroup {
-				touch[recordString(row, "id")] = struct{}{}
-			}
-		}
-	}
-	if tuple.GetResource().GetType() == "group" && tuple.GetRelation() == "member" {
-		for _, row := range rows {
-			if recordString(row, "resource_type") == "Group" && recordString(row, "id") == tuple.GetResource().GetId() {
-				touch[recordString(row, "id")] = struct{}{}
-			}
-		}
-		for _, row := range rows {
-			if recordString(row, "resource_type") != "Group" || recordString(row, "id") != tuple.GetResource().GetId() {
-				continue
-			}
-			clientID := recordString(row, "client_id")
-			memberUsers, err := s.affectedGroupMemberUsers(ctx, clientID, tuple)
-			if err != nil {
-				return err
-			}
-			for _, coreID := range memberUsers {
-				for _, userRow := range rows {
-					if recordString(userRow, "resource_type") == "User" && recordString(userRow, "client_id") == clientID && recordString(userRow, "core_user_id") == coreID {
-						touch[recordString(userRow, "id")] = struct{}{}
-					}
+				for _, row := range rows {
+					touch[recordString(row, "id")] = struct{}{}
 				}
 			}
 		}
 	}
-	if len(touch) == 0 {
-		return nil
+	if tuple.GetResource().GetType() == "group" && tuple.GetRelation() == "member" {
+		for clientID := range s.clients {
+			group, err := s.findGroup(ctx, clientID, tuple.GetResource().GetId())
+			if errors.Is(err, idb.ErrNotFound) {
+				continue
+			}
+			if err != nil {
+				return nil, err
+			}
+			touch[group.ID] = struct{}{}
+			memberUsers, err := s.affectedGroupMemberUsers(ctx, tuple)
+			if err != nil {
+				return nil, err
+			}
+			for _, coreID := range memberUsers {
+				userRows, err := s.db.ObjectStore(coredata.StoreSCIMResources).Index("by_client_core_user").GetAll(ctx, []any{clientID, "User", coreID})
+				if err != nil {
+					return nil, err
+				}
+				for _, userRow := range userRows {
+					touch[recordString(userRow, "id")] = struct{}{}
+				}
+			}
+		}
 	}
-	return s.touchRows(ctx, touch)
+	return touch, nil
 }
 
 // touchRows performs read-modify-write in one transaction so an external
@@ -457,19 +537,14 @@ func (s *CompactService) clientHasGroup(ctx context.Context, clientID, resourceT
 	if resourceType != "group" {
 		return false, nil
 	}
-	rows, err := s.listRecords(ctx, clientID, "Group")
-	if err != nil {
-		return false, err
+	_, err := s.findGroup(ctx, clientID, resourceID)
+	if errors.Is(err, idb.ErrNotFound) {
+		return false, nil
 	}
-	for _, row := range rows {
-		if recordString(row, "id") == resourceID {
-			return true, nil
-		}
-	}
-	return false, nil
+	return err == nil, err
 }
 
-func (s *CompactService) affectedGroupMemberUsers(ctx context.Context, clientID string, tuple *proto.RelationshipTuple) ([]string, error) {
+func (s *CompactService) affectedGroupMemberUsers(ctx context.Context, tuple *proto.RelationshipTuple) ([]string, error) {
 	groupTarget := tuple.GetTarget().GetSubjectSet()
 	if groupTarget == nil || groupTarget.GetResource().GetType() != "group" {
 		if subject := tuple.GetTarget().GetSubject(); subject != nil && strings.HasPrefix(subject.GetId(), "user:") {
@@ -510,81 +585,196 @@ func (s *CompactService) affectedGroupMemberUsers(ctx context.Context, clientID 
 	return out, nil
 }
 func (s *CompactService) apply(ctx context.Context, from, to []*proto.RelationshipTuple) error {
-	// AuthorizationProvider exposes only one-tuple Add/Delete operations. A
-	// remote provider therefore cannot make this multi-tuple diff atomic. We
-	// apply it deterministically and return an error at the first failure; the
-	// SCIM caller sees 503 and retries against the provider's live state. This
-	// is an explicit RFC 7644 §3.5.2 compliance limitation until the provider
-	// API offers a transactional multi-relationship primitive.
-	fm := map[string]*proto.RelationshipTuple{}
-	tm := map[string]*proto.RelationshipTuple{}
+	fromByLogical := map[string][]*proto.RelationshipTuple{}
+	toByLogical := map[string]*proto.RelationshipTuple{}
 	for _, t := range from {
-		fm[tupleKey(t)] = t
+		fromByLogical[tupleKey(t)] = append(fromByLogical[tupleKey(t)], t)
 	}
 	for _, t := range to {
-		tm[tupleKey(t)] = t
-	}
-	keys := []string{}
-	for k := range fm {
-		if _, ok := tm[k]; !ok {
-			keys = append(keys, k)
+		if _, exists := toByLogical[tupleKey(t)]; !exists {
+			toByLogical[tupleKey(t)] = t
 		}
 	}
-	sort.Strings(keys)
-	for _, k := range keys {
-		if e := s.deleteRelationship(ctx, fm[k]); e != nil {
-			return e
+	type tupleChange struct {
+		logicalKey  string
+		physicalKey string
+		tuple       *proto.RelationshipTuple
+	}
+	deletes := []tupleChange{}
+	for logicalKey, tuples := range fromByLogical {
+		if _, retained := toByLogical[logicalKey]; retained {
+			continue
+		}
+		for _, tuple := range tuples {
+			deletes = append(deletes, tupleChange{logicalKey: logicalKey, physicalKey: physicalTupleKey(tuple), tuple: tuple})
 		}
 	}
-	keys = nil
-	for k := range tm {
-		if _, ok := fm[k]; !ok {
-			keys = append(keys, k)
+	adds := make([]tupleChange, 0, len(toByLogical))
+	for logicalKey, tuple := range toByLogical {
+		if _, present := fromByLogical[logicalKey]; !present {
+			adds = append(adds, tupleChange{logicalKey: logicalKey, tuple: tuple})
 		}
 	}
-	sort.Strings(keys)
-	for _, k := range keys {
-		if e := s.addRelationship(ctx, tm[k]); e != nil {
-			return e
+	sort.Slice(deletes, func(i, j int) bool {
+		if deletes[i].logicalKey != deletes[j].logicalKey {
+			return deletes[i].logicalKey < deletes[j].logicalKey
 		}
+		return deletes[i].physicalKey < deletes[j].physicalKey
+	})
+	sort.Slice(adds, func(i, j int) bool { return adds[i].logicalKey < adds[j].logicalKey })
+	if len(deletes) == 0 && len(adds) == 0 {
+		return nil
 	}
-	return nil
-}
 
-func (s *CompactService) addRelationship(ctx context.Context, tuple *proto.RelationshipTuple) error {
-	_, err := s.authorization.AddRelationship(ctx, &proto.AddRelationshipRequest{Relationship: &proto.Relationship{Tuple: tuple, SourceLayer: proto.SourceLayer_SOURCE_LAYER_RUNTIME}})
-	if isAlreadyExistsError(err) {
-		return s.touchRelationship(ctx, tuple)
+	updates := make([]*proto.RelationshipUpdate, 0, len(deletes)+len(adds))
+	for _, change := range deletes {
+		updates = append(updates, &proto.RelationshipUpdate{
+			Operation: proto.RelationshipUpdate_OPERATION_DELETE,
+			Relationship: &proto.Relationship{
+				Tuple:       change.tuple,
+				SourceLayer: proto.SourceLayer_SOURCE_LAYER_RUNTIME,
+			},
+		})
 	}
-	if err != nil {
-		return err
+	for _, change := range adds {
+		updates = append(updates, &proto.RelationshipUpdate{
+			Operation: proto.RelationshipUpdate_OPERATION_TOUCH,
+			Relationship: &proto.Relationship{
+				Tuple:       change.tuple,
+				SourceLayer: proto.SourceLayer_SOURCE_LAYER_RUNTIME,
+			},
+		})
 	}
-	return s.touchRelationship(ctx, tuple)
-}
-
-func (s *CompactService) deleteRelationship(ctx context.Context, tuple *proto.RelationshipTuple) error {
-	var affected []string
-	if tuple != nil && tuple.GetTarget().GetSubjectSet() != nil {
-		var err error
-		affected, err = s.affectedGroupMemberUsers(ctx, "", tuple)
+	affected := map[string]struct{}{}
+	affectedByLogical := map[string]map[string]struct{}{}
+	captured := map[string]struct{}{}
+	for _, change := range deletes {
+		if _, alreadyCaptured := captured[change.logicalKey]; alreadyCaptured {
+			continue
+		}
+		tuple := change.tuple
+		if tuple == nil || tuple.GetTarget().GetSubjectSet() == nil {
+			continue
+		}
+		captured[change.logicalKey] = struct{}{}
+		users, err := s.affectedGroupMemberUsers(ctx, tuple)
 		if err != nil {
 			return err
 		}
+		capturedUsers := map[string]struct{}{}
+		for _, user := range users {
+			affected[user] = struct{}{}
+			capturedUsers[user] = struct{}{}
+		}
+		affectedByLogical[change.logicalKey] = capturedUsers
 	}
-	_, err := s.authorization.DeleteRelationship(ctx, &proto.DeleteRelationshipRequest{RelationshipTuple: tuple})
-	if isNotFoundError(err) {
-		if err := s.touchRelationship(ctx, tuple); err != nil {
+
+	applied, err := s.applyBatch(ctx, updates)
+	if err != nil {
+		if applied > 0 {
+			prefixAffected := map[string]struct{}{}
+			for _, update := range updates[:applied] {
+				for user := range affectedByLogical[tupleKey(update.GetRelationship().GetTuple())] {
+					prefixAffected[user] = struct{}{}
+				}
+			}
+			_ = s.touchAppliedRelationships(ctx, updates[:applied], prefixAffected)
+		}
+		return err
+	}
+	return s.touchAppliedRelationships(ctx, updates, affected)
+}
+
+func (s *CompactService) applyBatch(ctx context.Context, updates []*proto.RelationshipUpdate) (int, error) {
+	if s.writerUnsupported.Load() {
+		return s.applyLegacy(ctx, updates)
+	}
+	writer, ok := s.authorization.(core.AuthorizationRelationshipWriter)
+	if !ok {
+		s.writerUnsupported.Store(true)
+		return s.applyLegacy(ctx, updates)
+	}
+	_, err := writer.WriteRelationships(ctx, &proto.WriteRelationshipsRequest{Updates: updates})
+	if err == nil {
+		return len(updates), nil
+	}
+	if status.Code(err) == codes.Unimplemented {
+		s.writerUnsupported.Store(true)
+		return s.applyLegacy(ctx, updates)
+	}
+	return 0, err
+}
+
+func (s *CompactService) applyLegacy(ctx context.Context, updates []*proto.RelationshipUpdate) (int, error) {
+	for i, update := range updates {
+		if update == nil || update.Relationship == nil {
+			return i, status.Error(codes.InvalidArgument, "invalid relationship update")
+		}
+		switch update.Operation {
+		case proto.RelationshipUpdate_OPERATION_DELETE:
+			_, err := s.authorization.DeleteRelationship(ctx, &proto.DeleteRelationshipRequest{RelationshipTuple: update.Relationship.Tuple})
+			if err != nil && !isNotFoundError(err) {
+				return i, err
+			}
+		case proto.RelationshipUpdate_OPERATION_TOUCH:
+			_, err := s.authorization.AddRelationship(ctx, &proto.AddRelationshipRequest{Relationship: &proto.Relationship{
+				Tuple: update.Relationship.Tuple, SourceLayer: proto.SourceLayer_SOURCE_LAYER_RUNTIME,
+			}})
+			if err != nil && !isAlreadyExistsError(err) {
+				return i, err
+			}
+		default:
+			return i, status.Error(codes.InvalidArgument, "SCIM relationship updates must be TOUCH or DELETE")
+		}
+	}
+	return len(updates), nil
+}
+
+func (s *CompactService) touchAppliedRelationships(ctx context.Context, updates []*proto.RelationshipUpdate, affected map[string]struct{}) error {
+	ids := map[string]struct{}{}
+	seen := map[string]struct{}{}
+	for _, update := range updates {
+		tuple := update.GetRelationship().GetTuple()
+		key := tupleKey(tuple)
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		touch, err := s.relationshipTouchIDs(ctx, tuple)
+		if err != nil {
 			return err
 		}
-		return s.touchCoreUsers(ctx, affected)
+		for id := range touch {
+			ids[id] = struct{}{}
+		}
 	}
-	if err != nil {
+	if err := s.collectCoreUserTouchIDs(ctx, affected, ids); err != nil {
 		return err
 	}
-	if err := s.touchRelationship(ctx, tuple); err != nil {
-		return err
+	return s.touchRows(ctx, ids)
+}
+
+func (s *CompactService) collectCoreUserTouchIDs(ctx context.Context, coreIDs map[string]struct{}, ids map[string]struct{}) error {
+	affected := make(map[string]map[string]struct{}, len(s.clients))
+	for clientID := range s.clients {
+		affected[clientID] = coreIDs
 	}
-	return s.touchCoreUsers(ctx, affected)
+	return s.collectClientCoreUserTouchIDs(ctx, affected, ids)
+}
+
+func (s *CompactService) collectClientCoreUserTouchIDs(ctx context.Context, affected map[string]map[string]struct{}, ids map[string]struct{}) error {
+	for clientID, coreIDs := range affected {
+		for coreID := range coreIDs {
+			rows, err := s.db.ObjectStore(coredata.StoreSCIMResources).Index("by_client_core_user").GetAll(ctx, []any{clientID, "User", coreID})
+			if err != nil {
+				return err
+			}
+			for _, row := range rows {
+				ids[recordString(row, "id")] = struct{}{}
+			}
+		}
+	}
+	return nil
 }
 
 func isAlreadyExistsError(err error) bool {
@@ -595,52 +785,6 @@ func isNotFoundError(err error) bool {
 	return errors.Is(err, core.ErrNotFound) || errors.Is(err, idb.ErrNotFound) || status.Code(err) == codes.NotFound
 }
 
-func (s *CompactService) touchCoreUsers(ctx context.Context, coreIDs []string) error {
-	if len(coreIDs) == 0 {
-		return nil
-	}
-	wanted := make(map[string]struct{}, len(coreIDs))
-	for _, id := range coreIDs {
-		wanted[id] = struct{}{}
-	}
-	rows, err := s.db.ObjectStore(coredata.StoreSCIMResources).GetAll(ctx, nil)
-	if err != nil {
-		return err
-	}
-	ids := make(map[string]struct{})
-	for _, row := range rows {
-		if recordString(row, "resource_type") == "User" {
-			if _, ok := wanted[recordString(row, "core_user_id")]; ok {
-				ids[recordString(row, "id")] = struct{}{}
-			}
-		}
-	}
-	return s.touchRows(ctx, ids)
-}
-
-// touchCoreUsersByClient limits relationship-driven timestamp updates to the
-// SCIM namespaces whose public representation can actually change.
-func (s *CompactService) touchCoreUsersByClient(ctx context.Context, affected map[string]map[string]struct{}) error {
-	if len(affected) == 0 {
-		return nil
-	}
-	rows, err := s.db.ObjectStore(coredata.StoreSCIMResources).GetAll(ctx, nil)
-	if err != nil {
-		return err
-	}
-	ids := make(map[string]struct{})
-	for _, row := range rows {
-		if recordString(row, "resource_type") != "User" {
-			continue
-		}
-		clientUsers := affected[recordString(row, "client_id")]
-		if _, ok := clientUsers[recordString(row, "core_user_id")]; ok {
-			ids[recordString(row, "id")] = struct{}{}
-		}
-	}
-	return s.touchRows(ctx, ids)
-}
-
 // captureRelationshipAffectedUsers records the users whose SCIM groups or
 // active projection may be changed by tuple before that tuple is deleted or a
 // provider state replacement runs. The provider is canonical, so this is
@@ -648,10 +792,6 @@ func (s *CompactService) touchCoreUsersByClient(ctx context.Context, affected ma
 func (s *CompactService) captureRelationshipAffectedUsers(ctx context.Context, tuple *proto.RelationshipTuple, affected map[string]map[string]struct{}) error {
 	if tuple == nil || tuple.GetTarget() == nil || tuple.GetResource() == nil {
 		return nil
-	}
-	rows, err := s.db.ObjectStore(coredata.StoreSCIMResources).GetAll(ctx, nil)
-	if err != nil {
-		return err
 	}
 	mark := func(clientID, coreID string) {
 		if affected[clientID] == nil {
@@ -661,22 +801,24 @@ func (s *CompactService) captureRelationshipAffectedUsers(ctx context.Context, t
 	}
 	if subject := tuple.GetTarget().GetSubject(); subject != nil && strings.HasPrefix(subject.GetId(), "user:") {
 		coreID := strings.TrimPrefix(subject.GetId(), "user:")
-		for _, row := range rows {
-			if recordString(row, "resource_type") != "User" || recordString(row, "core_user_id") != coreID {
-				continue
-			}
-			clientID := recordString(row, "client_id")
+		for clientID := range s.clients {
 			relevant := s.isConfiguredProjection(clientID, tuple)
 			if !relevant && tuple.GetResource().GetType() == "group" && tuple.GetRelation() == "member" {
-				for _, group := range rows {
-					if recordString(group, "resource_type") == "Group" && recordString(group, "client_id") == clientID && recordString(group, "id") == tuple.GetResource().GetId() {
-						relevant = true
-						break
-					}
+				_, err := s.findGroup(ctx, clientID, tuple.GetResource().GetId())
+				if err == nil {
+					relevant = true
+				} else if !errors.Is(err, idb.ErrNotFound) {
+					return err
 				}
 			}
 			if relevant {
-				mark(clientID, coreID)
+				rows, err := s.db.ObjectStore(coredata.StoreSCIMResources).Index("by_client_core_user").GetAll(ctx, []any{clientID, "User", coreID})
+				if err != nil {
+					return err
+				}
+				if len(rows) > 0 {
+					mark(clientID, coreID)
+				}
 			}
 		}
 		return nil
@@ -684,23 +826,51 @@ func (s *CompactService) captureRelationshipAffectedUsers(ctx context.Context, t
 	if subjectSet := tuple.GetTarget().GetSubjectSet(); subjectSet == nil || subjectSet.GetResource() == nil || subjectSet.GetResource().GetType() != "group" {
 		return nil
 	}
-	coreIDs, err := s.affectedGroupMemberUsers(ctx, "", tuple)
+	coreIDs, err := s.affectedGroupMemberUsers(ctx, tuple)
 	if err != nil {
 		return err
 	}
-	for _, row := range rows {
-		if recordString(row, "resource_type") != "Group" || recordString(row, "id") != tuple.GetResource().GetId() {
-			continue
+	for clientID := range s.clients {
+		if _, err := s.findGroup(ctx, clientID, tuple.GetResource().GetId()); err != nil {
+			if errors.Is(err, idb.ErrNotFound) {
+				continue
+			}
+			return err
 		}
 		for _, coreID := range coreIDs {
-			mark(recordString(row, "client_id"), coreID)
+			mark(clientID, coreID)
 		}
 	}
 	return nil
 }
 
 func tupleKey(t *proto.RelationshipTuple) string {
-	return t.GetRelation() + "\x00" + t.GetResource().GetType() + "\x00" + t.GetResource().GetId() + "\x00" + t.GetTarget().String()
+	return t.GetRelation() + "\x00" + t.GetResource().GetType() + "\x00" + t.GetResource().GetId() + "\x00" + relationshipTargetKey(t.GetTarget())
+}
+
+func physicalTupleKey(t *proto.RelationshipTuple) string {
+	data, err := (gproto.MarshalOptions{Deterministic: true}).Marshal(t)
+	if err != nil {
+		return tupleKey(t)
+	}
+	return string(data)
+}
+
+func relationshipTargetKey(target *proto.RelationshipTarget) string {
+	if target == nil {
+		return "nil"
+	}
+	if subject := target.GetSubject(); subject != nil {
+		return "subject\x00" + subject.GetType() + "\x00" + subject.GetId()
+	}
+	if resource := target.GetResource(); resource != nil {
+		return "resource\x00" + resource.GetType() + "\x00" + resource.GetId()
+	}
+	if subjectSet := target.GetSubjectSet(); subjectSet != nil {
+		resource := subjectSet.GetResource()
+		return "subject-set\x00" + resource.GetType() + "\x00" + resource.GetId() + "\x00" + subjectSet.GetRelation()
+	}
+	return "empty"
 }
 func (s *CompactService) desiredUser(r storedResource, active bool) []*proto.RelationshipTuple {
 	if !active || r.CoreUserID == "" {
@@ -845,7 +1015,7 @@ func (s *CompactService) list(ctx context.Context, clientID, raw string, start, 
 	if e != nil {
 		return listResponse[User]{}, invalidFilter(e.Error())
 	}
-	rs, e := s.listRecords(ctx, clientID, "User")
+	rs, e := s.listUserRecords(ctx, clientID, clauses)
 	if e != nil {
 		return listResponse[User]{}, unavailable("could not list SCIM users")
 	}
@@ -866,9 +1036,16 @@ func (s *CompactService) list(ctx context.Context, clientID, raw string, start, 
 	}
 	end := pageMin(start-1+count, len(matching))
 	page := matching[start-1 : end]
+	var hydration *scimHydration
+	if len(page) > 0 {
+		hydration, e = s.newHydration(ctx, clientID)
+		if e != nil {
+			return listResponse[User]{}, unavailable("could not load SCIM group map")
+		}
+	}
 	out := make([]User, 0, len(page))
 	for i := range page {
-		u, e := s.userValue(ctx, stored(page[i]))
+		u, e := s.userValueWithHydration(ctx, stored(page[i]), hydration)
 		if e != nil {
 			return listResponse[User]{}, e
 		}
@@ -1046,7 +1223,7 @@ func (s *CompactService) Delete(ctx context.Context, clientID, id, ifMatch strin
 	if e != nil {
 		return e
 	}
-	actual, e := s.actualUserTuples(ctx, r)
+	actual, e := s.userDeleteTuples(ctx, clientID, r.CoreUserID)
 	if e != nil {
 		return unavailable("could not read authorization state")
 	}
@@ -1090,9 +1267,6 @@ func (s *CompactService) Delete(ctx context.Context, clientID, id, ifMatch strin
 	if e = s.apply(ctx, actual, nil); e != nil {
 		return unavailable("could not remove authorization relationships")
 	}
-	if e = s.removeUserFromClientGroups(ctx, clientID, r.CoreUserID); e != nil {
-		return unavailable("could not remove authorization relationships")
-	}
 	if e = s.db.ObjectStore(coredata.StoreSCIMResources).Delete(ctx, id); e != nil {
 		return unavailable("could not delete SCIM user")
 	}
@@ -1100,46 +1274,66 @@ func (s *CompactService) Delete(ctx context.Context, clientID, id, ifMatch strin
 }
 func (s *CompactService) actualUserTuples(ctx context.Context, r storedResource) ([]*proto.RelationshipTuple, error) {
 	desired := s.desiredUser(r, true)
-	actual := make([]*proto.RelationshipTuple, 0, len(desired))
+	target := &proto.RelationshipTarget{Kind: &proto.RelationshipTarget_Subject{Subject: &proto.Subject{Type: "subject", Id: "user:" + r.CoreUserID}}}
+	relationships, err := s.listRelationships(ctx, &proto.RelationshipFilter{Target: target, SourceLayer: proto.SourceLayer_SOURCE_LAYER_RUNTIME}, 100)
+	if err != nil {
+		return nil, err
+	}
+	present := make(map[string][]*proto.RelationshipTuple, len(relationships))
+	for _, relationship := range relationships {
+		if relationship.GetSourceLayer() == proto.SourceLayer_SOURCE_LAYER_RUNTIME && sameRelationshipTarget(relationship.GetTuple().GetTarget(), target) {
+			key := tupleKey(relationship.GetTuple())
+			present[key] = append(present[key], relationship.GetTuple())
+		}
+	}
+	actual := make([]*proto.RelationshipTuple, 0, len(relationships))
 	for _, tuple := range desired {
-		present, err := s.hasTuple(ctx, tuple)
-		if err != nil {
-			return nil, err
-		}
-		if present {
-			actual = append(actual, tuple)
-		}
+		actual = append(actual, present[tupleKey(tuple)]...)
 	}
 	return actual, nil
 }
 
-// removeUserFromClientGroups cleans references only from SCIM groups in the
-// same client namespace. Runtime relationships for unrelated authorization
-// resources are left untouched.
-func (s *CompactService) removeUserFromClientGroups(ctx context.Context, clientID, coreID string) error {
+func (s *CompactService) userDeleteTuples(ctx context.Context, clientID, coreID string) ([]*proto.RelationshipTuple, error) {
 	groups, err := s.listRecords(ctx, clientID, "Group")
 	if err != nil {
-		return err
+		return nil, err
 	}
+	groupIDs := make(map[string]struct{}, len(groups))
 	for _, row := range groups {
-		groupID := recordString(row, "id")
-		relationships, err := s.listRelationships(ctx, &proto.RelationshipFilter{Resource: &proto.Resource{Type: "group", Id: groupID}, Relation: "member", SourceLayer: proto.SourceLayer_SOURCE_LAYER_RUNTIME}, 100)
-		if err != nil {
-			return err
+		groupIDs[recordString(row, "id")] = struct{}{}
+	}
+	target := &proto.RelationshipTarget{Kind: &proto.RelationshipTarget_Subject{Subject: &proto.Subject{Type: "subject", Id: "user:" + coreID}}}
+	relationships, err := s.listRelationships(ctx, &proto.RelationshipFilter{Target: target, SourceLayer: proto.SourceLayer_SOURCE_LAYER_RUNTIME}, 100)
+	if err != nil {
+		return nil, err
+	}
+	seen := map[string][]*proto.RelationshipTuple{}
+	for _, relationship := range relationships {
+		if relationship.GetSourceLayer() != proto.SourceLayer_SOURCE_LAYER_RUNTIME || !sameRelationshipTarget(relationship.GetTuple().GetTarget(), target) {
+			continue
 		}
-		for _, relationship := range relationships {
-			tuple := relationship.GetTuple()
-			subject := tuple.GetTarget().GetSubject()
-			if subject == nil || subject.GetId() != "user:"+coreID {
-				continue
-			}
-			if err := s.deleteRelationship(ctx, tuple); err != nil {
-				return err
-			}
+		tuple := relationship.GetTuple()
+		resource := tuple.GetResource()
+		_, isKnownGroup := groupIDs[resource.GetId()]
+		if s.isConfiguredProjection(clientID, tuple) || (tuple.GetRelation() == "member" && resource.GetType() == "group" && isKnownGroup) {
+			key := tupleKey(tuple)
+			seen[key] = append(seen[key], tuple)
 		}
 	}
-	return nil
+	keys := make([]string, 0, len(seen))
+	for key := range seen {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	result := make([]*proto.RelationshipTuple, 0, len(relationships))
+	for _, key := range keys {
+		tuples := seen[key]
+		sort.SliceStable(tuples, func(i, j int) bool { return physicalTupleKey(tuples[i]) < physicalTupleKey(tuples[j]) })
+		result = append(result, tuples...)
+	}
+	return result, nil
 }
+
 func (s *CompactService) IsEligible(ctx context.Context, coreID, email string) (bool, error) {
 	owner := s.domainOwners[domain(email)]
 	if owner == "" {
@@ -1152,7 +1346,13 @@ func (s *CompactService) IsEligible(ctx context.Context, coreID, email string) (
 	if len(rs) != 1 {
 		return false, nil
 	}
-	return s.userActive(ctx, stored(rs[0]))
+	r := stored(rs[0])
+	target := &proto.RelationshipTarget{Kind: &proto.RelationshipTarget_Subject{Subject: &proto.Subject{Type: "subject", Id: "user:" + coreID}}}
+	relationships, err := s.listRelationships(ctx, &proto.RelationshipFilter{Target: target, SourceLayer: proto.SourceLayer_SOURCE_LAYER_RUNTIME}, 100)
+	if err != nil {
+		return false, err
+	}
+	return activeFromRelationships(r.CoreUserID, relationships, s.clients[owner]), nil
 }
 func domain(email string) string {
 	p := strings.LastIndex(normalize(email), "@")
@@ -1162,76 +1362,76 @@ func domain(email string) string {
 	return normalize(email[p+1:])
 }
 
-func (s *CompactService) userGroupsNested(ctx context.Context, cid, coreID string) ([]GroupRef, error) {
-	rows, e := s.listRecords(ctx, cid, "Group")
-	if e != nil {
-		return nil, e
-	}
-	type node struct {
-		members []Member
-	}
-	nodes := map[string]node{}
-	for _, rr := range rows {
-		g := stored(rr)
-		m, e := s.liveMembers(ctx, cid, g.ID)
-		if e != nil {
-			return nil, e
+func (s *CompactService) userGroupsNestedWithHydration(ctx context.Context, cid, coreID string, hydration *scimHydration, relationships []*proto.Relationship) ([]GroupRef, error) {
+	if hydration == nil {
+		var err error
+		hydration, err = s.newHydration(ctx, cid)
+		if err != nil {
+			return nil, err
 		}
-		nodes[g.ID] = node{members: m}
 	}
-	refs := []GroupRef{}
-	for gid := range nodes {
-		queue := []struct {
-			id       string
-			indirect bool
-		}{{gid, false}}
-		seen := map[string]bool{}
-		for len(queue) > 0 {
-			q := queue[0]
-			queue = queue[1:]
-			if seen[q.id] {
+	refs := make(map[string]GroupRef)
+	queue := make([]string, 0)
+	for _, relationship := range relationships {
+		tuple := relationship.GetTuple()
+		if relationship.GetSourceLayer() != proto.SourceLayer_SOURCE_LAYER_RUNTIME || tuple.GetRelation() != "member" || tuple.GetResource().GetType() != "group" {
+			continue
+		}
+		target := tuple.GetTarget().GetSubject()
+		if target == nil || target.GetId() != "user:"+coreID {
+			continue
+		}
+		groupID := tuple.GetResource().GetId()
+		if _, ok := hydration.groups[groupID]; !ok {
+			continue
+		}
+		if _, ok := refs[groupID]; !ok {
+			refs[groupID] = GroupRef{Value: groupID, Ref: s.baseURL + "/scim/v2/Groups/" + groupID, Type: "direct"}
+			queue = append(queue, groupID)
+		}
+	}
+	// A parent must itself be a SCIM group in this client. With one group in
+	// the namespace there cannot be a valid parent, so avoid an unnecessary
+	// provider lookup while preserving nested-group expansion for larger maps.
+	if len(hydration.groups) <= 1 {
+		return sortedGroupRefs(refs), nil
+	}
+	visited := map[string]struct{}{}
+	for len(queue) > 0 {
+		groupID := queue[0]
+		queue = queue[1:]
+		if _, ok := visited[groupID]; ok {
+			continue
+		}
+		visited[groupID] = struct{}{}
+		parents, err := hydration.parentRelationships(ctx, groupID)
+		if err != nil {
+			return nil, err
+		}
+		for _, relationship := range parents {
+			parentID := relationship.GetTuple().GetResource().GetId()
+			if relationship.GetTuple().GetResource().GetType() != "group" {
 				continue
 			}
-			seen[q.id] = true
-			cur, ok := nodes[q.id]
-			if !ok {
+			if _, ok := hydration.groups[parentID]; !ok {
 				continue
 			}
-			for _, m := range cur.members {
-				switch m.Type {
-				case "User":
-					u, e := s.findUser(ctx, cid, m.Value)
-					if e != nil && !errors.Is(e, idb.ErrNotFound) {
-						return nil, e
-					}
-					if e == nil && u.CoreUserID == coreID {
-						typ := "direct"
-						if q.indirect {
-							typ = "indirect"
-						}
-						refs = append(refs, GroupRef{Value: gid, Ref: s.baseURL + "/scim/v2/Groups/" + gid, Type: typ})
-					}
-				case "Group":
-					queue = append(queue, struct {
-						id       string
-						indirect bool
-					}{m.Value, true})
-				}
+			if existing, ok := refs[parentID]; !ok || existing.Type == "indirect" {
+				refs[parentID] = GroupRef{Value: parentID, Ref: s.baseURL + "/scim/v2/Groups/" + parentID, Type: "indirect"}
 			}
+			queue = append(queue, parentID)
 		}
 	}
-	uniq := map[string]GroupRef{}
-	for _, r := range refs {
-		if old, ok := uniq[r.Value]; !ok || old.Type == "indirect" {
-			uniq[r.Value] = r
-		}
+	return sortedGroupRefs(refs), nil
+}
+
+func sortedGroupRefs(refs map[string]GroupRef) []GroupRef {
+	out := make([]GroupRef, 0, len(refs))
+	for _, ref := range refs {
+		out = append(out, ref)
 	}
-	refs = refs[:0]
-	for _, r := range uniq {
-		refs = append(refs, r)
-	}
-	sort.Slice(refs, func(i, j int) bool { return refs[i].Value < refs[j].Value })
-	return refs, nil
+	sort.Slice(out, func(i, j int) bool { return out[i].Value < out[j].Value })
+	return out
 }
 
 // Group operations live in compact_groups.go.

--- a/gestaltd/internal/scim/filter.go
+++ b/gestaltd/internal/scim/filter.go
@@ -12,6 +12,15 @@ type filterClause struct {
 	value     string
 }
 
+func usernameFilterValue(clauses []filterClause) (string, bool) {
+	for _, clause := range clauses {
+		if clause.attribute == "username" {
+			return clause.value, true
+		}
+	}
+	return "", false
+}
+
 type groupFilterClause struct {
 	attribute string
 	value     string
@@ -165,27 +174,4 @@ func parseGroupMemberFilter(raw string) (string, bool) {
 		return "", false
 	}
 	return strings.TrimSpace(value), true
-}
-
-func matchesGroupFilter(group persistedGroup, clauses []groupFilterClause) bool {
-	for _, clause := range clauses {
-		matched := false
-		switch clause.attribute {
-		case "displayname":
-			matched = normalize(group.DisplayName) == clause.value
-		case "externalid":
-			matched = group.ExternalID == clause.value
-		case "members.value":
-			for _, member := range group.Members {
-				if strings.TrimSpace(member.Value) == clause.value {
-					matched = true
-					break
-				}
-			}
-		}
-		if !matched {
-			return false
-		}
-	}
-	return true
 }

--- a/gestaltd/internal/scim/groups_http_test.go
+++ b/gestaltd/internal/scim/groups_http_test.go
@@ -4,13 +4,17 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/url"
 	"testing"
 
+	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/scim"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	gproto "google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 func TestSCIMGroupsCRUDAndUserGroups(t *testing.T) {
@@ -123,7 +127,7 @@ func TestSCIMGroupsCRUDAndUserGroups(t *testing.T) {
 	}
 	groupBeforeExternal := decodeResponse[scim.Group](t, scimRequest(t, handler, http.MethodGet, "/scim/v2/Groups/"+created.ID, testCurrentToken, nil))
 	bobBeforeExternal := decodeResponse[scim.User](t, scimRequest(t, handler, http.MethodGet, "/scim/v2/Users/"+bob.ID, testCurrentToken, nil))
-	external := &proto.Relationship{Tuple: &proto.RelationshipTuple{Target: &proto.RelationshipTarget{Kind: &proto.RelationshipTarget_Subject{Subject: &proto.Subject{Type: "subject", Id: "user:" + coreBob.ID}}}, Relation: "member", Resource: &proto.Resource{Type: "group", Id: created.ID}}}
+	external := &proto.Relationship{Tuple: &proto.RelationshipTuple{Target: &proto.RelationshipTarget{Kind: &proto.RelationshipTarget_Subject{Subject: &proto.Subject{Type: "subject", Id: "user:" + coreBob.ID}}}, Relation: "member", Resource: &proto.Resource{Type: "group", Id: created.ID}}, SourceLayer: proto.SourceLayer_SOURCE_LAYER_RUNTIME}
 	if _, err := scim.WrapAuthorization(authorization, services.Users, secondService).AddRelationship(context.Background(), &proto.AddRelationshipRequest{Relationship: external}); err != nil {
 		t.Fatalf("ordinary add to SCIM Group: %v", err)
 	}
@@ -295,6 +299,80 @@ func TestSCIMUserDeleteRemovesGroupMembership(t *testing.T) {
 	}
 }
 
+func TestSCIMGroupsExposeOnlyRuntimeMembership(t *testing.T) {
+	t.Parallel()
+
+	authorization := newRecordingAuthorization()
+	service, services, handler := newSCIMService(t, nil, authorization, testSCIMConfig(map[string]config.SCIMClientConfig{
+		"rippling": ripplingClient(nil),
+	}))
+	user, response := createUser(t, handler, testCurrentToken, "runtime-membership@valon.com", true, nil)
+	if response.Code != http.StatusCreated {
+		t.Fatalf("create user = %d %s", response.Code, response.Body.String())
+	}
+	groupResponse := scimRequest(t, handler, http.MethodPost, "/scim/v2/Groups", testCurrentToken, map[string]any{
+		"schemas": []string{scim.GroupSchemaURN}, "displayName": "Runtime membership",
+	})
+	group := decodeResponse[scim.Group](t, groupResponse)
+	if groupResponse.Code != http.StatusCreated {
+		t.Fatalf("create group = %d %s", groupResponse.Code, groupResponse.Body.String())
+	}
+	coreUser, err := services.Users.FindUserByEmail(context.Background(), "runtime-membership@valon.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	staticRelationship := runtimeGroupMember(coreUser.ID, group.ID)
+	staticRelationship.SourceLayer = proto.SourceLayer_SOURCE_LAYER_STATIC_CONFIG
+	gate := scim.WrapAuthorization(authorization, services.Users, service)
+	if _, err := gate.AddRelationship(context.Background(), &proto.AddRelationshipRequest{Relationship: staticRelationship}); err != nil {
+		t.Fatalf("add static relationship = %v", err)
+	}
+	staticRead := decodeResponse[scim.Group](t, scimRequest(t, handler, http.MethodGet, "/scim/v2/Groups/"+group.ID, testCurrentToken, nil))
+	if len(staticRead.Members) != 0 {
+		t.Fatalf("static relationship exposed as members = %#v", staticRead.Members)
+	}
+	if staticRead.Meta.Version != group.Meta.Version || !staticRead.Meta.LastModified.Equal(group.Meta.LastModified) {
+		t.Fatalf("static relationship changed SCIM metadata: before=%#v after=%#v", group.Meta, staticRead.Meta)
+	}
+	if _, err := gate.AddRelationship(context.Background(), &proto.AddRelationshipRequest{Relationship: runtimeGroupMember(coreUser.ID, group.ID)}); err != nil {
+		t.Fatalf("add runtime relationship = %v", err)
+	}
+	runtimeRead := decodeResponse[scim.Group](t, scimRequest(t, handler, http.MethodGet, "/scim/v2/Groups/"+group.ID, testCurrentToken, nil))
+	if len(runtimeRead.Members) != 1 || runtimeRead.Members[0].Value != user.ID {
+		t.Fatalf("runtime relationship not exposed as member = %#v", runtimeRead.Members)
+	}
+}
+
+func TestSCIMGroupMemberFilterDistinguishesNotFoundAndDatastoreError(t *testing.T) {
+	t.Parallel()
+
+	filter := url.QueryEscape(`members[value eq "missing-user"]`)
+	_, _, healthyHandler := newSCIMService(t, nil, newRecordingAuthorization(), testSCIMConfig(map[string]config.SCIMClientConfig{
+		"rippling": ripplingClient(nil),
+	}))
+	missing := scimRequest(t, healthyHandler, http.MethodGet, "/scim/v2/Groups?startIndex=10&filter="+filter, testCurrentToken, nil)
+	if missing.Code != http.StatusOK {
+		t.Fatalf("missing member filter = %d %s", missing.Code, missing.Body.String())
+	}
+	missingList := decodeResponse[struct {
+		TotalResults int          `json:"totalResults"`
+		StartIndex   int          `json:"startIndex"`
+		Resources    []scim.Group `json:"Resources"`
+	}](t, missing)
+	if missingList.TotalResults != 0 || missingList.StartIndex != 1 || missingList.Resources == nil {
+		t.Fatalf("missing member filter result = %#v", missingList)
+	}
+
+	db := &coretesting.StubIndexedDB{Err: errors.New("member lookup datastore unavailable")}
+	_, _, failingHandler := newSCIMService(t, db, newRecordingAuthorization(), testSCIMConfig(map[string]config.SCIMClientConfig{
+		"rippling": ripplingClient(nil),
+	}))
+	failure := scimRequest(t, failingHandler, http.MethodGet, "/scim/v2/Groups?filter="+filter, testCurrentToken, nil)
+	if failure.Code != http.StatusServiceUnavailable {
+		t.Fatalf("member lookup datastore error = %d %s", failure.Code, failure.Body.String())
+	}
+}
+
 func TestSCIMUserDeleteRemovesConfiguredTuplesAndGroupReferences(t *testing.T) {
 	t.Parallel()
 	authorization := newRecordingAuthorization()
@@ -323,5 +401,73 @@ func TestSCIMUserDeleteRemovesConfiguredTuplesAndGroupReferences(t *testing.T) {
 	updated := decodeResponse[scim.Group](t, scimRequest(t, handler, http.MethodGet, "/scim/v2/Groups/"+group.ID, testCurrentToken, nil))
 	if len(updated.Members) != 0 || authorization.relationshipForUser(coreUser.ID) != nil {
 		t.Fatalf("group references after user deletion = %#v", updated.Members)
+	}
+}
+
+func TestSCIMRelationshipPropertiesDoNotCauseMemberDiff(t *testing.T) {
+	t.Parallel()
+
+	authorization := newRecordingAuthorization()
+	cfg := testSCIMConfig(map[string]config.SCIMClientConfig{"rippling": ripplingClient(nil)})
+	_, services, handler := newSCIMService(t, nil, authorization, cfg)
+	user, response := createUser(t, handler, testCurrentToken, "physical-variants@valon.com", true, nil)
+	if response.Code != http.StatusCreated {
+		t.Fatalf("create user = %d %s", response.Code, response.Body.String())
+	}
+	groupResponse := scimRequest(t, handler, http.MethodPost, "/scim/v2/Groups", testCurrentToken, map[string]any{
+		"schemas": []string{scim.GroupSchemaURN}, "displayName": "Physical variants", "members": []map[string]any{{"value": user.ID}},
+	})
+	group := decodeResponse[scim.Group](t, groupResponse)
+	if groupResponse.Code != http.StatusCreated {
+		t.Fatalf("create group = %d %s", groupResponse.Code, groupResponse.Body.String())
+	}
+	coreUser, err := services.Users.FindUserByEmail(context.Background(), "physical-variants@valon.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	base := authorization.relationshipForGroupUser(coreUser.ID, group.ID)
+	if base == nil {
+		t.Fatal("created relationship is missing")
+	}
+	for _, property := range []string{"one", "two"} {
+		variant := gproto.Clone(base).(*proto.Relationship)
+		variant.Tuple.Target.GetSubject().Properties, err = structpb.NewStruct(map[string]any{"variant": property})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := authorization.AddRelationship(context.Background(), &proto.AddRelationshipRequest{Relationship: variant}); err != nil {
+			t.Fatalf("add %s relationship variant = %v", property, err)
+		}
+	}
+	read := decodeResponse[scim.Group](t, scimRequest(t, handler, http.MethodGet, "/scim/v2/Groups/"+group.ID, testCurrentToken, nil))
+	if len(read.Members) != 1 {
+		t.Fatalf("physical variants projected members = %#v", read.Members)
+	}
+	if response = scimRequest(t, handler, http.MethodPut, "/scim/v2/Groups/"+group.ID, testCurrentToken, map[string]any{
+		"schemas": []string{scim.GroupSchemaURN}, "displayName": read.DisplayName, "members": []map[string]any{{"value": user.ID}},
+	}, map[string]string{"If-Match": read.Meta.Version}); response.Code != http.StatusOK {
+		t.Fatalf("physical-variant no-op replacement = %d %s", response.Code, response.Body.String())
+	}
+	noop := decodeResponse[scim.Group](t, response)
+	if noop.Meta.Version != read.Meta.Version {
+		t.Fatalf("property-only no-op changed version from %q to %q", read.Meta.Version, noop.Meta.Version)
+	}
+	if response = scimRequest(t, handler, http.MethodPut, "/scim/v2/Groups/"+group.ID, testCurrentToken, map[string]any{
+		"schemas": []string{scim.GroupSchemaURN}, "displayName": read.DisplayName, "members": []map[string]any{},
+	}, map[string]string{"If-Match": noop.Meta.Version}); response.Code != http.StatusOK {
+		t.Fatalf("remove physical-variant member = %d %s", response.Code, response.Body.String())
+	}
+	removed := decodeResponse[scim.Group](t, response)
+	if len(removed.Members) != 0 {
+		t.Fatalf("removed physical variants still projected members = %#v", removed.Members)
+	}
+	remaining, err := authorization.ListRelationships(context.Background(), &proto.ListRelationshipsRequest{Filter: &proto.RelationshipFilter{
+		Resource: &proto.Resource{Type: "group", Id: group.ID}, Relation: "member", SourceLayer: proto.SourceLayer_SOURCE_LAYER_RUNTIME,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(remaining.Relationships) != 0 {
+		t.Fatalf("physical variants remaining after HTTP removal = %#v", remaining.Relationships)
 	}
 }

--- a/gestaltd/internal/scim/users_http_test.go
+++ b/gestaltd/internal/scim/users_http_test.go
@@ -948,6 +948,14 @@ func TestSCIMUserListHydratesOnlyRequestedPage(t *testing.T) {
 	if calls := authorization.listCallCount(); calls != 1 {
 		t.Fatalf("provider hydration calls = %d, want 1", calls)
 	}
+	authorization.resetListCalls()
+	emptyPage := scimRequest(t, handler, http.MethodGet, "/scim/v2/Users?startIndex=100&count=1", testCurrentToken, nil)
+	if emptyPage.Code != http.StatusOK {
+		t.Fatalf("empty user page = %d %s", emptyPage.Code, emptyPage.Body.String())
+	}
+	if calls := authorization.listCallCount(); calls != 0 {
+		t.Fatalf("empty-page provider hydration calls = %d, want 0", calls)
+	}
 }
 
 func TestSCIMActivationRetriesFromActualProviderTuples(t *testing.T) {
@@ -1298,13 +1306,16 @@ func (a *recordingAuthorization) ListRelationships(_ context.Context, req *proto
 	filtered := make([]*proto.Relationship, 0, len(a.relations))
 	for _, relationship := range a.relations {
 		if req != nil && req.Filter != nil {
-			if req.Filter.Target != nil && !gproto.Equal(req.Filter.Target, relationship.Tuple.Target) {
+			if req.Filter.Target != nil && relationshipTargetTestKey(req.Filter.Target) != relationshipTargetTestKey(relationship.Tuple.Target) {
 				continue
 			}
 			if req.Filter.Relation != "" && req.Filter.Relation != relationship.Tuple.Relation {
 				continue
 			}
-			if req.Filter.Resource != nil && !gproto.Equal(req.Filter.Resource, relationship.Tuple.Resource) {
+			if req.Filter.Resource != nil && (req.Filter.Resource.GetType() != relationship.Tuple.GetResource().GetType() || req.Filter.Resource.GetId() != relationship.Tuple.GetResource().GetId()) {
+				continue
+			}
+			if req.Filter.SourceLayer != proto.SourceLayer_SOURCE_LAYER_UNSPECIFIED && req.Filter.SourceLayer != relationship.SourceLayer {
 				continue
 			}
 		}
@@ -1440,6 +1451,23 @@ func (a *recordingAuthorization) relationshipForUser(coreUserID string) *proto.R
 	return nil
 }
 
+func (a *recordingAuthorization) relationshipForGroupUser(coreUserID, groupID string) *proto.Relationship {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	for _, relationship := range a.relations {
+		tuple := relationship.GetTuple()
+		if tuple.GetRelation() == "member" && tuple.GetResource().GetType() == "group" && tuple.GetResource().GetId() == groupID && tuple.GetTarget().GetSubject().GetId() == "user:"+coreUserID {
+			return gproto.Clone(relationship).(*proto.Relationship)
+		}
+	}
+	return nil
+}
+
+func (a *recordingAuthorization) additionCount() int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.additions
+}
 func projectedRelationship(coreUserID string, source proto.SourceLayer) *proto.Relationship {
 	return &proto.Relationship{
 		Tuple: &proto.RelationshipTuple{
@@ -1452,12 +1480,31 @@ func projectedRelationship(coreUserID string, source proto.SourceLayer) *proto.R
 }
 
 func relationshipKey(tuple *proto.RelationshipTuple) string {
+	if data, err := (gproto.MarshalOptions{Deterministic: true}).Marshal(tuple); err == nil {
+		return string(data)
+	}
 	target := tuple.GetTarget()
 	targetKey := "subject\x00" + target.GetSubject().GetType() + "\x00" + target.GetSubject().GetId()
 	if subjectSet := target.GetSubjectSet(); subjectSet != nil {
 		targetKey = "subject-set\x00" + subjectSet.GetResource().GetType() + "\x00" + subjectSet.GetResource().GetId() + "\x00" + subjectSet.GetRelation()
 	}
 	return targetKey + "\x00" + tuple.GetRelation() + "\x00" + tuple.GetResource().GetType() + "\x00" + tuple.GetResource().GetId()
+}
+
+func relationshipTargetTestKey(target *proto.RelationshipTarget) string {
+	if target == nil {
+		return "nil"
+	}
+	if subject := target.GetSubject(); subject != nil {
+		return "subject\x00" + subject.GetType() + "\x00" + subject.GetId()
+	}
+	if resource := target.GetResource(); resource != nil {
+		return "resource\x00" + resource.GetType() + "\x00" + resource.GetId()
+	}
+	if subjectSet := target.GetSubjectSet(); subjectSet != nil {
+		return "subject-set\x00" + subjectSet.GetResource().GetType() + "\x00" + subjectSet.GetResource().GetId() + "\x00" + subjectSet.GetRelation()
+	}
+	return "empty"
 }
 
 var _ core.AuthorizationProvider = (*recordingAuthorization)(nil)


### PR DESCRIPTION
## Problem Statement

SCIM User and Group reads amplified authorization traffic because relationship access was shaped around hydration instead of the caller's filter and requested page. A selective User collection request could first load the stored candidate set, then hydrate every candidate. Active-state projection and nested group expansion performed repeated authorization lookups, including broad relationship scans. Group filtering had a similar hydrate-then-filter shape. The result was one external SCIM request fanning out into many downstream relationship reads.

The retained-log sample that motivated this work contained approximately 1,293 external SCIM requests and 3,403 downstream authorization request entries associated with Rippling, with no comparable Rippling traffic in the preceding six hours. These numbers establish correlation and an amplification shape, not an exact causal trace: retained aggregate logs do not preserve the full outer HTTP method/filter mix or request-to-tuple lineage.

After this change, stored filters and pagination run before authorization hydration. Each User on the requested page uses one exact runtime-subject query for both active projection and direct group membership. Nested group expansion uses exact runtime subject-set queries cached once per visited group for the request. Empty pages perform no authorization reads. Group member filters and group hydration likewise use exact target/resource shapes rather than an unfiltered relationship walk.

## Solution

- Filter and paginate stored User and Group records before hydrating authorization-derived fields.
- Use the `by_client_user_name` SCIM resource index for exact `userName` filters.
- Read each hydrated User's runtime relationships once with an exact subject target and reuse them for active state and direct group membership.
- Expand nested groups with request-scoped exact parent queries, a visited set for cycles, and direct-membership precedence over inherited membership.
- Resolve `members.value` filters before group hydration and distinguish a real User/Group miss from a datastore failure.
- Restrict SCIM projections and metadata maintenance to `SOURCE_LAYER_RUNTIME`; static and unspecified-layer relationships are not exposed through SCIM.
- Compare logical tuples without endpoint properties while retaining every physical property-bearing tuple returned by the provider, so removing a logical SCIM membership deletes all of its stored variants.
- Build one deterministic non-empty relationship batch, with `DELETE` operations before `TOUCH` operations, and invoke G1's optional writer once.
- Fall back to the legacy Add/Delete operations only when the optional capability is absent or returns gRPC `Unimplemented`; cache that negative capability for the service lifetime.
- If a legacy batch fails after a successful prefix, update the SCIM metadata and projections affected by that prefix before returning the original failure.
- Keep SCIM PATCH and Bulk unsupported.

### App Operations

The externally visible operations remain the existing SCIM HTTP endpoints:

- `GET /scim/v2/Users` and `GET /scim/v2/Users/{id}`
- `POST`, `PUT`, and `DELETE` on `/scim/v2/Users`
- `GET /scim/v2/Groups` and `GET /scim/v2/Groups/{id}`
- `POST`, `PUT`, and `DELETE` on `/scim/v2/Groups`

External authorization writers may also invoke the exported optional `AuthorizationRelationshipWriter`; the SCIM authorization gate forwards one batch and updates the affected SCIM User/Group metadata after a successful runtime relationship change.

### Interface / Index Changes

This PR does not add another public API, change SCIM wire schemas, or create provider storage indexes. It consumes the optional `AuthorizationRelationshipWriter` introduced by G1 and sends exact `RelationshipFilter` shapes that provider P1 can satisfy through its three new indexes:

- exact resource + relation + source;
- exact direct subject + source;
- exact subject-set + source.

Within Gestalt's existing `scim_resources` store, exact `userName` filtering uses the existing `by_client_user_name` index. Broader supported filters retain their stored-record fallback.

### Standards Alignment

SCIM collection filtering/pagination and resource replacement behavior follow [RFC 7644 §3.4.2](https://www.rfc-editor.org/rfc/rfc7644.html#section-3.4.2) and [RFC 7644 §3.5.2](https://www.rfc-editor.org/rfc/rfc7644.html#section-3.5.2).

Relationship state remains a Gestalt-native API using the Zanzibar tuple model described in [Zanzibar §§2.4.1–2.4.2](https://storage.googleapis.com/gweb-research2023-media/pubtools/5068.pdf) and [Authzed's core tuple definitions](https://github.com/authzed/api/blob/main/authzed/api/v1/core.proto). Batched mutation uses the supported `TOUCH`/`DELETE` and atomic-commit subset documented by [Authzed PermissionService](https://github.com/authzed/api/blob/main/authzed/api/v1/permission_service.proto) and [SpiceDB relationship writing](https://authzed.com/docs/spicedb/ops/data/writing-relationships).

The API is not wire-compatible with Authzed/SpiceDB and does not implement ZedTokens, consistency selectors, Watch, caveats, expiration, transaction metadata, or bulk-filter deletion. It is intentionally not described as AuthZEN-conformant: [AuthZEN 1.0](https://openid.net/specs/authorization-api-1_0.html) standardizes authorization evaluation and search, not relationship administration.

### Compatibility and Failure Modes

- SCIM endpoint paths, request/response schemas, ETags, and supported filter grammar remain unchanged.
- Providers without the optional writer retain the legacy Add/Delete behavior after one capability check.
- Only `Unimplemented` triggers fallback. Validation, capacity, transaction, and other writer failures are returned without replaying the batch through legacy calls.
- The atomic writer path applies the whole relationship diff or none. The legacy fallback remains intentionally non-atomic; a failure returns HTTP 503 and a retry reconciles against live provider state.
- A successful relationship write followed by a SCIM metadata-touch failure can return an error after canonical provider state has committed. Retrying is safe because diffs are computed from current provider state.
- Logical tuple equality ignores endpoint properties, while provider storage identity may retain them. Unchanged property-bearing variants are preserved; removing the logical membership deletes every physical variant.
- Stored static and unspecified source layers do not appear in SCIM membership/active projections. An unspecified-source delete is resolved against current runtime state before mutation and advances SCIM metadata when it removes a runtime tuple.
- PATCH and Bulk remain disabled.

### Validation

- Full `internal/scim` HTTP and authorization contract suite passes.
- The same suite passes under Go's race detector.
- Focused Go vet passes.
- Adjacent authorization RPC, server, and provider-gateway suites pass.
- Behavioral HTTP coverage verifies requested-page-only hydration, zero reads for empty pages, exact runtime filtering, nested groups with cycles and direct precedence, member-filter datastore failures versus true misses, scoped deletion, pagination, property-bearing tuple variants, logical no-op diffs, and successful-prefix metadata after a legacy failure.
- Exported-contract coverage verifies one writer invocation for a non-empty batch, deterministic `DELETE`-before-`TOUCH` ordering, no call for an empty diff, cached negative capability detection, fallback only for `Unimplemented`, and no legacy replay after other writer errors.
- External writes through the exported authorization gate verify updated Group/User projections and `meta.lastModified` through SCIM HTTP responses, including an unspecified-source delete of a stored runtime tuple. Tests do not call private planner, diff, transaction, or metadata helpers.

### Rollout

G1 and provider P1 are merged. This PR can merge independently of provider P2 because writer capability discovery retains the legacy fallback. Deploy the optimized atomic path only after provider P2 supplies the writer. Monitor authorization relationship query volume, SCIM request latency, optional-writer fallback frequency, legacy partial failures, and metadata-touch failures. PATCH and Bulk remain disabled.

### Workflows

[G1 #3169](https://github.com/valon-technologies/gestalt/pull/3169) and [provider P1 #1310](https://github.com/valon-technologies/gestalt-providers/pull/1310) are merged. [Provider P2 #1311](https://github.com/valon-technologies/gestalt-providers/pull/1311) is based on provider `main` and pinned to G1's immutable merge SHA. No deployment PR is included in this stack.
