### PR TITLE
[gestalt] fix runtime allowed operations reload

### DIFF
--- a/gestaltd/internal/bootstrap/app_provider_restart.go
+++ b/gestaltd/internal/bootstrap/app_provider_restart.go
@@ -246,6 +246,31 @@ func (r *AppProviderRestarter) StartApp(ctx context.Context, app, version string
 	return nil
 }
 
+func (r *AppProviderRestarter) RestartApp(ctx context.Context, app string) error {
+	if r == nil {
+		return fmt.Errorf("restart app provider: restarter is not configured")
+	}
+	app = strings.TrimSpace(app)
+	if app == "" {
+		return fmt.Errorf("restart app provider: app is required")
+	}
+	entry, err := r.appEntry(app)
+	if err != nil {
+		return err
+	}
+	version := ""
+	if entry.Source.IsRegistry() {
+		var ok bool
+		if version, ok = r.RunningVersion(app); !ok {
+			return fmt.Errorf("restart app provider: %q has no running registry version", app)
+		}
+	}
+	if err := r.StopApp(ctx, app); err != nil {
+		return err
+	}
+	return r.StartApp(ctx, app, version)
+}
+
 func (r *AppProviderRestarter) RunningVersion(app string) (string, bool) {
 	if r == nil {
 		return "", false

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -1115,6 +1115,9 @@ func applyAllowedOperations(name string, allowedOperations map[string]*config.Op
 	if matched == nil {
 		return pluginProv, nil
 	}
+	if len(matched) == 0 {
+		return operationexposure.NewRestricted(pluginProv, map[string]string{}), nil
+	}
 	policy, err := operationexposure.New(matched)
 	if err != nil {
 		return nil, fmt.Errorf("integration %q plugin: %w", name, err)

--- a/gestaltd/internal/bootstrap/provider_build_allowed_operations_test.go
+++ b/gestaltd/internal/bootstrap/provider_build_allowed_operations_test.go
@@ -63,3 +63,30 @@ func TestApplyAllowedOperationsSkipsRestrictionWhenNoMatches(t *testing.T) {
 		t.Fatalf("catalog operations = %#v, want unrestricted get_item", filtered.Operations)
 	}
 }
+
+func TestApplyAllowedOperationsWrapsEmptyAllowlist(t *testing.T) {
+	t.Parallel()
+
+	prov := &coretesting.StubIntegration{
+		N: "example",
+		CatalogVal: &catalog.Catalog{
+			Name: "example",
+			Operations: []catalog.CatalogOperation{
+				{ID: "get_item"},
+			},
+		},
+	}
+
+	wrapped, err := applyAllowedOperations("example", map[string]*config.OperationOverride{}, prov)
+	if err != nil {
+		t.Fatalf("applyAllowedOperations: %v", err)
+	}
+	if wrapped == prov {
+		t.Fatal("expected provider to be wrapped for explicit empty allowlist")
+	}
+
+	filtered := wrapped.Catalog()
+	if len(filtered.Operations) != 0 {
+		t.Fatalf("catalog operations = %#v, want no operations", filtered.Operations)
+	}
+}

--- a/gestaltd/internal/server/handlers_app_admin_allowed_operations.go
+++ b/gestaltd/internal/server/handlers_app_admin_allowed_operations.go
@@ -128,9 +128,11 @@ func (s *Server) putAppAdminAllowedOperations(w http.ResponseWriter, r *http.Req
 		writeError(w, http.StatusServiceUnavailable, "allowed operations are unavailable")
 		return
 	}
-	// Rebuild providers so invoke gates and catalogs pick up the merged overlay.
-	if s.activateAppProviders != nil {
-		s.activateAppProviders(r.Context())
+	// Rebuild this app provider so invoke gates and catalogs pick up the merged overlay.
+	if err := s.restartAppProviderForAllowedOperations(r.Context(), appName); err != nil {
+		slog.Error("app admin allowed operations provider restart failed", "app", appName, "error", err)
+		writeError(w, http.StatusServiceUnavailable, "allowed operations were saved but the app provider did not restart")
+		return
 	}
 	rows, err := s.projectAppAdminAllowedOperationRows(r.Context(), appName, entry)
 	if err != nil {
@@ -142,6 +144,13 @@ func (s *Server) putAppAdminAllowedOperations(w http.ResponseWriter, r *http.Req
 		App:        appName,
 		Operations: rows,
 	})
+}
+
+func (s *Server) restartAppProviderForAllowedOperations(ctx context.Context, appName string) error {
+	if s.appProviderRestarter == nil {
+		return errors.New("app provider restarter is unavailable")
+	}
+	return s.appProviderRestarter.RestartApp(ctx, appName)
 }
 
 func (s *Server) projectAppAdminAllowedOperationRows(

--- a/gestaltd/internal/server/handlers_app_admin_allowed_operations_test.go
+++ b/gestaltd/internal/server/handlers_app_admin_allowed_operations_test.go
@@ -1,11 +1,23 @@
 package server
 
 import (
+	"context"
 	"testing"
 
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/services/apps/operationexposure"
 )
+
+type appAllowedOperationsRestartRecorder struct {
+	app   string
+	calls int
+}
+
+func (r *appAllowedOperationsRestartRecorder) RestartApp(_ context.Context, app string) error {
+	r.app = app
+	r.calls++
+	return nil
+}
 
 func TestAllowedOperationSource(t *testing.T) {
 	t.Parallel()
@@ -50,5 +62,18 @@ func TestNormalizeRemovedOperationIDs(t *testing.T) {
 	got := normalizeRemovedOperationIDs([]string{" delete ", "delete", ""})
 	if len(got) != 1 || got[0] != "delete" {
 		t.Fatalf("normalizeRemovedOperationIDs = %#v", got)
+	}
+}
+
+func TestRestartAppProviderForAllowedOperationsUsesAppRestarter(t *testing.T) {
+	t.Parallel()
+
+	restarter := &appAllowedOperationsRestartRecorder{}
+	server := &Server{appProviderRestarter: restarter}
+	if err := server.restartAppProviderForAllowedOperations(context.Background(), "toolshed"); err != nil {
+		t.Fatalf("restartAppProviderForAllowedOperations: %v", err)
+	}
+	if restarter.calls != 1 || restarter.app != "toolshed" {
+		t.Fatalf("restart calls = %d app = %q, want one toolshed restart", restarter.calls, restarter.app)
 	}
 }

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -83,6 +83,9 @@ func run(ctx context.Context, cfg *config.Config, result *bootstrap.Result, gest
 		publicIndexedDB = result.Services.DB
 	}
 	appRuntimeState, _ := result.AppRestarter.(AppRuntimeState)
+	appProviderRestarter, _ := result.AppRestarter.(interface {
+		RestartApp(context.Context, string) error
+	})
 	var reverseRemote *reverseRemoteSetup
 	reverseRemote, err = setupReverseRemoteUpstream(ctx, cfg, result.Services, authorizationProvider)
 	if err != nil {
@@ -160,6 +163,7 @@ func run(ctx context.Context, cfg *config.Config, result *bootstrap.Result, gest
 		GestaltdVersion:         strings.TrimSpace(gestaltdVersion),
 		SourceVersion:           appregistry.ResolveSourceVersion(),
 		AppRuntimeState:         appRuntimeState,
+		AppProviderRestarter:    appProviderRestarter,
 	}
 
 	publishService, err := bootstrapAppRegistryPublish(cfg)

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -204,6 +204,9 @@ type Server struct {
 	appRuntimeState               AppRuntimeState
 	routeProfile                  RouteProfile
 	activateAppProviders          func(context.Context)
+	appProviderRestarter          interface {
+		RestartApp(context.Context, string) error
+	}
 }
 
 func (s *Server) catalogSelectorConfig() invocation.CatalogSelectorConfig {
@@ -278,11 +281,14 @@ type Config struct {
 	MeterProvider                 metric.MeterProvider
 	TracerProvider                trace.TracerProvider
 	ActivateAppProviders          func(context.Context)
-	IndexedDB                     indexeddb.IndexedDB
-	RemoteManagement              proto.RemoteManagementServer
-	FrpsHandler                   http.Handler
-	FrpsConnectHandler            http.Handler
-	TunnelResolver                TunnelResolverConfig
+	AppProviderRestarter          interface {
+		RestartApp(context.Context, string) error
+	}
+	IndexedDB          indexeddb.IndexedDB
+	RemoteManagement   proto.RemoteManagementServer
+	FrpsHandler        http.Handler
+	FrpsConnectHandler http.Handler
+	TunnelResolver     TunnelResolverConfig
 	// AppAutoDeployNotify requests prompt auto-deploy reconciliation for an app.
 	AppAutoDeployNotify func(app string)
 	// AppRegistryReconcileNotify requests prompt local runtime reconciliation.
@@ -536,6 +542,7 @@ func New(cfg Config) (*Server, error) {
 		appRuntimeState:               cfg.AppRuntimeState,
 		routeProfile:                  cfg.RouteProfile,
 		activateAppProviders:          cfg.ActivateAppProviders,
+		appProviderRestarter:          cfg.AppProviderRestarter,
 	}
 	s.workflowSchedules = workflowmanager.New(workflowmanager.Config{
 		Providers:         cfg.Providers,

--- a/gestaltd/services/apps/operationexposure/merge.go
+++ b/gestaltd/services/apps/operationexposure/merge.go
@@ -21,9 +21,6 @@ func MergeAllowedOperationsWithOverlay(
 	for id, override := range operations {
 		merged[id] = cloneOperationOverride(override)
 	}
-	if len(merged) == 0 {
-		return nil
-	}
 	return merged
 }
 

--- a/gestaltd/services/apps/operationexposure/merge_test.go
+++ b/gestaltd/services/apps/operationexposure/merge_test.go
@@ -45,6 +45,22 @@ func TestMergeAllowedOperationsWithOverlayReturnsStaticWhenEmptyOverlay(t *testi
 	}
 }
 
+func TestMergeAllowedOperationsWithOverlayPreservesEmptyOverlayResult(t *testing.T) {
+	t.Parallel()
+
+	static := map[string]*OperationOverride{
+		"get_item": {AllowedRoles: []string{"viewer"}},
+	}
+
+	got := MergeAllowedOperationsWithOverlay(static, nil, []string{"get_item"})
+	if got == nil {
+		t.Fatal("got nil, want explicit empty allowlist")
+	}
+	if len(got) != 0 {
+		t.Fatalf("got = %#v, want no allowed operations", got)
+	}
+}
+
 func TestMergeOverlayPatchAppliesDeltaWithoutDroppingExistingOverrides(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- restart the affected app provider after runtime allowedOperations writes
- preserve explicit empty overlays as deny-all instead of falling back to allow-all
- add targeted merge/build/handler tests

## Test plan
- [x] go test ./gestaltd/services/apps/operationexposure ./gestaltd/internal/bootstrap ./gestaltd/internal/server