### PR TITLE
Deploy downtime step 13: authorization seedFile empty-store bootstrap

### DIFF
--- a/gestaltd/internal/bootstrap/authorization_bootstrap.go
+++ b/gestaltd/internal/bootstrap/authorization_bootstrap.go
@@ -78,6 +78,11 @@ func bootstrapAuthorizationProviderState(
 	if provider == nil {
 		return nil
 	}
+	if !resolveAuthorizationStateApply(cfg) {
+		if err := bootstrapAuthorizationSeedIfEmpty(ctx, name, provider, cfg.Authorization, users); err != nil {
+			return fmt.Errorf("bootstrap: authorization provider %q: %w", name, err)
+		}
+	}
 	model, err := staticAuthorizationModel(cfg)
 	if err != nil {
 		return fmt.Errorf("bootstrap: authorization provider %q: %w", name, err)

--- a/gestaltd/internal/bootstrap/authorization_bootstrap.go
+++ b/gestaltd/internal/bootstrap/authorization_bootstrap.go
@@ -78,7 +78,8 @@ func bootstrapAuthorizationProviderState(
 	if provider == nil {
 		return nil
 	}
-	if !resolveAuthorizationStateApply(cfg) {
+	apply := resolveAuthorizationStateApply(cfg)
+	if !apply {
 		if err := bootstrapAuthorizationSeedIfEmpty(ctx, name, provider, cfg.Authorization, users); err != nil {
 			return fmt.Errorf("bootstrap: authorization provider %q: %w", name, err)
 		}
@@ -105,7 +106,6 @@ func bootstrapAuthorizationProviderState(
 	}
 	staticRelationships = append(staticRelationships, runtimeRelationships...)
 	digest := model.GetId()
-	apply := resolveAuthorizationStateApply(cfg)
 	if !apply {
 		slog.InfoContext(ctx, "authorization state plan (no-op): startup will not mutate authorization provider state",
 			"provider", name,

--- a/gestaltd/internal/bootstrap/authorization_bootstrap.go
+++ b/gestaltd/internal/bootstrap/authorization_bootstrap.go
@@ -78,12 +78,10 @@ func bootstrapAuthorizationProviderState(
 	if provider == nil {
 		return nil
 	}
-	apply := resolveAuthorizationStateApply(cfg)
-	if !apply {
-		if err := bootstrapAuthorizationSeedIfEmpty(ctx, name, provider, cfg.Authorization, users); err != nil {
-			return fmt.Errorf("bootstrap: authorization provider %q: %w", name, err)
-		}
+	if err := bootstrapAuthorizationSeedIfEmpty(ctx, name, provider, cfg.Authorization, users); err != nil {
+		return fmt.Errorf("bootstrap: authorization provider %q: %w", name, err)
 	}
+	apply := resolveAuthorizationStateApply(cfg)
 	model, err := staticAuthorizationModel(cfg)
 	if err != nil {
 		return fmt.Errorf("bootstrap: authorization provider %q: %w", name, err)
@@ -107,7 +105,7 @@ func bootstrapAuthorizationProviderState(
 	staticRelationships = append(staticRelationships, runtimeRelationships...)
 	digest := model.GetId()
 	if !apply {
-		slog.InfoContext(ctx, "authorization state plan (no-op): startup will not mutate authorization provider state",
+		slog.InfoContext(ctx, "authorization state plan (no-op): config authorization overlay not applied at startup",
 			"provider", name,
 			"model_digest", digest,
 			"resource_type_count", len(model.GetResourceTypes()),
@@ -412,6 +410,19 @@ func AuthorizationResourceTypeNames(cfg *config.Config) map[string]struct{} {
 	}
 	for _, model := range cfg.Authorization.Models {
 		for name := range model.ResourceTypes {
+			names[name] = struct{}{}
+		}
+	}
+	seedFile := strings.TrimSpace(cfg.Authorization.SeedFile)
+	if seedFile == "" {
+		return names
+	}
+	req, err := loadAuthorizationSeedFile(seedFile)
+	if err != nil {
+		return names
+	}
+	for _, resourceType := range req.GetModel().GetResourceTypes() {
+		if name := strings.TrimSpace(resourceType.GetName()); name != "" {
 			names[name] = struct{}{}
 		}
 	}

--- a/gestaltd/internal/bootstrap/authorization_seed.go
+++ b/gestaltd/internal/bootstrap/authorization_seed.go
@@ -32,6 +32,10 @@ func bootstrapAuthorizationSeedIfEmpty(
 		return fmt.Errorf("check authorization store: %w", err)
 	}
 	if !empty {
+		slog.InfoContext(ctx, "authorization state seed skipped: store already has model or relationships",
+			"provider", providerName,
+			"seed_file", seedFile,
+		)
 		return nil
 	}
 

--- a/gestaltd/internal/bootstrap/authorization_seed.go
+++ b/gestaltd/internal/bootstrap/authorization_seed.go
@@ -13,7 +13,6 @@ import (
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	gproto "google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
@@ -44,7 +43,7 @@ func bootstrapAuthorizationSeedIfEmpty(
 	if err != nil {
 		return fmt.Errorf("resolve configured authorization relationships: %w", err)
 	}
-	req.Relationships = append(append([]*proto.Relationship(nil), req.GetRelationships()...), configRelationships...)
+	req.Relationships = append(req.GetRelationships(), configRelationships...)
 	if _, err := authorizationstate.Apply(ctx, provider, req); err != nil {
 		return fmt.Errorf("apply authorization seed %q: %w", seedFile, err)
 	}
@@ -91,5 +90,5 @@ func loadAuthorizationSeedFile(path string) (*proto.SetAuthorizationStateRequest
 	if err := protojson.Unmarshal(data, &req); err != nil {
 		return nil, fmt.Errorf("parse authorization seed file %q: %w", path, err)
 	}
-	return gproto.Clone(&req).(*proto.SetAuthorizationStateRequest), nil
+	return &req, nil
 }

--- a/gestaltd/internal/bootstrap/authorization_seed.go
+++ b/gestaltd/internal/bootstrap/authorization_seed.go
@@ -1,0 +1,95 @@
+package bootstrap
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/authorizationstate"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	gproto "google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+func bootstrapAuthorizationSeedIfEmpty(
+	ctx context.Context,
+	providerName string,
+	provider core.AuthorizationProvider,
+	cfg config.AuthorizationConfig,
+	users authorizationUserResolver,
+) error {
+	seedFile := strings.TrimSpace(cfg.SeedFile)
+	if seedFile == "" {
+		return nil
+	}
+	empty, err := authorizationProviderStoreIsEmpty(ctx, provider)
+	if err != nil {
+		return fmt.Errorf("check authorization store: %w", err)
+	}
+	if !empty {
+		return nil
+	}
+
+	req, err := loadAuthorizationSeedFile(seedFile)
+	if err != nil {
+		return err
+	}
+	configRelationships, err := staticAuthorizationRelationships(ctx, cfg, users)
+	if err != nil {
+		return fmt.Errorf("resolve configured authorization relationships: %w", err)
+	}
+	req.Relationships = append(append([]*proto.Relationship(nil), req.GetRelationships()...), configRelationships...)
+	if _, err := authorizationstate.Apply(ctx, provider, req); err != nil {
+		return fmt.Errorf("apply authorization seed %q: %w", seedFile, err)
+	}
+	slog.InfoContext(ctx, "authorization state seeded: empty store loaded seed file",
+		"provider", providerName,
+		"seed_file", seedFile,
+		"resource_type_count", len(req.GetModel().GetResourceTypes()),
+		"relationship_count", len(req.GetRelationships()),
+	)
+	return nil
+}
+
+func authorizationProviderStoreIsEmpty(ctx context.Context, provider core.AuthorizationProvider) (bool, error) {
+	resourceTypes, err := provider.ListActiveModelResourceTypes(ctx, &proto.ListActiveModelResourceTypesRequest{
+		PageSize: 1,
+	})
+	if err != nil {
+		if status.Code(err) == codes.NotFound {
+			return true, nil
+		}
+		return false, err
+	}
+	if len(resourceTypes.GetResourceTypes()) > 0 {
+		return false, nil
+	}
+	relationships, err := provider.ListRelationships(ctx, &proto.ListRelationshipsRequest{
+		PageSize: 1,
+	})
+	if err != nil {
+		if status.Code(err) == codes.NotFound {
+			return true, nil
+		}
+		return false, err
+	}
+	return len(relationships.GetRelationships()) == 0, nil
+}
+
+func loadAuthorizationSeedFile(path string) (*proto.SetAuthorizationStateRequest, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read authorization seed file %q: %w", path, err)
+	}
+	var req proto.SetAuthorizationStateRequest
+	if err := protojson.Unmarshal(data, &req); err != nil {
+		return nil, fmt.Errorf("parse authorization seed file %q: %w", path, err)
+	}
+	return gproto.Clone(&req).(*proto.SetAuthorizationStateRequest), nil
+}

--- a/gestaltd/internal/bootstrap/authorization_seed_test.go
+++ b/gestaltd/internal/bootstrap/authorization_seed_test.go
@@ -110,6 +110,44 @@ func TestBootstrapAuthorizationSeedIfEmptyAppliesSeedFile(t *testing.T) {
 	}
 }
 
+func TestBootstrapAuthorizationSeedIfEmptyRunsWhenApplyEnabled(t *testing.T) {
+	t.Parallel()
+
+	seedPath := writeAuthorizationSeedFile(t, `{
+  "model": {
+    "resourceTypes": [
+      {
+        "name": "app",
+        "sourceLayer": "SOURCE_LAYER_STATIC_CONFIG",
+        "relations": [
+          {
+            "name": "admin",
+            "allowedTargets": [{ "subjectType": "subject" }]
+          }
+        ]
+      }
+    ]
+  }
+}`)
+
+	provider := &seedTrackingAuthorizationProvider{emptyStore: true}
+	cfg := authorizationBootstrapTestConfig(boolPtr(true))
+	cfg.Authorization.SeedFile = seedPath
+	cfg.Authorization.Models = nil
+
+	if err := bootstrapAuthorizationProviderState(
+		context.Background(),
+		cfg,
+		map[string]core.AuthorizationProvider{"authz": provider},
+		nil,
+	); err != nil {
+		t.Fatalf("bootstrapAuthorizationProviderState: %v", err)
+	}
+	if provider.setModelCalls != 1 {
+		t.Fatalf("SetActiveModel calls = %d, want 1", provider.setModelCalls)
+	}
+}
+
 func TestBootstrapAuthorizationSeedIfEmptySkipsPopulatedStore(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/bootstrap/authorization_seed_test.go
+++ b/gestaltd/internal/bootstrap/authorization_seed_test.go
@@ -1,0 +1,189 @@
+package bootstrap
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+type seedTrackingAuthorizationProvider struct {
+	recordingAuthorizationProvider
+	setModelCalls int
+	addCalls      int
+	emptyStore    bool
+	populated     bool
+}
+
+func (p *seedTrackingAuthorizationProvider) ListActiveModelResourceTypes(ctx context.Context, req *proto.ListActiveModelResourceTypesRequest) (*proto.ListActiveModelResourceTypesResponse, error) {
+	if p.emptyStore {
+		return nil, status.Error(codes.NotFound, "no active model")
+	}
+	if p.populated {
+		if req.GetPageToken() != "" {
+			return &proto.ListActiveModelResourceTypesResponse{}, nil
+		}
+		return &proto.ListActiveModelResourceTypesResponse{
+			ResourceTypes: []*proto.AuthorizationModelResourceType{{
+				Name:        "runtime",
+				SourceLayer: proto.SourceLayer_SOURCE_LAYER_RUNTIME,
+			}},
+		}, nil
+	}
+	return p.recordingAuthorizationProvider.ListActiveModelResourceTypes(ctx, req)
+}
+
+func (p *seedTrackingAuthorizationProvider) ListRelationships(ctx context.Context, req *proto.ListRelationshipsRequest) (*proto.ListRelationshipsResponse, error) {
+	if p.emptyStore {
+		return &proto.ListRelationshipsResponse{}, nil
+	}
+	return p.recordingAuthorizationProvider.ListRelationships(ctx, req)
+}
+
+func (p *seedTrackingAuthorizationProvider) SetActiveModel(ctx context.Context, req *proto.SetActiveModelRequest) (*proto.SetActiveModelResponse, error) {
+	p.setModelCalls++
+	return p.recordingAuthorizationProvider.SetActiveModel(ctx, req)
+}
+
+func (p *seedTrackingAuthorizationProvider) AddRelationship(ctx context.Context, req *proto.AddRelationshipRequest) (*proto.AddRelationshipResponse, error) {
+	p.addCalls++
+	return p.recordingAuthorizationProvider.AddRelationship(ctx, req)
+}
+
+func TestBootstrapAuthorizationSeedIfEmptyAppliesSeedFile(t *testing.T) {
+	t.Parallel()
+
+	seedPath := writeAuthorizationSeedFile(t, `{
+  "model": {
+    "resourceTypes": [
+      {
+        "name": "app",
+        "sourceLayer": "SOURCE_LAYER_STATIC_CONFIG",
+        "relations": [
+          {
+            "name": "admin",
+            "allowedTargets": [{ "subjectType": "subject" }]
+          }
+        ]
+      }
+    ]
+  },
+  "relationships": [
+    {
+      "tuple": {
+        "resource": { "type": "app", "id": "home" },
+        "relation": "admin",
+        "target": {
+          "subject": { "type": "subject", "id": "user:alice" }
+        }
+      }
+    }
+  ]
+}`)
+
+	provider := &seedTrackingAuthorizationProvider{emptyStore: true}
+	cfg := authorizationBootstrapTestConfig(boolPtr(false))
+	cfg.Authorization.SeedFile = seedPath
+	cfg.Authorization.Relationships = nil
+
+	if err := bootstrapAuthorizationProviderState(
+		context.Background(),
+		cfg,
+		map[string]core.AuthorizationProvider{"authz": provider},
+		nil,
+	); err != nil {
+		t.Fatalf("bootstrapAuthorizationProviderState: %v", err)
+	}
+	if provider.setAuthorizationState != nil {
+		t.Fatal("SetAuthorizationState should not be called in plan-only mode")
+	}
+	if provider.setModelCalls != 1 {
+		t.Fatalf("SetActiveModel calls = %d, want 1", provider.setModelCalls)
+	}
+	if provider.addCalls != 1 {
+		t.Fatalf("AddRelationship calls = %d, want 1", provider.addCalls)
+	}
+}
+
+func TestBootstrapAuthorizationSeedIfEmptySkipsPopulatedStore(t *testing.T) {
+	t.Parallel()
+
+	seedPath := writeAuthorizationSeedFile(t, `{
+  "model": {
+    "resourceTypes": [
+      {
+        "name": "app",
+        "sourceLayer": "SOURCE_LAYER_STATIC_CONFIG"
+      }
+    ]
+  }
+}`)
+
+	provider := &seedTrackingAuthorizationProvider{populated: true}
+	cfg := authorizationBootstrapTestConfig(boolPtr(false))
+	cfg.Authorization.SeedFile = seedPath
+
+	if err := bootstrapAuthorizationProviderState(
+		context.Background(),
+		cfg,
+		map[string]core.AuthorizationProvider{"authz": provider},
+		nil,
+	); err != nil {
+		t.Fatalf("bootstrapAuthorizationProviderState: %v", err)
+	}
+	if provider.setModelCalls != 0 {
+		t.Fatalf("SetActiveModel calls = %d, want 0", provider.setModelCalls)
+	}
+}
+
+func TestBootstrapAuthorizationSeedIfEmptyMergesConfiguredRelationships(t *testing.T) {
+	t.Parallel()
+
+	seedPath := writeAuthorizationSeedFile(t, `{
+  "model": {
+    "resourceTypes": [
+      {
+        "name": "github",
+        "sourceLayer": "SOURCE_LAYER_STATIC_CONFIG",
+        "relations": [
+          {
+            "name": "viewer",
+            "allowedTargets": [{ "subjectType": "subject" }]
+          }
+        ]
+      }
+    ]
+  }
+}`)
+
+	provider := &seedTrackingAuthorizationProvider{emptyStore: true}
+	cfg := authorizationBootstrapTestConfig(boolPtr(false))
+	cfg.Authorization.SeedFile = seedPath
+
+	if err := bootstrapAuthorizationProviderState(
+		context.Background(),
+		cfg,
+		map[string]core.AuthorizationProvider{"authz": provider},
+		nil,
+	); err != nil {
+		t.Fatalf("bootstrapAuthorizationProviderState: %v", err)
+	}
+	if provider.addCalls != 1 {
+		t.Fatalf("AddRelationship calls = %d, want 1 for configured relationship", provider.addCalls)
+	}
+}
+
+func writeAuthorizationSeedFile(t *testing.T, contents string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "seed.json")
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	return path
+}

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -1861,10 +1861,7 @@ type AuthorizationConfig struct {
 	Models        map[string]AuthorizationModelDef          `yaml:"models,omitempty"`
 	Relationships []AuthorizationRelationshipDef            `yaml:"relationships,omitempty"`
 	ResourceTypes map[string]AuthorizationResourcePolicyDef `yaml:"resourceTypes,omitempty"`
-	// SeedFile points at a SetAuthorizationStateRequest JSON artifact used to
-	// bootstrap an empty authorization store on startup without enabling
-	// authorizationStateApply.
-	SeedFile string `yaml:"seedFile,omitempty"`
+	SeedFile      string                                    `yaml:"seedFile,omitempty"`
 }
 
 type AuthorizationModelDef struct {

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -1861,6 +1861,10 @@ type AuthorizationConfig struct {
 	Models        map[string]AuthorizationModelDef          `yaml:"models,omitempty"`
 	Relationships []AuthorizationRelationshipDef            `yaml:"relationships,omitempty"`
 	ResourceTypes map[string]AuthorizationResourcePolicyDef `yaml:"resourceTypes,omitempty"`
+	// SeedFile points at a SetAuthorizationStateRequest JSON artifact used to
+	// bootstrap an empty authorization store on startup without enabling
+	// authorizationStateApply.
+	SeedFile string `yaml:"seedFile,omitempty"`
 }
 
 type AuthorizationModelDef struct {
@@ -4090,6 +4094,7 @@ func resolveRelativePaths(configPath string, cfg *Config) {
 	for _, entry := range cfg.Apps {
 		resolveEntry(entry)
 	}
+	cfg.Authorization.SeedFile = resolveRelativePath(baseDir, cfg.Authorization.SeedFile)
 }
 
 func resolveRelativePath(baseDir, value string) string {

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -3924,6 +3924,10 @@ func resolveRelativePathsInValue(configPath string, root map[string]any) {
 		resolveRelativeStringField(server, "artifactsDir", baseDir)
 	}
 
+	if authorization := nestedMap(root, "authorization"); authorization != nil {
+		resolveRelativeStringField(authorization, "seedFile", baseDir)
+	}
+
 	if providers := nestedMap(root, "providers"); providers != nil {
 		for _, section := range []struct {
 			key  string
@@ -4091,7 +4095,6 @@ func resolveRelativePaths(configPath string, cfg *Config) {
 	for _, entry := range cfg.Apps {
 		resolveEntry(entry)
 	}
-	cfg.Authorization.SeedFile = resolveRelativePath(baseDir, cfg.Authorization.SeedFile)
 }
 
 func resolveRelativePath(baseDir, value string) string {

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -6041,6 +6041,181 @@ apps:
 	})
 }
 
+func TestLoadPathsAuthorizationSeedFileResolvesRelativeToOverlay(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	baseDir := filepath.Join(dir, "base")
+	overlayDir := filepath.Join(dir, "overlay")
+	if err := os.MkdirAll(baseDir, 0o755); err != nil {
+		t.Fatalf("mkdir base: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(overlayDir, "authorization"), 0o755); err != nil {
+		t.Fatalf("mkdir overlay: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(overlayDir, "authorization", "seed.json"), []byte(`{
+  "model": {
+    "resourceTypes": [
+      {
+        "name": "team",
+        "relations": [
+          {
+            "name": "member",
+            "allowedTargets": [
+              {"subjectType": "subject"}
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}`), 0o644); err != nil {
+		t.Fatalf("write overlay seed: %v", err)
+	}
+	basePath := filepath.Join(baseDir, "config.yaml")
+	overlayPath := filepath.Join(overlayDir, "config.yaml")
+	if err := os.WriteFile(basePath, []byte(`
+apiVersion: gestaltd.config/v8
+authorization:
+  seedFile: base-seed.json
+`), 0o644); err != nil {
+		t.Fatalf("write base: %v", err)
+	}
+	if err := os.WriteFile(overlayPath, []byte(`
+apiVersion: gestaltd.config/v8
+authorization:
+  seedFile: authorization/seed.json
+`), 0o644); err != nil {
+		t.Fatalf("write overlay: %v", err)
+	}
+
+	cfg, err := LoadPaths([]string{basePath, overlayPath})
+	if err != nil {
+		t.Fatalf("LoadPaths: %v", err)
+	}
+	want := filepath.Join(overlayDir, "authorization", "seed.json")
+	if got := cfg.Authorization.SeedFile; got != want {
+		t.Fatalf("Authorization.SeedFile = %q, want %q", got, want)
+	}
+}
+
+func TestLoadPathsAuthorizationRelationshipsValidateAgainstSeedFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "authorization"), 0o755); err != nil {
+		t.Fatalf("mkdir authorization: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "authorization", "seed.json"), []byte(`{
+  "model": {
+    "resourceTypes": [
+      {
+        "name": "authorization",
+        "relations": [
+          {
+            "name": "admin",
+            "allowedTargets": [
+              {"subjectType": "subject"}
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}`), 0o644); err != nil {
+		t.Fatalf("write seed: %v", err)
+	}
+	basePath := filepath.Join(dir, "base.yaml")
+	overlayPath := filepath.Join(dir, "overlay.yaml")
+	if err := os.WriteFile(basePath, []byte(`
+apiVersion: gestaltd.config/v8
+authorization:
+  seedFile: authorization/seed.json
+`), 0o644); err != nil {
+		t.Fatalf("write base: %v", err)
+	}
+	if err := os.WriteFile(overlayPath, []byte(`
+apiVersion: gestaltd.config/v8
+authorization:
+  relationships:
+    - resource:
+        type: authorization
+        id: authorization
+      relation: admin
+      subject:
+        type: subject
+        id: user:alice
+`), 0o644); err != nil {
+		t.Fatalf("write overlay: %v", err)
+	}
+
+	if _, err := LoadPaths([]string{basePath, overlayPath}); err != nil {
+		t.Fatalf("LoadPaths: %v", err)
+	}
+}
+
+func TestLoadPathsSCIMValidatesAgainstSeedFileAndInlineResourcePolicy(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "authorization"), 0o755); err != nil {
+		t.Fatalf("mkdir authorization: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "authorization", "seed.json"), []byte(`{
+  "model": {
+    "resourceTypes": [
+      {
+        "name": "group",
+        "relations": [
+          {
+            "name": "member",
+            "allowedTargets": [
+              {"subjectType": "subject"},
+              {"subjectSetType": {"resourceType": "group", "relation": "member"}}
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}`), 0o644); err != nil {
+		t.Fatalf("write seed: %v", err)
+	}
+	configPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(`
+apiVersion: gestaltd.config/v8
+server:
+  scim:
+    clients:
+      rippling:
+        credentials:
+          - id: current
+            bearerToken: token
+        activeUserRelationships:
+          - relation: member
+            resource:
+              type: group
+              id: valon-employees
+providers:
+  authorization:
+    indexeddb:
+      source:
+        path: /tmp/authorization/manifest.yaml
+authorization:
+  seedFile: authorization/seed.json
+  resourceTypes:
+    group:
+      dynamic:
+        allowAdditionalRelationships: true
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	if _, err := Load(configPath); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+}
+
 func TestLoadRejectsUnknownProviderFields(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -21,7 +21,9 @@ import (
 	coreagent "github.com/valon-technologies/gestalt/server/core/agent"
 	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
 	"github.com/valon-technologies/gestalt/server/internal/providerregistry"
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 // ValidateStructure checks config shape: integration references, app
@@ -166,11 +168,9 @@ func validateSCIMConfig(cfg *Config) error {
 	if cfg == nil || len(cfg.Server.SCIM.Clients) == 0 {
 		return nil
 	}
-	resourceTypes := make(map[string]AuthorizationResourceTypeDef)
-	for _, model := range cfg.Authorization.Models {
-		for name, resourceType := range model.ResourceTypes {
-			resourceTypes[name] = resourceType
-		}
+	resourceTypes, _, err := authorizationResourceTypesForValidation(cfg)
+	if err != nil {
+		return err
 	}
 	groupType, hasGroup := resourceTypes["group"]
 	if !hasGroup {
@@ -1964,33 +1964,19 @@ func normalizeProviderRuntimeConfig(subject string, entry *ProviderEntry, allowL
 }
 
 func validateAuthorizationModelConfig(cfg *Config) error {
-	definedResourceTypes := make(map[string]string)
-	resourceTypeRelations := make(map[string]map[string]AuthorizationRelationDef)
-	for modelName, model := range cfg.Authorization.Models {
-		if err := validateAuthorizationMapKey("authorization.models", modelName); err != nil {
-			return err
-		}
-		if err := validateAuthorizationSourceMetadata("authorization.models."+modelName+".source", model.Source); err != nil {
-			return err
-		}
-		for resourceTypeName, resourceType := range model.ResourceTypes {
-			resourcePath := fmt.Sprintf("authorization.models.%s.resourceTypes.%s", modelName, resourceTypeName)
-			if err := validateAuthorizationResourceTypeDef(fmt.Sprintf("authorization.models.%s.resourceTypes", modelName), resourceTypeName, resourcePath, resourceType); err != nil {
-				return err
-			}
-			if prev, exists := definedResourceTypes[resourceTypeName]; exists {
-				return fmt.Errorf("config validation: %s duplicates resource type already defined at %s", resourcePath, prev)
-			}
-			definedResourceTypes[resourceTypeName] = resourcePath
-			resourceTypeRelations[resourceTypeName] = resourceType.Relations
-		}
+	resourceTypes, definedResourceTypes, err := authorizationResourceTypesForValidation(cfg)
+	if err != nil {
+		return err
 	}
-	for modelName, model := range cfg.Authorization.Models {
-		for resourceTypeName, resourceType := range model.ResourceTypes {
-			resourcePath := fmt.Sprintf("authorization.models.%s.resourceTypes.%s", modelName, resourceTypeName)
-			if err := validateAuthorizationResourceTypeReferences(resourcePath, resourceType, resourceTypeRelations); err != nil {
-				return err
-			}
+	resourceTypeRelations := make(map[string]map[string]AuthorizationRelationDef)
+	for resourceTypeName, resourceType := range resourceTypes {
+		resourceTypeRelations[resourceTypeName] = resourceType.Relations
+	}
+
+	for resourceTypeName, resourceType := range resourceTypes {
+		resourcePath := definedResourceTypes[resourceTypeName]
+		if err := validateAuthorizationResourceTypeReferences(resourcePath, resourceType, resourceTypeRelations); err != nil {
+			return err
 		}
 	}
 	for resourceTypeName := range cfg.Authorization.ResourceTypes {
@@ -2009,6 +1995,105 @@ func validateAuthorizationModelConfig(cfg *Config) error {
 		}
 	}
 	return nil
+}
+
+func authorizationResourceTypesForValidation(cfg *Config) (map[string]AuthorizationResourceTypeDef, map[string]string, error) {
+	resourceTypes := make(map[string]AuthorizationResourceTypeDef)
+	definedResourceTypes := make(map[string]string)
+	if cfg == nil {
+		return resourceTypes, definedResourceTypes, nil
+	}
+	if strings.TrimSpace(cfg.Authorization.SeedFile) != "" {
+		seedResourceTypes, err := loadAuthorizationSeedResourceTypes(cfg.Authorization.SeedFile)
+		if err != nil {
+			return nil, nil, err
+		}
+		for resourceTypeName, resourceType := range seedResourceTypes {
+			resourcePath := fmt.Sprintf("authorization.seedFile(%q).model.resourceTypes.%s", cfg.Authorization.SeedFile, resourceTypeName)
+			if err := validateAuthorizationResourceTypeDef("authorization.seedFile.model.resourceTypes", resourceTypeName, resourcePath, resourceType); err != nil {
+				return nil, nil, err
+			}
+			resourceTypes[resourceTypeName] = resourceType
+			definedResourceTypes[resourceTypeName] = resourcePath
+		}
+	}
+	for modelName, model := range cfg.Authorization.Models {
+		if err := validateAuthorizationMapKey("authorization.models", modelName); err != nil {
+			return nil, nil, err
+		}
+		if err := validateAuthorizationSourceMetadata("authorization.models."+modelName+".source", model.Source); err != nil {
+			return nil, nil, err
+		}
+		for resourceTypeName, resourceType := range model.ResourceTypes {
+			resourcePath := fmt.Sprintf("authorization.models.%s.resourceTypes.%s", modelName, resourceTypeName)
+			if err := validateAuthorizationResourceTypeDef(fmt.Sprintf("authorization.models.%s.resourceTypes", modelName), resourceTypeName, resourcePath, resourceType); err != nil {
+				return nil, nil, err
+			}
+			if prev, exists := definedResourceTypes[resourceTypeName]; exists {
+				return nil, nil, fmt.Errorf("config validation: %s duplicates resource type already defined at %s", resourcePath, prev)
+			}
+			definedResourceTypes[resourceTypeName] = resourcePath
+			resourceTypes[resourceTypeName] = resourceType
+		}
+	}
+	for resourceTypeName, policy := range cfg.Authorization.ResourceTypes {
+		if resourceType, ok := resourceTypes[resourceTypeName]; ok {
+			resourceType.Dynamic = policy.Dynamic
+			resourceTypes[resourceTypeName] = resourceType
+		}
+	}
+	return resourceTypes, definedResourceTypes, nil
+}
+
+func loadAuthorizationSeedResourceTypes(path string) (map[string]AuthorizationResourceTypeDef, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("config validation: read authorization seed file %q: %w", path, err)
+	}
+	var req proto.SetAuthorizationStateRequest
+	if err := protojson.Unmarshal(data, &req); err != nil {
+		return nil, fmt.Errorf("config validation: parse authorization seed file %q: %w", path, err)
+	}
+	resourceTypes := make(map[string]AuthorizationResourceTypeDef)
+	for _, resourceType := range req.GetModel().GetResourceTypes() {
+		name := strings.TrimSpace(resourceType.GetName())
+		if _, exists := resourceTypes[name]; exists {
+			return nil, fmt.Errorf("config validation: authorization.seedFile(%q).model.resourceTypes.%s duplicates resource type already defined in seed file", path, name)
+		}
+		def := AuthorizationResourceTypeDef{
+			DefaultRole: strings.TrimSpace(resourceType.GetDefaultRole()),
+			Relations:   make(map[string]AuthorizationRelationDef),
+			Actions:     make(map[string]AuthorizationActionDef),
+		}
+		for _, relation := range resourceType.GetRelations() {
+			relationName := strings.TrimSpace(relation.GetName())
+			relationDef := AuthorizationRelationDef{}
+			for _, target := range relation.GetAllowedTargets() {
+				targetDef := AuthorizationAllowedTargetDef{
+					SubjectType:  strings.TrimSpace(target.GetSubjectType()),
+					ResourceType: strings.TrimSpace(target.GetResourceType()),
+				}
+				if subjectSetType := target.GetSubjectSetType(); subjectSetType != nil {
+					targetDef.SubjectSet = &AuthorizationSubjectSetTargetDef{
+						ResourceType: strings.TrimSpace(subjectSetType.GetResourceType()),
+						Relation:     strings.TrimSpace(subjectSetType.GetRelation()),
+					}
+				}
+				relationDef.AllowedTargets = append(relationDef.AllowedTargets, targetDef)
+			}
+			def.Relations[relationName] = relationDef
+		}
+		for _, action := range resourceType.GetActions() {
+			actionName := strings.TrimSpace(action.GetName())
+			relations := make([]string, 0, len(action.GetRelations()))
+			for _, relation := range action.GetRelations() {
+				relations = append(relations, strings.TrimSpace(relation))
+			}
+			def.Actions[actionName] = AuthorizationActionDef{Relations: relations}
+		}
+		resourceTypes[name] = def
+	}
+	return resourceTypes, nil
 }
 
 func validateAuthorizationResourceTypeReferences(path string, def AuthorizationResourceTypeDef, resourceTypes map[string]map[string]AuthorizationRelationDef) error {


### PR DESCRIPTION
## Summary
- Add `authorization.seedFile` config pointing at a `SetAuthorizationStateRequest` JSON artifact.
- On startup when `authorizationStateApply` is false, seed an empty authorization store via `authorizationstate.Apply` (idempotent merge).
- Merge overlay `authorization.relationships` into the seed apply for local dev grants.

## Test plan
- [x] `go test ./gestaltd/internal/bootstrap/... -run AuthorizationSeed -count=1`
- [ ] CI green on gestalt
- [ ] After merge: gestalt release + gestaltd deploy before toolshed config PR


Made with [Cursor](https://cursor.com)