### PR TITLE
Support atomic SCIM Group membership PATCH

### DIFF
--- a/gestaltd/internal/scim/compact_groups.go
+++ b/gestaltd/internal/scim/compact_groups.go
@@ -14,21 +14,19 @@ import (
 )
 
 func (s *CompactService) groupValue(ctx context.Context, r storedResource) (Group, error) {
+	g, _, err := s.groupValueAndTuples(ctx, r)
+	return g, err
+}
+
+func (s *CompactService) groupValueAndTuples(ctx context.Context, r storedResource) (Group, []*proto.RelationshipTuple, error) {
 	g := Group{Schemas: []string{GroupSchemaURN}, ID: r.ID, ExternalID: r.ExternalID, DisplayName: r.DisplayName, Meta: Meta{ResourceType: "Group", Created: r.CreatedAt, LastModified: r.UpdatedAt, Location: s.baseURL + "/scim/v2/Groups/" + r.ID}}
-	m, e := s.liveMembers(ctx, r.ClientID, r.ID)
-	if e != nil {
-		return Group{}, unavailable("could not read group membership")
+	m, tuples, err := s.liveMembersAndTuples(ctx, r.ClientID, r.ID)
+	if err != nil {
+		return Group{}, nil, unavailable("could not read group membership")
 	}
 	g.Members = m
-	canon := struct {
-		Schemas     []string `json:"schemas"`
-		ID          string   `json:"id"`
-		ExternalID  string   `json:"externalId,omitempty"`
-		DisplayName string   `json:"displayName"`
-		Members     []Member `json:"members,omitempty"`
-	}{g.Schemas, g.ID, g.ExternalID, g.DisplayName, g.Members}
-	g.Meta.Version = etag(canon)
-	return g, nil
+	g.Meta.Version = groupContentETag(g)
+	return g, tuples, nil
 }
 
 func validateRetainedMemberAttributes(previous, next []Member) error {
@@ -50,12 +48,13 @@ func validateRetainedMemberAttributes(previous, next []Member) error {
 	return nil
 }
 
-func (s *CompactService) liveMembers(ctx context.Context, cid, gid string) ([]Member, error) {
+func (s *CompactService) liveMembersAndTuples(ctx context.Context, cid, gid string) ([]Member, []*proto.RelationshipTuple, error) {
 	rs, e := s.listRelationships(ctx, &proto.RelationshipFilter{Resource: &proto.Resource{Type: "group", Id: gid}, Relation: "member", SourceLayer: proto.SourceLayer_SOURCE_LAYER_RUNTIME}, 100)
 	if e != nil {
-		return nil, e
+		return nil, nil, e
 	}
 	out := []Member{}
+	physical := []*proto.RelationshipTuple{}
 	seen := map[string]struct{}{}
 	for _, x := range rs {
 		if x.GetSourceLayer() != proto.SourceLayer_SOURCE_LAYER_RUNTIME {
@@ -65,11 +64,12 @@ func (s *CompactService) liveMembers(ctx context.Context, cid, gid string) ([]Me
 		if sub := t.GetSubject(); sub != nil && strings.HasPrefix(sub.Id, "user:") {
 			users, err := s.db.ObjectStore(coredata.StoreSCIMResources).Index("by_client_core_user").GetAll(ctx, []any{cid, "User", strings.TrimPrefix(sub.Id, "user:")})
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 			if len(users) != 1 {
 				continue
 			}
+			physical = append(physical, x.GetTuple())
 			u := users[0]
 			member := Member{Value: recordString(u, "id"), Ref: s.baseURL + "/scim/v2/Users/" + recordString(u, "id"), Type: "User"}
 			key := member.Type + "\x00" + member.Value
@@ -82,10 +82,11 @@ func (s *CompactService) liveMembers(ctx context.Context, cid, gid string) ([]Me
 			gr, e := s.findGroup(ctx, cid, ss.Resource.Id)
 			if e != nil {
 				if !errors.Is(e, idb.ErrNotFound) {
-					return nil, e
+					return nil, nil, e
 				}
 				continue
 			}
+			physical = append(physical, x.GetTuple())
 			member := Member{Value: gr.ID, Ref: s.baseURL + "/scim/v2/Groups/" + gr.ID, Type: "Group"}
 			key := member.Type + "\x00" + member.Value
 			if _, exists := seen[key]; exists {
@@ -95,8 +96,18 @@ func (s *CompactService) liveMembers(ctx context.Context, cid, gid string) ([]Me
 			out = append(out, member)
 		}
 	}
-	sort.Slice(out, func(i, j int) bool { return out[i].Value < out[j].Value })
-	return out, nil
+	sortMembers(out)
+	sort.SliceStable(physical, func(i, j int) bool { return physicalTupleKey(physical[i]) < physicalTupleKey(physical[j]) })
+	return out, physical, nil
+}
+
+func sortMembers(members []Member) {
+	sort.Slice(members, func(i, j int) bool {
+		if members[i].Value != members[j].Value {
+			return members[i].Value < members[j].Value
+		}
+		return members[i].Type < members[j].Type
+	})
 }
 func (s *CompactService) groupTuple(ctx context.Context, cid, gid string, m Member) (*proto.RelationshipTuple, error) {
 	if strings.TrimSpace(m.Value) == "" {

--- a/gestaltd/internal/scim/group_patch.go
+++ b/gestaltd/internal/scim/group_patch.go
@@ -1,0 +1,526 @@
+package scim
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const PatchOpSchemaURN = "urn:ietf:params:scim:api:messages:2.0:PatchOp"
+
+type groupPatchRequest struct {
+	operations []groupPatchOperation
+}
+
+type groupPatchOperation struct {
+	op      string
+	path    groupPatchPath
+	members []Member
+}
+
+type groupPatchPath struct {
+	kind     groupPatchPathKind
+	memberID string
+}
+
+type groupPatchPathKind int
+
+const (
+	groupPatchPathless groupPatchPathKind = iota
+	groupPatchMembers
+	groupPatchFilteredMember
+	groupPatchSubattribute
+	groupPatchMetadata
+)
+
+var memberFilterExpression = regexp.MustCompile(`(?is)^\s*value\s+eq\s+("(?:\\.|[^"\\])*")\s*$`)
+
+// parseGroupPatchRequest validates the PatchOp envelope and all operation
+// shapes that can be understood without consulting the SCIM resource store.
+// Resource/member existence and $ref/type validation happen while evaluating
+// the request under the per-group lock.
+func parseGroupPatchRequest(raw json.RawMessage) (groupPatchRequest, error) {
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &envelope); err != nil || envelope == nil {
+		return groupPatchRequest{}, invalidSyntax("PatchOp must be a JSON object")
+	}
+	schemasRaw, ok := rawField(envelope, "schemas")
+	if !ok {
+		return groupPatchRequest{}, invalidSyntax("PatchOp schemas is required")
+	}
+	var schemas []string
+	if err := json.Unmarshal(schemasRaw, &schemas); err != nil || len(schemas) == 0 {
+		return groupPatchRequest{}, invalidSyntax("PatchOp schemas must be a non-empty array")
+	}
+	patchSchemaCount := 0
+	for _, schema := range schemas {
+		if strings.TrimSpace(schema) == "" {
+			return groupPatchRequest{}, invalidSyntax("PatchOp schemas must not contain empty values")
+		}
+		if !strings.HasPrefix(strings.ToLower(strings.TrimSpace(schema)), "urn:") {
+			return groupPatchRequest{}, invalidSyntax("PatchOp schemas must contain URNs")
+		}
+		if schema == PatchOpSchemaURN {
+			patchSchemaCount++
+		}
+	}
+	if patchSchemaCount != 1 {
+		return groupPatchRequest{}, invalidSyntax("PatchOp schemas must contain exactly one PatchOp schema")
+	}
+	operationsRaw, ok := rawField(envelope, "Operations")
+	if !ok {
+		return groupPatchRequest{}, invalidSyntax("PatchOp Operations is required")
+	}
+	var operationValues []json.RawMessage
+	if err := json.Unmarshal(operationsRaw, &operationValues); err != nil || len(operationValues) == 0 {
+		return groupPatchRequest{}, invalidSyntax("PatchOp Operations must be a non-empty array")
+	}
+	request := groupPatchRequest{operations: make([]groupPatchOperation, 0, len(operationValues))}
+	for _, operationRaw := range operationValues {
+		operation, err := parseGroupPatchOperation(operationRaw)
+		if err != nil {
+			return groupPatchRequest{}, err
+		}
+		request.operations = append(request.operations, operation)
+	}
+	return request, nil
+}
+
+func parseGroupPatchOperation(raw json.RawMessage) (groupPatchOperation, error) {
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &object); err != nil || object == nil {
+		return groupPatchOperation{}, invalid("each PatchOp operation must be an object")
+	}
+	opRaw, ok := rawField(object, "op")
+	if !ok {
+		return groupPatchOperation{}, invalid("PatchOp operation op is required")
+	}
+	var op string
+	if err := json.Unmarshal(opRaw, &op); err != nil || strings.TrimSpace(op) == "" {
+		return groupPatchOperation{}, invalid("PatchOp operation op must be a string")
+	}
+	op = strings.ToLower(strings.TrimSpace(op))
+	pathRaw, hasPath := rawField(object, "path")
+	var pathText string
+	if hasPath {
+		if string(bytes.TrimSpace(pathRaw)) == "null" {
+			return groupPatchOperation{}, invalid("PatchOp operation path must be a string")
+		}
+		if err := json.Unmarshal(pathRaw, &pathText); err != nil {
+			return groupPatchOperation{}, invalid("PatchOp operation path must be a string")
+		}
+	}
+	valueRaw, hasValue := rawField(object, "value")
+	if op != "add" && op != "remove" && op != "replace" {
+		return groupPatchOperation{}, invalid(fmt.Sprintf("unsupported PatchOp operation %q", op))
+	}
+	if (op == "add" || op == "replace") && !hasValue {
+		return groupPatchOperation{}, invalid("PatchOp add and replace operations require value")
+	}
+	path, err := parseGroupPatchPath(pathText, hasPath)
+	if err != nil {
+		return groupPatchOperation{}, err
+	}
+	operation := groupPatchOperation{op: op, path: path}
+	if path.kind == groupPatchSubattribute {
+		return groupPatchOperation{}, mutability("group member subattributes are immutable or read-only")
+	}
+	if path.kind == groupPatchMetadata {
+		return groupPatchOperation{}, notImplementedPatch("Group metadata PATCH is not supported")
+	}
+	if op == "replace" {
+		return groupPatchOperation{}, notImplementedPatch("Group PATCH replace is not supported")
+	}
+	if op == "remove" {
+		if !hasPath || path.kind == groupPatchPathless {
+			return groupPatchOperation{}, noTarget("remove requires a member path")
+		}
+		if path.kind == groupPatchMembers {
+			return groupPatchOperation{}, notImplementedPatch("removing the entire members collection is not supported")
+		}
+		return operation, nil
+	}
+	if !hasValue {
+		return groupPatchOperation{}, invalid("add requires a value")
+	}
+	if path.kind == groupPatchFilteredMember {
+		return groupPatchOperation{}, notImplementedPatch("filtered member add is not supported")
+	}
+	if path.kind == groupPatchPathless {
+		var objectValue map[string]json.RawMessage
+		if err := json.Unmarshal(valueRaw, &objectValue); err != nil || objectValue == nil {
+			return groupPatchOperation{}, invalid("pathless add value must contain members")
+		}
+		for key := range objectValue {
+			if strings.EqualFold(key, "displayName") || strings.EqualFold(key, "externalId") || strings.EqualFold(key, "schemas") {
+				return groupPatchOperation{}, notImplementedPatch("Group metadata PATCH is not supported")
+			}
+		}
+		membersRaw, ok := rawField(objectValue, "members")
+		if !ok || len(objectValue) != 1 {
+			return groupPatchOperation{}, invalid("pathless add value must contain only members")
+		}
+		members, err := parsePatchMembers(membersRaw)
+		if err != nil {
+			return groupPatchOperation{}, err
+		}
+		operation.members = members
+		return operation, nil
+	}
+	members, err := parsePatchMembers(valueRaw)
+	if err != nil {
+		return groupPatchOperation{}, err
+	}
+	operation.members = members
+	return operation, nil
+}
+
+func rawField(object map[string]json.RawMessage, name string) (json.RawMessage, bool) {
+	if value, ok := object[name]; ok {
+		return value, true
+	}
+	for key, value := range object {
+		if strings.EqualFold(key, name) {
+			return value, true
+		}
+	}
+	return nil, false
+}
+
+func parsePatchMembers(raw json.RawMessage) ([]Member, error) {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil, invalid("member value is required")
+	}
+	var values []json.RawMessage
+	switch raw[0] {
+	case '[':
+		if err := json.Unmarshal(raw, &values); err != nil {
+			return nil, invalid("members value must be an array or object")
+		}
+	case '{':
+		values = []json.RawMessage{raw}
+	default:
+		return nil, invalid("members value must be an array or object")
+	}
+	if len(values) == 0 {
+		return []Member{}, nil
+	}
+	result := make([]Member, 0, len(values))
+	for _, value := range values {
+		var object map[string]json.RawMessage
+		if err := json.Unmarshal(value, &object); err != nil || object == nil {
+			return nil, invalid("each group member must be an object")
+		}
+		for key := range object {
+			switch strings.ToLower(key) {
+			case "value", "$ref", "type", "display":
+			default:
+				return nil, invalid("unsupported group member attribute")
+			}
+		}
+		valueRaw, ok := rawField(object, "value")
+		if !ok {
+			return nil, invalid("group member value is required")
+		}
+		var id string
+		if err := json.Unmarshal(valueRaw, &id); err != nil || strings.TrimSpace(id) == "" {
+			return nil, invalid("group member value must be a non-empty string")
+		}
+		member := Member{Value: id}
+		for _, field := range []struct {
+			name        string
+			destination *string
+		}{{"$ref", &member.Ref}, {"type", &member.Type}, {"display", &member.Display}} {
+			fieldRaw, present := rawField(object, field.name)
+			if !present {
+				continue
+			}
+			if string(bytes.TrimSpace(fieldRaw)) == "null" {
+				return nil, invalid(fmt.Sprintf("group member %s must be a string", field.name))
+			}
+			if err := json.Unmarshal(fieldRaw, field.destination); err != nil {
+				return nil, invalid(fmt.Sprintf("group member %s must be a string", field.name))
+			}
+		}
+		result = append(result, member)
+	}
+	return result, nil
+}
+
+func parseGroupPatchPath(path string, supplied bool) (groupPatchPath, error) {
+	path = strings.TrimSpace(path)
+	if !supplied || path == "" {
+		return groupPatchPath{kind: groupPatchPathless}, nil
+	}
+	lower := strings.ToLower(path)
+	base := lower
+	if index := strings.Index(base, "["); index >= 0 {
+		close := strings.LastIndex(path, "]")
+		if close < 0 {
+			return groupPatchPath{}, invalidPath("malformed group member filter")
+		}
+		base = strings.TrimSpace(base[:index])
+		if !isMembersPathBase(base) {
+			return groupPatchPath{}, invalidPath("unknown Group PATCH path")
+		}
+		expression := path[index+1 : close]
+		match := memberFilterExpression.FindStringSubmatch(expression)
+		if len(match) != 2 {
+			return groupPatchPath{}, invalidPath("malformed group member filter")
+		}
+		var id string
+		if err := json.Unmarshal([]byte(match[1]), &id); err != nil {
+			return groupPatchPath{}, invalidPath("malformed group member filter value")
+		}
+		if trailing := strings.TrimSpace(path[close+1:]); trailing != "" {
+			if strings.HasPrefix(trailing, ".") {
+				if isMemberSubattribute(strings.TrimPrefix(strings.ToLower(trailing), ".")) {
+					return groupPatchPath{kind: groupPatchSubattribute}, nil
+				}
+				return groupPatchPath{}, invalidPath("unknown Group member subattribute")
+			}
+			return groupPatchPath{}, invalidPath("malformed group member filter")
+		}
+		return groupPatchPath{kind: groupPatchFilteredMember, memberID: id}, nil
+	}
+	if strings.Contains(lower, ".") {
+		for _, prefix := range []string{"members.", strings.ToLower(GroupSchemaURN) + ":members."} {
+			if strings.HasPrefix(lower, prefix) {
+				if isMemberSubattribute(strings.TrimPrefix(lower, prefix)) {
+					return groupPatchPath{kind: groupPatchSubattribute}, nil
+				}
+				return groupPatchPath{}, invalidPath("unknown Group member subattribute")
+			}
+		}
+	}
+	if isMembersPathBase(lower) {
+		return groupPatchPath{kind: groupPatchMembers}, nil
+	}
+	if lower == "displayname" || lower == "externalid" || lower == "schemas" || lower == strings.ToLower(GroupSchemaURN)+":displayname" || lower == strings.ToLower(GroupSchemaURN)+":externalid" || lower == strings.ToLower(GroupSchemaURN)+":schemas" {
+		return groupPatchPath{kind: groupPatchMetadata}, nil
+	}
+	return groupPatchPath{}, invalidPath("unknown Group PATCH path")
+}
+
+func isMembersPathBase(path string) bool {
+	return path == "members" || path == strings.ToLower(GroupSchemaURN)+":members"
+}
+
+func isMemberSubattribute(path string) bool {
+	switch strings.TrimSpace(path) {
+	case "value", "$ref", "type", "display":
+		return true
+	default:
+		return false
+	}
+}
+
+func invalidPath(detail string) *Error {
+	return &Error{Status: http.StatusBadRequest, SCIMType: "invalidPath", Detail: detail}
+}
+
+func notImplementedPatch(detail string) *Error {
+	return &Error{Status: http.StatusNotImplemented, Detail: detail}
+}
+
+type patchMemberState struct {
+	member Member
+	tuple  *proto.RelationshipTuple
+}
+
+func (s *CompactService) PatchGroup(ctx context.Context, cid, id, ifMatch string, request groupPatchRequest) (*Group, error) {
+	unlock := s.lock(id)
+	defer unlock()
+	storedGroup, err := s.findGroup(ctx, cid, id)
+	if err != nil {
+		if isNotFoundError(err) {
+			return nil, notFoundResource("SCIM Group")
+		}
+		return nil, unavailable("could not load SCIM group")
+	}
+	old, initialTuples, err := s.groupValueAndTuples(ctx, storedGroup)
+	if err != nil {
+		return nil, err
+	}
+	if ifMatch != "" && ifMatch != "*" && ifMatch != old.Meta.Version {
+		return nil, &Error{Status: 412, Detail: "SCIM resource version does not match"}
+	}
+	state := make(map[string]patchMemberState, len(old.Members))
+	for _, member := range old.Members {
+		resolved, err := s.resolvePatchMember(ctx, cid, id, member)
+		if err != nil {
+			return nil, err
+		}
+		state[tupleKey(resolved.tuple)] = resolved
+	}
+	for _, operation := range request.operations {
+		switch operation.op {
+		case "add":
+			for _, member := range operation.members {
+				resolved, err := s.resolvePatchMember(ctx, cid, id, member)
+				if err != nil {
+					return nil, err
+				}
+				key := tupleKey(resolved.tuple)
+				if _, exists := state[key]; !exists {
+					state[key] = resolved
+				}
+			}
+		case "remove":
+			resolved, err := s.resolvePatchMemberID(ctx, cid, id, operation.path.memberID)
+			if err != nil {
+				return nil, err
+			}
+			delete(state, tupleKey(resolved.tuple))
+		}
+	}
+	keys := make([]string, 0, len(state))
+	for key := range state {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		left, right := state[keys[i]].member, state[keys[j]].member
+		if left.Value != right.Value {
+			return left.Value < right.Value
+		}
+		return left.Type < right.Type
+	})
+	finalMembers := make([]Member, 0, len(keys))
+	finalTuples := make([]*proto.RelationshipTuple, 0, len(keys))
+	for _, key := range keys {
+		finalMembers = append(finalMembers, state[key].member)
+		finalTuples = append(finalTuples, state[key].tuple)
+	}
+	// Keep the public representation in exactly the same canonical order as
+	// groupValue, so a PATCH response and an immediate GET hash identically.
+	sortMembers(finalMembers)
+	updates := relationshipDiffUpdates(initialTuples, finalTuples)
+	if len(updates) == 0 {
+		return &old, nil
+	}
+	writer, ok := s.authorization.(core.AuthorizationRelationshipWriter)
+	if !ok {
+		return nil, notImplementedPatch("atomic authorization relationship writes are not available")
+	}
+	if _, err := writer.WriteRelationships(ctx, &proto.WriteRelationshipsRequest{Updates: updates}); err != nil {
+		if status.Code(err) == codes.Unimplemented {
+			return nil, notImplementedPatch("atomic authorization relationship writes are not available")
+		}
+		return nil, unavailable("could not apply group membership atomically")
+	}
+	// Membership is canonical in the provider. Timestamp maintenance is only
+	// informational and must not turn a committed provider mutation into a
+	// failed SCIM request.
+	touchCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), time.Second)
+	if err := s.touchAppliedRelationships(touchCtx, updates, nil); err != nil {
+		slog.WarnContext(touchCtx, "SCIM Group PATCH committed but metadata touch failed", "group_id", id, "error", err)
+	}
+	cancel()
+	next := old
+	next.Members = finalMembers
+	next.Meta.LastModified = s.nowUTC()
+	if touched, err := s.findGroup(ctx, cid, id); err == nil && !touched.UpdatedAt.IsZero() {
+		next.Meta.LastModified = touched.UpdatedAt
+	}
+	next.Meta.Version = groupContentETag(next)
+	return &next, nil
+}
+
+func (s *CompactService) resolvePatchMember(ctx context.Context, cid, gid string, member Member) (patchMemberState, error) {
+	tuple, err := s.groupTuple(ctx, cid, gid, member)
+	if err != nil {
+		return patchMemberState{}, err
+	}
+	resourceType := "Group"
+	ref := s.baseURL + "/scim/v2/Groups/" + member.Value
+	if tuple.GetTarget().GetSubject() != nil {
+		resourceType = "User"
+		ref = s.baseURL + "/scim/v2/Users/" + member.Value
+	}
+	return patchMemberState{member: Member{Value: member.Value, Ref: ref, Type: resourceType}, tuple: tuple}, nil
+}
+
+func (s *CompactService) resolvePatchMemberID(ctx context.Context, cid, gid, id string) (patchMemberState, error) {
+	if user, err := s.findUser(ctx, cid, id); err == nil {
+		return s.resolvePatchMember(ctx, cid, gid, Member{Value: user.ID, Type: "User", Ref: s.baseURL + "/scim/v2/Users/" + user.ID})
+	} else if !isNotFoundError(err) {
+		return patchMemberState{}, unavailable("could not validate group member")
+	}
+	if group, err := s.findGroup(ctx, cid, id); err == nil {
+		return s.resolvePatchMember(ctx, cid, gid, Member{Value: group.ID, Type: "Group", Ref: s.baseURL + "/scim/v2/Groups/" + group.ID})
+	} else if !isNotFoundError(err) {
+		return patchMemberState{}, unavailable("could not validate group member")
+	}
+	return patchMemberState{}, noTarget("group member must reference a User or Group in this SCIM client")
+}
+
+func relationshipDiffUpdates(from, to []*proto.RelationshipTuple) []*proto.RelationshipUpdate {
+	fromByKey := map[string][]*proto.RelationshipTuple{}
+	for _, tuple := range from {
+		fromByKey[tupleKey(tuple)] = append(fromByKey[tupleKey(tuple)], tuple)
+	}
+	toByKey := map[string]*proto.RelationshipTuple{}
+	for _, tuple := range to {
+		if _, exists := toByKey[tupleKey(tuple)]; !exists {
+			toByKey[tupleKey(tuple)] = tuple
+		}
+	}
+	type change struct {
+		logical, physical string
+		tuple             *proto.RelationshipTuple
+	}
+	deletes := []change{}
+	for key, tuples := range fromByKey {
+		if _, keep := toByKey[key]; keep {
+			continue
+		}
+		for _, tuple := range tuples {
+			deletes = append(deletes, change{logical: key, physical: physicalTupleKey(tuple), tuple: tuple})
+		}
+	}
+	adds := []change{}
+	for key, tuple := range toByKey {
+		if _, exists := fromByKey[key]; !exists {
+			adds = append(adds, change{logical: key, tuple: tuple})
+		}
+	}
+	sort.Slice(deletes, func(i, j int) bool {
+		if deletes[i].logical != deletes[j].logical {
+			return deletes[i].logical < deletes[j].logical
+		}
+		return deletes[i].physical < deletes[j].physical
+	})
+	sort.Slice(adds, func(i, j int) bool { return adds[i].logical < adds[j].logical })
+	updates := make([]*proto.RelationshipUpdate, 0, len(deletes)+len(adds))
+	for _, item := range deletes {
+		updates = append(updates, &proto.RelationshipUpdate{Operation: proto.RelationshipUpdate_OPERATION_DELETE, Relationship: &proto.Relationship{Tuple: item.tuple, SourceLayer: proto.SourceLayer_SOURCE_LAYER_RUNTIME}})
+	}
+	for _, item := range adds {
+		updates = append(updates, &proto.RelationshipUpdate{Operation: proto.RelationshipUpdate_OPERATION_TOUCH, Relationship: &proto.Relationship{Tuple: item.tuple, SourceLayer: proto.SourceLayer_SOURCE_LAYER_RUNTIME}})
+	}
+	return updates
+}
+
+func groupContentETag(group Group) string {
+	canon := struct {
+		Schemas     []string `json:"schemas"`
+		ID          string   `json:"id"`
+		ExternalID  string   `json:"externalId,omitempty"`
+		DisplayName string   `json:"displayName"`
+		Members     []Member `json:"members,omitempty"`
+	}{group.Schemas, group.ID, group.ExternalID, group.DisplayName, group.Members}
+	return etag(canon)
+}

--- a/gestaltd/internal/scim/groups_http_test.go
+++ b/gestaltd/internal/scim/groups_http_test.go
@@ -105,9 +105,9 @@ func TestSCIMGroupsCRUDAndUserGroups(t *testing.T) {
 	if groupProjection.Code != http.StatusOK || bytes.Contains(groupProjection.Body.Bytes(), []byte(`"displayName"`)) || !bytes.Contains(groupProjection.Body.Bytes(), []byte(`"schemas"`)) || !bytes.Contains(groupProjection.Body.Bytes(), []byte(`"id"`)) {
 		t.Fatalf("Group excludedAttributes projection = %d %s", groupProjection.Code, groupProjection.Body.String())
 	}
-	unsupportedPatch := scimRequest(t, handler, http.MethodPatch, "/scim/v2/Groups/"+created.ID, testCurrentToken, map[string]any{"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"}, "Operations": []map[string]any{}})
-	if payload := decodeResponse[testErrorResponse](t, unsupportedPatch); unsupportedPatch.Code != http.StatusNotImplemented || payload.Status != "501" {
-		t.Fatalf("unsupported Group PATCH = %d %#v", unsupportedPatch.Code, payload)
+	invalidPatch := scimRequest(t, handler, http.MethodPatch, "/scim/v2/Groups/"+created.ID, testCurrentToken, map[string]any{"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"}, "Operations": []map[string]any{}})
+	if payload := decodeResponse[testErrorResponse](t, invalidPatch); invalidPatch.Code != http.StatusBadRequest || payload.SCIMType != "invalidSyntax" {
+		t.Fatalf("invalid Group PATCH = %d %#v", invalidPatch.Code, payload)
 	}
 	coreAlice, err := services.Users.FindUserByEmail(context.Background(), "alice@valon.com")
 	if err != nil {

--- a/gestaltd/internal/scim/groups_patch_http_test.go
+++ b/gestaltd/internal/scim/groups_patch_http_test.go
@@ -1,0 +1,416 @@
+package scim_test
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/scim"
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	gproto "google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+func TestSCIMGroupPatchMembershipOperations(t *testing.T) {
+	t.Parallel()
+
+	authorization := &batchRecordingAuthorization{recordingAuthorization: newRecordingAuthorization()}
+	clients := map[string]config.SCIMClientConfig{
+		"rippling": ripplingClient(nil),
+		"entra":    {Credentials: []config.SCIMCredentialConfig{{ID: "current", BearerToken: "entra-token"}}},
+	}
+	_, _, handler := newSCIMService(t, nil, authorization, testSCIMConfig(clients))
+	alice, response := createUser(t, handler, testCurrentToken, "patch-alice@valon.com", true, nil)
+	if response.Code != http.StatusCreated {
+		t.Fatalf("create Alice = %d %s", response.Code, response.Body.String())
+	}
+	bob, response := createUser(t, handler, testCurrentToken, "patch-bob@valon.com", true, nil)
+	if response.Code != http.StatusCreated {
+		t.Fatalf("create Bob = %d %s", response.Code, response.Body.String())
+	}
+	charlie, response := createUser(t, handler, testCurrentToken, "patch-charlie@valon.com", true, nil)
+	if response.Code != http.StatusCreated {
+		t.Fatalf("create Charlie = %d %s", response.Code, response.Body.String())
+	}
+	foreign, response := createUser(t, handler, "entra-token", "patch-foreign@example.com", true, nil)
+	if response.Code != http.StatusCreated {
+		t.Fatalf("create foreign user = %d %s", response.Code, response.Body.String())
+	}
+	createdResponse := scimRequest(t, handler, http.MethodPost, "/scim/v2/Groups", testCurrentToken, map[string]any{
+		"schemas": []string{scim.GroupSchemaURN}, "displayName": "Patch group",
+	})
+	group := decodeResponse[scim.Group](t, createdResponse)
+	if createdResponse.Code != http.StatusCreated {
+		t.Fatalf("create group = %d %s", createdResponse.Code, createdResponse.Body.String())
+	}
+	unrelated := &proto.Relationship{Tuple: &proto.RelationshipTuple{Target: &proto.RelationshipTarget{Kind: &proto.RelationshipTarget_Subject{Subject: &proto.Subject{Type: "subject", Id: "user:unrelated"}}}, Relation: "viewer", Resource: &proto.Resource{Type: "app", Id: "unrelated"}}, SourceLayer: proto.SourceLayer_SOURCE_LAYER_RUNTIME}
+	if _, err := authorization.AddRelationship(context.Background(), &proto.AddRelationshipRequest{Relationship: unrelated}); err != nil {
+		t.Fatalf("seed unrelated relationship = %v", err)
+	}
+
+	add := scimRequest(t, handler, http.MethodPatch, "/scim/v2/Groups/"+group.ID+"?attributes=members", testCurrentToken, map[string]any{
+		"schemas":    []string{scim.PatchOpSchemaURN},
+		"Operations": []map[string]any{{"op": "ADD", "path": " members ", "value": []map[string]any{{"value": alice.ID, "type": "User", "display": "ignored"}, {"value": bob.ID}}}},
+	}, map[string]string{"If-Match": group.Meta.Version})
+	if add.Code != http.StatusOK {
+		t.Fatalf("add members = %d %s", add.Code, add.Body.String())
+	}
+	group = decodeResponse[scim.Group](t, add)
+	if len(group.Members) != 2 || add.Header().Get("Location") == "" || add.Header().Get("Content-Location") == "" || add.Header().Get("ETag") == "" {
+		t.Fatalf("add response = %d headers=%v body=%#v", add.Code, add.Header(), group)
+	}
+	if strings.Contains(add.Body.String(), "displayName") {
+		t.Fatalf("PATCH attributes projection retained displayName: %s", add.Body.String())
+	}
+	immediate := decodeResponse[scim.Group](t, scimRequest(t, handler, http.MethodGet, "/scim/v2/Groups/"+group.ID, testCurrentToken, nil))
+	if add.Header().Get("Location") != immediate.Meta.Location || add.Header().Get("Content-Location") != immediate.Meta.Location || add.Header().Get("ETag") != immediate.Meta.Version || !immediate.Meta.LastModified.After(immediate.Meta.Created) || len(immediate.Members) != len(group.Members) {
+		t.Fatalf("PATCH response differs from immediate GET = response %#v get %#v", group, immediate)
+	}
+	group = immediate
+	authorization.mu.Lock()
+	if len(authorization.writes) == 0 || len(authorization.writes[len(authorization.writes)-1]) != 2 {
+		authorization.mu.Unlock()
+		t.Fatal("add did not issue one two-tuple atomic write")
+	}
+	writesAfterAdd := len(authorization.writes)
+	authorization.mu.Unlock()
+
+	duplicate := scimRequest(t, handler, http.MethodPatch, "/scim/v2/Groups/"+group.ID, testCurrentToken, map[string]any{
+		"schemas": []string{scim.PatchOpSchemaURN}, "Operations": []map[string]any{{"op": "add", "path": "members", "value": map[string]any{"value": alice.ID}}},
+	}, map[string]string{"If-Match": group.Meta.Version})
+	duplicateGroup := decodeResponse[scim.Group](t, duplicate)
+	if duplicate.Code != http.StatusOK || duplicateGroup.Meta.Version != group.Meta.Version || !duplicateGroup.Meta.LastModified.Equal(group.Meta.LastModified) {
+		t.Fatalf("duplicate add changed representation = %d %#v (before %#v)", duplicate.Code, duplicateGroup, group)
+	}
+	authorization.mu.Lock()
+	if len(authorization.writes) != writesAfterAdd {
+		authorization.mu.Unlock()
+		t.Fatal("duplicate add issued an atomic write")
+	}
+	authorization.mu.Unlock()
+
+	qualifiedRemove := scimRequest(t, handler, http.MethodPatch, "/scim/v2/Groups/"+group.ID, testCurrentToken, map[string]any{
+		"schemas": []string{scim.PatchOpSchemaURN}, "Operations": []map[string]any{{"op": " ReMoVe ", "path": "  " + scim.GroupSchemaURN + ":members [ value EQ \"" + strings.ReplaceAll(alice.ID, "-", "\\u002d") + "\" ] "}},
+	}, map[string]string{"If-Match": group.Meta.Version})
+	if qualifiedRemove.Code != http.StatusOK {
+		t.Fatalf("qualified filtered remove = %d %s", qualifiedRemove.Code, qualifiedRemove.Body.String())
+	}
+	group = decodeResponse[scim.Group](t, qualifiedRemove)
+	if len(group.Members) != 1 || group.Members[0].Value != bob.ID {
+		t.Fatalf("qualified filtered remove members = %#v", group.Members)
+	}
+	authorization.mu.Lock()
+	writesBeforeAbsentRemove := len(authorization.writes)
+	authorization.mu.Unlock()
+	absentRemove := scimRequest(t, handler, http.MethodPatch, "/scim/v2/Groups/"+group.ID, testCurrentToken, map[string]any{
+		"schemas": []string{scim.PatchOpSchemaURN}, "Operations": []map[string]any{{"op": "remove", "path": "members[value eq \"" + alice.ID + "\"]"}},
+	}, map[string]string{"If-Match": group.Meta.Version})
+	absentGroup := decodeResponse[scim.Group](t, absentRemove)
+	if absentRemove.Code != http.StatusOK || absentGroup.Meta.Version != group.Meta.Version || !absentGroup.Meta.LastModified.Equal(group.Meta.LastModified) {
+		t.Fatalf("already-absent removal = %d %#v (before %#v)", absentRemove.Code, absentGroup, group)
+	}
+	authorization.mu.Lock()
+	if len(authorization.writes) != writesBeforeAbsentRemove {
+		authorization.mu.Unlock()
+		t.Fatal("already-absent removal issued an atomic write")
+	}
+	authorization.mu.Unlock()
+
+	pathlessAdd := scimRequest(t, handler, http.MethodPatch, "/scim/v2/Groups/"+group.ID, testCurrentToken, map[string]any{
+		"SCHEMAS": []string{scim.PatchOpSchemaURN}, "OPERATIONS": []map[string]any{{"OP": "add", "VALUE": map[string]any{"MEMBERS": map[string]any{"VALUE": alice.ID}}}},
+	}, map[string]string{"If-Match": group.Meta.Version})
+	if pathlessAdd.Code != http.StatusOK || len(decodeResponse[scim.Group](t, pathlessAdd).Members) != 2 {
+		t.Fatalf("pathless add = %d %s", pathlessAdd.Code, pathlessAdd.Body.String())
+	}
+	group = decodeResponse[scim.Group](t, pathlessAdd)
+
+	authorization.mu.Lock()
+	writesBeforeOrdering := len(authorization.writes)
+	addCallsBeforeOrdering, deleteCallsBeforeOrdering := authorization.addCalls, authorization.deleteCalls
+	authorization.mu.Unlock()
+	ordering := scimRequest(t, handler, http.MethodPatch, "/scim/v2/Groups/"+group.ID, testCurrentToken, map[string]any{
+		"schemas": []string{scim.PatchOpSchemaURN}, "Operations": []map[string]any{
+			{"op": "remove", "path": "members[value eq \"" + bob.ID + "\"]"},
+			{"op": "add", "path": "members", "value": map[string]any{"value": charlie.ID}},
+		},
+	}, map[string]string{"If-Match": group.Meta.Version})
+	ordered := decodeResponse[scim.Group](t, ordering)
+	if ordering.Code != http.StatusOK || ordered.Meta.Version == group.Meta.Version || len(ordered.Members) != 2 {
+		t.Fatalf("remove/add ordering = %d %#v", ordering.Code, ordered)
+	}
+	authorization.mu.Lock()
+	if len(authorization.writes) != writesBeforeOrdering+1 || authorization.addCalls != addCallsBeforeOrdering || authorization.deleteCalls != deleteCallsBeforeOrdering {
+		authorization.mu.Unlock()
+		t.Fatalf("PATCH used unexpected relationship calls: writes=%d adds=%d deletes=%d", len(authorization.writes), authorization.addCalls, authorization.deleteCalls)
+	}
+	authorization.mu.Unlock()
+	if response := scimRequest(t, handler, http.MethodPatch, "/scim/v2/Groups/"+group.ID, testCurrentToken, map[string]any{
+		"schemas": []string{scim.PatchOpSchemaURN}, "Operations": []map[string]any{{"op": "remove", "path": "members[value eq \"" + bob.ID + "\"]"}},
+	}, map[string]string{"If-Match": "W/\"stale\""}); response.Code != http.StatusPreconditionFailed || decodeResponse[testErrorResponse](t, response).Status != "412" {
+		t.Fatalf("stale If-Match = %d %s", response.Code, response.Body.String())
+	}
+	if response := scimRequest(t, handler, http.MethodPatch, "/scim/v2/Groups/"+group.ID, testCurrentToken, map[string]any{
+		"schemas": []string{scim.PatchOpSchemaURN}, "Operations": []map[string]any{{"op": "add", "path": "members", "value": map[string]any{"value": foreign.ID}}},
+	}); response.Code != http.StatusBadRequest || decodeResponse[testErrorResponse](t, response).SCIMType != "noTarget" {
+		t.Fatalf("foreign member namespace = %d %s", response.Code, response.Body.String())
+	}
+	if response := scimRequest(t, handler, http.MethodPatch, "/scim/v2/Groups/"+group.ID, testCurrentToken, map[string]any{
+		"schemas": []string{scim.PatchOpSchemaURN}, "Operations": []map[string]any{{"op": "remove", "path": "members[value eq \"missing\"]"}},
+	}); response.Code != http.StatusBadRequest || decodeResponse[testErrorResponse](t, response).SCIMType != "noTarget" {
+		t.Fatalf("missing member removal = %d %s", response.Code, response.Body.String())
+	}
+	foreignGroupResponse := scimRequest(t, handler, http.MethodPost, "/scim/v2/Groups", "entra-token", map[string]any{"schemas": []string{scim.GroupSchemaURN}, "displayName": "Foreign patch group"})
+	foreignGroup := decodeResponse[scim.Group](t, foreignGroupResponse)
+	if foreignGroupResponse.Code != http.StatusCreated {
+		t.Fatalf("create foreign Group = %d %s", foreignGroupResponse.Code, foreignGroupResponse.Body.String())
+	}
+	foreignRead := scimRequest(t, handler, http.MethodPatch, "/scim/v2/Groups/"+foreignGroup.ID, testCurrentToken, map[string]any{
+		"schemas": []string{scim.PatchOpSchemaURN}, "Operations": []map[string]any{{"op": "add", "path": "members", "value": map[string]any{"value": bob.ID}}},
+	})
+	if foreignRead.Code != http.StatusNotFound || decodeResponse[testErrorResponse](t, foreignRead).Status != "404" {
+		t.Fatalf("foreign Group PATCH = %d %s", foreignRead.Code, foreignRead.Body.String())
+	}
+	missingRead := scimRequest(t, handler, http.MethodPatch, "/scim/v2/Groups/missing-group", testCurrentToken, map[string]any{
+		"schemas": []string{scim.PatchOpSchemaURN}, "Operations": []map[string]any{{"op": "add", "path": "members", "value": map[string]any{"value": bob.ID}}},
+	})
+	if missingRead.Code != http.StatusNotFound || decodeResponse[testErrorResponse](t, missingRead).Status != "404" {
+		t.Fatalf("missing Group PATCH = %d %s", missingRead.Code, missingRead.Body.String())
+	}
+	authorization.mu.Lock()
+	if _, ok := authorization.relations[relationshipKey(unrelated.Tuple)]; !ok {
+		authorization.mu.Unlock()
+		t.Fatal("PATCH removed an unrelated runtime relationship")
+	}
+	authorization.mu.Unlock()
+}
+
+func TestSCIMGroupPatchValidationAndAtomicFailures(t *testing.T) {
+	t.Parallel()
+
+	authorization := &batchRecordingAuthorization{recordingAuthorization: newRecordingAuthorization()}
+	_, _, handler := newSCIMService(t, nil, authorization, testSCIMConfig(map[string]config.SCIMClientConfig{"rippling": ripplingClient(nil)}))
+	user, response := createUser(t, handler, testCurrentToken, "patch-validation@valon.com", true, nil)
+	if response.Code != http.StatusCreated {
+		t.Fatalf("create user = %d %s", response.Code, response.Body.String())
+	}
+	groupResponse := scimRequest(t, handler, http.MethodPost, "/scim/v2/Groups", testCurrentToken, map[string]any{"schemas": []string{scim.GroupSchemaURN}, "displayName": "Patch validation"})
+	group := decodeResponse[scim.Group](t, groupResponse)
+	if groupResponse.Code != http.StatusCreated {
+		t.Fatalf("create group = %d %s", groupResponse.Code, groupResponse.Body.String())
+	}
+	tests := []struct {
+		name string
+		body map[string]any
+		code int
+		typ  string
+	}{
+		{"missing schema", map[string]any{"Operations": []map[string]any{{"op": "add", "path": "members", "value": map[string]any{"value": user.ID}}}}, 400, "invalidSyntax"},
+		{"unknown path", map[string]any{"schemas": []string{scim.PatchOpSchemaURN}, "Operations": []map[string]any{{"op": "add", "path": "unknown", "value": map[string]any{"value": user.ID}}}}, 400, "invalidPath"},
+		{"immutable subattribute", map[string]any{"schemas": []string{scim.PatchOpSchemaURN}, "Operations": []map[string]any{{"op": "add", "path": "members.value", "value": user.ID}}}, 400, "mutability"},
+		{"unsupported replace", map[string]any{"schemas": []string{scim.PatchOpSchemaURN}, "Operations": []map[string]any{{"op": "replace", "path": "members", "value": []map[string]any{{"value": user.ID}}}}}, 501, ""},
+		{"unsupported remove all", map[string]any{"schemas": []string{scim.PatchOpSchemaURN}, "Operations": []map[string]any{{"op": "remove", "path": "members"}}}, 501, ""},
+		{"metadata path", map[string]any{"schemas": []string{scim.PatchOpSchemaURN}, "Operations": []map[string]any{{"op": "add", "path": "schemas", "value": []string{scim.GroupSchemaURN}}}}, 501, ""},
+		{"metadata path missing value", map[string]any{"schemas": []string{scim.PatchOpSchemaURN}, "Operations": []map[string]any{{"op": "add", "path": "schemas"}}}, 400, "invalidValue"},
+		{"metadata in pathless value", map[string]any{"schemas": []string{scim.PatchOpSchemaURN}, "Operations": []map[string]any{{"op": "add", "value": map[string]any{"members": []map[string]any{}, "displayName": "renamed"}}}}, 501, ""},
+		{"replace missing value", map[string]any{"schemas": []string{scim.PatchOpSchemaURN}, "Operations": []map[string]any{{"op": "replace", "path": "members"}}}, 400, "invalidValue"},
+		{"immutable filtered display", map[string]any{"schemas": []string{scim.PatchOpSchemaURN}, "Operations": []map[string]any{{"op": "remove", "path": "members[value eq \"" + user.ID + "\"].display"}}}, 400, "mutability"},
+		{"mismatched type", map[string]any{"schemas": []string{scim.PatchOpSchemaURN}, "Operations": []map[string]any{{"op": "add", "path": "members", "value": map[string]any{"value": user.ID, "type": "Group"}}}}, 400, "invalidValue"},
+		{"mismatched ref", map[string]any{"schemas": []string{scim.PatchOpSchemaURN}, "Operations": []map[string]any{{"op": "add", "path": "members", "value": map[string]any{"value": user.ID, "$ref": "https://wrong.example/Users/" + user.ID}}}}, 400, "invalidValue"},
+		{"unknown member", map[string]any{"schemas": []string{scim.PatchOpSchemaURN}, "Operations": []map[string]any{{"op": "add", "path": "members", "value": map[string]any{"value": "missing-user"}}}}, 400, "noTarget"},
+		{"unknown member subattribute", map[string]any{"schemas": []string{scim.PatchOpSchemaURN}, "Operations": []map[string]any{{"op": "add", "path": "members.bogus", "value": user.ID}}}, 400, "invalidPath"},
+	}
+	for _, test := range tests { //nolint:paralleltest // these cases share the provider to verify zero writes
+		t.Run(test.name, func(t *testing.T) {
+			authorization.mu.Lock()
+			writesBefore := len(authorization.writes)
+			authorization.mu.Unlock()
+			result := scimRequest(t, handler, http.MethodPatch, "/scim/v2/Groups/"+group.ID, testCurrentToken, test.body)
+			payload := decodeResponse[testErrorResponse](t, result)
+			if result.Code != test.code || test.typ != "" && payload.SCIMType != test.typ {
+				t.Fatalf("result = %d %#v, want %d/%s", result.Code, payload, test.code, test.typ)
+			}
+			authorization.mu.Lock()
+			writesAfter := len(authorization.writes)
+			authorization.mu.Unlock()
+			if writesAfter != writesBefore {
+				t.Fatalf("invalid/unsupported request issued a provider write: %d -> %d", writesBefore, writesAfter)
+			}
+		})
+	}
+	authorization.mu.Lock()
+	writesBeforePrevalidation := len(authorization.writes)
+	authorization.mu.Unlock()
+	prevalidation := scimRequest(t, handler, http.MethodPatch, "/scim/v2/Groups/"+group.ID, testCurrentToken, map[string]any{
+		"schemas": []string{scim.PatchOpSchemaURN}, "Operations": []map[string]any{
+			{"op": "add", "path": "members", "value": map[string]any{"value": user.ID}},
+			{"op": "replace", "path": "members", "value": []map[string]any{{"value": user.ID}}},
+		},
+	})
+	if prevalidation.Code != http.StatusNotImplemented {
+		t.Fatalf("valid operation followed by unsupported operation = %d %s", prevalidation.Code, prevalidation.Body.String())
+	}
+	authorization.mu.Lock()
+	if len(authorization.writes) != writesBeforePrevalidation {
+		authorization.mu.Unlock()
+		t.Fatal("request-wide prevalidation issued a provider write")
+	}
+	authorization.mu.Unlock()
+	authorization.mu.Lock()
+	writesBeforeFailure := len(authorization.writes)
+	authorization.mode = relationshipWriterFails
+	authorization.mu.Unlock()
+	failed := scimRequest(t, handler, http.MethodPatch, "/scim/v2/Groups/"+group.ID, testCurrentToken, map[string]any{
+		"schemas": []string{scim.PatchOpSchemaURN}, "Operations": []map[string]any{{"op": "add", "path": "members", "value": map[string]any{"value": user.ID}}},
+	})
+	failedPayload := decodeResponse[testErrorResponse](t, failed)
+	if failed.Code != http.StatusServiceUnavailable || failed.Header().Get("Retry-After") != "1" || failedPayload.Status != "503" || len(failedPayload.Schemas) != 1 || failedPayload.Schemas[0] != scim.ErrorSchemaURN {
+		t.Fatalf("transient writer failure = %d headers=%v body=%s", failed.Code, failed.Header(), failed.Body.String())
+	}
+	if got := decodeResponse[scim.Group](t, scimRequest(t, handler, http.MethodGet, "/scim/v2/Groups/"+group.ID, testCurrentToken, nil)); len(got.Members) != 0 {
+		t.Fatalf("failed atomic patch changed membership = %#v", got.Members)
+	}
+	authorization.mu.Lock()
+	if len(authorization.writes) != writesBeforeFailure+1 {
+		t.Fatalf("writer calls after transient failure = %d, want %d", len(authorization.writes), writesBeforeFailure+1)
+	}
+	authorization.mode = relationshipWriterUnimplemented
+	authorization.mu.Unlock()
+	unimplemented := scimRequest(t, handler, http.MethodPatch, "/scim/v2/Groups/"+group.ID, testCurrentToken, map[string]any{
+		"schemas": []string{scim.PatchOpSchemaURN}, "Operations": []map[string]any{{"op": "add", "path": "members", "value": map[string]any{"value": user.ID}}},
+	})
+	unimplementedPayload := decodeResponse[testErrorResponse](t, unimplemented)
+	if unimplemented.Code != http.StatusNotImplemented || unimplementedPayload.Status != "501" || len(unimplementedPayload.Schemas) != 1 || unimplementedPayload.Schemas[0] != scim.ErrorSchemaURN {
+		t.Fatalf("unimplemented writer = %d %s", unimplemented.Code, unimplemented.Body.String())
+	}
+	noWriter := newRecordingAuthorization()
+	_, _, noWriterHandler := newSCIMService(t, nil, noWriter, testSCIMConfig(map[string]config.SCIMClientConfig{"rippling": ripplingClient(nil)}))
+	noWriterUser, response := createUser(t, noWriterHandler, testCurrentToken, "patch-no-writer@valon.com", true, nil)
+	if response.Code != http.StatusCreated {
+		t.Fatalf("create no-writer user = %d %s", response.Code, response.Body.String())
+	}
+	noWriterGroupResponse := scimRequest(t, noWriterHandler, http.MethodPost, "/scim/v2/Groups", testCurrentToken, map[string]any{"schemas": []string{scim.GroupSchemaURN}, "displayName": "No writer"})
+	noWriterGroup := decodeResponse[scim.Group](t, noWriterGroupResponse)
+	noWriterPatch := scimRequest(t, noWriterHandler, http.MethodPatch, "/scim/v2/Groups/"+noWriterGroup.ID, testCurrentToken, map[string]any{
+		"schemas": []string{scim.PatchOpSchemaURN}, "Operations": []map[string]any{{"op": "add", "path": "members", "value": map[string]any{"value": noWriterUser.ID}}},
+	})
+	if noWriterPatch.Code != http.StatusNotImplemented || decodeResponse[testErrorResponse](t, noWriterPatch).Status != "501" {
+		t.Fatalf("missing atomic writer = %d %s", noWriterPatch.Code, noWriterPatch.Body.String())
+	}
+	if noWriter.additionCount() != 0 {
+		t.Fatalf("missing atomic writer fell back to AddRelationship: %d", noWriter.additionCount())
+	}
+}
+
+func TestSCIMGroupPatchNestedGroupMembers(t *testing.T) {
+	t.Parallel()
+
+	authorization := &batchRecordingAuthorization{recordingAuthorization: newRecordingAuthorization()}
+	_, _, handler := newSCIMService(t, nil, authorization, testSCIMConfig(map[string]config.SCIMClientConfig{"rippling": ripplingClient(nil)}))
+	user, response := createUser(t, handler, testCurrentToken, "patch-nested@valon.com", true, nil)
+	if response.Code != http.StatusCreated {
+		t.Fatalf("create user = %d %s", response.Code, response.Body.String())
+	}
+	childResponse := scimRequest(t, handler, http.MethodPost, "/scim/v2/Groups", testCurrentToken, map[string]any{"schemas": []string{scim.GroupSchemaURN}, "displayName": "Patch child"})
+	child := decodeResponse[scim.Group](t, childResponse)
+	parentResponse := scimRequest(t, handler, http.MethodPost, "/scim/v2/Groups", testCurrentToken, map[string]any{"schemas": []string{scim.GroupSchemaURN}, "displayName": "Patch parent"})
+	parent := decodeResponse[scim.Group](t, parentResponse)
+	if childResponse.Code != http.StatusCreated || parentResponse.Code != http.StatusCreated {
+		t.Fatalf("create nested groups = child %d/%s parent %d/%s", childResponse.Code, childResponse.Body.String(), parentResponse.Code, parentResponse.Body.String())
+	}
+	added := scimRequest(t, handler, http.MethodPatch, "/scim/v2/Groups/"+parent.ID, testCurrentToken, map[string]any{
+		"schemas": []string{scim.PatchOpSchemaURN}, "Operations": []map[string]any{{"op": "add", "path": "members", "value": map[string]any{"value": child.ID, "type": "Group"}}},
+	}, map[string]string{"If-Match": parent.Meta.Version})
+	parent = decodeResponse[scim.Group](t, added)
+	if added.Code != http.StatusOK || len(parent.Members) != 1 || parent.Members[0].Value != child.ID || parent.Members[0].Type != "Group" {
+		t.Fatalf("nested Group add = %d %#v", added.Code, parent)
+	}
+	child = decodeResponse[scim.Group](t, scimRequest(t, handler, http.MethodPatch, "/scim/v2/Groups/"+child.ID, testCurrentToken, map[string]any{
+		"schemas": []string{scim.PatchOpSchemaURN}, "Operations": []map[string]any{{"op": "add", "path": "members", "value": map[string]any{"value": user.ID}}},
+	}, map[string]string{"If-Match": child.Meta.Version}))
+	if len(child.Members) != 1 || child.Members[0].Value != user.ID {
+		t.Fatalf("nested child member = %#v", child.Members)
+	}
+	removed := scimRequest(t, handler, http.MethodPatch, "/scim/v2/Groups/"+parent.ID, testCurrentToken, map[string]any{
+		"schemas": []string{scim.PatchOpSchemaURN}, "Operations": []map[string]any{{"op": "remove", "path": "members[value eq \"" + child.ID + "\"]"}},
+	}, map[string]string{"If-Match": parent.Meta.Version})
+	if removed.Code != http.StatusOK || len(decodeResponse[scim.Group](t, removed).Members) != 0 {
+		t.Fatalf("nested Group remove = %d %s", removed.Code, removed.Body.String())
+	}
+}
+
+func TestSCIMGroupPatchRemovesAllPhysicalMemberVariants(t *testing.T) {
+	t.Parallel()
+
+	authorization := &batchRecordingAuthorization{recordingAuthorization: newRecordingAuthorization()}
+	_, services, handler := newSCIMService(t, nil, authorization, testSCIMConfig(map[string]config.SCIMClientConfig{"rippling": ripplingClient(nil)}))
+	user, response := createUser(t, handler, testCurrentToken, "patch-physical-variants@valon.com", true, nil)
+	if response.Code != http.StatusCreated {
+		t.Fatalf("create user = %d %s", response.Code, response.Body.String())
+	}
+	groupResponse := scimRequest(t, handler, http.MethodPost, "/scim/v2/Groups", testCurrentToken, map[string]any{
+		"schemas": []string{scim.GroupSchemaURN}, "displayName": "Patch physical variants", "members": []map[string]any{{"value": user.ID}},
+	})
+	group := decodeResponse[scim.Group](t, groupResponse)
+	if groupResponse.Code != http.StatusCreated {
+		t.Fatalf("create group = %d %s", groupResponse.Code, groupResponse.Body.String())
+	}
+	coreUser, err := services.Users.FindUserByEmail(context.Background(), "patch-physical-variants@valon.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	base := authorization.relationshipForGroupUser(coreUser.ID, group.ID)
+	if base == nil {
+		t.Fatal("created relationship is missing")
+	}
+	for _, property := range []string{"one", "two"} {
+		variant := gproto.Clone(base).(*proto.Relationship)
+		variant.Tuple.Target.GetSubject().Properties, err = structpb.NewStruct(map[string]any{"variant": property})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := authorization.AddRelationship(context.Background(), &proto.AddRelationshipRequest{Relationship: variant}); err != nil {
+			t.Fatalf("add %s relationship variant = %v", property, err)
+		}
+	}
+	read := decodeResponse[scim.Group](t, scimRequest(t, handler, http.MethodGet, "/scim/v2/Groups/"+group.ID, testCurrentToken, nil))
+	if len(read.Members) != 1 {
+		t.Fatalf("physical variants projected members = %#v", read.Members)
+	}
+	authorization.mu.Lock()
+	writesBefore := len(authorization.writes)
+	authorization.mu.Unlock()
+	removed := scimRequest(t, handler, http.MethodPatch, "/scim/v2/Groups/"+group.ID, testCurrentToken, map[string]any{
+		"schemas": []string{scim.PatchOpSchemaURN}, "Operations": []map[string]any{{"op": "remove", "path": "members[value eq \"" + user.ID + "\"]"}},
+	}, map[string]string{"If-Match": read.Meta.Version})
+	if removed.Code != http.StatusOK {
+		t.Fatalf("remove physical variants = %d %s", removed.Code, removed.Body.String())
+	}
+	if got := decodeResponse[scim.Group](t, removed); len(got.Members) != 0 {
+		t.Fatalf("PATCH response retained physical variants = %#v", got.Members)
+	}
+	immediate := decodeResponse[scim.Group](t, scimRequest(t, handler, http.MethodGet, "/scim/v2/Groups/"+group.ID, testCurrentToken, nil))
+	if len(immediate.Members) != 0 {
+		t.Fatalf("immediate GET retained physical variants = %#v", immediate.Members)
+	}
+	remaining, err := authorization.ListRelationships(context.Background(), &proto.ListRelationshipsRequest{Filter: &proto.RelationshipFilter{
+		Resource: &proto.Resource{Type: "group", Id: group.ID}, Relation: "member", SourceLayer: proto.SourceLayer_SOURCE_LAYER_RUNTIME,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(remaining.Relationships) != 0 {
+		t.Fatalf("physical variants remaining after PATCH = %#v", remaining.Relationships)
+	}
+	authorization.mu.Lock()
+	defer authorization.mu.Unlock()
+	if len(authorization.writes) != writesBefore+1 || len(authorization.writes[len(authorization.writes)-1]) != 3 {
+		t.Fatalf("physical variant PATCH writer calls = %d updates=%#v", len(authorization.writes)-writesBefore, authorization.writes[len(authorization.writes)-1])
+	}
+	for _, update := range authorization.writes[len(authorization.writes)-1] {
+		if update.GetOperation() != proto.RelationshipUpdate_OPERATION_DELETE {
+			t.Fatalf("physical variant PATCH operation = %v, want DELETE", update.GetOperation())
+		}
+	}
+}

--- a/gestaltd/internal/scim/lean_handler.go
+++ b/gestaltd/internal/scim/lean_handler.go
@@ -53,8 +53,8 @@ func (h *leanHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func (h *leanHandler) serviceProviderConfig(w http.ResponseWriter) {
 	writeJSON(w, http.StatusOK, map[string]any{
 		"schemas": []string{ServiceProviderConfigSchemaURN},
-		// PATCH returns 501 until AuthorizationProvider gains a multi-tuple
-		// transaction primitive that can satisfy RFC 7644 atomicity.
+		// PATCH is deliberately not advertised service-wide: this release only
+		// accepts the narrow atomic Group-membership subset used by Rippling.
 		"patch": map[string]any{"supported": false},
 		"bulk":  map[string]any{"supported": false},
 		// The endpoint accepts the documented equality/conjunction subset; it is
@@ -299,7 +299,22 @@ func (h *leanHandler) group(w http.ResponseWriter, r *http.Request, c, id string
 		}
 		writeResourceForRequest(w, r, 200, g)
 	case http.MethodPatch:
-		writeError(w, &Error{Status: http.StatusNotImplemented, Detail: "SCIM PATCH requires an atomic authorization-provider mutation primitive"})
+		var raw json.RawMessage
+		if e := decodeBody(r, &raw); e != nil {
+			writeError(w, e)
+			return
+		}
+		patch, e := parseGroupPatchRequest(raw)
+		if e != nil {
+			writeError(w, e)
+			return
+		}
+		g, e := h.s.PatchGroup(r.Context(), c, id, strings.TrimSpace(r.Header.Get("If-Match")), patch)
+		if e != nil {
+			writeError(w, e)
+			return
+		}
+		writeResourceForRequest(w, r, http.StatusOK, g)
 	case http.MethodDelete:
 		if e := h.s.DeleteGroup(r.Context(), c, id, strings.TrimSpace(r.Header.Get("If-Match"))); e != nil {
 			writeError(w, e)


### PR DESCRIPTION
## Summary

Rippling created the Gestalt Team SCIM Group and then sent membership PATCH requests. Gestalt returned 501, so the group stayed empty. This change adds the bounded, atomic Group-membership PATCH surface needed for that synchronization while keeping the AuthorizationProvider as the only membership source of truth.

## REST interface

Endpoint:

```http
PATCH /scim/v2/Groups/{groupId}
Authorization: Bearer <client-token>
Content-Type: application/scim+json
If-Match: W/"<current-content-etag>"   # optional
```

Accepted add request (array or one Member object is accepted):

```json
{
  "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
  "Operations": [{
    "op": "add",
    "path": "members",
    "value": [{"value": "<scim-user-or-group-id>"}]
  }]
}
```

Accepted filtered removal:

```json
{
  "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
  "Operations": [{
    "op": "remove",
    "path": "members[value eq \"<scim-user-or-group-id>\"]"
  }]
}
```

Pathless `add` with `{ "members": ... }`, multiple sequential add/remove operations, Group-schema-qualified paths, case-insensitive operation/attribute names, flexible whitespace, and JSON-escaped filtered IDs are supported. A successful nonempty change returns `200` with the Group representation, `Location`, `Content-Location`, and a weak content ETag (`ETag`/`meta.version`). Duplicate adds and removal of an already-absent member return `200` without a provider write or timestamp/ETag change.

Errors use SCIM `application/scim+json` payloads and the standard status/type mapping: `400` (`invalidSyntax`, `invalidValue`, `invalidPath`, `noTarget`, or `mutability`), `404` for an absent/foreign Group, `412` for a supplied stale `If-Match`, `501` for valid but unsupported shapes or a missing/unimplemented atomic writer, and retryable `503` with `Retry-After: 1` for transient writer failures.

`ServiceProviderConfig.patch.supported` remains `false` because PATCH is not a complete service-wide surface; this is an intentionally narrow compatibility subset for Rippling. User PATCH remains 501.

## Assumptions and constraints

- This is incremental Group membership only.
- `ServiceProviderConfig.patch.supported` remains false.
- User PATCH, `replace`, remove-all, and metadata PATCH remain unsupported.
- AuthorizationProvider relationships are the sole membership source.
- The atomic relationship writer is required; there is no legacy Add/Delete fallback.
- No new storage, migrations, dual writes, or reconciliation are introduced.
- Complete collection replacement requires a future group revision/CAS primitive.

## Atomicity and idempotency

The entire PatchOp envelope and every operation/member shape are validated before any write. Operations are evaluated sequentially against one virtual membership set, then reduced to deterministic TOUCH/DELETE updates. A nonempty diff is sent exactly once through `AuthorizationRelationshipWriter.WriteRelationships`, whose contract applies the batch atomically; unsupported writers return 501 and provider failures return 503 without partial membership. PATCH never falls back to sequential Add/Delete calls. The provider remains canonical. Metadata timestamp touching is detached, bounded, and informational; a touch failure is logged without turning a committed provider mutation into a false failure. No-op operations do not call the writer or change the ETag/lastModified.

## Tests

- `GOCACHE=/tmp/gestalt-scim-patch-gocache go test ./internal/scim -count=1 -timeout=180s` — passed.
- `GOCACHE=/tmp/gestalt-scim-patch-gocache go test -race ./internal/scim -count=1 -timeout=240s` — passed.
- `GOCACHE=/tmp/gestalt-scim-patch-gocache go vet ./internal/scim` — passed.
- `GOCACHE=/tmp/gestalt-scim-patch-gocache GOLANGCI_LINT_CACHE=/tmp/gestalt-scim-patch-lint-cache golangci-lint run ./internal/scim` — `0 issues`.
- `git diff --check` — passed.
- Unsandboxed `GOCACHE=/tmp/gestalt-scim-patch-gocache go test ./...` — passed.

Coverage includes Rippling add/remove payloads, nested Groups, pathless and qualified paths, case/whitespace/escaping, sequential ordering, no-op idempotency, ETags and projections, namespace/reference validation, SCIM error fidelity, prevalidation with zero writes, provider atomic failure/unimplemented behavior, and preservation of unrelated relationships.
