### PR TITLE
Decouple registry app bootstrap from server readiness

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -290,14 +290,13 @@ type Result struct {
 	workflowConfigReconcileTasks        []workflowConfigReconcileTask
 	workflowConfigReconcileTasksStarted bool
 	startupWorkflowConfigReconcile      func(context.Context) error
-	startupWorkflowConfigReconcileOnce  sync.Once
-	startupWorkflowConfigReconcileErr   error
+	registryAppStartupOnce              sync.Once
+	registryAppStartupErr               error
 	startupOperations                   sync.WaitGroup
 	auditClose                          func(context.Context) error
 	appHostServiceCleanup               func()
 	startAppProviders                   func()
 	appProvidersInitialized             chan struct{}
-	appProvidersInitializedOnce         sync.Once
 	activateAppProviders                func(context.Context)
 	startup                             *deferredProviders
 	deferred                            *deferredProviders
@@ -307,10 +306,9 @@ type Result struct {
 	scimStart                           sync.Once
 }
 
-// StartAppProviders starts app providers that are required during normal
-// server startup. Daemons may defer this until after their public listener is
-// bound so hosted apps can call back through the public host-service relay
-// while they configure.
+// StartAppProviders starts configured app providers and waits for them to be
+// ready. Daemons defer this until after their public listener is bound so
+// hosted apps can call back through the public host-service relay.
 func (r *Result) StartAppProviders(ctx context.Context) error {
 	if r == nil || r.startAppProviders == nil {
 		return nil
@@ -335,20 +333,43 @@ func (r *Result) StartAppProviders(ctx context.Context) error {
 			return fmt.Errorf("app provider startup interrupted: %w", ctx.Err())
 		}
 	}
-	if r.RegistryAppStartup != nil {
-		r.RegistryAppStartup(ctx)
+	return nil
+}
+
+// StartRegistryApps restores registry-backed apps and reconciles their
+// workflow declarations. It must run only after the server is ready to serve
+// public host-service callbacks.
+func (r *Result) StartRegistryApps(ctx context.Context) error {
+	if r == nil {
+		return nil
 	}
-	r.appProvidersInitializedOnce.Do(func() {
+	r.mu.Lock()
+	if r.closed {
+		r.mu.Unlock()
+		return fmt.Errorf("bootstrap result already closed")
+	}
+	r.startupOperations.Add(1)
+	r.mu.Unlock()
+	defer r.startupOperations.Done()
+
+	r.registryAppStartupOnce.Do(func() {
+		if r.RegistryAppStartup != nil {
+			r.RegistryAppStartup(ctx)
+		}
 		if r.appProvidersInitialized != nil {
 			close(r.appProvidersInitialized)
 		}
-	})
-	r.startupWorkflowConfigReconcileOnce.Do(func() {
 		if r.startupWorkflowConfigReconcile != nil {
-			r.startupWorkflowConfigReconcileErr = r.startupWorkflowConfigReconcile(ctx)
+			r.registryAppStartupErr = r.startupWorkflowConfigReconcile(ctx)
+			if r.registryAppStartupErr != nil && ctx.Err() == nil {
+				go runWorkflowConfigReconcileTask(ctx, workflowConfigReconcileTask{
+					name:      "workflow definitions after registry app startup",
+					reconcile: r.startupWorkflowConfigReconcile,
+				})
+			}
 		}
 	})
-	return r.startupWorkflowConfigReconcileErr
+	return r.registryAppStartupErr
 }
 
 func (r *Result) ActivateAppProviders(ctx context.Context) {
@@ -474,9 +495,7 @@ func (r *Result) Close(ctx context.Context) error {
 	if r.closed {
 		return nil
 	}
-	// StartAppProviders continues past provider readiness to reconcile workflow
-	// declarations. Wait for that entire operation before closing its runtime
-	// dependencies.
+	// App and registry startup may still be using runtime dependencies.
 	r.startupOperations.Wait()
 	if r.startup != nil {
 		r.startup.waitReady()

--- a/gestaltd/internal/bootstrap/provider_activation_test.go
+++ b/gestaltd/internal/bootstrap/provider_activation_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/config"
 )
 
-func TestResultStartAppProvidersReconcilesAfterProvidersReady(t *testing.T) {
+func TestResultStartRegistryAppsReconcilesAfterProvidersReady(t *testing.T) {
 	t.Parallel()
 
 	startup := newDeferredProviders()
@@ -33,8 +33,10 @@ func TestResultStartAppProvidersReconcilesAfterProvidersReady(t *testing.T) {
 			}()
 		},
 		startupWorkflowConfigReconcile: func(context.Context) error {
-			reconciled.Add(1)
-			return wantErr
+			if reconciled.Add(1) == 1 {
+				return wantErr
+			}
+			return nil
 		},
 	}
 
@@ -53,34 +55,37 @@ func TestResultStartAppProvidersReconcilesAfterProvidersReady(t *testing.T) {
 	close(release)
 	select {
 	case err := <-done:
-		if !errors.Is(err, wantErr) {
-			t.Fatalf("StartAppProviders error = %v, want %v", err, wantErr)
+		if err != nil {
+			t.Fatalf("StartAppProviders error = %v", err)
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("StartAppProviders did not finish after providers became ready")
 	}
-	if got := reconciled.Load(); got != 1 {
-		t.Fatalf("workflow reconciliations = %d, want 1", got)
+	if err := result.StartRegistryApps(context.Background()); !errors.Is(err, wantErr) {
+		t.Fatalf("StartRegistryApps error = %v, want %v", err, wantErr)
 	}
-	if err := result.StartAppProviders(context.Background()); !errors.Is(err, wantErr) {
-		t.Fatalf("second StartAppProviders error = %v, want %v", err, wantErr)
+	deadline := time.After(5 * time.Second)
+	for reconciled.Load() != 2 {
+		select {
+		case <-deadline:
+			t.Fatal("failed registry workflow reconciliation was not retried")
+		case <-time.After(time.Millisecond):
+		}
 	}
-	if got := reconciled.Load(); got != 1 {
-		t.Fatalf("workflow reconciliations after second start = %d, want 1", got)
+	if err := result.StartRegistryApps(context.Background()); !errors.Is(err, wantErr) {
+		t.Fatalf("second StartRegistryApps error = %v, want %v", err, wantErr)
+	}
+	if got := reconciled.Load(); got != 2 {
+		t.Fatalf("workflow reconciliations after second start = %d, want 2", got)
 	}
 }
 
-func TestResultStartupOperationsWaitForWorkflowReconcile(t *testing.T) {
+func TestResultStartupOperationsWaitForRegistryWorkflowReconcile(t *testing.T) {
 	t.Parallel()
 
-	startup := newDeferredProviders()
-	startup.finish()
 	reconcileStarted := make(chan struct{})
 	reconcileRelease := make(chan struct{})
 	result := &Result{
-		StartupProvidersReady: startup.ready(),
-		startup:               startup,
-		startAppProviders:     func() {},
 		startupWorkflowConfigReconcile: func(context.Context) error {
 			close(reconcileStarted)
 			<-reconcileRelease
@@ -89,7 +94,7 @@ func TestResultStartupOperationsWaitForWorkflowReconcile(t *testing.T) {
 	}
 
 	startDone := make(chan error, 1)
-	go func() { startDone <- result.StartAppProviders(context.Background()) }()
+	go func() { startDone <- result.StartRegistryApps(context.Background()) }()
 	select {
 	case <-reconcileStarted:
 	case <-time.After(5 * time.Second):
@@ -111,10 +116,10 @@ func TestResultStartupOperationsWaitForWorkflowReconcile(t *testing.T) {
 	select {
 	case err := <-startDone:
 		if err != nil {
-			t.Fatalf("StartAppProviders: %v", err)
+			t.Fatalf("StartRegistryApps: %v", err)
 		}
 	case <-time.After(5 * time.Second):
-		t.Fatal("StartAppProviders did not finish")
+		t.Fatal("StartRegistryApps did not finish")
 	}
 	select {
 	case <-waitDone:

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -415,8 +415,6 @@ func serveRuntime(ctx context.Context, cfg *config.Config, connMaps bootstrap.Co
 			return
 		}
 		close(workflowProvidersReady)
-
-		result.StartWorkflowConfigReconciliation(ctx)
 		slog.Debug("workflow providers ready", "count", len(result.ExtraWorkflows))
 
 		mcpHandler, err := newMCPHandler(cfg, connMaps, result, mcpInvoker)
@@ -426,6 +424,11 @@ func serveRuntime(ctx context.Context, cfg *config.Config, connMaps bootstrap.Co
 		}
 		mcpSlot.Set(mcpHandler)
 		slog.Debug("MCP endpoint enabled", "path", "/mcp")
+
+		if err := result.StartRegistryApps(ctx); err != nil && ctx.Err() == nil {
+			slog.WarnContext(ctx, "registry app workflow reconciliation failed; continuing", "error", err)
+		}
+		result.StartWorkflowConfigReconciliation(ctx)
 
 		select {
 		case <-result.ProvidersReady:

--- a/gestaltd/internal/server/runtime_test.go
+++ b/gestaltd/internal/server/runtime_test.go
@@ -176,6 +176,44 @@ func TestServeRuntimeReadyAfterWorkflowProvidersStart(t *testing.T) {
 	<-serveDone
 }
 
+func TestServeRuntimeReadyBeforeRegistryAppsStart(t *testing.T) {
+	t.Parallel()
+
+	registryStarted := make(chan struct{})
+	result := &bootstrap.Result{
+		Invoker: invocation.NewBroker(nil, nil, nil),
+		RegistryAppStartup: func(ctx context.Context) {
+			close(registryStarted)
+			<-ctx.Done()
+		},
+	}
+	workflowProvidersReady := make(chan struct{})
+	ready := runtimeReadinessStatus(workflowProvidersReady, fakeIndexedDBPinger{})
+	servers := []namedHTTPServer{{
+		name:   "public",
+		server: newHTTPServer("127.0.0.1:0", http.NewServeMux()),
+	}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	serveDone := make(chan struct{})
+	go func() {
+		defer close(serveDone)
+		_ = serveRuntime(ctx, &config.Config{}, bootstrap.ConnectionMaps{}, result, nil, servers, &switchableHandler{}, workflowProvidersReady, nil, nil, nil)
+	}()
+
+	select {
+	case <-registryStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("registry app startup was never invoked")
+	}
+	if got := ready(); got != "" {
+		t.Fatalf("readiness while registry apps start = %q, want ready", got)
+	}
+
+	cancel()
+	<-serveDone
+}
+
 type runtimeTestCacheServer struct {
 	proto.UnimplementedCacheServer
 


### PR DESCRIPTION
## Summary

- Publish core HTTP and workflow readiness before restoring registry-backed apps.
- Preserve the existing AppProvidersInitialized gate so registry heartbeats and catalog restarts do not race bootstrap.
- Treat registry app workflow-declaration reconciliation failures as app degradation instead of terminating gestaltd, and retry the complete reconciliation independently of deferred app activation.

## Root cause

A fresh valon.tools Cloud Run instance restored registry apps synchronously inside StartAppProviders before workflowProvidersReady could close. The sdt-pipeline app configures IndexedDB migrations during startup through the public host-service relay at valon.tools. Cloud Run does not route that hostname to an instance until its startup probe passes, while the startup probe could not pass until the registry call returned. Once the last previously healthy instance drained, every new instance called a hostname with no routable backend and received Google Frontend 500 responses, producing a circular bootstrap deadlock.

After sdt-pipeline was temporarily excluded, roadmap-linting exposed a second availability bug: its invalid user-scoped workflow run_as caused startup workflow reconciliation to return an error, and serveRuntime terminated the otherwise healthy daemon. This change moves registry restoration after core readiness and treats app-level reconciliation failure as degraded state. The failed broad reconciliation is registered with the existing immediate retry runner, so transient provider or deploy-level workflow failures cannot remain unapplied behind deferred.ready() when auto-activation is off.

The outage affected SCIM only as a downstream availability failure: /scim/v2/Users was mounted, but callers received platform 500s because no Cloud Run instance could start. This PR does not change SCIM, AuthZEN, or Zanzibar interfaces.

## Test plan

- [x] go test ./... from gestaltd
- [x] go vet ./internal/bootstrap ./internal/server
- [x] Behavioral regression: serveRuntime reports ready while registry app startup is still blocked
- [x] Contract regression: a failed post-registry workflow reconciliation is retried without deferred app activation
- [x] Live recovery validation: /health and /ready return 200, and unauthenticated /scim/v2/Users returns the expected 401 on the isolated recovery revision