### PR TITLE
Deploy downtime step 14: app-scoped allowedOperations mutations

### DIFF
--- a/gestaltd/internal/bootstrap/allowed_operations.go
+++ b/gestaltd/internal/bootstrap/allowed_operations.go
@@ -1,0 +1,25 @@
+package bootstrap
+
+import (
+	"context"
+	"errors"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/services/apps/operationexposure"
+)
+
+func buildAllowedOperations(ctx context.Context, app string, entry *config.ProviderEntry, deps Deps) map[string]*config.OperationOverride {
+	static := entry.EffectiveAllowedOperations()
+	if deps.Services == nil || deps.Services.AppAllowedOperations == nil {
+		return static
+	}
+	overlay, err := deps.Services.AppAllowedOperations.GetOverlay(ctx, app)
+	if err != nil {
+		if errors.Is(err, core.ErrNotFound) {
+			return static
+		}
+		return static
+	}
+	return operationexposure.MergeAllowedOperationsWithOverlay(static, overlay.Operations, overlay.Removed)
+}

--- a/gestaltd/internal/bootstrap/allowed_operations.go
+++ b/gestaltd/internal/bootstrap/allowed_operations.go
@@ -3,6 +3,7 @@ package bootstrap
 import (
 	"context"
 	"errors"
+	"log/slog"
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/config"
@@ -15,10 +16,11 @@ func buildAllowedOperations(ctx context.Context, app string, entry *config.Provi
 		return static
 	}
 	overlay, err := deps.Services.AppAllowedOperations.GetOverlay(ctx, app)
+	if errors.Is(err, core.ErrNotFound) {
+		return static
+	}
 	if err != nil {
-		if errors.Is(err, core.ErrNotFound) {
-			return static
-		}
+		slog.ErrorContext(ctx, "allowed operations overlay unavailable; using deploy config baseline", "app", app, "error", err)
 		return static
 	}
 	return operationexposure.MergeAllowedOperationsWithOverlay(static, overlay.Operations, overlay.Removed)

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -598,7 +598,7 @@ func buildProvider(ctx context.Context, name string, entry *config.ProviderEntry
 		return nil, fmt.Errorf("integration %q must resolve to a provider manifest", name)
 	}
 
-	allowedOperations := entry.EffectiveAllowedOperations()
+	allowedOperations := buildAllowedOperations(ctx, name, entry, deps)
 
 	switch {
 	case manifestApp.IsSpecLoaded() && manifest.Entrypoint == nil:
@@ -649,7 +649,7 @@ func buildExecutableAppProvider(ctx context.Context, name string, entry *config.
 		return nil, err
 	}
 	workflowDeclarations := appservice.DeclaredWorkflowDefinitions(pluginProv)
-	allowedOperations := entry.EffectiveAllowedOperations()
+	allowedOperations := buildAllowedOperations(ctx, name, entry, deps)
 
 	if manifestApp.IsDeclarative() {
 		restConnections, restSelectors, restLocks, err := plan.RESTOperationConnectionBindings(manifestApp)

--- a/gestaltd/internal/coredata/app_allowed_operations.go
+++ b/gestaltd/internal/coredata/app_allowed_operations.go
@@ -15,8 +15,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/apps/operationexposure"
 )
 
-// AppAllowedOperationsOverlay is the runtime delta app administrators manage
-// without a deploy PR.
+// AppAllowedOperationsOverlay is the runtime delta app administrators manage without a deploy PR.
 type AppAllowedOperationsOverlay struct {
 	App        string
 	Operations map[string]*operationexposure.OperationOverride
@@ -76,7 +75,11 @@ func (s *AppAllowedOperationsService) SetOverlay(ctx context.Context, overlay *A
 		return err
 	}
 	overlay.UpdatedAt = time.Now().UTC().Truncate(time.Millisecond)
-	if err := s.store.Put(ctx, appAllowedOperationsRecord(overlay)); err != nil {
+	record, err := appAllowedOperationsRecord(overlay)
+	if err != nil {
+		return fmt.Errorf("set app allowed operations overlay: encode: %w", err)
+	}
+	if err := s.store.Put(ctx, record); err != nil {
 		return fmt.Errorf("set app allowed operations overlay: write: %w", err)
 	}
 	return nil
@@ -99,16 +102,45 @@ func (s *AppAllowedOperationsService) DeleteOverlay(ctx context.Context, app str
 	return nil
 }
 
-func appAllowedOperationsRecord(overlay *AppAllowedOperationsOverlay) idb.Record {
-	operationsJSON, _ := json.Marshal(overlay.Operations)
-	removedJSON, _ := json.Marshal(overlay.Removed)
+func MergeOverlayPatch(
+	current *AppAllowedOperationsOverlay,
+	app string,
+	operations map[string]*operationexposure.OperationOverride,
+	removed []string,
+) *AppAllowedOperationsOverlay {
+	var currentOps map[string]*operationexposure.OperationOverride
+	var currentRemoved []string
+	if current != nil {
+		currentOps = current.Operations
+		currentRemoved = current.Removed
+	}
+	ops, mergedRemoved := operationexposure.MergeOverlayPatch(currentOps, currentRemoved, operations, removed)
+	if ops == nil && mergedRemoved == nil {
+		return nil
+	}
+	return &AppAllowedOperationsOverlay{
+		App:        app,
+		Operations: ops,
+		Removed:    mergedRemoved,
+	}
+}
+
+func appAllowedOperationsRecord(overlay *AppAllowedOperationsOverlay) (idb.Record, error) {
+	operationsJSON, err := json.Marshal(overlay.Operations)
+	if err != nil {
+		return nil, fmt.Errorf("encode operations_json: %w", err)
+	}
+	removedJSON, err := json.Marshal(overlay.Removed)
+	if err != nil {
+		return nil, fmt.Errorf("encode removed_json: %w", err)
+	}
 	return idb.Record{
 		"id":              overlay.App,
 		"app":             overlay.App,
 		"operations_json": string(operationsJSON),
 		"removed_json":    string(removedJSON),
 		"updated_at":      overlay.UpdatedAt,
-	}
+	}, nil
 }
 
 func recordToAppAllowedOperationsOverlay(rec idb.Record) (*AppAllowedOperationsOverlay, error) {

--- a/gestaltd/internal/coredata/app_allowed_operations.go
+++ b/gestaltd/internal/coredata/app_allowed_operations.go
@@ -1,0 +1,133 @@
+package coredata
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	idb "github.com/valon-technologies/gestalt/sdk/go/indexeddb"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/indexeddb"
+	"github.com/valon-technologies/gestalt/server/services/apps/operationexposure"
+)
+
+// AppAllowedOperationsOverlay is the runtime delta app administrators manage
+// without a deploy PR.
+type AppAllowedOperationsOverlay struct {
+	App        string
+	Operations map[string]*operationexposure.OperationOverride
+	Removed    []string
+	UpdatedAt  time.Time
+}
+
+type AppAllowedOperationsService struct {
+	db    indexeddb.IndexedDB
+	store idb.ObjectStore
+}
+
+func NewAppAllowedOperationsService(ds indexeddb.IndexedDB) *AppAllowedOperationsService {
+	return &AppAllowedOperationsService{
+		db:    ds,
+		store: ds.ObjectStore(StoreAppAllowedOperations),
+	}
+}
+
+func (s *AppAllowedOperationsService) EnsureStore(ctx context.Context) error {
+	if s == nil || s.db == nil {
+		return fmt.Errorf("ensure app allowed operations store: service is not configured")
+	}
+	return ensureAppAllowedOperationsStore(ctx, s.db)
+}
+
+func (s *AppAllowedOperationsService) GetOverlay(ctx context.Context, app string) (*AppAllowedOperationsOverlay, error) {
+	if s == nil {
+		return nil, fmt.Errorf("get app allowed operations overlay: service is not configured")
+	}
+	app = strings.TrimSpace(app)
+	if app == "" {
+		return nil, fmt.Errorf("get app allowed operations overlay: app is required")
+	}
+	rec, err := s.store.Get(ctx, app)
+	if err != nil {
+		if errors.Is(err, idb.ErrNotFound) {
+			return nil, core.ErrNotFound
+		}
+		return nil, fmt.Errorf("get app allowed operations overlay: %w", err)
+	}
+	return recordToAppAllowedOperationsOverlay(rec)
+}
+
+func (s *AppAllowedOperationsService) SetOverlay(ctx context.Context, overlay *AppAllowedOperationsOverlay) error {
+	if s == nil || s.db == nil {
+		return fmt.Errorf("set app allowed operations overlay: service is not configured")
+	}
+	if overlay == nil {
+		return fmt.Errorf("set app allowed operations overlay: overlay is required")
+	}
+	overlay.App = strings.TrimSpace(overlay.App)
+	if overlay.App == "" {
+		return fmt.Errorf("set app allowed operations overlay: app is required")
+	}
+	if err := s.EnsureStore(ctx); err != nil {
+		return err
+	}
+	overlay.UpdatedAt = time.Now().UTC().Truncate(time.Millisecond)
+	if err := s.store.Put(ctx, appAllowedOperationsRecord(overlay)); err != nil {
+		return fmt.Errorf("set app allowed operations overlay: write: %w", err)
+	}
+	return nil
+}
+
+func (s *AppAllowedOperationsService) DeleteOverlay(ctx context.Context, app string) error {
+	if s == nil {
+		return fmt.Errorf("delete app allowed operations overlay: service is not configured")
+	}
+	app = strings.TrimSpace(app)
+	if app == "" {
+		return fmt.Errorf("delete app allowed operations overlay: app is required")
+	}
+	if err := s.EnsureStore(ctx); err != nil {
+		return err
+	}
+	if err := s.store.Delete(ctx, app); err != nil && !errors.Is(err, idb.ErrNotFound) {
+		return fmt.Errorf("delete app allowed operations overlay: %w", err)
+	}
+	return nil
+}
+
+func appAllowedOperationsRecord(overlay *AppAllowedOperationsOverlay) idb.Record {
+	operationsJSON, _ := json.Marshal(overlay.Operations)
+	removedJSON, _ := json.Marshal(overlay.Removed)
+	return idb.Record{
+		"id":              overlay.App,
+		"app":             overlay.App,
+		"operations_json": string(operationsJSON),
+		"removed_json":    string(removedJSON),
+		"updated_at":      overlay.UpdatedAt,
+	}
+}
+
+func recordToAppAllowedOperationsOverlay(rec idb.Record) (*AppAllowedOperationsOverlay, error) {
+	operations := map[string]*operationexposure.OperationOverride{}
+	if raw := recString(rec, "operations_json"); raw != "" {
+		if err := json.Unmarshal([]byte(raw), &operations); err != nil {
+			return nil, fmt.Errorf("decode operations_json: %w", err)
+		}
+	}
+	var removed []string
+	if raw := recString(rec, "removed_json"); raw != "" {
+		if err := json.Unmarshal([]byte(raw), &removed); err != nil {
+			return nil, fmt.Errorf("decode removed_json: %w", err)
+		}
+	}
+	return &AppAllowedOperationsOverlay{
+		App:        recString(rec, "app"),
+		Operations: operations,
+		Removed:    removed,
+		UpdatedAt:  recTime(rec, "updated_at"),
+	}, nil
+}

--- a/gestaltd/internal/coredata/app_allowed_operations_test.go
+++ b/gestaltd/internal/coredata/app_allowed_operations_test.go
@@ -1,0 +1,65 @@
+package coredata_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/coredata"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
+	"github.com/valon-technologies/gestalt/server/services/apps/operationexposure"
+)
+
+func TestAppAllowedOperationsService(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	svc := testutil.NewStubServices(t).AppAllowedOperations
+	const app = "hello-world"
+
+	if _, err := svc.GetOverlay(ctx, app); !errors.Is(err, core.ErrNotFound) {
+		t.Fatalf("missing overlay error = %v, want %v", err, core.ErrNotFound)
+	}
+
+	if err := svc.SetOverlay(ctx, &coredata.AppAllowedOperationsOverlay{
+		App: app,
+		Operations: map[string]*operationexposure.OperationOverride{
+			"get_item": {AllowedRoles: []string{"viewer"}},
+		},
+	}); err != nil {
+		t.Fatalf("SetOverlay: %v", err)
+	}
+
+	overlay, err := svc.GetOverlay(ctx, app)
+	if err != nil {
+		t.Fatalf("GetOverlay: %v", err)
+	}
+	if overlay.Operations["get_item"].AllowedRoles[0] != "viewer" {
+		t.Fatalf("overlay = %#v", overlay)
+	}
+
+	patched := coredata.MergeOverlayPatch(overlay, app, map[string]*operationexposure.OperationOverride{
+		"create": {AllowedRoles: []string{"admin"}},
+	}, []string{"get_item"})
+	if err := svc.SetOverlay(ctx, patched); err != nil {
+		t.Fatalf("SetOverlay patch: %v", err)
+	}
+	overlay, err = svc.GetOverlay(ctx, app)
+	if err != nil {
+		t.Fatalf("GetOverlay after patch: %v", err)
+	}
+	if overlay.Operations["create"] == nil || overlay.Operations["get_item"] != nil {
+		t.Fatalf("patched overlay = %#v", overlay)
+	}
+	if len(overlay.Removed) != 1 || overlay.Removed[0] != "get_item" {
+		t.Fatalf("patched removed = %#v", overlay.Removed)
+	}
+
+	if err := svc.DeleteOverlay(ctx, app); err != nil {
+		t.Fatalf("DeleteOverlay: %v", err)
+	}
+	if _, err := svc.GetOverlay(ctx, app); !errors.Is(err, core.ErrNotFound) {
+		t.Fatalf("deleted overlay error = %v, want %v", err, core.ErrNotFound)
+	}
+}

--- a/gestaltd/internal/coredata/schemas.go
+++ b/gestaltd/internal/coredata/schemas.go
@@ -22,6 +22,7 @@ const (
 	StoreRemoteProviders                = "remote_providers"
 	StoreConnectionInstancePreferences  = "connection_instance_preferences"
 	StoreAppAccessProfiles              = "app_access_profiles"
+	StoreAppAllowedOperations           = "app_allowed_operations"
 	StoreSCIMResources                  = "scim_resources"
 )
 
@@ -250,6 +251,16 @@ var ConnectionInstancePreferencesSchema = idb.ObjectStoreOptions{
 		{Name: "subject_id", Type: idb.TypeString, NotNull: true},
 		{Name: "connection_id", Type: idb.TypeString, NotNull: true},
 		{Name: "instance", Type: idb.TypeString, NotNull: true},
+		{Name: "updated_at", Type: idb.TypeTime, NotNull: true},
+	},
+}
+
+var AppAllowedOperationsSchema = idb.ObjectStoreOptions{
+	Columns: []idb.ColumnDef{
+		{Name: "id", Type: idb.TypeString, PrimaryKey: true},
+		{Name: "app", Type: idb.TypeString, NotNull: true},
+		{Name: "operations_json", Type: idb.TypeString},
+		{Name: "removed_json", Type: idb.TypeString},
 		{Name: "updated_at", Type: idb.TypeTime, NotNull: true},
 	},
 }

--- a/gestaltd/internal/coredata/services.go
+++ b/gestaltd/internal/coredata/services.go
@@ -24,6 +24,7 @@ type Services struct {
 	RemoteRegistrations            *RemoteRegistrationService
 	ConnectionInstancePreferences  *ConnectionInstancePreferenceService
 	AppAccessProfiles              *AppAccessProfileService
+	AppAllowedOperations           *AppAllowedOperationsService
 	DB                             indexeddb.IndexedDB
 }
 
@@ -95,6 +96,9 @@ func NewWithOptions(ctx context.Context, ds indexeddb.IndexedDB, opts NewOptions
 		if _, err := ds.CreateObjectStore(ctx, StoreAppAccessProfiles, AppAccessProfilesSchema); err != nil {
 			return nil, fmt.Errorf("create app_access_profiles store: %w", err)
 		}
+		if _, err := ds.CreateObjectStore(ctx, StoreAppAllowedOperations, AppAllowedOperationsSchema); err != nil {
+			return nil, fmt.Errorf("create app_allowed_operations store: %w", err)
+		}
 		if _, err := ds.CreateObjectStore(ctx, StoreSCIMResources, SCIMResourcesSchema); err != nil {
 			return nil, fmt.Errorf("create scim_resources store: %w", err)
 		}
@@ -117,6 +121,7 @@ func NewWithOptions(ctx context.Context, ds indexeddb.IndexedDB, opts NewOptions
 	remoteRegistrations := NewRemoteRegistrationService(ds)
 	connectionInstancePreferences := NewConnectionInstancePreferenceService(ds)
 	appAccessProfiles := NewAppAccessProfileService(ds)
+	appAllowedOperations := NewAppAllowedOperationsService(ds)
 	return &Services{
 		ExternalCredentials:            nil,
 		Users:                          users,
@@ -133,6 +138,7 @@ func NewWithOptions(ctx context.Context, ds indexeddb.IndexedDB, opts NewOptions
 		RemoteRegistrations:            remoteRegistrations,
 		ConnectionInstancePreferences:  connectionInstancePreferences,
 		AppAccessProfiles:              appAccessProfiles,
+		AppAllowedOperations:           appAllowedOperations,
 		DB:                             ds,
 	}, nil
 }
@@ -167,6 +173,16 @@ func ensureDeferredAppRegistryStores(ctx context.Context, ds indexeddb.IndexedDB
 	}
 	if err := ensureAppAccessProfilesStore(ctx, ds); err != nil {
 		return err
+	}
+	if err := ensureAppAllowedOperationsStore(ctx, ds); err != nil {
+		return err
+	}
+	return nil
+}
+
+func ensureAppAllowedOperationsStore(ctx context.Context, ds indexeddb.IndexedDB) error {
+	if _, err := ds.CreateObjectStore(ctx, StoreAppAllowedOperations, AppAllowedOperationsSchema); err != nil {
+		return fmt.Errorf("ensure app_allowed_operations store: %w", err)
 	}
 	return nil
 }

--- a/gestaltd/internal/coredata/services_test.go
+++ b/gestaltd/internal/coredata/services_test.go
@@ -278,8 +278,8 @@ func TestNew(t *testing.T) {
 			t.Fatalf("coredata.NewWithOptions: %v", err)
 		}
 		contexts := db.createdStoreContexts()
-		if len(contexts) != 6 {
-			t.Fatalf("CreateObjectStore calls = %d, want 6", len(contexts))
+		if len(contexts) != 7 {
+			t.Fatalf("CreateObjectStore calls = %d, want 7", len(contexts))
 		}
 		for _, store := range []string{
 			coredata.StoreAppAutoDeploySettings,

--- a/gestaltd/internal/coredata/services_test.go
+++ b/gestaltd/internal/coredata/services_test.go
@@ -256,6 +256,7 @@ func TestNew(t *testing.T) {
 			coredata.StoreRemoteProviders,
 			coredata.StoreConnectionInstancePreferences,
 			coredata.StoreAppAccessProfiles,
+			coredata.StoreAppAllowedOperations,
 			coredata.StoreSCIMResources,
 		} {
 			if _, ok := contexts[store]; !ok {
@@ -286,6 +287,7 @@ func TestNew(t *testing.T) {
 			coredata.StoreGestaltdInstanceHeartbeats,
 			coredata.StoreAppVersionRecoveryObservations,
 			coredata.StoreAppAccessProfiles,
+			coredata.StoreAppAllowedOperations,
 			coredata.StoreSCIMResources,
 		} {
 			if _, ok := contexts[store]; !ok {

--- a/gestaltd/internal/server/handlers_app_admin_allowed_operations.go
+++ b/gestaltd/internal/server/handlers_app_admin_allowed_operations.go
@@ -1,0 +1,275 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"maps"
+	"net/http"
+	"slices"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/coredata"
+	"github.com/valon-technologies/gestalt/server/services/apps/operationexposure"
+	"github.com/valon-technologies/gestalt/server/services/apps/packageio"
+)
+
+type appAdminAllowedOperationRow struct {
+	ID           string   `json:"id"`
+	AllowedRoles []string `json:"allowedRoles,omitempty"`
+	Source       string   `json:"source"`
+	Mutable      bool     `json:"mutable"`
+}
+
+type appAdminAllowedOperationsResponse struct {
+	App        string                          `json:"app"`
+	Operations []appAdminAllowedOperationRow   `json:"operations"`
+}
+
+type appAdminAllowedOperationsUpdateRequest struct {
+	Operations map[string]*operationexposure.OperationOverride `json:"operations"`
+	Removed    []string                                        `json:"removed,omitempty"`
+}
+
+func (s *Server) mountAppAdminAllowedOperationsRoutes(r chi.Router) {
+	r.With(s.pluginRouteAuthMiddleware("app"), s.appAdminAuthorizationMiddleware).
+		Get("/apps/{app}/admin/allowed-operations", s.getAppAdminAllowedOperations)
+	r.With(s.pluginRouteAuthMiddleware("app"), s.appAdminAuthorizationMiddleware).
+		Put("/apps/{app}/admin/allowed-operations", s.putAppAdminAllowedOperations)
+}
+
+func (s *Server) getAppAdminAllowedOperations(w http.ResponseWriter, r *http.Request) {
+	appName := strings.TrimSpace(chi.URLParam(r, "app"))
+	if appName == "" {
+		writeError(w, http.StatusBadRequest, "app is required")
+		return
+	}
+	entry, ok := s.pluginDefs[appName]
+	if !ok || entry == nil {
+		writeError(w, http.StatusNotFound, "app not found")
+		return
+	}
+	rows, err := s.projectAppAdminAllowedOperationRows(r.Context(), appName, entry)
+	if err != nil {
+		slog.Error("app admin allowed operations projection failed", "app", appName, "error", err)
+		writeError(w, http.StatusServiceUnavailable, "allowed operations are unavailable")
+		return
+	}
+	writeJSON(w, http.StatusOK, appAdminAllowedOperationsResponse{
+		App:        appName,
+		Operations: rows,
+	})
+}
+
+func (s *Server) putAppAdminAllowedOperations(w http.ResponseWriter, r *http.Request) {
+	appName := strings.TrimSpace(chi.URLParam(r, "app"))
+	if appName == "" {
+		writeError(w, http.StatusBadRequest, "app is required")
+		return
+	}
+	entry, ok := s.pluginDefs[appName]
+	if !ok || entry == nil {
+		writeError(w, http.StatusNotFound, "app not found")
+		return
+	}
+	if s.appAllowedOperations == nil {
+		writeError(w, http.StatusServiceUnavailable, "allowed operations are unavailable")
+		return
+	}
+	var request appAdminAllowedOperationsUpdateRequest
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&request); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	if request.Operations == nil {
+		writeError(w, http.StatusBadRequest, "operations is required")
+		return
+	}
+	if err := s.validateAppAdminAllowedOperationsUpdate(entry, request); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if err := s.appAllowedOperations.EnsureStore(r.Context()); err != nil {
+		slog.Error("app admin allowed operations store unavailable", "app", appName, "error", err)
+		writeError(w, http.StatusServiceUnavailable, "allowed operations are unavailable")
+		return
+	}
+	overlay := &coredata.AppAllowedOperationsOverlay{
+		App:        appName,
+		Operations: request.Operations,
+		Removed:    normalizeRemovedOperationIDs(request.Removed),
+	}
+	if len(overlay.Operations) == 0 && len(overlay.Removed) == 0 {
+		if err := s.appAllowedOperations.DeleteOverlay(r.Context(), appName); err != nil {
+			slog.Error("app admin allowed operations delete failed", "app", appName, "error", err)
+			writeError(w, http.StatusServiceUnavailable, "allowed operations are unavailable")
+			return
+		}
+	} else if err := s.appAllowedOperations.SetOverlay(r.Context(), overlay); err != nil {
+		slog.Error("app admin allowed operations update failed", "app", appName, "error", err)
+		writeError(w, http.StatusServiceUnavailable, "allowed operations are unavailable")
+		return
+	}
+	if s.activateAppProviders != nil {
+		s.activateAppProviders(r.Context())
+	}
+	rows, err := s.projectAppAdminAllowedOperationRows(r.Context(), appName, entry)
+	if err != nil {
+		slog.Error("app admin allowed operations projection failed", "app", appName, "error", err)
+		writeError(w, http.StatusServiceUnavailable, "allowed operations are unavailable")
+		return
+	}
+	writeJSON(w, http.StatusOK, appAdminAllowedOperationsResponse{
+		App:        appName,
+		Operations: rows,
+	})
+}
+
+func (s *Server) projectAppAdminAllowedOperationRows(
+	ctx context.Context,
+	appName string,
+	entry *config.ProviderEntry,
+) ([]appAdminAllowedOperationRow, error) {
+	static := entry.EffectiveAllowedOperations()
+	var runtimeOps map[string]*operationexposure.OperationOverride
+	var removed []string
+	if s.appAllowedOperations != nil {
+		overlay, err := s.appAllowedOperations.GetOverlay(ctx, appName)
+		if err == nil && overlay != nil {
+			runtimeOps = overlay.Operations
+			removed = overlay.Removed
+		} else if err != nil && !errors.Is(err, core.ErrNotFound) {
+			return nil, err
+		}
+	}
+	effective := operationexposure.MergeAllowedOperationsWithOverlay(static, runtimeOps, removed)
+	removedSet := make(map[string]struct{}, len(removed))
+	for _, id := range removed {
+		removedSet[id] = struct{}{}
+	}
+	ids := slices.Sorted(maps.Keys(effective))
+	rows := make([]appAdminAllowedOperationRow, 0, len(ids))
+	for _, id := range ids {
+		override := effective[id]
+		row := appAdminAllowedOperationRow{
+			ID:     id,
+			Source: allowedOperationSource(id, static, runtimeOps, removedSet),
+			Mutable: true,
+		}
+		if override != nil && len(override.AllowedRoles) > 0 {
+			row.AllowedRoles = append([]string(nil), override.AllowedRoles...)
+		}
+		rows = append(rows, row)
+	}
+	return rows, nil
+}
+
+func allowedOperationSource(
+	id string,
+	static map[string]*operationexposure.OperationOverride,
+	runtimeOps map[string]*operationexposure.OperationOverride,
+	removedSet map[string]struct{},
+) string {
+	if _, ok := removedSet[id]; ok {
+		return "runtime"
+	}
+	_, inRuntime := runtimeOps[id]
+	_, inStatic := static[id]
+	switch {
+	case inRuntime:
+		return "runtime"
+	case inStatic:
+		return "config"
+	default:
+		return "runtime"
+	}
+}
+
+func (s *Server) validateAppAdminAllowedOperationsUpdate(
+	entry *config.ProviderEntry,
+	request appAdminAllowedOperationsUpdateRequest,
+) error {
+	known := appManifestOperationIDs(entry)
+	for _, id := range request.Removed {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			return errors.New("removed operation id is required")
+		}
+	}
+	for id, override := range request.Operations {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			return errors.New("operation id is required")
+		}
+		if len(known) > 0 {
+			if _, ok := known[id]; !ok {
+				return errors.New("operation " + id + " is not in the app catalog")
+			}
+		}
+		if override != nil && len(override.AllowedRoles) > 0 {
+			if _, err := packageio.NormalizeUIAllowedRoles("allowedRoles", override.AllowedRoles); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func appManifestOperationIDs(entry *config.ProviderEntry) map[string]struct{} {
+	if entry == nil {
+		return nil
+	}
+	if entry.ResolvedCatalog != nil {
+		ids := make(map[string]struct{}, len(entry.ResolvedCatalog.Operations))
+		for _, op := range entry.ResolvedCatalog.Operations {
+			id := strings.TrimSpace(op.ID)
+			if id != "" {
+				ids[id] = struct{}{}
+			}
+		}
+		if len(ids) > 0 {
+			return ids
+		}
+	}
+	static := entry.EffectiveAllowedOperations()
+	if len(static) == 0 {
+		return nil
+	}
+	ids := make(map[string]struct{}, len(static))
+	for id := range static {
+		ids[id] = struct{}{}
+	}
+	return ids
+}
+
+func normalizeRemovedOperationIDs(removed []string) []string {
+	if len(removed) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(removed))
+	seen := make(map[string]struct{}, len(removed))
+	for _, id := range removed {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
+	}
+	return out
+}

--- a/gestaltd/internal/server/handlers_app_admin_allowed_operations.go
+++ b/gestaltd/internal/server/handlers_app_admin_allowed_operations.go
@@ -234,8 +234,8 @@ func appManifestOperationIDs(entry *config.ProviderEntry) map[string]struct{} {
 	}
 	if entry.ResolvedCatalog != nil {
 		ids := make(map[string]struct{}, len(entry.ResolvedCatalog.Operations))
-		for _, op := range entry.ResolvedCatalog.Operations {
-			id := strings.TrimSpace(op.ID)
+		for i := range entry.ResolvedCatalog.Operations {
+			id := strings.TrimSpace(entry.ResolvedCatalog.Operations[i].ID)
 			if id != "" {
 				ids[id] = struct{}{}
 			}

--- a/gestaltd/internal/server/handlers_app_admin_allowed_operations.go
+++ b/gestaltd/internal/server/handlers_app_admin_allowed_operations.go
@@ -24,12 +24,11 @@ type appAdminAllowedOperationRow struct {
 	ID           string   `json:"id"`
 	AllowedRoles []string `json:"allowedRoles,omitempty"`
 	Source       string   `json:"source"`
-	Mutable      bool     `json:"mutable"`
 }
 
 type appAdminAllowedOperationsResponse struct {
-	App        string                          `json:"app"`
-	Operations []appAdminAllowedOperationRow   `json:"operations"`
+	App        string                        `json:"app"`
+	Operations []appAdminAllowedOperationRow `json:"operations"`
 }
 
 type appAdminAllowedOperationsUpdateRequest struct {
@@ -106,12 +105,19 @@ func (s *Server) putAppAdminAllowedOperations(w http.ResponseWriter, r *http.Req
 		writeError(w, http.StatusServiceUnavailable, "allowed operations are unavailable")
 		return
 	}
-	overlay := &coredata.AppAllowedOperationsOverlay{
-		App:        appName,
-		Operations: request.Operations,
-		Removed:    normalizeRemovedOperationIDs(request.Removed),
+	current, err := s.appAllowedOperations.GetOverlay(r.Context(), appName)
+	if err != nil && !errors.Is(err, core.ErrNotFound) {
+		slog.Error("app admin allowed operations load failed", "app", appName, "error", err)
+		writeError(w, http.StatusServiceUnavailable, "allowed operations are unavailable")
+		return
 	}
-	if len(overlay.Operations) == 0 && len(overlay.Removed) == 0 {
+	overlay := coredata.MergeOverlayPatch(
+		current,
+		appName,
+		request.Operations,
+		normalizeRemovedOperationIDs(request.Removed),
+	)
+	if overlay == nil {
 		if err := s.appAllowedOperations.DeleteOverlay(r.Context(), appName); err != nil {
 			slog.Error("app admin allowed operations delete failed", "app", appName, "error", err)
 			writeError(w, http.StatusServiceUnavailable, "allowed operations are unavailable")
@@ -122,6 +128,7 @@ func (s *Server) putAppAdminAllowedOperations(w http.ResponseWriter, r *http.Req
 		writeError(w, http.StatusServiceUnavailable, "allowed operations are unavailable")
 		return
 	}
+	// Rebuild providers so invoke gates and catalogs pick up the merged overlay.
 	if s.activateAppProviders != nil {
 		s.activateAppProviders(r.Context())
 	}
@@ -155,18 +162,13 @@ func (s *Server) projectAppAdminAllowedOperationRows(
 		}
 	}
 	effective := operationexposure.MergeAllowedOperationsWithOverlay(static, runtimeOps, removed)
-	removedSet := make(map[string]struct{}, len(removed))
-	for _, id := range removed {
-		removedSet[id] = struct{}{}
-	}
 	ids := slices.Sorted(maps.Keys(effective))
 	rows := make([]appAdminAllowedOperationRow, 0, len(ids))
 	for _, id := range ids {
 		override := effective[id]
 		row := appAdminAllowedOperationRow{
 			ID:     id,
-			Source: allowedOperationSource(id, static, runtimeOps, removedSet),
-			Mutable: true,
+			Source: allowedOperationSource(id, static, runtimeOps),
 		}
 		if override != nil && len(override.AllowedRoles) > 0 {
 			row.AllowedRoles = append([]string(nil), override.AllowedRoles...)
@@ -180,21 +182,14 @@ func allowedOperationSource(
 	id string,
 	static map[string]*operationexposure.OperationOverride,
 	runtimeOps map[string]*operationexposure.OperationOverride,
-	removedSet map[string]struct{},
 ) string {
-	if _, ok := removedSet[id]; ok {
+	if runtimeOps[id] != nil {
 		return "runtime"
 	}
-	_, inRuntime := runtimeOps[id]
-	_, inStatic := static[id]
-	switch {
-	case inRuntime:
-		return "runtime"
-	case inStatic:
+	if static[id] != nil {
 		return "config"
-	default:
-		return "runtime"
 	}
+	return "runtime"
 }
 
 func (s *Server) validateAppAdminAllowedOperationsUpdate(
@@ -207,6 +202,11 @@ func (s *Server) validateAppAdminAllowedOperationsUpdate(
 		if id == "" {
 			return errors.New("removed operation id is required")
 		}
+		if len(known) > 0 {
+			if _, ok := known[id]; !ok {
+				return errors.New("operation " + id + " is not in the app catalog")
+			}
+		}
 	}
 	for id, override := range request.Operations {
 		id = strings.TrimSpace(id)
@@ -218,10 +218,11 @@ func (s *Server) validateAppAdminAllowedOperationsUpdate(
 				return errors.New("operation " + id + " is not in the app catalog")
 			}
 		}
-		if override != nil && len(override.AllowedRoles) > 0 {
-			if _, err := packageio.NormalizeUIAllowedRoles("allowedRoles", override.AllowedRoles); err != nil {
-				return err
-			}
+		if override == nil || len(override.AllowedRoles) == 0 {
+			return errors.New("allowedRoles is required for operation " + id)
+		}
+		if _, err := packageio.NormalizeUIAllowedRoles("allowedRoles", override.AllowedRoles); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/gestaltd/internal/server/handlers_app_admin_allowed_operations_test.go
+++ b/gestaltd/internal/server/handlers_app_admin_allowed_operations_test.go
@@ -1,0 +1,55 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/services/apps/operationexposure"
+)
+
+func TestAllowedOperationSource(t *testing.T) {
+	t.Parallel()
+
+	static := map[string]*operationexposure.OperationOverride{
+		"get_item": {AllowedRoles: []string{"viewer"}},
+	}
+	runtime := map[string]*operationexposure.OperationOverride{
+		"create": {AllowedRoles: []string{"admin"}},
+	}
+	removed := map[string]struct{}{"delete": {}}
+
+	if got := allowedOperationSource("get_item", static, runtime, removed); got != "config" {
+		t.Fatalf("get_item source = %q, want config", got)
+	}
+	if got := allowedOperationSource("create", static, runtime, removed); got != "runtime" {
+		t.Fatalf("create source = %q, want runtime", got)
+	}
+}
+
+func TestValidateAppAdminAllowedOperationsUpdateRejectsUnknownOperation(t *testing.T) {
+	t.Parallel()
+
+	server := &Server{}
+	entry := &config.ProviderEntry{
+		AllowedOperations: map[string]*config.OperationOverride{
+			"get_item": {AllowedRoles: []string{"viewer"}},
+		},
+	}
+	err := server.validateAppAdminAllowedOperationsUpdate(entry, appAdminAllowedOperationsUpdateRequest{
+		Operations: map[string]*operationexposure.OperationOverride{
+			"unknown": {AllowedRoles: []string{"admin"}},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected validation error for unknown operation")
+	}
+}
+
+func TestNormalizeRemovedOperationIDs(t *testing.T) {
+	t.Parallel()
+
+	got := normalizeRemovedOperationIDs([]string{" delete ", "delete", ""})
+	if len(got) != 1 || got[0] != "delete" {
+		t.Fatalf("normalizeRemovedOperationIDs = %#v", got)
+	}
+}

--- a/gestaltd/internal/server/handlers_app_admin_allowed_operations_test.go
+++ b/gestaltd/internal/server/handlers_app_admin_allowed_operations_test.go
@@ -16,12 +16,11 @@ func TestAllowedOperationSource(t *testing.T) {
 	runtime := map[string]*operationexposure.OperationOverride{
 		"create": {AllowedRoles: []string{"admin"}},
 	}
-	removed := map[string]struct{}{"delete": {}}
 
-	if got := allowedOperationSource("get_item", static, runtime, removed); got != "config" {
+	if got := allowedOperationSource("get_item", static, runtime); got != "config" {
 		t.Fatalf("get_item source = %q, want config", got)
 	}
-	if got := allowedOperationSource("create", static, runtime, removed); got != "runtime" {
+	if got := allowedOperationSource("create", static, runtime); got != "runtime" {
 		t.Fatalf("create source = %q, want runtime", got)
 	}
 }

--- a/gestaltd/internal/server/routes_user.go
+++ b/gestaltd/internal/server/routes_user.go
@@ -9,6 +9,7 @@ func (s *Server) mountAuthenticatedRoutes(r chi.Router) {
 	s.mountAppAdminRegistryRoutes(r)
 	s.mountAppAdminMembersRoutes(r)
 	s.mountAppAdminIdentitiesRoutes(r)
+	s.mountAppAdminAllowedOperationsRoutes(r)
 	s.mountAppAdminMetricsRoutes(r)
 
 	s.mountCatalogCLIRoutes(r)

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -126,6 +126,7 @@ type Server struct {
 	externalCredentials           core.ExternalCredentialProvider
 	connectionInstancePreferences *coredata.ConnectionInstancePreferenceService
 	appAccessProfiles             *coredata.AppAccessProfileService
+	appAllowedOperations          *coredata.AppAllowedOperationsService
 	managedSubjects               *coredata.ManagedSubjectService
 	agent                         bootstrap.AgentControl
 	workflowSchedules             workflowmanager.Service
@@ -470,6 +471,7 @@ func New(cfg Config) (*Server, error) {
 		externalCredentials:           externalCredentials,
 		connectionInstancePreferences: connectionInstancePreferences,
 		appAccessProfiles:             cfg.Services.AppAccessProfiles,
+		appAllowedOperations:          cfg.Services.AppAllowedOperations,
 		managedSubjects:               managedSubjects,
 		agent:                         cfg.Agent,
 		agentRuns:                     cfg.AgentManager,

--- a/gestaltd/services/apps/operationexposure/merge.go
+++ b/gestaltd/services/apps/operationexposure/merge.go
@@ -1,0 +1,50 @@
+package operationexposure
+
+// MergeAllowedOperationsWithOverlay combines the static deploy-config baseline
+// with a runtime overlay. Overlay operations replace or add entries; Removed
+// drops baseline keys before overrides are applied.
+func MergeAllowedOperationsWithOverlay(
+	static map[string]*OperationOverride,
+	operations map[string]*OperationOverride,
+	removed []string,
+) map[string]*OperationOverride {
+	if len(operations) == 0 && len(removed) == 0 {
+		return static
+	}
+	merged := cloneAllowedOperations(static)
+	for _, id := range removed {
+		delete(merged, id)
+	}
+	for id, override := range operations {
+		merged[id] = cloneOperationOverride(override)
+	}
+	if len(merged) == 0 {
+		return nil
+	}
+	return merged
+}
+
+func cloneAllowedOperations(in map[string]*OperationOverride) map[string]*OperationOverride {
+	if in == nil {
+		return make(map[string]*OperationOverride)
+	}
+	out := make(map[string]*OperationOverride, len(in))
+	for id, override := range in {
+		out[id] = cloneOperationOverride(override)
+	}
+	return out
+}
+
+func cloneOperationOverride(in *OperationOverride) *OperationOverride {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	if len(in.AllowedRoles) > 0 {
+		out.AllowedRoles = append([]string(nil), in.AllowedRoles...)
+	}
+	if len(in.Tags) > 0 {
+		out.Tags = append([]string(nil), in.Tags...)
+	}
+	return &out
+}

--- a/gestaltd/services/apps/operationexposure/merge.go
+++ b/gestaltd/services/apps/operationexposure/merge.go
@@ -1,15 +1,18 @@
 package operationexposure
 
-// MergeAllowedOperationsWithOverlay combines the static deploy-config baseline
-// with a runtime overlay. Overlay operations replace or add entries; Removed
-// drops baseline keys before overrides are applied.
+import (
+	"slices"
+	"strings"
+)
+
+// MergeAllowedOperationsWithOverlay combines static deploy-config with a runtime overlay.
 func MergeAllowedOperationsWithOverlay(
 	static map[string]*OperationOverride,
 	operations map[string]*OperationOverride,
 	removed []string,
 ) map[string]*OperationOverride {
 	if len(operations) == 0 && len(removed) == 0 {
-		return static
+		return cloneAllowedOperations(static)
 	}
 	merged := cloneAllowedOperations(static)
 	for _, id := range removed {
@@ -47,4 +50,45 @@ func cloneOperationOverride(in *OperationOverride) *OperationOverride {
 		out.Tags = append([]string(nil), in.Tags...)
 	}
 	return &out
+}
+
+func MergeOverlayPatch(
+	currentOps map[string]*OperationOverride,
+	currentRemoved []string,
+	patchOps map[string]*OperationOverride,
+	patchRemoved []string,
+) (map[string]*OperationOverride, []string) {
+	ops := cloneAllowedOperations(currentOps)
+	removedSet := make(map[string]struct{}, len(currentRemoved)+len(patchRemoved))
+	for _, id := range currentRemoved {
+		id = strings.TrimSpace(id)
+		if id != "" {
+			removedSet[id] = struct{}{}
+		}
+	}
+	for _, id := range patchRemoved {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		removedSet[id] = struct{}{}
+		delete(ops, id)
+	}
+	for id, override := range patchOps {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		ops[id] = cloneOperationOverride(override)
+		delete(removedSet, id)
+	}
+	if len(ops) == 0 && len(removedSet) == 0 {
+		return nil, nil
+	}
+	removed := make([]string, 0, len(removedSet))
+	for id := range removedSet {
+		removed = append(removed, id)
+	}
+	slices.Sort(removed)
+	return ops, removed
 }

--- a/gestaltd/services/apps/operationexposure/merge_test.go
+++ b/gestaltd/services/apps/operationexposure/merge_test.go
@@ -35,7 +35,29 @@ func TestMergeAllowedOperationsWithOverlayReturnsStaticWhenEmptyOverlay(t *testi
 	static := map[string]*OperationOverride{
 		"get_item": {AllowedRoles: []string{"viewer"}},
 	}
-	if got := MergeAllowedOperationsWithOverlay(static, nil, nil); got == nil || len(got) != 1 {
-		t.Fatalf("got = %#v, want static baseline preserved", got)
+	got := MergeAllowedOperationsWithOverlay(static, nil, nil)
+	if len(got) != 1 || got["get_item"].AllowedRoles[0] != "viewer" {
+		t.Fatalf("got = %#v, want cloned static baseline", got)
+	}
+	got["get_item"].AllowedRoles[0] = "admin"
+	if static["get_item"].AllowedRoles[0] != "viewer" {
+		t.Fatal("expected static baseline to remain unchanged")
+	}
+}
+
+func TestMergeOverlayPatchAppliesDeltaWithoutDroppingExistingOverrides(t *testing.T) {
+	t.Parallel()
+
+	current := map[string]*OperationOverride{
+		"create": {AllowedRoles: []string{"admin"}},
+	}
+	ops, removed := MergeOverlayPatch(current, nil, map[string]*OperationOverride{
+		"get_item": {AllowedRoles: []string{"viewer"}},
+	}, []string{"delete"})
+	if len(ops) != 2 || ops["create"] == nil || ops["get_item"] == nil {
+		t.Fatalf("ops = %#v, want create and get_item", ops)
+	}
+	if len(removed) != 1 || removed[0] != "delete" {
+		t.Fatalf("removed = %#v, want [delete]", removed)
 	}
 }

--- a/gestaltd/services/apps/operationexposure/merge_test.go
+++ b/gestaltd/services/apps/operationexposure/merge_test.go
@@ -1,0 +1,41 @@
+package operationexposure
+
+import "testing"
+
+func TestMergeAllowedOperationsWithOverlay(t *testing.T) {
+	t.Parallel()
+
+	static := map[string]*OperationOverride{
+		"get_item": {AllowedRoles: []string{"viewer"}},
+		"delete":   {AllowedRoles: []string{"admin"}},
+	}
+	overlay := map[string]*OperationOverride{
+		"get_item": {AllowedRoles: []string{"admin"}},
+		"create":   {AllowedRoles: []string{"editor"}},
+	}
+
+	merged := MergeAllowedOperationsWithOverlay(static, overlay, []string{"delete"})
+	if len(merged) != 2 {
+		t.Fatalf("merged = %#v, want 2 operations", merged)
+	}
+	if roles := merged["get_item"].AllowedRoles; len(roles) != 1 || roles[0] != "admin" {
+		t.Fatalf("get_item roles = %#v, want [admin]", roles)
+	}
+	if merged["create"] == nil {
+		t.Fatal("expected runtime create operation")
+	}
+	if merged["delete"] != nil {
+		t.Fatal("expected delete to be removed")
+	}
+}
+
+func TestMergeAllowedOperationsWithOverlayReturnsStaticWhenEmptyOverlay(t *testing.T) {
+	t.Parallel()
+
+	static := map[string]*OperationOverride{
+		"get_item": {AllowedRoles: []string{"viewer"}},
+	}
+	if got := MergeAllowedOperationsWithOverlay(static, nil, nil); got == nil || len(got) != 1 {
+		t.Fatalf("got = %#v, want static baseline preserved", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Deploy-downtime plan step **14** (#1541): holders of `app:{app} admin` can read and update their app's runtime `allowedOperations` overlay without `gestalt:admin`
- Persist overlays in IndexedDB (`app_allowed_operations`) and merge them with deploy-config baselines at provider build time
- Expose `GET` / `PUT /api/v1/apps/{app}/admin/allowed-operations` behind existing app-admin authorization middleware; reload providers after updates

## Test plan
- [x] `go test ./internal/coredata/... ./services/apps/operationexposure/... ./internal/server -run 'AllowedOperation|MergeAllowed'`
- [ ] After gestalt release: app admin can list operations, change `allowedRoles`, remove a config baseline op, and invoke gate reflects the update without redeploy
- [ ] Non-admin gets 403; unknown operation IDs rejected on PUT


Made with [Cursor](https://cursor.com)