### PR TITLE
Deploy downtime step 15: app-scoped relationship mutations

### DIFF
--- a/gestaltd/services/providergateway/authorization_access.go
+++ b/gestaltd/services/providergateway/authorization_access.go
@@ -7,6 +7,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	gproto "google.golang.org/protobuf/proto"
 )
 
 const (
@@ -38,6 +39,7 @@ func authorizationMethodAccessClass(fullMethod string) (read bool, write bool, o
 func (t *ProviderGatewayTransport) enforceAuthorizationPublicAccess(
 	ctx context.Context,
 	subjectID, fullMethod string,
+	req gproto.Message,
 ) error {
 	read, write, ok := authorizationMethodAccessClass(fullMethod)
 	if !ok {
@@ -47,13 +49,24 @@ func (t *ProviderGatewayTransport) enforceAuthorizationPublicAccess(
 	resource := &proto.Resource{Type: authorizationResourceType, Id: authorizationResourceID}
 	actions := authorizationPublicActions(read, write)
 	for _, action := range actions {
-		req := invocation.SubjectAccessRequest(subjectID, action, resource)
-		allowed, err := invocation.CheckSubjectAccess(ctx, t.authorization, req)
+		checkReq := invocation.SubjectAccessRequest(subjectID, action, resource)
+		allowed, err := invocation.CheckSubjectAccess(ctx, t.authorization, checkReq)
 		if err != nil {
 			return status.Error(codes.Unavailable, "authorization provider unavailable")
 		}
 		if allowed {
 			return nil
+		}
+	}
+	if write {
+		if tuple, ok := relationshipTupleFromAuthorizationRequest(fullMethod, req); ok {
+			allowed, err := allowsAppScopedRelationshipMutation(ctx, t.authorization, subjectID, tuple)
+			if err != nil {
+				return status.Error(codes.Unavailable, "authorization provider unavailable")
+			}
+			if allowed {
+				return nil
+			}
 		}
 	}
 	return status.Error(codes.PermissionDenied, "access denied")

--- a/gestaltd/services/providergateway/authorization_app_scope.go
+++ b/gestaltd/services/providergateway/authorization_app_scope.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	appAuthorizationResourceType = "app"
-	appAdminRelation               = "admin"
+	appAdminRelation             = "admin"
 )
 
 func relationshipTupleFromAuthorizationRequest(fullMethod string, req gproto.Message) (*proto.RelationshipTuple, bool) {

--- a/gestaltd/services/providergateway/authorization_app_scope.go
+++ b/gestaltd/services/providergateway/authorization_app_scope.go
@@ -1,0 +1,86 @@
+package providergateway
+
+import (
+	"context"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"github.com/valon-technologies/gestalt/server/services/invocation"
+	gproto "google.golang.org/protobuf/proto"
+)
+
+const appAuthorizationResourceType = "app"
+
+// appAdminRelation grants administration of an app resource.
+const appAdminRelation = "admin"
+
+func relationshipTupleFromAuthorizationRequest(fullMethod string, req gproto.Message) (*proto.RelationshipTuple, bool) {
+	if req == nil {
+		return nil, false
+	}
+	_, method := splitFullMethod(fullMethod)
+	switch method {
+	case "AddRelationship":
+		addReq, ok := req.(*proto.AddRelationshipRequest)
+		if !ok || addReq.GetRelationship() == nil {
+			return nil, false
+		}
+		return addReq.GetRelationship().GetTuple(), true
+	case "DeleteRelationship":
+		deleteReq, ok := req.(*proto.DeleteRelationshipRequest)
+		if !ok {
+			return nil, false
+		}
+		return deleteReq.GetRelationshipTuple(), true
+	default:
+		return nil, false
+	}
+}
+
+func allowsAppScopedRelationshipMutation(
+	ctx context.Context,
+	authorization core.AuthorizationProvider,
+	subjectID string,
+	tuple *proto.RelationshipTuple,
+) (bool, error) {
+	if authorization == nil || tuple == nil {
+		return false, nil
+	}
+	if strings.TrimSpace(tuple.GetResource().GetType()) != appAuthorizationResourceType {
+		return false, nil
+	}
+	appID := strings.TrimSpace(tuple.GetResource().GetId())
+	if appID == "" {
+		return false, nil
+	}
+	if strings.TrimSpace(tuple.GetRelation()) == "" {
+		return false, nil
+	}
+	if !relationshipTupleHasDelegableTarget(tuple) {
+		return false, nil
+	}
+	decision, err := invocation.CheckResourceAccess(ctx, authorization, invocation.ResourceAccessRequest{
+		SubjectID:    subjectID,
+		Action:       appID,
+		Resource:     &proto.Resource{Type: appAuthorizationResourceType, Id: appID},
+		AllowedRoles: []string{appAdminRelation},
+	})
+	if err != nil {
+		return false, err
+	}
+	return decision.Allowed && decision.Role == appAdminRelation, nil
+}
+
+func relationshipTupleHasDelegableTarget(tuple *proto.RelationshipTuple) bool {
+	switch tuple.GetTarget().GetKind().(type) {
+	case *proto.RelationshipTarget_Subject:
+		return strings.TrimSpace(tuple.GetTarget().GetSubject().GetId()) != ""
+	case *proto.RelationshipTarget_SubjectSet:
+		subjectSet := tuple.GetTarget().GetSubjectSet()
+		return strings.TrimSpace(subjectSet.GetResource().GetType()) != "" &&
+			strings.TrimSpace(subjectSet.GetResource().GetId()) != ""
+	default:
+		return false
+	}
+}

--- a/gestaltd/services/providergateway/authorization_app_scope.go
+++ b/gestaltd/services/providergateway/authorization_app_scope.go
@@ -10,10 +10,10 @@ import (
 	gproto "google.golang.org/protobuf/proto"
 )
 
-const appAuthorizationResourceType = "app"
-
-// appAdminRelation grants administration of an app resource.
-const appAdminRelation = "admin"
+const (
+	appAuthorizationResourceType = "app"
+	appAdminRelation               = "admin"
+)
 
 func relationshipTupleFromAuthorizationRequest(fullMethod string, req gproto.Message) (*proto.RelationshipTuple, bool) {
 	if req == nil {

--- a/gestaltd/services/providergateway/authorization_app_scope_test.go
+++ b/gestaltd/services/providergateway/authorization_app_scope_test.go
@@ -1,0 +1,254 @@
+package providergateway
+
+import (
+	"context"
+	"testing"
+
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"github.com/valon-technologies/gestalt/server/services/invocation"
+)
+
+type appScopedAuthorizationProvider struct {
+	*stubAuthorizationProvider
+	appAdmin map[string]bool
+}
+
+func (p *appScopedAuthorizationProvider) CheckAccess(
+	ctx context.Context,
+	req *proto.CheckAccessRequest,
+) (*proto.CheckAccessResponse, error) {
+	resource := req.GetResource()
+	if resource.GetType() == appAuthorizationResourceType {
+		appID := resource.GetId()
+		if p.appAdmin[appID] && req.GetAction().GetName() == appID {
+			return &proto.CheckAccessResponse{
+				Allowed:          true,
+				MatchedRelations: []string{appAdminRelation},
+			}, nil
+		}
+		return &proto.CheckAccessResponse{Allowed: false}, nil
+	}
+	if p.stubAuthorizationProvider != nil {
+		return p.stubAuthorizationProvider.CheckAccess(ctx, req)
+	}
+	return &proto.CheckAccessResponse{Allowed: false}, nil
+}
+
+func TestAllowsAppScopedRelationshipMutation(t *testing.T) {
+	t.Parallel()
+
+	viewerSubject := &proto.Subject{Type: "subject", Id: "user:viewer@example.com"}
+	tuple := &proto.RelationshipTuple{
+		Resource: &proto.Resource{Type: "app", Id: "roadmap"},
+		Relation: "viewer",
+		Target: &proto.RelationshipTarget{
+			Kind: &proto.RelationshipTarget_Subject{Subject: viewerSubject},
+		},
+	}
+
+	provider := &appScopedAuthorizationProvider{
+		appAdmin: map[string]bool{"roadmap": true},
+	}
+
+	allowed, err := allowsAppScopedRelationshipMutation(
+		context.Background(),
+		provider,
+		"user:admin@example.com",
+		tuple,
+	)
+	if err != nil {
+		t.Fatalf("allowsAppScopedRelationshipMutation error = %v", err)
+	}
+	if !allowed {
+		t.Fatal("allowsAppScopedRelationshipMutation allowed = false, want true")
+	}
+}
+
+func TestAllowsAppScopedRelationshipMutationRejectsOtherApps(t *testing.T) {
+	t.Parallel()
+
+	tuple := &proto.RelationshipTuple{
+		Resource: &proto.Resource{Type: "app", Id: "other-app"},
+		Relation: "viewer",
+		Target: &proto.RelationshipTarget{
+			Kind: &proto.RelationshipTarget_Subject{
+				Subject: &proto.Subject{Type: "subject", Id: "user:viewer@example.com"},
+			},
+		},
+	}
+	provider := &appScopedAuthorizationProvider{
+		appAdmin: map[string]bool{"roadmap": true},
+	}
+
+	allowed, err := allowsAppScopedRelationshipMutation(
+		context.Background(),
+		provider,
+		"user:admin@example.com",
+		tuple,
+	)
+	if err != nil {
+		t.Fatalf("allowsAppScopedRelationshipMutation error = %v", err)
+	}
+	if allowed {
+		t.Fatal("allowsAppScopedRelationshipMutation allowed = true, want false")
+	}
+}
+
+func TestAllowsAppScopedRelationshipMutationRejectsGlobalResources(t *testing.T) {
+	t.Parallel()
+
+	tuple := &proto.RelationshipTuple{
+		Resource: &proto.Resource{Type: "gestalt", Id: "admin"},
+		Relation: "admin",
+		Target: &proto.RelationshipTarget{
+			Kind: &proto.RelationshipTarget_Subject{
+				Subject: &proto.Subject{Type: "subject", Id: "user:viewer@example.com"},
+			},
+		},
+	}
+	provider := &appScopedAuthorizationProvider{
+		appAdmin: map[string]bool{"admin": true},
+	}
+
+	allowed, err := allowsAppScopedRelationshipMutation(
+		context.Background(),
+		provider,
+		"user:admin@example.com",
+		tuple,
+	)
+	if err != nil {
+		t.Fatalf("allowsAppScopedRelationshipMutation error = %v", err)
+	}
+	if allowed {
+		t.Fatal("allowsAppScopedRelationshipMutation allowed = true for gestalt tuple, want false")
+	}
+}
+
+func TestEnforceAuthorizationPublicAccessAllowsAppAdminRelationshipWrite(t *testing.T) {
+	t.Parallel()
+
+	provider := &appScopedAuthorizationProvider{
+		stubAuthorizationProvider: &stubAuthorizationProvider{
+			allowedActions: map[string]bool{"viewer": true},
+		},
+		appAdmin: map[string]bool{"roadmap": true},
+	}
+	transport := &ProviderGatewayTransport{authorization: provider}
+
+	req := &proto.AddRelationshipRequest{
+		Relationship: &proto.Relationship{
+			Tuple: &proto.RelationshipTuple{
+				Resource: &proto.Resource{Type: "app", Id: "roadmap"},
+				Relation: "viewer",
+				Target: &proto.RelationshipTarget{
+					Kind: &proto.RelationshipTarget_Subject{
+						Subject: &proto.Subject{Type: "subject", Id: "user:viewer@example.com"},
+					},
+				},
+			},
+		},
+	}
+	err := transport.enforceAuthorizationPublicAccess(
+		context.Background(),
+		"user:admin@example.com",
+		proto.Authorization_AddRelationship_FullMethodName,
+		req,
+	)
+	if err != nil {
+		t.Fatalf("enforceAuthorizationPublicAccess error = %v, want nil", err)
+	}
+}
+
+func TestEnforceAuthorizationPublicAccessDeniesAppAdminModelWrite(t *testing.T) {
+	t.Parallel()
+
+	provider := &appScopedAuthorizationProvider{
+		appAdmin: map[string]bool{"roadmap": true},
+	}
+	transport := &ProviderGatewayTransport{authorization: provider}
+
+	err := transport.enforceAuthorizationPublicAccess(
+		context.Background(),
+		"user:admin@example.com",
+		proto.Authorization_SetActiveModel_FullMethodName,
+		&proto.SetActiveModelRequest{},
+	)
+	if err == nil {
+		t.Fatal("enforceAuthorizationPublicAccess error = nil, want permission denied")
+	}
+}
+
+func TestRelationshipTupleFromAuthorizationRequest(t *testing.T) {
+	t.Parallel()
+
+	addReq := &proto.AddRelationshipRequest{
+		Relationship: &proto.Relationship{
+			Tuple: &proto.RelationshipTuple{
+				Resource: &proto.Resource{Type: "app", Id: "roadmap"},
+				Relation: "viewer",
+			},
+		},
+	}
+	tuple, ok := relationshipTupleFromAuthorizationRequest(
+		proto.Authorization_AddRelationship_FullMethodName,
+		addReq,
+	)
+	if !ok || tuple.GetResource().GetId() != "roadmap" {
+		t.Fatalf("relationshipTupleFromAuthorizationRequest add = %#v, %#v", tuple, ok)
+	}
+
+	deleteReq := &proto.DeleteRelationshipRequest{
+		RelationshipTuple: &proto.RelationshipTuple{
+			Resource: &proto.Resource{Type: "app", Id: "roadmap"},
+			Relation: "viewer",
+		},
+	}
+	tuple, ok = relationshipTupleFromAuthorizationRequest(
+		proto.Authorization_DeleteRelationship_FullMethodName,
+		deleteReq,
+	)
+	if !ok || tuple.GetResource().GetId() != "roadmap" {
+		t.Fatalf("relationshipTupleFromAuthorizationRequest delete = %#v, %#v", tuple, ok)
+	}
+}
+
+func TestAllowsAppScopedRelationshipMutationUsesResourceAccess(t *testing.T) {
+	t.Parallel()
+
+	tuple := &proto.RelationshipTuple{
+		Resource: &proto.Resource{Type: "app", Id: "roadmap"},
+		Relation: "viewer",
+		Target: &proto.RelationshipTarget{
+			Kind: &proto.RelationshipTarget_SubjectSet{
+				SubjectSet: &proto.SubjectSet{
+					Resource: &proto.Resource{Type: "group", Id: "valon-employees"},
+					Relation: "member",
+				},
+			},
+		},
+	}
+	provider := &appScopedAuthorizationProvider{
+		appAdmin: map[string]bool{"roadmap": true},
+	}
+	_, err := invocation.CheckResourceAccess(context.Background(), provider, invocation.ResourceAccessRequest{
+		SubjectID:    "user:admin@example.com",
+		Action:       "roadmap",
+		Resource:     &proto.Resource{Type: "app", Id: "roadmap"},
+		AllowedRoles: []string{appAdminRelation},
+	})
+	if err != nil {
+		t.Fatalf("CheckResourceAccess error = %v", err)
+	}
+	allowed, err := allowsAppScopedRelationshipMutation(
+		context.Background(),
+		provider,
+		"user:admin@example.com",
+		tuple,
+	)
+	if err != nil {
+		t.Fatalf("allowsAppScopedRelationshipMutation error = %v", err)
+	}
+	if !allowed {
+		t.Fatal("allowsAppScopedRelationshipMutation allowed = false for subject set target, want true")
+	}
+}

--- a/gestaltd/services/providergateway/authorization_app_scope_test.go
+++ b/gestaltd/services/providergateway/authorization_app_scope_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
-	"github.com/valon-technologies/gestalt/server/services/invocation"
 )
 
 type appScopedAuthorizationProvider struct {
@@ -212,7 +211,7 @@ func TestRelationshipTupleFromAuthorizationRequest(t *testing.T) {
 	}
 }
 
-func TestAllowsAppScopedRelationshipMutationUsesResourceAccess(t *testing.T) {
+func TestAllowsAppScopedRelationshipMutationAllowsSubjectSetTarget(t *testing.T) {
 	t.Parallel()
 
 	tuple := &proto.RelationshipTuple{
@@ -230,15 +229,7 @@ func TestAllowsAppScopedRelationshipMutationUsesResourceAccess(t *testing.T) {
 	provider := &appScopedAuthorizationProvider{
 		appAdmin: map[string]bool{"roadmap": true},
 	}
-	_, err := invocation.CheckResourceAccess(context.Background(), provider, invocation.ResourceAccessRequest{
-		SubjectID:    "user:admin@example.com",
-		Action:       "roadmap",
-		Resource:     &proto.Resource{Type: "app", Id: "roadmap"},
-		AllowedRoles: []string{appAdminRelation},
-	})
-	if err != nil {
-		t.Fatalf("CheckResourceAccess error = %v", err)
-	}
+
 	allowed, err := allowsAppScopedRelationshipMutation(
 		context.Background(),
 		provider,

--- a/gestaltd/services/providergateway/public_request.go
+++ b/gestaltd/services/providergateway/public_request.go
@@ -79,7 +79,7 @@ func (t *ProviderGatewayTransport) PreparePublicRequest(
 	if err != nil {
 		return nil, nil, err
 	}
-	if err := t.enforcePublicAuthorization(ctx, p, resourceID, fullMethod); err != nil {
+	if err := t.enforcePublicAuthorization(ctx, p, resourceID, fullMethod, req); err != nil {
 		return nil, nil, err
 	}
 	adapted, err := adaptPublicRequest(ctx, t.publicBaseURL, t.users, p, req, policy, fullMethod)
@@ -104,6 +104,7 @@ func (t *ProviderGatewayTransport) enforcePublicAuthorization(
 	ctx context.Context,
 	p *principal.Principal,
 	providerID, fullMethod string,
+	req gproto.Message,
 ) error {
 	service, _ := splitFullMethod(fullMethod)
 	if service == proto.App_ServiceDesc.ServiceName || service == proto.Identity_ServiceDesc.ServiceName || service == proto.RemoteManagement_ServiceDesc.ServiceName {
@@ -117,13 +118,13 @@ func (t *ProviderGatewayTransport) enforcePublicAuthorization(
 		return status.Error(codes.Unauthenticated, "authenticated subject is required")
 	}
 	if isAuthorizationServiceMethod(fullMethod) {
-		return t.enforceAuthorizationPublicAccess(ctx, subjectID, fullMethod)
+		return t.enforceAuthorizationPublicAccess(ctx, subjectID, fullMethod, req)
 	}
 	target := ProviderTarget{Kind: providerKindFromFullMethod(fullMethod), Name: providerID}
 	resource := &proto.Resource{Type: string(target.Kind), Id: strings.TrimSpace(target.Name)}
 	action := &proto.Action{Name: strings.TrimSpace(target.Name)}
-	req := invocation.SubjectAccessRequest(subjectID, action.GetName(), resource)
-	allowed, err := invocation.CheckSubjectAccess(ctx, t.authorization, req)
+	checkReq := invocation.SubjectAccessRequest(subjectID, action.GetName(), resource)
+	allowed, err := invocation.CheckSubjectAccess(ctx, t.authorization, checkReq)
 	if err != nil {
 		return status.Error(codes.Unavailable, "authorization provider unavailable")
 	}


### PR DESCRIPTION
## Summary
- Deploy-downtime plan step **15** (#1541): holders of `app:{app} admin` can add and remove relationship grants on their app via the public authorization API without `authorization:admin`
- Extend the provider gateway so `AddRelationship` and `DeleteRelationship` allow app-scoped writes when the tuple targets `app:{app}` and the caller has `admin` on that app
- Global authorization mutations (models, `gestalt:*`, `group:*`, other apps) still require `authorization:admin`

## Test plan
- [x] `go test ./services/providergateway/...`
- [ ] After gestalt release: app admin can grant/revoke a runtime viewer grant on their app via `/api/v2/authorization/relationships`
- [ ] App admin denied for `gestalt:*`, other apps, and `SetActiveModel` / state apply


Made with [Cursor](https://cursor.com)