### PR TITLE
Remove legacy SCIM relationship write fallbacks

### DIFF
--- a/gestaltd/core/authorization.go
+++ b/gestaltd/core/authorization.go
@@ -10,6 +10,7 @@ type AuthorizationProvider interface {
 	CheckAccess(ctx context.Context, req *proto.CheckAccessRequest) (*proto.CheckAccessResponse, error)
 	CheckAccessMany(ctx context.Context, req *proto.CheckAccessManyRequest) (*proto.CheckAccessManyResponse, error)
 	ListRelationships(ctx context.Context, req *proto.ListRelationshipsRequest) (*proto.ListRelationshipsResponse, error)
+	WriteRelationships(ctx context.Context, req *proto.WriteRelationshipsRequest) (*proto.WriteRelationshipsResponse, error)
 	AddRelationship(ctx context.Context, req *proto.AddRelationshipRequest) (*proto.AddRelationshipResponse, error)
 	DeleteRelationship(ctx context.Context, req *proto.DeleteRelationshipRequest) (*proto.DeleteRelationshipResponse, error)
 	SetAuthorizationState(ctx context.Context, req *proto.SetAuthorizationStateRequest) (*proto.SetAuthorizationStateResponse, error)
@@ -18,10 +19,4 @@ type AuthorizationProvider interface {
 	ListActiveModelResourceTypes(ctx context.Context, req *proto.ListActiveModelResourceTypesRequest) (*proto.ListActiveModelResourceTypesResponse, error)
 	Ping(ctx context.Context) error
 	Close() error
-}
-
-// AuthorizationRelationshipWriter is an optional authorization provider
-// capability for atomic relationship mutations.
-type AuthorizationRelationshipWriter interface {
-	WriteRelationships(context.Context, *proto.WriteRelationshipsRequest) (*proto.WriteRelationshipsResponse, error)
 }

--- a/gestaltd/internal/authorizationstate/apply_test.go
+++ b/gestaltd/internal/authorizationstate/apply_test.go
@@ -33,6 +33,10 @@ func (p *recordingProvider) ListRelationships(_ context.Context, req *proto.List
 	return &proto.ListRelationshipsResponse{Relationships: append([]*proto.Relationship(nil), p.relationships...)}, nil
 }
 
+func (p *recordingProvider) WriteRelationships(context.Context, *proto.WriteRelationshipsRequest) (*proto.WriteRelationshipsResponse, error) {
+	return &proto.WriteRelationshipsResponse{}, nil
+}
+
 func (p *recordingProvider) AddRelationship(_ context.Context, req *proto.AddRelationshipRequest) (*proto.AddRelationshipResponse, error) {
 	p.addCalls++
 	p.relationships = append(p.relationships, req.GetRelationship())

--- a/gestaltd/internal/bootstrap/authorization_bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/authorization_bootstrap_test.go
@@ -379,6 +379,10 @@ func (p *recordingAuthorizationProvider) ListRelationships(_ context.Context, re
 	return gproto.Clone(resp).(*proto.ListRelationshipsResponse), nil
 }
 
+func (p *recordingAuthorizationProvider) WriteRelationships(context.Context, *proto.WriteRelationshipsRequest) (*proto.WriteRelationshipsResponse, error) {
+	return &proto.WriteRelationshipsResponse{}, nil
+}
+
 func (p *recordingAuthorizationProvider) AddRelationship(context.Context, *proto.AddRelationshipRequest) (*proto.AddRelationshipResponse, error) {
 	return &proto.AddRelationshipResponse{}, nil
 }
@@ -494,6 +498,10 @@ func (p *statefulAuthorizationProvider) CheckAccessMany(context.Context, *proto.
 
 func (p *statefulAuthorizationProvider) ListRelationships(context.Context, *proto.ListRelationshipsRequest) (*proto.ListRelationshipsResponse, error) {
 	return &proto.ListRelationshipsResponse{}, nil
+}
+
+func (p *statefulAuthorizationProvider) WriteRelationships(context.Context, *proto.WriteRelationshipsRequest) (*proto.WriteRelationshipsResponse, error) {
+	return &proto.WriteRelationshipsResponse{}, nil
 }
 
 func (p *statefulAuthorizationProvider) AddRelationship(context.Context, *proto.AddRelationshipRequest) (*proto.AddRelationshipResponse, error) {

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -1329,6 +1329,10 @@ func (p *bootstrapTransportRecordingAuthorizationProvider) ListRelationships(con
 	return &proto.ListRelationshipsResponse{}, nil
 }
 
+func (p *bootstrapTransportRecordingAuthorizationProvider) WriteRelationships(context.Context, *proto.WriteRelationshipsRequest) (*proto.WriteRelationshipsResponse, error) {
+	return &proto.WriteRelationshipsResponse{}, nil
+}
+
 func (p *bootstrapTransportRecordingAuthorizationProvider) AddRelationship(context.Context, *proto.AddRelationshipRequest) (*proto.AddRelationshipResponse, error) {
 	return &proto.AddRelationshipResponse{}, nil
 }

--- a/gestaltd/internal/bootstrap/executable_app_test.go
+++ b/gestaltd/internal/bootstrap/executable_app_test.go
@@ -126,6 +126,9 @@ func (p *allowAllAuthorizationProvider) CheckAccessMany(ctx context.Context, req
 func (p *allowAllAuthorizationProvider) ListRelationships(context.Context, *proto.ListRelationshipsRequest) (*proto.ListRelationshipsResponse, error) {
 	return &proto.ListRelationshipsResponse{}, nil
 }
+func (p *allowAllAuthorizationProvider) WriteRelationships(context.Context, *proto.WriteRelationshipsRequest) (*proto.WriteRelationshipsResponse, error) {
+	return &proto.WriteRelationshipsResponse{}, nil
+}
 func (p *allowAllAuthorizationProvider) AddRelationship(context.Context, *proto.AddRelationshipRequest) (*proto.AddRelationshipResponse, error) {
 	return &proto.AddRelationshipResponse{}, nil
 }

--- a/gestaltd/internal/scim/authorization.go
+++ b/gestaltd/internal/scim/authorization.go
@@ -10,8 +10,6 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/coredata"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 type authorizationGate struct {
@@ -100,12 +98,8 @@ func (g *authorizationGate) ListRelationships(ctx context.Context, req *proto.Li
 }
 
 func (g *authorizationGate) WriteRelationships(ctx context.Context, req *proto.WriteRelationshipsRequest) (*proto.WriteRelationshipsResponse, error) {
-	writer, ok := g.underlying.(core.AuthorizationRelationshipWriter)
-	if !ok {
-		return nil, status.Error(codes.Unimplemented, "authorization relationship writes are not implemented")
-	}
 	if req == nil {
-		return writer.WriteRelationships(ctx, req)
+		return g.underlying.WriteRelationships(ctx, req)
 	}
 	affected := map[string]map[string]struct{}{}
 	runtimeChanges := map[string]struct{}{}
@@ -132,7 +126,7 @@ func (g *authorizationGate) WriteRelationships(ctx context.Context, req *proto.W
 			}
 		}
 	}
-	response, err := writer.WriteRelationships(ctx, req)
+	response, err := g.underlying.WriteRelationships(ctx, req)
 	if err != nil {
 		return response, err
 	}
@@ -169,58 +163,28 @@ func (g *authorizationGate) WriteRelationships(ctx context.Context, req *proto.W
 }
 
 func (g *authorizationGate) AddRelationship(ctx context.Context, req *proto.AddRelationshipRequest) (*proto.AddRelationshipResponse, error) {
-	if req == nil || req.Relationship == nil || req.Relationship.Tuple == nil || req.Relationship.GetSourceLayer() != proto.SourceLayer_SOURCE_LAYER_RUNTIME {
-		return g.underlying.AddRelationship(ctx, req)
+	relationship := req.GetRelationship()
+	_, err := g.WriteRelationships(ctx, &proto.WriteRelationshipsRequest{Updates: []*proto.RelationshipUpdate{{
+		Operation:    proto.RelationshipUpdate_OPERATION_TOUCH,
+		Relationship: relationship,
+	}}})
+	if err != nil {
+		return nil, err
 	}
-	before, beforeErr := g.scim.compact.relationshipPresent(ctx, req.Relationship.Tuple)
-	response, err := g.underlying.AddRelationship(ctx, req)
-	idempotent := isAlreadyExistsError(err)
-	if err != nil && !idempotent {
-		return response, err
-	}
-	after, afterErr := g.scim.compact.relationshipPresent(ctx, req.Relationship.Tuple)
-	if idempotent || beforeErr != nil || afterErr != nil || before != after {
-		if touchErr := g.scim.compact.touchRelationship(ctx, req.Relationship.Tuple); touchErr != nil {
-			return response, touchErr
-		}
-	}
-	return response, nil
+	return &proto.AddRelationshipResponse{Relationship: relationship}, nil
 }
 
 func (g *authorizationGate) DeleteRelationship(ctx context.Context, req *proto.DeleteRelationshipRequest) (*proto.DeleteRelationshipResponse, error) {
-	if req == nil || req.RelationshipTuple == nil {
-		return g.underlying.DeleteRelationship(ctx, req)
+	_, err := g.WriteRelationships(ctx, &proto.WriteRelationshipsRequest{Updates: []*proto.RelationshipUpdate{{
+		Operation: proto.RelationshipUpdate_OPERATION_DELETE,
+		Relationship: &proto.Relationship{
+			Tuple: req.GetRelationshipTuple(),
+		},
+	}}})
+	if err != nil {
+		return nil, err
 	}
-	before, beforeErr := g.scim.compact.relationshipPresent(ctx, req.RelationshipTuple)
-	affected := map[string]map[string]struct{}{}
-	if (before || beforeErr != nil) && g.scim != nil && g.scim.compact != nil {
-		if err := g.scim.compact.captureRelationshipAffectedUsers(ctx, req.RelationshipTuple, affected); err != nil {
-			return nil, err
-		}
-	}
-	response, err := g.underlying.DeleteRelationship(ctx, req)
-	idempotent := isNotFoundError(err)
-	if err != nil && !idempotent {
-		return response, err
-	}
-	after, afterErr := g.scim.compact.relationshipPresent(ctx, req.RelationshipTuple)
-	ids := map[string]struct{}{}
-	if idempotent || beforeErr != nil || afterErr != nil || before != after {
-		touch, touchErr := g.scim.compact.relationshipTouchIDs(ctx, req.RelationshipTuple)
-		if touchErr != nil {
-			return response, touchErr
-		}
-		for id := range touch {
-			ids[id] = struct{}{}
-		}
-	}
-	if err := g.scim.compact.collectClientCoreUserTouchIDs(ctx, affected, ids); err != nil {
-		return response, err
-	}
-	if err := g.scim.compact.touchRows(ctx, ids); err != nil {
-		return response, err
-	}
-	return response, nil
+	return &proto.DeleteRelationshipResponse{}, nil
 }
 
 func (g *authorizationGate) SetAuthorizationState(ctx context.Context, req *proto.SetAuthorizationStateRequest) (*proto.SetAuthorizationStateResponse, error) {

--- a/gestaltd/internal/scim/compact_http_test.go
+++ b/gestaltd/internal/scim/compact_http_test.go
@@ -55,6 +55,18 @@ func (a *authz) ListRelationships(_ context.Context, r *proto.ListRelationshipsR
 	return o, nil
 }
 func key(t *proto.RelationshipTuple) string { return t.String() }
+func (a *authz) WriteRelationships(_ context.Context, r *proto.WriteRelationshipsRequest) (*proto.WriteRelationshipsResponse, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	for _, update := range r.GetUpdates() {
+		if update.GetOperation() == proto.RelationshipUpdate_OPERATION_DELETE {
+			delete(a.rel, key(update.GetRelationship().GetTuple()))
+			continue
+		}
+		a.rel[key(update.GetRelationship().GetTuple())] = gproto.Clone(update.GetRelationship()).(*proto.Relationship)
+	}
+	return &proto.WriteRelationshipsResponse{}, nil
+}
 func (a *authz) AddRelationship(_ context.Context, r *proto.AddRelationshipRequest) (*proto.AddRelationshipResponse, error) {
 	a.mu.Lock()
 	defer a.mu.Unlock()

--- a/gestaltd/internal/scim/compact_relationships_test.go
+++ b/gestaltd/internal/scim/compact_relationships_test.go
@@ -6,27 +6,16 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/scim"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	gproto "google.golang.org/protobuf/proto"
-)
-
-type relationshipWriterMode int
-
-const (
-	relationshipWriterWorks relationshipWriterMode = iota
-	relationshipWriterUnimplemented
-	relationshipWriterFails
 )
 
 type batchRecordingAuthorization struct {
 	*recordingAuthorization
-	mode   relationshipWriterMode
-	writes [][]*proto.RelationshipUpdate
+	writeErr error
+	writes   [][]*proto.RelationshipUpdate
 }
 
 func (a *batchRecordingAuthorization) WriteRelationships(_ context.Context, req *proto.WriteRelationshipsRequest) (*proto.WriteRelationshipsResponse, error) {
@@ -36,13 +25,10 @@ func (a *batchRecordingAuthorization) WriteRelationships(_ context.Context, req 
 		updates = append(updates, gproto.Clone(update).(*proto.RelationshipUpdate))
 	}
 	a.writes = append(a.writes, updates)
-	mode := a.mode
+	writeErr := a.writeErr
 	a.mu.Unlock()
-	if mode == relationshipWriterUnimplemented {
-		return nil, status.Error(codes.Unimplemented, "writer unavailable")
-	}
-	if mode == relationshipWriterFails {
-		return nil, errors.New("injected writer failure")
+	if writeErr != nil {
+		return nil, writeErr
 	}
 	a.mu.Lock()
 	defer a.mu.Unlock()
@@ -146,148 +132,33 @@ func TestSCIMRelationshipBatchOrderAndEmptyDiff(t *testing.T) {
 	}
 }
 
-func TestSCIMRelationshipWriterFallsBackOnlyForUnimplemented(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name       string
-		mode       relationshipWriterMode
-		wantStatus int
-		wantAdds   int
-	}{
-		{name: "supported", mode: relationshipWriterWorks, wantStatus: http.StatusCreated},
-		{name: "unimplemented", mode: relationshipWriterUnimplemented, wantStatus: http.StatusCreated, wantAdds: 1},
-		{name: "other error", mode: relationshipWriterFails, wantStatus: http.StatusServiceUnavailable},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
-
-			authorization := &batchRecordingAuthorization{recordingAuthorization: newRecordingAuthorization(), mode: test.mode}
-			cfg := testSCIMConfig(map[string]config.SCIMClientConfig{"rippling": ripplingClient(nil)})
-			_, _, handler := newSCIMService(t, nil, authorization, cfg)
-			user, response := createUser(t, handler, testCurrentToken, "fallback-"+test.name+"@valon.com", true, nil)
-			if response.Code != http.StatusCreated {
-				t.Fatalf("create user = %d %s", response.Code, response.Body.String())
-			}
-			groupResponse := scimRequest(t, handler, http.MethodPost, "/scim/v2/Groups", testCurrentToken, map[string]any{
-				"schemas": []string{scim.GroupSchemaURN}, "displayName": "Fallback " + test.name, "members": []map[string]any{{"value": user.ID}},
-			})
-			if groupResponse.Code != test.wantStatus {
-				t.Fatalf("create group = %d %s, want %d", groupResponse.Code, groupResponse.Body.String(), test.wantStatus)
-			}
-			authorization.mu.Lock()
-			writeCalls := len(authorization.writes)
-			authorization.mu.Unlock()
-			if writeCalls != 1 {
-				t.Fatalf("writer calls = %d, want 1", writeCalls)
-			}
-			if got := authorization.additionCount(); got != test.wantAdds {
-				t.Fatalf("legacy additions = %d, want %d", got, test.wantAdds)
-			}
-		})
-	}
-}
-
-func TestSCIMLegacyFallbackTouchesSuccessfulPrefixOnFailure(t *testing.T) {
+func TestSCIMRelationshipWriterFailureDoesNotFallBack(t *testing.T) {
 	t.Parallel()
 
 	authorization := &batchRecordingAuthorization{
 		recordingAuthorization: newRecordingAuthorization(),
-		mode:                   relationshipWriterUnimplemented,
+		writeErr:               errors.New("injected writer failure"),
 	}
 	cfg := testSCIMConfig(map[string]config.SCIMClientConfig{"rippling": ripplingClient(nil)})
 	_, _, handler := newSCIMService(t, nil, authorization, cfg)
-	alice, response := createUser(t, handler, testCurrentToken, "prefix-alice@valon.com", true, nil)
-	if response.Code != http.StatusCreated {
-		t.Fatalf("create Alice = %d %s", response.Code, response.Body.String())
-	}
-	bob, response := createUser(t, handler, testCurrentToken, "prefix-bob@valon.com", true, nil)
-	if response.Code != http.StatusCreated {
-		t.Fatalf("create Bob = %d %s", response.Code, response.Body.String())
-	}
-	groupResponse := scimRequest(t, handler, http.MethodPost, "/scim/v2/Groups", testCurrentToken, map[string]any{
-		"schemas": []string{scim.GroupSchemaURN}, "displayName": "Fallback prefix",
-	})
-	group := decodeResponse[scim.Group](t, groupResponse)
-	if groupResponse.Code != http.StatusCreated {
-		t.Fatalf("create empty group = %d %s", groupResponse.Code, groupResponse.Body.String())
-	}
-	before := map[string]scim.Meta{}
-	for _, user := range []*scim.User{alice, bob} {
-		read := decodeResponse[scim.User](t, scimRequest(t, handler, http.MethodGet, "/scim/v2/Users/"+user.ID, testCurrentToken, nil))
-		before[user.ID] = read.Meta
-	}
-	authorization.setFailureAt(2, 0)
-	authorization.mu.Lock()
-	writesBefore := len(authorization.writes)
-	authorization.mu.Unlock()
-
-	replacement := scimRequest(t, handler, http.MethodPut, "/scim/v2/Groups/"+group.ID, testCurrentToken, map[string]any{
-		"schemas": []string{scim.GroupSchemaURN}, "displayName": group.DisplayName, "members": []map[string]any{{"value": alice.ID}, {"value": bob.ID}},
-	}, map[string]string{"If-Match": group.Meta.Version})
-	if replacement.Code != http.StatusServiceUnavailable {
-		t.Fatalf("partial fallback group replacement = %d %s, want 503", replacement.Code, replacement.Body.String())
-	}
-	authorization.mu.Lock()
-	writeCalls := len(authorization.writes) - writesBefore
-	authorization.mu.Unlock()
-	if writeCalls != 1 {
-		t.Fatalf("fallback writer calls = %d, want 1", writeCalls)
-	}
-	groupAfter := decodeResponse[scim.Group](t, scimRequest(t, handler, http.MethodGet, "/scim/v2/Groups/"+group.ID, testCurrentToken, nil))
-	if groupAfter.Meta.Version == group.Meta.Version || len(groupAfter.Members) != 1 {
-		t.Fatalf("successful legacy prefix group projection = %#v", groupAfter)
-	}
-	memberID := groupAfter.Members[0].Value
-	memberAfter := decodeResponse[scim.User](t, scimRequest(t, handler, http.MethodGet, "/scim/v2/Users/"+memberID, testCurrentToken, nil))
-	if !memberAfter.Meta.LastModified.After(before[memberID].LastModified) {
-		t.Fatalf("successful legacy prefix did not advance affected user metadata = before %#v after %#v", before[memberID], memberAfter.Meta)
-	}
-	if len(memberAfter.Groups) != 1 || memberAfter.Groups[0].Value != group.ID {
-		t.Fatalf("successful legacy prefix was not visible through the affected user = %#v", memberAfter.Groups)
-	}
-}
-
-func TestSCIMSupportedRelationshipWriterDowngradesAfterUnimplemented(t *testing.T) {
-	t.Parallel()
-
-	authorization := &batchRecordingAuthorization{recordingAuthorization: newRecordingAuthorization(), mode: relationshipWriterWorks}
-	cfg := testSCIMConfig(map[string]config.SCIMClientConfig{"rippling": ripplingClient(nil)})
-	_, _, handler := newSCIMService(t, nil, authorization, cfg)
-	user, response := createUser(t, handler, testCurrentToken, "downgrade@valon.com", true, nil)
+	user, response := createUser(t, handler, testCurrentToken, "write-failure@valon.com", true, nil)
 	if response.Code != http.StatusCreated {
 		t.Fatalf("create user = %d %s", response.Code, response.Body.String())
 	}
-	createGroup := func(name string) {
-		t.Helper()
-		response := scimRequest(t, handler, http.MethodPost, "/scim/v2/Groups", testCurrentToken, map[string]any{
-			"schemas": []string{scim.GroupSchemaURN}, "displayName": name, "members": []map[string]any{{"value": user.ID}},
-		})
-		if response.Code != http.StatusCreated {
-			t.Fatalf("create %s = %d %s", name, response.Code, response.Body.String())
-		}
+	groupResponse := scimRequest(t, handler, http.MethodPost, "/scim/v2/Groups", testCurrentToken, map[string]any{
+		"schemas": []string{scim.GroupSchemaURN}, "displayName": "Write failure", "members": []map[string]any{{"value": user.ID}},
+	})
+	if groupResponse.Code != http.StatusServiceUnavailable {
+		t.Fatalf("create group = %d %s, want %d", groupResponse.Code, groupResponse.Body.String(), http.StatusServiceUnavailable)
 	}
-	createGroup("Supported")
 	authorization.mu.Lock()
-	authorization.mode = relationshipWriterUnimplemented
+	writeCalls := len(authorization.writes)
 	authorization.mu.Unlock()
-	createGroup("Downgrade")
-	authorization.mu.Lock()
-	writerCalls := len(authorization.writes)
-	authorization.mu.Unlock()
-	if writerCalls != 2 {
-		t.Fatalf("writer calls after downgrade = %d, want 2", writerCalls)
+	if writeCalls != 1 {
+		t.Fatalf("writer calls = %d, want 1", writeCalls)
 	}
-	createGroup("Cached fallback")
-	authorization.mu.Lock()
-	writerCalls = len(authorization.writes)
-	authorization.mu.Unlock()
-	if writerCalls != 2 {
-		t.Fatalf("cached unsupported writer calls = %d, want 2", writerCalls)
-	}
-	if got := authorization.additionCount(); got != 2 {
-		t.Fatalf("legacy additions after downgrade = %d, want 2", got)
+	if got := authorization.additionCount(); got != 0 {
+		t.Fatalf("single-relationship add calls = %d, want none", got)
 	}
 }
 
@@ -330,10 +201,7 @@ func TestSCIMExternalRelationshipBatchUsesOneWriterAndUpdatesSCIMResources(t *te
 	authorization.mu.Lock()
 	writesBefore := len(authorization.writes)
 	authorization.mu.Unlock()
-	gate, ok := scim.WrapAuthorization(authorization, services.Users, service).(core.AuthorizationRelationshipWriter)
-	if !ok {
-		t.Fatal("wrapped authorization does not implement relationship writer")
-	}
+	gate := scim.WrapAuthorization(authorization, services.Users, service)
 	if _, err := gate.WriteRelationships(context.Background(), &proto.WriteRelationshipsRequest{Updates: updates}); err != nil {
 		t.Fatalf("external WriteRelationships = %v", err)
 	}

--- a/gestaltd/internal/scim/compact_service.go
+++ b/gestaltd/internal/scim/compact_service.go
@@ -15,7 +15,6 @@ import (
 	"sort"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -25,8 +24,6 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/coredata"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	gproto "google.golang.org/protobuf/proto"
 )
 
@@ -55,14 +52,13 @@ type userProfile struct {
 }
 
 type CompactService struct {
-	db                coredb.IndexedDB
-	authorization     core.AuthorizationProvider
-	baseURL           string
-	clients           map[string]*compactClient
-	credentials       []compactCredential
-	domainOwners      map[string]string
-	now               func() time.Time
-	writerUnsupported atomic.Bool
+	db            coredb.IndexedDB
+	authorization core.AuthorizationProvider
+	baseURL       string
+	clients       map[string]*compactClient
+	credentials   []compactCredential
+	domainOwners  map[string]string
+	now           func() time.Time
 }
 
 func NewService(db coredb.IndexedDB, authorization core.AuthorizationProvider, baseURL string, cfg config.ServerSCIMConfig) (*Service, error) {
@@ -416,17 +412,6 @@ func (s *CompactService) relationshipPresent(ctx context.Context, tuple *proto.R
 	return len(relationships) > 0, err
 }
 
-// touchRelationship updates only metadata whose public representation can be
-// affected by a successful shared authorization write. The provider remains
-// canonical; this timestamp is informational and is never used for ETags.
-func (s *CompactService) touchRelationship(ctx context.Context, tuple *proto.RelationshipTuple) error {
-	touch, err := s.relationshipTouchIDs(ctx, tuple)
-	if err != nil {
-		return err
-	}
-	return s.touchRows(ctx, touch)
-}
-
 func (s *CompactService) relationshipTouchIDs(ctx context.Context, tuple *proto.RelationshipTuple) (map[string]struct{}, error) {
 	touch := map[string]struct{}{}
 	if tuple == nil || tuple.GetTarget() == nil {
@@ -646,7 +631,6 @@ func (s *CompactService) apply(ctx context.Context, from, to []*proto.Relationsh
 		})
 	}
 	affected := map[string]struct{}{}
-	affectedByLogical := map[string]map[string]struct{}{}
 	captured := map[string]struct{}{}
 	for _, change := range deletes {
 		if _, alreadyCaptured := captured[change.logicalKey]; alreadyCaptured {
@@ -661,73 +645,15 @@ func (s *CompactService) apply(ctx context.Context, from, to []*proto.Relationsh
 		if err != nil {
 			return err
 		}
-		capturedUsers := map[string]struct{}{}
 		for _, user := range users {
 			affected[user] = struct{}{}
-			capturedUsers[user] = struct{}{}
 		}
-		affectedByLogical[change.logicalKey] = capturedUsers
 	}
 
-	applied, err := s.applyBatch(ctx, updates)
-	if err != nil {
-		if applied > 0 {
-			prefixAffected := map[string]struct{}{}
-			for _, update := range updates[:applied] {
-				for user := range affectedByLogical[tupleKey(update.GetRelationship().GetTuple())] {
-					prefixAffected[user] = struct{}{}
-				}
-			}
-			_ = s.touchAppliedRelationships(ctx, updates[:applied], prefixAffected)
-		}
+	if _, err := s.authorization.WriteRelationships(ctx, &proto.WriteRelationshipsRequest{Updates: updates}); err != nil {
 		return err
 	}
 	return s.touchAppliedRelationships(ctx, updates, affected)
-}
-
-func (s *CompactService) applyBatch(ctx context.Context, updates []*proto.RelationshipUpdate) (int, error) {
-	if s.writerUnsupported.Load() {
-		return s.applyLegacy(ctx, updates)
-	}
-	writer, ok := s.authorization.(core.AuthorizationRelationshipWriter)
-	if !ok {
-		s.writerUnsupported.Store(true)
-		return s.applyLegacy(ctx, updates)
-	}
-	_, err := writer.WriteRelationships(ctx, &proto.WriteRelationshipsRequest{Updates: updates})
-	if err == nil {
-		return len(updates), nil
-	}
-	if status.Code(err) == codes.Unimplemented {
-		s.writerUnsupported.Store(true)
-		return s.applyLegacy(ctx, updates)
-	}
-	return 0, err
-}
-
-func (s *CompactService) applyLegacy(ctx context.Context, updates []*proto.RelationshipUpdate) (int, error) {
-	for i, update := range updates {
-		if update == nil || update.Relationship == nil {
-			return i, status.Error(codes.InvalidArgument, "invalid relationship update")
-		}
-		switch update.Operation {
-		case proto.RelationshipUpdate_OPERATION_DELETE:
-			_, err := s.authorization.DeleteRelationship(ctx, &proto.DeleteRelationshipRequest{RelationshipTuple: update.Relationship.Tuple})
-			if err != nil && !isNotFoundError(err) {
-				return i, err
-			}
-		case proto.RelationshipUpdate_OPERATION_TOUCH:
-			_, err := s.authorization.AddRelationship(ctx, &proto.AddRelationshipRequest{Relationship: &proto.Relationship{
-				Tuple: update.Relationship.Tuple, SourceLayer: proto.SourceLayer_SOURCE_LAYER_RUNTIME,
-			}})
-			if err != nil && !isAlreadyExistsError(err) {
-				return i, err
-			}
-		default:
-			return i, status.Error(codes.InvalidArgument, "SCIM relationship updates must be TOUCH or DELETE")
-		}
-	}
-	return len(updates), nil
 }
 
 func (s *CompactService) touchAppliedRelationships(ctx context.Context, updates []*proto.RelationshipUpdate, affected map[string]struct{}) error {
@@ -775,14 +701,6 @@ func (s *CompactService) collectClientCoreUserTouchIDs(ctx context.Context, affe
 		}
 	}
 	return nil
-}
-
-func isAlreadyExistsError(err error) bool {
-	return errors.Is(err, core.ErrAlreadyExists) || errors.Is(err, idb.ErrAlreadyExists) || status.Code(err) == codes.AlreadyExists
-}
-
-func isNotFoundError(err error) bool {
-	return errors.Is(err, core.ErrNotFound) || errors.Is(err, idb.ErrNotFound) || status.Code(err) == codes.NotFound
 }
 
 // captureRelationshipAffectedUsers records the users whose SCIM groups or

--- a/gestaltd/internal/scim/group_patch.go
+++ b/gestaltd/internal/scim/group_patch.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -12,10 +13,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/valon-technologies/gestalt/server/core"
+	idb "github.com/valon-technologies/gestalt/sdk/go/indexeddb"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 const PatchOpSchemaURN = "urn:ietf:params:scim:api:messages:2.0:PatchOp"
@@ -346,7 +345,7 @@ func (s *CompactService) PatchGroup(ctx context.Context, cid, id, ifMatch string
 	defer unlock()
 	storedGroup, err := s.findGroup(ctx, cid, id)
 	if err != nil {
-		if isNotFoundError(err) {
+		if errors.Is(err, idb.ErrNotFound) {
 			return nil, notFoundResource("SCIM Group")
 		}
 		return nil, unavailable("could not load SCIM group")
@@ -411,14 +410,7 @@ func (s *CompactService) PatchGroup(ctx context.Context, cid, id, ifMatch string
 	if len(updates) == 0 {
 		return &old, nil
 	}
-	writer, ok := s.authorization.(core.AuthorizationRelationshipWriter)
-	if !ok {
-		return nil, notImplementedPatch("atomic authorization relationship writes are not available")
-	}
-	if _, err := writer.WriteRelationships(ctx, &proto.WriteRelationshipsRequest{Updates: updates}); err != nil {
-		if status.Code(err) == codes.Unimplemented {
-			return nil, notImplementedPatch("atomic authorization relationship writes are not available")
-		}
+	if _, err := s.authorization.WriteRelationships(ctx, &proto.WriteRelationshipsRequest{Updates: updates}); err != nil {
 		return nil, unavailable("could not apply group membership atomically")
 	}
 	// Membership is canonical in the provider. Timestamp maintenance is only
@@ -456,12 +448,12 @@ func (s *CompactService) resolvePatchMember(ctx context.Context, cid, gid string
 func (s *CompactService) resolvePatchMemberID(ctx context.Context, cid, gid, id string) (patchMemberState, error) {
 	if user, err := s.findUser(ctx, cid, id); err == nil {
 		return s.resolvePatchMember(ctx, cid, gid, Member{Value: user.ID, Type: "User", Ref: s.baseURL + "/scim/v2/Users/" + user.ID})
-	} else if !isNotFoundError(err) {
+	} else if !errors.Is(err, idb.ErrNotFound) {
 		return patchMemberState{}, unavailable("could not validate group member")
 	}
 	if group, err := s.findGroup(ctx, cid, id); err == nil {
 		return s.resolvePatchMember(ctx, cid, gid, Member{Value: group.ID, Type: "Group", Ref: s.baseURL + "/scim/v2/Groups/" + group.ID})
-	} else if !isNotFoundError(err) {
+	} else if !errors.Is(err, idb.ErrNotFound) {
 		return patchMemberState{}, unavailable("could not validate group member")
 	}
 	return patchMemberState{}, noTarget("group member must reference a User or Group in this SCIM client")

--- a/gestaltd/internal/scim/groups_patch_http_test.go
+++ b/gestaltd/internal/scim/groups_patch_http_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -332,7 +333,7 @@ func TestSCIMGroupPatchValidationAndAtomicFailures(t *testing.T) {
 	authorization.mu.Unlock()
 	authorization.mu.Lock()
 	writesBeforeFailure := len(authorization.writes)
-	authorization.mode = relationshipWriterFails
+	authorization.writeErr = errors.New("injected writer failure")
 	authorization.mu.Unlock()
 	failed := scimRequest(t, handler, http.MethodPatch, "/scim/v2/Groups/"+group.ID, testCurrentToken, map[string]any{
 		"schemas": []string{scim.PatchOpSchemaURN}, "Operations": []map[string]any{{"op": "add", "path": "members", "value": map[string]any{"value": user.ID}}},
@@ -348,32 +349,7 @@ func TestSCIMGroupPatchValidationAndAtomicFailures(t *testing.T) {
 	if len(authorization.writes) != writesBeforeFailure+1 {
 		t.Fatalf("writer calls after transient failure = %d, want %d", len(authorization.writes), writesBeforeFailure+1)
 	}
-	authorization.mode = relationshipWriterUnimplemented
 	authorization.mu.Unlock()
-	unimplemented := scimRequest(t, handler, http.MethodPatch, "/scim/v2/Groups/"+group.ID, testCurrentToken, map[string]any{
-		"schemas": []string{scim.PatchOpSchemaURN}, "Operations": []map[string]any{{"op": "add", "path": "members", "value": map[string]any{"value": user.ID}}},
-	})
-	unimplementedPayload := decodeResponse[testErrorResponse](t, unimplemented)
-	if unimplemented.Code != http.StatusNotImplemented || unimplementedPayload.Status != "501" || len(unimplementedPayload.Schemas) != 1 || unimplementedPayload.Schemas[0] != scim.ErrorSchemaURN {
-		t.Fatalf("unimplemented writer = %d %s", unimplemented.Code, unimplemented.Body.String())
-	}
-	noWriter := newRecordingAuthorization()
-	_, _, noWriterHandler := newSCIMService(t, nil, noWriter, testSCIMConfig(map[string]config.SCIMClientConfig{"rippling": ripplingClient(nil)}))
-	noWriterUser, response := createUser(t, noWriterHandler, testCurrentToken, "patch-no-writer@valon.com", true, nil)
-	if response.Code != http.StatusCreated {
-		t.Fatalf("create no-writer user = %d %s", response.Code, response.Body.String())
-	}
-	noWriterGroupResponse := scimRequest(t, noWriterHandler, http.MethodPost, "/scim/v2/Groups", testCurrentToken, map[string]any{"schemas": []string{scim.GroupSchemaURN}, "displayName": "No writer"})
-	noWriterGroup := decodeResponse[scim.Group](t, noWriterGroupResponse)
-	noWriterPatch := scimRequest(t, noWriterHandler, http.MethodPatch, "/scim/v2/Groups/"+noWriterGroup.ID, testCurrentToken, map[string]any{
-		"schemas": []string{scim.PatchOpSchemaURN}, "Operations": []map[string]any{{"op": "add", "path": "members", "value": map[string]any{"value": noWriterUser.ID}}},
-	})
-	if noWriterPatch.Code != http.StatusNotImplemented || decodeResponse[testErrorResponse](t, noWriterPatch).Status != "501" {
-		t.Fatalf("missing atomic writer = %d %s", noWriterPatch.Code, noWriterPatch.Body.String())
-	}
-	if noWriter.additionCount() != 0 {
-		t.Fatalf("missing atomic writer fell back to AddRelationship: %d", noWriter.additionCount())
-	}
 }
 
 func TestSCIMGroupPatchNestedGroupMembers(t *testing.T) {

--- a/gestaltd/internal/scim/users_http_test.go
+++ b/gestaltd/internal/scim/users_http_test.go
@@ -988,7 +988,7 @@ func TestSCIMActivationRetriesFromActualProviderTuples(t *testing.T) {
 	}
 }
 
-func TestSCIMDeactivationRetriesFromActualProviderTuples(t *testing.T) {
+func TestSCIMDeactivationBatchFailureIsAtomicAndRetryable(t *testing.T) {
 	t.Parallel()
 	projections := []config.SCIMRelationshipConfig{employeeProjection(), {Relation: "member", Resource: config.AuthorizationResourceDef{Type: "group", ID: "engineering"}}}
 	for failAt := 1; failAt <= len(projections); failAt++ {
@@ -1006,8 +1006,8 @@ func TestSCIMDeactivationRetriesFromActualProviderTuples(t *testing.T) {
 				t.Fatalf("partial deactivation = %d %s", failed.Code, failed.Body.String())
 			}
 			live := decodeResponse[scim.User](t, scimRequest(t, handler, http.MethodGet, "/scim/v2/Users/"+user.ID, testCurrentToken, nil))
-			if (failAt == 1 && !live.Active) || (failAt > 1 && live.Active) {
-				t.Fatalf("partial deactivation live state = %#v", live)
+			if !live.Active {
+				t.Fatalf("failed atomic deactivation was partially applied = %#v", live)
 			}
 			authorization.setFailures(false, false)
 			retried := decodeResponse[scim.User](t, scimRequest(t, handler, http.MethodPut, "/scim/v2/Users/"+user.ID, testCurrentToken, deactivate))
@@ -1349,6 +1349,44 @@ func (a *recordingAuthorization) ListRelationships(_ context.Context, req *proto
 		response.NextPageToken = strconv.Itoa(end)
 	}
 	return response, nil
+}
+
+func (a *recordingAuthorization) WriteRelationships(_ context.Context, req *proto.WriteRelationshipsRequest) (*proto.WriteRelationshipsResponse, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	addCalls := a.addCalls
+	deleteCalls := a.deleteCalls
+	for _, update := range req.GetUpdates() {
+		switch update.GetOperation() {
+		case proto.RelationshipUpdate_OPERATION_CREATE, proto.RelationshipUpdate_OPERATION_TOUCH:
+			addCalls++
+			if a.failAdd || a.failAddAt > 0 && addCalls == a.failAddAt {
+				a.addCalls = addCalls
+				return nil, errors.New("injected add failure")
+			}
+		case proto.RelationshipUpdate_OPERATION_DELETE:
+			deleteCalls++
+			if a.failDelete || a.failDeleteAt > 0 && deleteCalls == a.failDeleteAt {
+				a.deleteCalls = deleteCalls
+				return nil, errors.New("injected delete failure")
+			}
+		default:
+			return nil, errors.New("invalid relationship update")
+		}
+	}
+	a.addCalls = addCalls
+	a.deleteCalls = deleteCalls
+	for _, update := range req.GetUpdates() {
+		relationship := update.GetRelationship()
+		if update.GetOperation() == proto.RelationshipUpdate_OPERATION_DELETE {
+			a.deletions++
+			delete(a.relations, relationshipKey(relationship.GetTuple()))
+			continue
+		}
+		a.additions++
+		a.relations[relationshipKey(relationship.GetTuple())] = gproto.Clone(relationship).(*proto.Relationship)
+	}
+	return &proto.WriteRelationshipsResponse{}, nil
 }
 
 func (a *recordingAuthorization) AddRelationship(_ context.Context, req *proto.AddRelationshipRequest) (*proto.AddRelationshipResponse, error) {

--- a/gestaltd/rpc/authorization/client.go
+++ b/gestaltd/rpc/authorization/client.go
@@ -9,7 +9,6 @@ import (
 )
 
 var _ core.AuthorizationProvider = (*Client)(nil)
-var _ core.AuthorizationRelationshipWriter = (*Client)(nil)
 
 type Client struct {
 	grpc proto.AuthorizationClient

--- a/gestaltd/services/authorization/server.go
+++ b/gestaltd/services/authorization/server.go
@@ -45,11 +45,7 @@ func (s *providerServer) WriteRelationships(ctx context.Context, req *proto.Writ
 	if err := s.requireProvider(); err != nil {
 		return nil, err
 	}
-	writer, ok := s.provider.(core.AuthorizationRelationshipWriter)
-	if !ok {
-		return nil, status.Error(codes.Unimplemented, "authorization relationship writes are not implemented")
-	}
-	return writer.WriteRelationships(s.gatewayContext(ctx), req)
+	return s.provider.WriteRelationships(s.gatewayContext(ctx), req)
 }
 
 func (s *providerServer) AddRelationship(ctx context.Context, req *proto.AddRelationshipRequest) (*proto.AddRelationshipResponse, error) {

--- a/gestaltd/services/authorization/server_test.go
+++ b/gestaltd/services/authorization/server_test.go
@@ -7,8 +7,6 @@ import (
 	"github.com/valon-technologies/gestalt/server/core"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 func TestProviderServerStampsGRPCEntry(t *testing.T) {
@@ -26,20 +24,10 @@ func TestProviderServerStampsGRPCEntry(t *testing.T) {
 	}
 }
 
-func TestProviderServerWriteRelationshipsRequiresOptionalCapability(t *testing.T) {
+func TestProviderServerDispatchesWriteRelationships(t *testing.T) {
 	t.Parallel()
 
-	server := NewProviderServer(&entryRecordingAuthorizationProvider{})
-	_, err := server.WriteRelationships(context.Background(), &proto.WriteRelationshipsRequest{})
-	if status.Code(err) != codes.Unimplemented {
-		t.Fatalf("WriteRelationships() code = %v, want Unimplemented", status.Code(err))
-	}
-}
-
-func TestProviderServerDispatchesWriteRelationshipsCapability(t *testing.T) {
-	t.Parallel()
-
-	provider := &entryRecordingAuthorizationWriter{}
+	provider := &entryRecordingAuthorizationProvider{}
 	server := NewProviderServer(provider)
 	want := &proto.WriteRelationshipsRequest{}
 	got, err := server.WriteRelationships(context.Background(), want)
@@ -56,15 +44,11 @@ func TestProviderServerDispatchesWriteRelationshipsCapability(t *testing.T) {
 
 type entryRecordingAuthorizationProvider struct {
 	core.AuthorizationProvider
-	entry invocation.Entry
-}
-
-type entryRecordingAuthorizationWriter struct {
-	entryRecordingAuthorizationProvider
+	entry   invocation.Entry
 	request *proto.WriteRelationshipsRequest
 }
 
-func (p *entryRecordingAuthorizationWriter) WriteRelationships(ctx context.Context, request *proto.WriteRelationshipsRequest) (*proto.WriteRelationshipsResponse, error) {
+func (p *entryRecordingAuthorizationProvider) WriteRelationships(ctx context.Context, request *proto.WriteRelationshipsRequest) (*proto.WriteRelationshipsResponse, error) {
 	p.entry = invocation.EntryFromContext(ctx)
 	p.request = request
 	return &proto.WriteRelationshipsResponse{}, nil

--- a/gestaltd/services/invocation/authorization_check_test.go
+++ b/gestaltd/services/invocation/authorization_check_test.go
@@ -141,6 +141,10 @@ func (p *authorizationCheckTestProvider) ListRelationships(context.Context, *pro
 	return &proto.ListRelationshipsResponse{}, nil
 }
 
+func (p *authorizationCheckTestProvider) WriteRelationships(context.Context, *proto.WriteRelationshipsRequest) (*proto.WriteRelationshipsResponse, error) {
+	return &proto.WriteRelationshipsResponse{}, nil
+}
+
 func (p *authorizationCheckTestProvider) AddRelationship(context.Context, *proto.AddRelationshipRequest) (*proto.AddRelationshipResponse, error) {
 	return &proto.AddRelationshipResponse{}, nil
 }

--- a/gestaltd/services/invocation/broker_test.go
+++ b/gestaltd/services/invocation/broker_test.go
@@ -627,6 +627,10 @@ func (p *recordingAuthorizationProvider) ListRelationships(context.Context, *pro
 	return &proto.ListRelationshipsResponse{}, nil
 }
 
+func (p *recordingAuthorizationProvider) WriteRelationships(context.Context, *proto.WriteRelationshipsRequest) (*proto.WriteRelationshipsResponse, error) {
+	return &proto.WriteRelationshipsResponse{}, nil
+}
+
 func (p *recordingAuthorizationProvider) AddRelationship(context.Context, *proto.AddRelationshipRequest) (*proto.AddRelationshipResponse, error) {
 	return &proto.AddRelationshipResponse{}, nil
 }

--- a/gestaltd/services/providergateway/gateway_test.go
+++ b/gestaltd/services/providergateway/gateway_test.go
@@ -66,6 +66,10 @@ func (p *stubAuthorizationProvider) ListRelationships(context.Context, *proto.Li
 	return &proto.ListRelationshipsResponse{}, nil
 }
 
+func (p *stubAuthorizationProvider) WriteRelationships(context.Context, *proto.WriteRelationshipsRequest) (*proto.WriteRelationshipsResponse, error) {
+	return &proto.WriteRelationshipsResponse{}, nil
+}
+
 func (p *stubAuthorizationProvider) AddRelationship(context.Context, *proto.AddRelationshipRequest) (*proto.AddRelationshipResponse, error) {
 	return &proto.AddRelationshipResponse{}, nil
 }

--- a/gestaltd/services/remotemanagement/service_test.go
+++ b/gestaltd/services/remotemanagement/service_test.go
@@ -424,6 +424,9 @@ func (s *stubAuthz) CheckAccessMany(context.Context, *proto.CheckAccessManyReque
 func (s *stubAuthz) ListRelationships(context.Context, *proto.ListRelationshipsRequest) (*proto.ListRelationshipsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "")
 }
+func (s *stubAuthz) WriteRelationships(context.Context, *proto.WriteRelationshipsRequest) (*proto.WriteRelationshipsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "")
+}
 func (s *stubAuthz) AddRelationship(context.Context, *proto.AddRelationshipRequest) (*proto.AddRelationshipResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "")
 }

--- a/sdk/go/authorization_provider.go
+++ b/sdk/go/authorization_provider.go
@@ -285,16 +285,11 @@ type AuthorizationProvider interface {
 	CheckAccess(ctx context.Context, req *CheckAccessRequest) (*CheckAccessResponse, error)
 	CheckAccessMany(ctx context.Context, req *CheckAccessManyRequest) (*CheckAccessManyResponse, error)
 	ListRelationships(ctx context.Context, req *ListRelationshipsRequest) (*ListRelationshipsResponse, error)
+	WriteRelationships(ctx context.Context, req *WriteRelationshipsRequest) (*WriteRelationshipsResponse, error)
 	AddRelationship(ctx context.Context, req *AddRelationshipRequest) (*AddRelationshipResponse, error)
 	DeleteRelationship(ctx context.Context, req *DeleteRelationshipRequest) (*DeleteRelationshipResponse, error)
 	SetAuthorizationState(ctx context.Context, req *SetAuthorizationStateRequest) (*SetAuthorizationStateResponse, error)
 	GetActiveModelRef(ctx context.Context) (*GetActiveModelRefResponse, error)
 	SetActiveModel(ctx context.Context, req *SetActiveModelRequest) (*SetActiveModelResponse, error)
 	ListActiveModelResourceTypes(ctx context.Context, req *ListActiveModelResourceTypesRequest) (*ListActiveModelResourceTypesResponse, error)
-}
-
-// AuthorizationRelationshipWriter is an optional capability implemented by
-// providers that support atomic relationship writes.
-type AuthorizationRelationshipWriter interface {
-	WriteRelationships(context.Context, *WriteRelationshipsRequest) (*WriteRelationshipsResponse, error)
 }

--- a/sdk/go/serve_authorization.go
+++ b/sdk/go/serve_authorization.go
@@ -40,11 +40,7 @@ func (s authorizationProviderServer) ListRelationships(ctx context.Context, req 
 }
 
 func (s authorizationProviderServer) WriteRelationships(ctx context.Context, req *proto.WriteRelationshipsRequest) (*proto.WriteRelationshipsResponse, error) {
-	writer, ok := s.provider.(AuthorizationRelationshipWriter)
-	if !ok {
-		return nil, status.Error(codes.Unimplemented, "authorization relationship writes are not implemented")
-	}
-	resp, err := writer.WriteRelationships(ctx, writeRelationshipsRequestFromProto(req))
+	resp, err := s.provider.WriteRelationships(ctx, writeRelationshipsRequestFromProto(req))
 	return authorizationProtoResponse(resp, protoWriteRelationshipsResponse, "authorization write relationships", err)
 }
 


### PR DESCRIPTION
## Summary

- Make `WriteRelationships` a required method of both the daemon `core.AuthorizationProvider` and public Go SDK `AuthorizationProvider` interfaces.
- Route SCIM user, group PUT, and group PATCH relationship changes directly through one atomic batch write.
- Delete optional capability detection, the process-lifetime `Unimplemented` downgrade cache, sequential `AddRelationship`/`DeleteRelationship` fallback, and partial-prefix metadata repair.
- Keep the single-tuple methods as compatibility entry points, but make the SCIM authorization gate translate them into `TOUCH` or `DELETE` batch operations.
- Replace fallback-specific internal tests with high-level SCIM HTTP behavior and authorization-provider contract coverage for atomic failure, retry, metadata updates, and direct dispatch.

## Root cause

The migration introduced a Zanzibar-style relationship mutation contract, but the daemon still treated it as optional. If a provider returned `Unimplemented` once, the daemon permanently cached that result and downgraded every later SCIM group mutation to a sequence of single-tuple writes. A batch such as removing an old group membership and adding a new one could therefore apply only a prefix. The SCIM request returned an error while authorization state and SCIM projections had already diverged, and the fallback added branching and repair bookkeeping throughout the write path.

The indexed relationship provider and the daemon batch endpoint are now deployed as the prerequisite migration. This change makes the new contract explicit: providers either implement atomic relationship writes or fail to compile/register. Runtime feature negotiation is no longer needed.

## Interface and protocol notes

- `WriteRelationships` is a Zanzibar-style tuple mutation API: a request carries ordered relationship updates plus optional preconditions, and the provider applies the request atomically. This follows the relationship-tuple model described by the [Zanzibar paper](https://research.google/pubs/zanzibar-googles-consistent-global-authorization-system/).
- AuthZEN standardizes authorization evaluation and search surfaces, not a relationship-storage mutation API. The existing decision APIs remain the AuthZEN-aligned surface; this provider write contract deliberately follows Zanzibar semantics instead of claiming a non-existent AuthZEN write operation. See the [OpenID AuthZEN specification](https://openid.github.io/authzen/).
- SCIM group `PUT` and `PATCH` requests are resource-level operations. Applying all derived relationship changes atomically prevents a failed group update from exposing a partially changed membership projection. See [RFC 7644 section 3.5.1](https://www.rfc-editor.org/rfc/rfc7644#section-3.5.1) and [section 3.5.2](https://www.rfc-editor.org/rfc/rfc7644#section-3.5.2).

## Test plan

- [x] `go test ./...` from `gestaltd`
- [x] `go test ./...` from `sdk/go`
- [x] `go vet ./...` from `gestaltd`
- [x] `go vet ./...` from `sdk/go`
- [x] CI lint for `gestaltd` and `sdk/go`
- [x] High-level SCIM HTTP tests verify a failed batch does not fall back or partially apply and remains retryable.
- [x] Authorization service and SDK contract tests verify direct `WriteRelationships` dispatch.

## Rollout

- [x] The indexed provider implementation and relationship indexes are merged and running on valon.tools.
- [x] The registry-readiness fix in #3178 is merged.
- [ ] Merge this interface cleanup and publish its Gestalt CI image.
- [ ] Pin Toolshed to the cleanup merge SHA, merge the roadmap workflow fix, and deploy normally to remove the recovery wrapper.
- [ ] Validate SCIM health, authentication, atomic writes, and authorization/index logs before removing recovery revisions.