### PR TITLE
Deploy downtime step 16: app-admin UI observability

### DIFF
--- a/gestaltd/internal/server/app_admin_ui_observability.go
+++ b/gestaltd/internal/server/app_admin_ui_observability.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"context"
 	"net/http"
 	"strings"
 	"time"
@@ -41,12 +40,12 @@ func (s *Server) appAdminUIObservabilityMiddleware(next http.Handler) http.Handl
 		next.ServeHTTP(recorder, r)
 		failed := recorder.status >= http.StatusBadRequest
 		interaction := observability.AppAdminUIInteraction{
-			App:       appName,
-			Surface:   surface,
-			Action:    action,
-			Failed:    failed,
+			App:        appName,
+			Surface:    surface,
+			Action:     action,
+			Failed:     failed,
 			StatusCode: recorder.status,
-			RequestID: appAdminUIRequestID(r),
+			RequestID:  appAdminUIRequestID(r),
 		}
 		if failed {
 			interaction.FailureCategory = observability.AppAdminUIFailureCategoryHTTP(recorder.status)
@@ -74,22 +73,6 @@ func appAdminUIRouteSpecForRequest(r *http.Request) (surface, action string, ok 
 		}
 	}
 	return "", "", false
-}
-
-func recordAppAdminUIAuthFailure(ctx context.Context, r *http.Request, appName, surface, action string, err error) {
-	if strings.TrimSpace(appName) == "" || surface == "" || action == "" {
-		return
-	}
-	observability.RecordAppAdminUIInteraction(ctx, time.Now(), observability.AppAdminUIInteraction{
-		App:             appName,
-		Surface:         surface,
-		Action:          action,
-		Failed:          true,
-		FailureCategory: observability.AppAdminUIFailureAuth,
-		StatusCode:      http.StatusForbidden,
-		Err:             err,
-		RequestID:       appAdminUIRequestID(r),
-	})
 }
 
 func appAdminUIRequestID(r *http.Request) string {

--- a/gestaltd/internal/server/app_admin_ui_observability.go
+++ b/gestaltd/internal/server/app_admin_ui_observability.go
@@ -1,0 +1,211 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/valon-technologies/gestalt/server/services/invocation"
+	"github.com/valon-technologies/gestalt/server/services/observability"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+const (
+	appAdminUISurfaceMembers           = "members"
+	appAdminUISurfaceAllowedOperations = "allowed_operations"
+
+	appAdminUIActionList       = "list"
+	appAdminUIActionSave       = "save"
+	appAdminUIActionGrantAdd   = "grant_add"
+	appAdminUIActionGrantRemove = "grant_remove"
+
+	appAdminUIOutcomeSuccess = "success"
+	appAdminUIOutcomeFailure = "failure"
+
+	appAdminUIFailureAuth       = "auth_failure"
+	appAdminUIFailureValidation = "validation"
+	appAdminUIFailureServer     = "server"
+	appAdminUIFailureOther      = "other"
+)
+
+type appAdminUIResponseRecorder struct {
+	http.ResponseWriter
+	status int
+}
+
+func (w *appAdminUIResponseRecorder) WriteHeader(statusCode int) {
+	w.status = statusCode
+	w.ResponseWriter.WriteHeader(statusCode)
+}
+
+func (w *appAdminUIResponseRecorder) Write(p []byte) (int, error) {
+	if w.status == 0 {
+		w.status = http.StatusOK
+	}
+	return w.ResponseWriter.Write(p)
+}
+
+func (s *Server) appAdminUIObservabilityMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		surface, action, ok := appAdminUIRouteSpecForRequest(r)
+		if !ok {
+			next.ServeHTTP(w, r)
+			return
+		}
+		appName := strings.TrimSpace(chi.URLParam(r, "app"))
+		startedAt := time.Now()
+		recorder := &appAdminUIResponseRecorder{ResponseWriter: w, status: http.StatusOK}
+		next.ServeHTTP(recorder, r)
+		failed := recorder.status >= http.StatusBadRequest
+		failureCategory := ""
+		if failed {
+			failureCategory = appAdminUIFailureCategoryFromStatus(recorder.status)
+		}
+		recordAppAdminUIInteraction(
+			r.Context(),
+			r,
+			startedAt,
+			appName,
+			surface,
+			action,
+			failed,
+			failureCategory,
+			recorder.status,
+			nil,
+		)
+	})
+}
+
+func appAdminUIRouteSpecForRequest(r *http.Request) (surface, action string, ok bool) {
+	if r == nil {
+		return "", "", false
+	}
+	path := strings.TrimRight(r.URL.Path, "/")
+	switch r.Method {
+	case http.MethodGet:
+		switch {
+		case strings.HasSuffix(path, "/admin/members"):
+			return appAdminUISurfaceMembers, appAdminUIActionList, true
+		case strings.HasSuffix(path, "/admin/allowed-operations"):
+			return appAdminUISurfaceAllowedOperations, appAdminUIActionList, true
+		}
+	case http.MethodPut:
+		if strings.HasSuffix(path, "/admin/allowed-operations") {
+			return appAdminUISurfaceAllowedOperations, appAdminUIActionSave, true
+		}
+	}
+	return "", "", false
+}
+
+func appAdminUIFailureCategoryFromStatus(status int) string {
+	switch {
+	case status == http.StatusUnauthorized || status == http.StatusForbidden:
+		return appAdminUIFailureAuth
+	case status == http.StatusBadRequest:
+		return appAdminUIFailureValidation
+	case status >= http.StatusInternalServerError:
+		return appAdminUIFailureServer
+	default:
+		return appAdminUIFailureOther
+	}
+}
+
+func recordAppAdminUIAuthFailure(ctx context.Context, r *http.Request, appName, surface, action string, err error) {
+	if strings.TrimSpace(appName) == "" || surface == "" || action == "" {
+		return
+	}
+	recordAppAdminUIInteraction(
+		ctx,
+		r,
+		time.Now(),
+		appName,
+		surface,
+		action,
+		true,
+		appAdminUIFailureAuth,
+		http.StatusForbidden,
+		err,
+	)
+}
+
+func recordAppAdminUIInteraction(
+	ctx context.Context,
+	r *http.Request,
+	startedAt time.Time,
+	appName, surface, action string,
+	failed bool,
+	failureCategory string,
+	statusCode int,
+	err error,
+) {
+	appName = strings.TrimSpace(appName)
+	if appName == "" || surface == "" || action == "" {
+		return
+	}
+	outcome := appAdminUIOutcomeSuccess
+	if failed {
+		outcome = appAdminUIOutcomeFailure
+	}
+	attrs := []attribute.KeyValue{
+		observability.AttrAppAdminUIApp.String(appName),
+		observability.AttrAppAdminUISurface.String(surface),
+		observability.AttrAppAdminUIAction.String(action),
+		observability.AttrAppAdminUIOutcome.String(outcome),
+	}
+	if failed && failureCategory != "" {
+		attrs = append(attrs, observability.AttrAppAdminUIFailureCategory.String(failureCategory))
+	}
+	observability.RecordAppAdminUI(ctx, startedAt, failed, attrs...)
+	if failed {
+		logAppAdminUIFailure(ctx, r, appName, surface, action, failureCategory, statusCode, err)
+	}
+}
+
+func logAppAdminUIFailure(
+	ctx context.Context,
+	r *http.Request,
+	app, surface, action, failureCategory string,
+	statusCode int,
+	err error,
+) {
+	attrs := []any{
+		slog.String("event", "app_admin.ui"),
+		slog.String("app", app),
+		slog.String("surface", surface),
+		slog.String("action", action),
+		slog.String("failure_category", failureCategory),
+	}
+	if err != nil {
+		attrs = append(attrs, slog.String("error", err.Error()))
+	} else if statusCode > 0 {
+		attrs = append(attrs, slog.String("error", fmt.Sprintf("HTTP %d", statusCode)))
+	}
+	if r != nil {
+		if requestID := strings.TrimSpace(r.Header.Get("X-Request-ID")); requestID != "" {
+			attrs = append(attrs, slog.String("request_id", requestID))
+		}
+	}
+	if meta := invocation.MetaFromContext(ctx); meta != nil {
+		if requestID := strings.TrimSpace(meta.RequestID); requestID != "" {
+			attrs = append(attrs, slog.String("request_id", requestID))
+		}
+	}
+	spanCtx := trace.SpanContextFromContext(ctx)
+	if spanCtx.IsValid() {
+		attrs = append(attrs, slog.String("trace_id", spanCtx.TraceID().String()))
+	}
+	slog.WarnContext(ctx, "app admin ui interaction failed", attrs...)
+}
+
+func appAdminUIAuthFailureError(message string) error {
+	if strings.TrimSpace(message) == "" {
+		return errors.New("app access denied")
+	}
+	return errors.New(message)
+}

--- a/gestaltd/internal/server/app_admin_ui_observability.go
+++ b/gestaltd/internal/server/app_admin_ui_observability.go
@@ -2,9 +2,6 @@ package server
 
 import (
 	"context"
-	"errors"
-	"fmt"
-	"log/slog"
 	"net/http"
 	"strings"
 	"time"
@@ -12,26 +9,6 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"github.com/valon-technologies/gestalt/server/services/observability"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/trace"
-)
-
-const (
-	appAdminUISurfaceMembers           = "members"
-	appAdminUISurfaceAllowedOperations = "allowed_operations"
-
-	appAdminUIActionList       = "list"
-	appAdminUIActionSave       = "save"
-	appAdminUIActionGrantAdd   = "grant_add"
-	appAdminUIActionGrantRemove = "grant_remove"
-
-	appAdminUIOutcomeSuccess = "success"
-	appAdminUIOutcomeFailure = "failure"
-
-	appAdminUIFailureAuth       = "auth_failure"
-	appAdminUIFailureValidation = "validation"
-	appAdminUIFailureServer     = "server"
-	appAdminUIFailureOther      = "other"
 )
 
 type appAdminUIResponseRecorder struct {
@@ -63,22 +40,18 @@ func (s *Server) appAdminUIObservabilityMiddleware(next http.Handler) http.Handl
 		recorder := &appAdminUIResponseRecorder{ResponseWriter: w, status: http.StatusOK}
 		next.ServeHTTP(recorder, r)
 		failed := recorder.status >= http.StatusBadRequest
-		failureCategory := ""
-		if failed {
-			failureCategory = appAdminUIFailureCategoryFromStatus(recorder.status)
+		interaction := observability.AppAdminUIInteraction{
+			App:       appName,
+			Surface:   surface,
+			Action:    action,
+			Failed:    failed,
+			StatusCode: recorder.status,
+			RequestID: appAdminUIRequestID(r),
 		}
-		recordAppAdminUIInteraction(
-			r.Context(),
-			r,
-			startedAt,
-			appName,
-			surface,
-			action,
-			failed,
-			failureCategory,
-			recorder.status,
-			nil,
-		)
+		if failed {
+			interaction.FailureCategory = observability.AppAdminUIFailureCategoryHTTP(recorder.status)
+		}
+		observability.RecordAppAdminUIInteraction(r.Context(), startedAt, interaction)
 	})
 }
 
@@ -91,121 +64,43 @@ func appAdminUIRouteSpecForRequest(r *http.Request) (surface, action string, ok 
 	case http.MethodGet:
 		switch {
 		case strings.HasSuffix(path, "/admin/members"):
-			return appAdminUISurfaceMembers, appAdminUIActionList, true
+			return observability.AppAdminUISurfaceMembers, observability.AppAdminUIActionList, true
 		case strings.HasSuffix(path, "/admin/allowed-operations"):
-			return appAdminUISurfaceAllowedOperations, appAdminUIActionList, true
+			return observability.AppAdminUISurfaceAllowedOperations, observability.AppAdminUIActionList, true
 		}
 	case http.MethodPut:
 		if strings.HasSuffix(path, "/admin/allowed-operations") {
-			return appAdminUISurfaceAllowedOperations, appAdminUIActionSave, true
+			return observability.AppAdminUISurfaceAllowedOperations, observability.AppAdminUIActionSave, true
 		}
 	}
 	return "", "", false
-}
-
-func appAdminUIFailureCategoryFromStatus(status int) string {
-	switch {
-	case status == http.StatusUnauthorized || status == http.StatusForbidden:
-		return appAdminUIFailureAuth
-	case status == http.StatusBadRequest:
-		return appAdminUIFailureValidation
-	case status >= http.StatusInternalServerError:
-		return appAdminUIFailureServer
-	default:
-		return appAdminUIFailureOther
-	}
 }
 
 func recordAppAdminUIAuthFailure(ctx context.Context, r *http.Request, appName, surface, action string, err error) {
 	if strings.TrimSpace(appName) == "" || surface == "" || action == "" {
 		return
 	}
-	recordAppAdminUIInteraction(
-		ctx,
-		r,
-		time.Now(),
-		appName,
-		surface,
-		action,
-		true,
-		appAdminUIFailureAuth,
-		http.StatusForbidden,
-		err,
-	)
+	observability.RecordAppAdminUIInteraction(ctx, time.Now(), observability.AppAdminUIInteraction{
+		App:             appName,
+		Surface:         surface,
+		Action:          action,
+		Failed:          true,
+		FailureCategory: observability.AppAdminUIFailureAuth,
+		StatusCode:      http.StatusForbidden,
+		Err:             err,
+		RequestID:       appAdminUIRequestID(r),
+	})
 }
 
-func recordAppAdminUIInteraction(
-	ctx context.Context,
-	r *http.Request,
-	startedAt time.Time,
-	appName, surface, action string,
-	failed bool,
-	failureCategory string,
-	statusCode int,
-	err error,
-) {
-	appName = strings.TrimSpace(appName)
-	if appName == "" || surface == "" || action == "" {
-		return
+func appAdminUIRequestID(r *http.Request) string {
+	if r == nil {
+		return ""
 	}
-	outcome := appAdminUIOutcomeSuccess
-	if failed {
-		outcome = appAdminUIOutcomeFailure
+	if requestID := strings.TrimSpace(r.Header.Get("X-Request-ID")); requestID != "" {
+		return requestID
 	}
-	attrs := []attribute.KeyValue{
-		observability.AttrAppAdminUIApp.String(appName),
-		observability.AttrAppAdminUISurface.String(surface),
-		observability.AttrAppAdminUIAction.String(action),
-		observability.AttrAppAdminUIOutcome.String(outcome),
+	if meta := invocation.MetaFromContext(r.Context()); meta != nil {
+		return strings.TrimSpace(meta.RequestID)
 	}
-	if failed && failureCategory != "" {
-		attrs = append(attrs, observability.AttrAppAdminUIFailureCategory.String(failureCategory))
-	}
-	observability.RecordAppAdminUI(ctx, startedAt, failed, attrs...)
-	if failed {
-		logAppAdminUIFailure(ctx, r, appName, surface, action, failureCategory, statusCode, err)
-	}
-}
-
-func logAppAdminUIFailure(
-	ctx context.Context,
-	r *http.Request,
-	app, surface, action, failureCategory string,
-	statusCode int,
-	err error,
-) {
-	attrs := []any{
-		slog.String("event", "app_admin.ui"),
-		slog.String("app", app),
-		slog.String("surface", surface),
-		slog.String("action", action),
-		slog.String("failure_category", failureCategory),
-	}
-	if err != nil {
-		attrs = append(attrs, slog.String("error", err.Error()))
-	} else if statusCode > 0 {
-		attrs = append(attrs, slog.String("error", fmt.Sprintf("HTTP %d", statusCode)))
-	}
-	if r != nil {
-		if requestID := strings.TrimSpace(r.Header.Get("X-Request-ID")); requestID != "" {
-			attrs = append(attrs, slog.String("request_id", requestID))
-		}
-	}
-	if meta := invocation.MetaFromContext(ctx); meta != nil {
-		if requestID := strings.TrimSpace(meta.RequestID); requestID != "" {
-			attrs = append(attrs, slog.String("request_id", requestID))
-		}
-	}
-	spanCtx := trace.SpanContextFromContext(ctx)
-	if spanCtx.IsValid() {
-		attrs = append(attrs, slog.String("trace_id", spanCtx.TraceID().String()))
-	}
-	slog.WarnContext(ctx, "app admin ui interaction failed", attrs...)
-}
-
-func appAdminUIAuthFailureError(message string) error {
-	if strings.TrimSpace(message) == "" {
-		return errors.New("app access denied")
-	}
-	return errors.New(message)
+	return ""
 }

--- a/gestaltd/internal/server/app_admin_ui_observability_test.go
+++ b/gestaltd/internal/server/app_admin_ui_observability_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/valon-technologies/gestalt/server/internal/testutil/metrictest"
+	"github.com/valon-technologies/gestalt/server/services/observability"
 	"github.com/valon-technologies/gestalt/server/services/observability/metricutil"
 )
 
@@ -85,14 +86,14 @@ func TestAppAdminUIFailureCategoryFromStatus(t *testing.T) {
 		status int
 		want   string
 	}{
-		{status: http.StatusUnauthorized, want: appAdminUIFailureAuth},
-		{status: http.StatusForbidden, want: appAdminUIFailureAuth},
-		{status: http.StatusBadRequest, want: appAdminUIFailureValidation},
-		{status: http.StatusNotFound, want: appAdminUIFailureOther},
-		{status: http.StatusInternalServerError, want: appAdminUIFailureServer},
+		{status: http.StatusUnauthorized, want: observability.AppAdminUIFailureAuth},
+		{status: http.StatusForbidden, want: observability.AppAdminUIFailureAuth},
+		{status: http.StatusBadRequest, want: observability.AppAdminUIFailureValidation},
+		{status: http.StatusNotFound, want: observability.AppAdminUIFailureOther},
+		{status: http.StatusInternalServerError, want: observability.AppAdminUIFailureServer},
 	}
 	for _, tc := range tests {
-		if got := appAdminUIFailureCategoryFromStatus(tc.status); got != tc.want {
+		if got := observability.AppAdminUIFailureCategoryHTTP(tc.status); got != tc.want {
 			t.Fatalf("status %d category = %q, want %q", tc.status, got, tc.want)
 		}
 	}

--- a/gestaltd/internal/server/app_admin_ui_observability_test.go
+++ b/gestaltd/internal/server/app_admin_ui_observability_test.go
@@ -79,6 +79,43 @@ func TestAppAdminUIObservabilityMiddlewareRecordsValidationFailure(t *testing.T)
 	metrictest.RequireFloat64Histogram(t, rm, "gestaltd.app_admin.ui.duration", attrs)
 }
 
+func TestAppAdminUIObservabilityMiddlewareRecordsAuthorizationUnavailable(t *testing.T) {
+	t.Parallel()
+
+	metrics := metrictest.NewManualMeterProvider(t)
+	ctx := metricutil.WithMeterProvider(context.Background(), metrics.Provider)
+
+	s := &Server{}
+	handler := s.appAdminUIObservabilityMiddleware(s.appAdminAuthorizationMiddleware(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Fatal("next handler should not run when authorization is unavailable")
+	})))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/apps/g-issues/admin/members", nil)
+	req = req.WithContext(ctx)
+	routeCtx := chi.NewRouteContext()
+	routeCtx.URLParams.Add("app", "g-issues")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, routeCtx))
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusServiceUnavailable)
+	}
+
+	rm := metrictest.CollectMetrics(t, metrics.Reader)
+	attrs := map[string]string{
+		"gestaltd.app_admin.ui.app":              "g-issues",
+		"gestaltd.app_admin.ui.surface":          "members",
+		"gestaltd.app_admin.ui.action":           "list",
+		"gestaltd.app_admin.ui.outcome":          "failure",
+		"gestaltd.app_admin.ui.failure_category": "server",
+	}
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.app_admin.ui.count", 1, attrs)
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.app_admin.ui.error_count", 1, attrs)
+	metrictest.RequireFloat64Histogram(t, rm, "gestaltd.app_admin.ui.duration", attrs)
+}
+
 func TestAppAdminUIFailureCategoryFromStatus(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/server/app_admin_ui_observability_test.go
+++ b/gestaltd/internal/server/app_admin_ui_observability_test.go
@@ -1,0 +1,129 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/valon-technologies/gestalt/server/internal/testutil/metrictest"
+	"github.com/valon-technologies/gestalt/server/services/observability/metricutil"
+)
+
+func TestAppAdminUIObservabilityMiddlewareRecordsSuccess(t *testing.T) {
+	t.Parallel()
+
+	metrics := metrictest.NewManualMeterProvider(t)
+	ctx := metricutil.WithMeterProvider(context.Background(), metrics.Provider)
+
+	handler := (&Server{}).appAdminUIObservabilityMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusOK, map[string]string{"ok": "true"})
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/apps/g-issues/admin/members", nil)
+	req = req.WithContext(ctx)
+	routeCtx := chi.NewRouteContext()
+	routeCtx.URLParams.Add("app", "g-issues")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, routeCtx))
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusOK)
+	}
+
+	rm := metrictest.CollectMetrics(t, metrics.Reader)
+	attrs := map[string]string{
+		"gestaltd.app_admin.ui.app":     "g-issues",
+		"gestaltd.app_admin.ui.surface": "members",
+		"gestaltd.app_admin.ui.action":  "list",
+		"gestaltd.app_admin.ui.outcome": "success",
+	}
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.app_admin.ui.count", 1, attrs)
+	metrictest.RequireNoInt64Sum(t, rm, "gestaltd.app_admin.ui.error_count", attrs)
+	metrictest.RequireFloat64Histogram(t, rm, "gestaltd.app_admin.ui.duration", attrs)
+}
+
+func TestAppAdminUIObservabilityMiddlewareRecordsValidationFailure(t *testing.T) {
+	t.Parallel()
+
+	metrics := metrictest.NewManualMeterProvider(t)
+	ctx := metricutil.WithMeterProvider(context.Background(), metrics.Provider)
+
+	handler := (&Server{}).appAdminUIObservabilityMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+	}))
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/apps/g-issues/admin/allowed-operations", nil)
+	req = req.WithContext(ctx)
+	routeCtx := chi.NewRouteContext()
+	routeCtx.URLParams.Add("app", "g-issues")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, routeCtx))
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, req)
+
+	rm := metrictest.CollectMetrics(t, metrics.Reader)
+	attrs := map[string]string{
+		"gestaltd.app_admin.ui.app":              "g-issues",
+		"gestaltd.app_admin.ui.surface":          "allowed_operations",
+		"gestaltd.app_admin.ui.action":           "save",
+		"gestaltd.app_admin.ui.outcome":          "failure",
+		"gestaltd.app_admin.ui.failure_category": "validation",
+	}
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.app_admin.ui.count", 1, attrs)
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.app_admin.ui.error_count", 1, attrs)
+	metrictest.RequireFloat64Histogram(t, rm, "gestaltd.app_admin.ui.duration", attrs)
+}
+
+func TestAppAdminUIFailureCategoryFromStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		status int
+		want   string
+	}{
+		{status: http.StatusUnauthorized, want: appAdminUIFailureAuth},
+		{status: http.StatusForbidden, want: appAdminUIFailureAuth},
+		{status: http.StatusBadRequest, want: appAdminUIFailureValidation},
+		{status: http.StatusNotFound, want: appAdminUIFailureOther},
+		{status: http.StatusInternalServerError, want: appAdminUIFailureServer},
+	}
+	for _, tc := range tests {
+		if got := appAdminUIFailureCategoryFromStatus(tc.status); got != tc.want {
+			t.Fatalf("status %d category = %q, want %q", tc.status, got, tc.want)
+		}
+	}
+}
+
+func TestAppAdminUIRouteSpecForRequest(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		method  string
+		path    string
+		surface string
+		action  string
+		ok      bool
+	}{
+		{method: http.MethodGet, path: "/api/v1/apps/demo/admin/members", surface: "members", action: "list", ok: true},
+		{method: http.MethodGet, path: "/api/v1/apps/demo/admin/allowed-operations", surface: "allowed_operations", action: "list", ok: true},
+		{method: http.MethodPut, path: "/api/v1/apps/demo/admin/allowed-operations", surface: "allowed_operations", action: "save", ok: true},
+		{method: http.MethodGet, path: "/api/v1/apps/demo/admin/registry", ok: false},
+	}
+	for _, tc := range tests {
+		req := httptest.NewRequest(tc.method, tc.path, nil)
+		surface, action, ok := appAdminUIRouteSpecForRequest(req)
+		if ok != tc.ok {
+			t.Fatalf("%s %s ok = %v, want %v", tc.method, tc.path, ok, tc.ok)
+		}
+		if !tc.ok {
+			continue
+		}
+		if surface != tc.surface || action != tc.action {
+			t.Fatalf("%s %s spec = (%q, %q), want (%q, %q)", tc.method, tc.path, surface, action, tc.surface, tc.action)
+		}
+	}
+}

--- a/gestaltd/internal/server/handlers_app_admin_allowed_operations.go
+++ b/gestaltd/internal/server/handlers_app_admin_allowed_operations.go
@@ -37,9 +37,9 @@ type appAdminAllowedOperationsUpdateRequest struct {
 }
 
 func (s *Server) mountAppAdminAllowedOperationsRoutes(r chi.Router) {
-	r.With(s.pluginRouteAuthMiddleware("app"), s.appAdminAuthorizationMiddleware, s.appAdminUIObservabilityMiddleware).
+	r.With(s.pluginRouteAuthMiddleware("app"), s.appAdminUIObservabilityMiddleware, s.appAdminAuthorizationMiddleware).
 		Get("/apps/{app}/admin/allowed-operations", s.getAppAdminAllowedOperations)
-	r.With(s.pluginRouteAuthMiddleware("app"), s.appAdminAuthorizationMiddleware, s.appAdminUIObservabilityMiddleware).
+	r.With(s.pluginRouteAuthMiddleware("app"), s.appAdminUIObservabilityMiddleware, s.appAdminAuthorizationMiddleware).
 		Put("/apps/{app}/admin/allowed-operations", s.putAppAdminAllowedOperations)
 }
 

--- a/gestaltd/internal/server/handlers_app_admin_allowed_operations.go
+++ b/gestaltd/internal/server/handlers_app_admin_allowed_operations.go
@@ -37,9 +37,9 @@ type appAdminAllowedOperationsUpdateRequest struct {
 }
 
 func (s *Server) mountAppAdminAllowedOperationsRoutes(r chi.Router) {
-	r.With(s.pluginRouteAuthMiddleware("app"), s.appAdminAuthorizationMiddleware).
+	r.With(s.pluginRouteAuthMiddleware("app"), s.appAdminAuthorizationMiddleware, s.appAdminUIObservabilityMiddleware).
 		Get("/apps/{app}/admin/allowed-operations", s.getAppAdminAllowedOperations)
-	r.With(s.pluginRouteAuthMiddleware("app"), s.appAdminAuthorizationMiddleware).
+	r.With(s.pluginRouteAuthMiddleware("app"), s.appAdminAuthorizationMiddleware, s.appAdminUIObservabilityMiddleware).
 		Put("/apps/{app}/admin/allowed-operations", s.putAppAdminAllowedOperations)
 }
 

--- a/gestaltd/internal/server/handlers_app_admin_members.go
+++ b/gestaltd/internal/server/handlers_app_admin_members.go
@@ -29,7 +29,7 @@ type appAdminMemberRow struct {
 }
 
 func (s *Server) mountAppAdminMembersRoutes(r chi.Router) {
-	r.With(s.pluginRouteAuthMiddleware("app"), s.appAdminAuthorizationMiddleware).
+	r.With(s.pluginRouteAuthMiddleware("app"), s.appAdminAuthorizationMiddleware, s.appAdminUIObservabilityMiddleware).
 		Get("/apps/{app}/admin/members", s.listAppAdminMembers)
 }
 

--- a/gestaltd/internal/server/handlers_app_admin_members.go
+++ b/gestaltd/internal/server/handlers_app_admin_members.go
@@ -29,7 +29,7 @@ type appAdminMemberRow struct {
 }
 
 func (s *Server) mountAppAdminMembersRoutes(r chi.Router) {
-	r.With(s.pluginRouteAuthMiddleware("app"), s.appAdminAuthorizationMiddleware, s.appAdminUIObservabilityMiddleware).
+	r.With(s.pluginRouteAuthMiddleware("app"), s.appAdminUIObservabilityMiddleware, s.appAdminAuthorizationMiddleware).
 		Get("/apps/{app}/admin/members", s.listAppAdminMembers)
 }
 

--- a/gestaltd/internal/server/handlers_app_admin_registry.go
+++ b/gestaltd/internal/server/handlers_app_admin_registry.go
@@ -183,11 +183,11 @@ func (s *Server) appAdminAuthorizationMiddleware(next http.Handler) http.Handler
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		surface, action, instrumented := appAdminUIRouteSpecForRequest(r)
 		appName := strings.TrimSpace(chi.URLParam(r, "app"))
-		recordAuthFailure := func(status int, message string) {
+		recordAuthFailure := func(message string) {
 			if !instrumented {
 				return
 			}
-			recordAppAdminUIAuthFailure(r.Context(), r, appName, surface, action, appAdminUIAuthFailureError(message))
+			recordAppAdminUIAuthFailure(r.Context(), r, appName, surface, action, errors.New(message))
 		}
 
 		if s.authorization == nil {
@@ -196,22 +196,22 @@ func (s *Server) appAdminAuthorizationMiddleware(next http.Handler) http.Handler
 		}
 		p := PrincipalFromContext(r.Context())
 		if p == nil {
-			recordAuthFailure(http.StatusUnauthorized, "missing authorization")
+			recordAuthFailure("missing authorization")
 			writeError(w, http.StatusUnauthorized, "missing authorization")
 			return
 		}
 		if err := requireUserCaller(w, p); err != nil {
-			recordAuthFailure(http.StatusForbidden, errUserRequired.Error())
+			recordAuthFailure(errUserRequired.Error())
 			return
 		}
 		subjectID, err := principal.ResolveAuthorizationSubjectID(r.Context(), s.credentialUserResolver(), p)
 		switch {
 		case errors.Is(err, principal.ErrCredentialSubjectRequired):
-			recordAuthFailure(http.StatusUnauthorized, "missing authorization")
+			recordAuthFailure("missing authorization")
 			writeError(w, http.StatusUnauthorized, "missing authorization")
 			return
 		case errors.Is(err, principal.ErrOpaqueCredentialSubject):
-			recordAuthFailure(http.StatusForbidden, "app access denied")
+			recordAuthFailure("app access denied")
 			writeError(w, http.StatusForbidden, "app access denied")
 			return
 		case err != nil:
@@ -220,7 +220,7 @@ func (s *Server) appAdminAuthorizationMiddleware(next http.Handler) http.Handler
 		}
 		subjectID = strings.TrimSpace(subjectID)
 		if subjectID == "" {
-			recordAuthFailure(http.StatusUnauthorized, "missing authorization")
+			recordAuthFailure("missing authorization")
 			writeError(w, http.StatusUnauthorized, "missing authorization")
 			return
 		}
@@ -231,7 +231,7 @@ func (s *Server) appAdminAuthorizationMiddleware(next http.Handler) http.Handler
 			return
 		}
 		if !allowed {
-			recordAuthFailure(http.StatusForbidden, "app access denied")
+			recordAuthFailure("app access denied")
 			writeError(w, http.StatusForbidden, "app access denied")
 			return
 		}

--- a/gestaltd/internal/server/handlers_app_admin_registry.go
+++ b/gestaltd/internal/server/handlers_app_admin_registry.go
@@ -181,24 +181,37 @@ func (s *Server) mountAppAdminRegistryRoutes(r chi.Router) {
 
 func (s *Server) appAdminAuthorizationMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		surface, action, instrumented := appAdminUIRouteSpecForRequest(r)
+		appName := strings.TrimSpace(chi.URLParam(r, "app"))
+		recordAuthFailure := func(status int, message string) {
+			if !instrumented {
+				return
+			}
+			recordAppAdminUIAuthFailure(r.Context(), r, appName, surface, action, appAdminUIAuthFailureError(message))
+		}
+
 		if s.authorization == nil {
 			writeError(w, http.StatusServiceUnavailable, "authorization is unavailable")
 			return
 		}
 		p := PrincipalFromContext(r.Context())
 		if p == nil {
+			recordAuthFailure(http.StatusUnauthorized, "missing authorization")
 			writeError(w, http.StatusUnauthorized, "missing authorization")
 			return
 		}
 		if err := requireUserCaller(w, p); err != nil {
+			recordAuthFailure(http.StatusForbidden, errUserRequired.Error())
 			return
 		}
 		subjectID, err := principal.ResolveAuthorizationSubjectID(r.Context(), s.credentialUserResolver(), p)
 		switch {
 		case errors.Is(err, principal.ErrCredentialSubjectRequired):
+			recordAuthFailure(http.StatusUnauthorized, "missing authorization")
 			writeError(w, http.StatusUnauthorized, "missing authorization")
 			return
 		case errors.Is(err, principal.ErrOpaqueCredentialSubject):
+			recordAuthFailure(http.StatusForbidden, "app access denied")
 			writeError(w, http.StatusForbidden, "app access denied")
 			return
 		case err != nil:
@@ -207,16 +220,18 @@ func (s *Server) appAdminAuthorizationMiddleware(next http.Handler) http.Handler
 		}
 		subjectID = strings.TrimSpace(subjectID)
 		if subjectID == "" {
+			recordAuthFailure(http.StatusUnauthorized, "missing authorization")
 			writeError(w, http.StatusUnauthorized, "missing authorization")
 			return
 		}
-		appName := strings.TrimSpace(chi.URLParam(r, "app"))
+		appName = strings.TrimSpace(chi.URLParam(r, "app"))
 		allowed, err := s.hasExplicitAppAdmin(r.Context(), subjectID, appName)
 		if err != nil {
 			writeError(w, http.StatusServiceUnavailable, "authorization is unavailable")
 			return
 		}
 		if !allowed {
+			recordAuthFailure(http.StatusForbidden, "app access denied")
 			writeError(w, http.StatusForbidden, "app access denied")
 			return
 		}

--- a/gestaltd/internal/server/handlers_app_admin_registry.go
+++ b/gestaltd/internal/server/handlers_app_admin_registry.go
@@ -181,37 +181,24 @@ func (s *Server) mountAppAdminRegistryRoutes(r chi.Router) {
 
 func (s *Server) appAdminAuthorizationMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		surface, action, instrumented := appAdminUIRouteSpecForRequest(r)
-		appName := strings.TrimSpace(chi.URLParam(r, "app"))
-		recordAuthFailure := func(message string) {
-			if !instrumented {
-				return
-			}
-			recordAppAdminUIAuthFailure(r.Context(), r, appName, surface, action, errors.New(message))
-		}
-
 		if s.authorization == nil {
 			writeError(w, http.StatusServiceUnavailable, "authorization is unavailable")
 			return
 		}
 		p := PrincipalFromContext(r.Context())
 		if p == nil {
-			recordAuthFailure("missing authorization")
 			writeError(w, http.StatusUnauthorized, "missing authorization")
 			return
 		}
 		if err := requireUserCaller(w, p); err != nil {
-			recordAuthFailure(errUserRequired.Error())
 			return
 		}
 		subjectID, err := principal.ResolveAuthorizationSubjectID(r.Context(), s.credentialUserResolver(), p)
 		switch {
 		case errors.Is(err, principal.ErrCredentialSubjectRequired):
-			recordAuthFailure("missing authorization")
 			writeError(w, http.StatusUnauthorized, "missing authorization")
 			return
 		case errors.Is(err, principal.ErrOpaqueCredentialSubject):
-			recordAuthFailure("app access denied")
 			writeError(w, http.StatusForbidden, "app access denied")
 			return
 		case err != nil:
@@ -220,18 +207,16 @@ func (s *Server) appAdminAuthorizationMiddleware(next http.Handler) http.Handler
 		}
 		subjectID = strings.TrimSpace(subjectID)
 		if subjectID == "" {
-			recordAuthFailure("missing authorization")
 			writeError(w, http.StatusUnauthorized, "missing authorization")
 			return
 		}
-		appName = strings.TrimSpace(chi.URLParam(r, "app"))
+		appName := strings.TrimSpace(chi.URLParam(r, "app"))
 		allowed, err := s.hasExplicitAppAdmin(r.Context(), subjectID, appName)
 		if err != nil {
 			writeError(w, http.StatusServiceUnavailable, "authorization is unavailable")
 			return
 		}
 		if !allowed {
-			recordAuthFailure("app access denied")
 			writeError(w, http.StatusForbidden, "app access denied")
 			return
 		}

--- a/gestaltd/internal/server/handlers_authorization_apply.go
+++ b/gestaltd/internal/server/handlers_authorization_apply.go
@@ -44,7 +44,7 @@ func handleRESTApplyAuthorizationState(
 		httpHeadersToGRPCMetadata(r.Header),
 	))
 	ctx = stripInternalIdentityMetadata(ctx)
-	if _, _, err := transport.PreparePublicRequest(ctx, applyAuthorizationStateFullMethod, &protoReq); err != nil {
+	if _, _, _, err := transport.PreparePublicRequest(ctx, applyAuthorizationStateFullMethod, &protoReq); err != nil {
 		publicRESTErrorHandler(ctx, nil, nil, w, r, err)
 		return
 	}

--- a/gestaltd/internal/server/public_grpc.go
+++ b/gestaltd/internal/server/public_grpc.go
@@ -133,7 +133,7 @@ func publicPrepareUnaryInterceptor(transport *providergateway.ProviderGatewayTra
 		if !ok {
 			return nil, status.Error(codes.Internal, "request type mismatch")
 		}
-		p, adapted, err := transport.PreparePublicRequest(ctx, origin.FullMethod, msg)
+		ctx, p, adapted, err := transport.PreparePublicRequest(ctx, origin.FullMethod, msg)
 		if err != nil {
 			if reportSubject != nil {
 				reportSubject(ctx, nil)
@@ -189,6 +189,7 @@ type publicAuthStream struct {
 	fullMethod    string
 	authed        bool
 	principal     *principal.Principal
+	preparedCtx   context.Context
 	reportSubject publicStreamSubjectLabelReporter
 }
 
@@ -196,7 +197,11 @@ func (s *publicAuthStream) Context() context.Context {
 	// Always strip caller-supplied internal identity metadata, mirroring the
 	// unary public interceptor: a public caller must not forge a trusted
 	// caller subject. The resolved principal is reattached below.
-	ctx := stripInternalIdentityMetadata(s.ServerStream.Context())
+	ctx := s.ServerStream.Context()
+	if s.preparedCtx != nil {
+		ctx = s.preparedCtx
+	}
+	ctx = stripInternalIdentityMetadata(ctx)
 	if s.principal != nil {
 		canonical := principal.Canonicalized(s.principal)
 		ctx = principal.WithPrincipal(ctx, canonical)
@@ -218,7 +223,7 @@ func (s *publicAuthStream) RecvMsg(msg any) error {
 			return status.Error(codes.Internal, "request type mismatch")
 		}
 		ctx := stripInternalIdentityMetadata(s.ServerStream.Context())
-		p, adapted, err := s.transport.PreparePublicRequest(ctx, s.fullMethod, m)
+		ctx, p, adapted, err := s.transport.PreparePublicRequest(ctx, s.fullMethod, m)
 		if err != nil {
 			if s.reportSubject != nil {
 				s.reportSubject(s, nil)
@@ -228,6 +233,7 @@ func (s *publicAuthStream) RecvMsg(msg any) error {
 		if s.reportSubject != nil {
 			s.reportSubject(s, p)
 		}
+		s.preparedCtx = ctx
 		s.principal = p
 		if adapted != nil && m != adapted {
 			gproto.Reset(m)

--- a/gestaltd/internal/server/public_rest.go
+++ b/gestaltd/internal/server/public_rest.go
@@ -179,7 +179,7 @@ func handleRESTInvoke(
 	))
 	ctx = stripInternalIdentityMetadata(ctx)
 
-	p, adapted, err := transport.PreparePublicRequest(ctx, invokeFullMethod, &protoReq)
+	ctx, p, adapted, err := transport.PreparePublicRequest(ctx, invokeFullMethod, &protoReq)
 	if err != nil {
 		publicRESTErrorHandler(ctx, nil, nil, w, r, err)
 		return

--- a/gestaltd/services/authorization/app_admin_ui_test.go
+++ b/gestaltd/services/authorization/app_admin_ui_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/publicrpc"
 	"github.com/valon-technologies/gestalt/server/internal/testutil/metrictest"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"github.com/valon-technologies/gestalt/server/services/observability"
 	"github.com/valon-technologies/gestalt/server/services/observability/metricutil"
 	"github.com/valon-technologies/gestalt/server/services/providergateway"
 	"google.golang.org/grpc/codes"
@@ -116,13 +117,13 @@ func (p *stubAuthorizationProvider) DeleteRelationship(context.Context, *proto.D
 func TestAppAdminUIFailureCategoryFromRPC(t *testing.T) {
 	t.Parallel()
 
-	if got := appAdminUIFailureCategoryFromRPC(status.Error(codes.PermissionDenied, "denied")); got != "auth_failure" {
+	if got := observability.AppAdminUIFailureCategoryGRPC(status.Error(codes.PermissionDenied, "denied")); got != "auth_failure" {
 		t.Fatalf("category = %q, want auth_failure", got)
 	}
-	if got := appAdminUIFailureCategoryFromRPC(status.Error(codes.InvalidArgument, "bad")); got != "validation" {
+	if got := observability.AppAdminUIFailureCategoryGRPC(status.Error(codes.InvalidArgument, "bad")); got != "validation" {
 		t.Fatalf("category = %q, want validation", got)
 	}
-	if got := appAdminUIFailureCategoryFromRPC(status.Error(codes.Internal, "boom")); got != "server" {
+	if got := observability.AppAdminUIFailureCategoryGRPC(status.Error(codes.Internal, "boom")); got != "server" {
 		t.Fatalf("category = %q, want server", got)
 	}
 }

--- a/gestaltd/services/authorization/app_admin_ui_test.go
+++ b/gestaltd/services/authorization/app_admin_ui_test.go
@@ -1,0 +1,128 @@
+package authorization
+
+import (
+	"context"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/publicrpc"
+	"github.com/valon-technologies/gestalt/server/internal/testutil/metrictest"
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"github.com/valon-technologies/gestalt/server/services/observability/metricutil"
+	"github.com/valon-technologies/gestalt/server/services/providergateway"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestAddRelationshipRecordsAppScopedMutationMetrics(t *testing.T) {
+	t.Parallel()
+
+	metrics := metrictest.NewManualMeterProvider(t)
+	ctx := metricutil.WithMeterProvider(context.Background(), metrics.Provider)
+	ctx = publicrpc.WithPublicOrigin(ctx, proto.Authorization_AddRelationship_FullMethodName)
+	ctx = providergateway.WithAppScopedRelationshipMutationAuth(ctx, "roadmap", "grant_add")
+
+	provider := &stubAuthorizationProvider{}
+	server := NewProviderServer(provider)
+
+	_, err := server.AddRelationship(ctx, &proto.AddRelationshipRequest{
+		Relationship: &proto.Relationship{
+			Tuple: &proto.RelationshipTuple{
+				Resource: &proto.Resource{Type: "app", Id: "roadmap"},
+				Relation: "viewer",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("AddRelationship: %v", err)
+	}
+
+	rm := metrictest.CollectMetrics(t, metrics.Reader)
+	attrs := map[string]string{
+		"gestaltd.app_admin.ui.app":     "roadmap",
+		"gestaltd.app_admin.ui.surface": "members",
+		"gestaltd.app_admin.ui.action":  "grant_add",
+		"gestaltd.app_admin.ui.outcome": "success",
+	}
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.app_admin.ui.count", 1, attrs)
+	metrictest.RequireNoInt64Sum(t, rm, "gestaltd.app_admin.ui.error_count", attrs)
+}
+
+func TestAddRelationshipSkipsMetricsWithoutAppScopedMarker(t *testing.T) {
+	t.Parallel()
+
+	metrics := metrictest.NewManualMeterProvider(t)
+	ctx := metricutil.WithMeterProvider(context.Background(), metrics.Provider)
+	ctx = publicrpc.WithPublicOrigin(ctx, proto.Authorization_AddRelationship_FullMethodName)
+
+	provider := &stubAuthorizationProvider{}
+	server := NewProviderServer(provider)
+
+	_, err := server.AddRelationship(ctx, &proto.AddRelationshipRequest{})
+	if err != nil {
+		t.Fatalf("AddRelationship: %v", err)
+	}
+
+	rm := metrictest.CollectMetrics(t, metrics.Reader)
+	metrictest.RequireNoMetric(t, rm, "gestaltd.app_admin.ui.count")
+}
+
+func TestDeleteRelationshipRecordsAppScopedMutationFailure(t *testing.T) {
+	t.Parallel()
+
+	metrics := metrictest.NewManualMeterProvider(t)
+	ctx := metricutil.WithMeterProvider(context.Background(), metrics.Provider)
+	ctx = publicrpc.WithPublicOrigin(ctx, proto.Authorization_DeleteRelationship_FullMethodName)
+	ctx = providergateway.WithAppScopedRelationshipMutationAuth(ctx, "roadmap", "grant_remove")
+
+	provider := &stubAuthorizationProvider{
+		deleteErr: status.Error(codes.InvalidArgument, "invalid tuple"),
+	}
+	server := NewProviderServer(provider)
+
+	_, err := server.DeleteRelationship(ctx, &proto.DeleteRelationshipRequest{})
+	if err == nil {
+		t.Fatal("DeleteRelationship error = nil, want error")
+	}
+
+	rm := metrictest.CollectMetrics(t, metrics.Reader)
+	attrs := map[string]string{
+		"gestaltd.app_admin.ui.app":              "roadmap",
+		"gestaltd.app_admin.ui.surface":          "members",
+		"gestaltd.app_admin.ui.action":           "grant_remove",
+		"gestaltd.app_admin.ui.outcome":          "failure",
+		"gestaltd.app_admin.ui.failure_category": "validation",
+	}
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.app_admin.ui.count", 1, attrs)
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.app_admin.ui.error_count", 1, attrs)
+}
+
+type stubAuthorizationProvider struct {
+	core.AuthorizationProvider
+	deleteErr error
+}
+
+func (p *stubAuthorizationProvider) AddRelationship(context.Context, *proto.AddRelationshipRequest) (*proto.AddRelationshipResponse, error) {
+	return &proto.AddRelationshipResponse{}, nil
+}
+
+func (p *stubAuthorizationProvider) DeleteRelationship(context.Context, *proto.DeleteRelationshipRequest) (*proto.DeleteRelationshipResponse, error) {
+	if p.deleteErr != nil {
+		return nil, p.deleteErr
+	}
+	return &proto.DeleteRelationshipResponse{}, nil
+}
+
+func TestAppAdminUIFailureCategoryFromRPC(t *testing.T) {
+	t.Parallel()
+
+	if got := appAdminUIFailureCategoryFromRPC(status.Error(codes.PermissionDenied, "denied")); got != "auth_failure" {
+		t.Fatalf("category = %q, want auth_failure", got)
+	}
+	if got := appAdminUIFailureCategoryFromRPC(status.Error(codes.InvalidArgument, "bad")); got != "validation" {
+		t.Fatalf("category = %q, want validation", got)
+	}
+	if got := appAdminUIFailureCategoryFromRPC(status.Error(codes.Internal, "boom")); got != "server" {
+		t.Fatalf("category = %q, want server", got)
+	}
+}

--- a/gestaltd/services/authorization/server.go
+++ b/gestaltd/services/authorization/server.go
@@ -2,10 +2,18 @@ package authorization
 
 import (
 	"context"
+	"log/slog"
+	"strings"
+	"time"
 
 	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/publicrpc"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
+	"github.com/valon-technologies/gestalt/server/services/observability"
+	"github.com/valon-technologies/gestalt/server/services/providergateway"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -52,14 +60,20 @@ func (s *providerServer) AddRelationship(ctx context.Context, req *proto.AddRela
 	if err := s.requireProvider(); err != nil {
 		return nil, err
 	}
-	return s.provider.AddRelationship(s.gatewayContext(ctx), req)
+	startedAt := time.Now()
+	resp, err := s.provider.AddRelationship(s.gatewayContext(ctx), req)
+	recordAppScopedRelationshipMutation(ctx, startedAt, err)
+	return resp, err
 }
 
 func (s *providerServer) DeleteRelationship(ctx context.Context, req *proto.DeleteRelationshipRequest) (*proto.DeleteRelationshipResponse, error) {
 	if err := s.requireProvider(); err != nil {
 		return nil, err
 	}
-	return s.provider.DeleteRelationship(s.gatewayContext(ctx), req)
+	startedAt := time.Now()
+	resp, err := s.provider.DeleteRelationship(s.gatewayContext(ctx), req)
+	recordAppScopedRelationshipMutation(ctx, startedAt, err)
+	return resp, err
 }
 
 func (s *providerServer) SetAuthorizationState(ctx context.Context, req *proto.SetAuthorizationStateRequest) (*proto.SetAuthorizationStateResponse, error) {
@@ -99,4 +113,72 @@ func (s *providerServer) requireProvider() error {
 		return status.Error(codes.FailedPrecondition, "authorization provider is not configured")
 	}
 	return nil
+}
+
+func recordAppScopedRelationshipMutation(ctx context.Context, startedAt time.Time, err error) {
+	if _, ok := publicrpc.PublicOriginFromContext(ctx); !ok {
+		return
+	}
+	appID, action, ok := providergateway.AppScopedRelationshipMutationFromContext(ctx)
+	if !ok {
+		return
+	}
+	failed := err != nil
+	outcome := "success"
+	if failed {
+		outcome = "failure"
+	}
+	attrs := []attribute.KeyValue{
+		observability.AttrAppAdminUIApp.String(appID),
+		observability.AttrAppAdminUISurface.String("members"),
+		observability.AttrAppAdminUIAction.String(action),
+		observability.AttrAppAdminUIOutcome.String(outcome),
+	}
+	if failed {
+		failureCategory := appAdminUIFailureCategoryFromRPC(err)
+		attrs = append(attrs, observability.AttrAppAdminUIFailureCategory.String(failureCategory))
+	}
+	observability.RecordAppAdminUI(ctx, startedAt, failed, attrs...)
+	if failed {
+		logAppScopedRelationshipMutationFailure(ctx, appID, action, appAdminUIFailureCategoryFromRPC(err), err)
+	}
+}
+
+func appAdminUIFailureCategoryFromRPC(err error) string {
+	if err == nil {
+		return ""
+	}
+	switch status.Code(err) {
+	case codes.Unauthenticated, codes.PermissionDenied:
+		return "auth_failure"
+	case codes.InvalidArgument:
+		return "validation"
+	case codes.Internal, codes.Unavailable:
+		return "server"
+	default:
+		return "other"
+	}
+}
+
+func logAppScopedRelationshipMutationFailure(ctx context.Context, appID, action, failureCategory string, err error) {
+	attrs := []any{
+		slog.String("event", "app_admin.ui"),
+		slog.String("app", appID),
+		slog.String("surface", "members"),
+		slog.String("action", action),
+		slog.String("failure_category", failureCategory),
+	}
+	if err != nil {
+		attrs = append(attrs, slog.String("error", err.Error()))
+	}
+	if meta := invocation.MetaFromContext(ctx); meta != nil {
+		if requestID := strings.TrimSpace(meta.RequestID); requestID != "" {
+			attrs = append(attrs, slog.String("request_id", requestID))
+		}
+	}
+	spanCtx := trace.SpanContextFromContext(ctx)
+	if spanCtx.IsValid() {
+		attrs = append(attrs, slog.String("trace_id", spanCtx.TraceID().String()))
+	}
+	slog.WarnContext(ctx, "app admin ui interaction failed", attrs...)
 }

--- a/gestaltd/services/authorization/server.go
+++ b/gestaltd/services/authorization/server.go
@@ -2,7 +2,6 @@ package authorization
 
 import (
 	"context"
-	"log/slog"
 	"strings"
 	"time"
 
@@ -12,8 +11,6 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"github.com/valon-technologies/gestalt/server/services/observability"
 	"github.com/valon-technologies/gestalt/server/services/providergateway"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -124,61 +121,18 @@ func recordAppScopedRelationshipMutation(ctx context.Context, startedAt time.Tim
 		return
 	}
 	failed := err != nil
-	outcome := "success"
-	if failed {
-		outcome = "failure"
-	}
-	attrs := []attribute.KeyValue{
-		observability.AttrAppAdminUIApp.String(appID),
-		observability.AttrAppAdminUISurface.String("members"),
-		observability.AttrAppAdminUIAction.String(action),
-		observability.AttrAppAdminUIOutcome.String(outcome),
+	interaction := observability.AppAdminUIInteraction{
+		App:     appID,
+		Surface: observability.AppAdminUISurfaceMembers,
+		Action:  action,
+		Failed:  failed,
+		Err:     err,
 	}
 	if failed {
-		failureCategory := appAdminUIFailureCategoryFromRPC(err)
-		attrs = append(attrs, observability.AttrAppAdminUIFailureCategory.String(failureCategory))
-	}
-	observability.RecordAppAdminUI(ctx, startedAt, failed, attrs...)
-	if failed {
-		logAppScopedRelationshipMutationFailure(ctx, appID, action, appAdminUIFailureCategoryFromRPC(err), err)
-	}
-}
-
-func appAdminUIFailureCategoryFromRPC(err error) string {
-	if err == nil {
-		return ""
-	}
-	switch status.Code(err) {
-	case codes.Unauthenticated, codes.PermissionDenied:
-		return "auth_failure"
-	case codes.InvalidArgument:
-		return "validation"
-	case codes.Internal, codes.Unavailable:
-		return "server"
-	default:
-		return "other"
-	}
-}
-
-func logAppScopedRelationshipMutationFailure(ctx context.Context, appID, action, failureCategory string, err error) {
-	attrs := []any{
-		slog.String("event", "app_admin.ui"),
-		slog.String("app", appID),
-		slog.String("surface", "members"),
-		slog.String("action", action),
-		slog.String("failure_category", failureCategory),
-	}
-	if err != nil {
-		attrs = append(attrs, slog.String("error", err.Error()))
+		interaction.FailureCategory = observability.AppAdminUIFailureCategoryGRPC(err)
 	}
 	if meta := invocation.MetaFromContext(ctx); meta != nil {
-		if requestID := strings.TrimSpace(meta.RequestID); requestID != "" {
-			attrs = append(attrs, slog.String("request_id", requestID))
-		}
+		interaction.RequestID = strings.TrimSpace(meta.RequestID)
 	}
-	spanCtx := trace.SpanContextFromContext(ctx)
-	if spanCtx.IsValid() {
-		attrs = append(attrs, slog.String("trace_id", spanCtx.TraceID().String()))
-	}
-	slog.WarnContext(ctx, "app admin ui interaction failed", attrs...)
+	observability.RecordAppAdminUIInteraction(ctx, startedAt, interaction)
 }

--- a/gestaltd/services/observability/app_admin_ui.go
+++ b/gestaltd/services/observability/app_admin_ui.go
@@ -1,0 +1,20 @@
+package observability
+
+import (
+	"context"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+)
+
+var (
+	AttrAppAdminUIApp             = attribute.Key("gestaltd.app_admin.ui.app")
+	AttrAppAdminUISurface         = attribute.Key("gestaltd.app_admin.ui.surface")
+	AttrAppAdminUIAction          = attribute.Key("gestaltd.app_admin.ui.action")
+	AttrAppAdminUIOutcome         = attribute.Key("gestaltd.app_admin.ui.outcome")
+	AttrAppAdminUIFailureCategory = attribute.Key("gestaltd.app_admin.ui.failure_category")
+)
+
+func RecordAppAdminUI(ctx context.Context, startedAt time.Time, failed bool, attrs ...attribute.KeyValue) {
+	record(ctx, &appAdminUIMetrics, "gestaltd.app_admin.ui", "gestaltd app admin UI interactions", startedAt, failed, attrs...)
+}

--- a/gestaltd/services/observability/app_admin_ui.go
+++ b/gestaltd/services/observability/app_admin_ui.go
@@ -2,9 +2,34 @@ package observability
 
 import (
 	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	AppAdminUISurfaceMembers           = "members"
+	AppAdminUISurfaceAllowedOperations = "allowed_operations"
+
+	AppAdminUIActionList        = "list"
+	AppAdminUIActionSave        = "save"
+	AppAdminUIActionGrantAdd    = "grant_add"
+	AppAdminUIActionGrantRemove = "grant_remove"
+
+	AppAdminUIOutcomeSuccess = "success"
+	AppAdminUIOutcomeFailure = "failure"
+
+	AppAdminUIFailureAuth       = "auth_failure"
+	AppAdminUIFailureValidation = "validation"
+	AppAdminUIFailureServer     = "server"
+	AppAdminUIFailureOther      = "other"
 )
 
 var (
@@ -15,6 +40,95 @@ var (
 	AttrAppAdminUIFailureCategory = attribute.Key("gestaltd.app_admin.ui.failure_category")
 )
 
+type AppAdminUIInteraction struct {
+	App             string
+	Surface         string
+	Action          string
+	Failed          bool
+	FailureCategory string
+	StatusCode      int
+	Err             error
+	RequestID       string
+}
+
 func RecordAppAdminUI(ctx context.Context, startedAt time.Time, failed bool, attrs ...attribute.KeyValue) {
 	record(ctx, &appAdminUIMetrics, "gestaltd.app_admin.ui", "gestaltd app admin UI interactions", startedAt, failed, attrs...)
+}
+
+func RecordAppAdminUIInteraction(ctx context.Context, startedAt time.Time, interaction AppAdminUIInteraction) {
+	interaction.App = strings.TrimSpace(interaction.App)
+	interaction.Surface = strings.TrimSpace(interaction.Surface)
+	interaction.Action = strings.TrimSpace(interaction.Action)
+	if interaction.App == "" || interaction.Surface == "" || interaction.Action == "" {
+		return
+	}
+	outcome := AppAdminUIOutcomeSuccess
+	if interaction.Failed {
+		outcome = AppAdminUIOutcomeFailure
+	}
+	attrs := []attribute.KeyValue{
+		AttrAppAdminUIApp.String(interaction.App),
+		AttrAppAdminUISurface.String(interaction.Surface),
+		AttrAppAdminUIAction.String(interaction.Action),
+		AttrAppAdminUIOutcome.String(outcome),
+	}
+	if interaction.Failed && interaction.FailureCategory != "" {
+		attrs = append(attrs, AttrAppAdminUIFailureCategory.String(interaction.FailureCategory))
+	}
+	RecordAppAdminUI(ctx, startedAt, interaction.Failed, attrs...)
+	if interaction.Failed {
+		LogAppAdminUIFailure(ctx, interaction)
+	}
+}
+
+func LogAppAdminUIFailure(ctx context.Context, interaction AppAdminUIInteraction) {
+	attrs := []any{
+		slog.String("event", "app_admin.ui"),
+		slog.String("app", interaction.App),
+		slog.String("surface", interaction.Surface),
+		slog.String("action", interaction.Action),
+		slog.String("failure_category", interaction.FailureCategory),
+	}
+	if interaction.Err != nil {
+		attrs = append(attrs, slog.String("error", interaction.Err.Error()))
+	} else if interaction.StatusCode > 0 {
+		attrs = append(attrs, slog.String("error", fmt.Sprintf("HTTP %d", interaction.StatusCode)))
+	}
+	if requestID := strings.TrimSpace(interaction.RequestID); requestID != "" {
+		attrs = append(attrs, slog.String("request_id", requestID))
+	}
+	spanCtx := trace.SpanContextFromContext(ctx)
+	if spanCtx.IsValid() {
+		attrs = append(attrs, slog.String("trace_id", spanCtx.TraceID().String()))
+	}
+	slog.WarnContext(ctx, "app admin ui interaction failed", attrs...)
+}
+
+func AppAdminUIFailureCategoryHTTP(status int) string {
+	switch {
+	case status == http.StatusUnauthorized || status == http.StatusForbidden:
+		return AppAdminUIFailureAuth
+	case status == http.StatusBadRequest:
+		return AppAdminUIFailureValidation
+	case status >= http.StatusInternalServerError:
+		return AppAdminUIFailureServer
+	default:
+		return AppAdminUIFailureOther
+	}
+}
+
+func AppAdminUIFailureCategoryGRPC(err error) string {
+	if err == nil {
+		return ""
+	}
+	switch status.Code(err) {
+	case codes.Unauthenticated, codes.PermissionDenied:
+		return AppAdminUIFailureAuth
+	case codes.InvalidArgument:
+		return AppAdminUIFailureValidation
+	case codes.Internal, codes.Unavailable:
+		return AppAdminUIFailureServer
+	default:
+		return AppAdminUIFailureOther
+	}
 }

--- a/gestaltd/services/observability/app_admin_ui_test.go
+++ b/gestaltd/services/observability/app_admin_ui_test.go
@@ -1,0 +1,55 @@
+package observability
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/internal/testutil/metrictest"
+	"github.com/valon-technologies/gestalt/server/services/observability/metricutil"
+)
+
+func TestRecordAppAdminUI(t *testing.T) {
+	t.Parallel()
+
+	metrics := metrictest.NewManualMeterProvider(t)
+	ctx := metricutil.WithMeterProvider(context.Background(), metrics.Provider)
+	startedAt := time.Now()
+
+	RecordAppAdminUI(ctx, startedAt, false,
+		AttrAppAdminUIApp.String("g-issues"),
+		AttrAppAdminUISurface.String("members"),
+		AttrAppAdminUIAction.String("list"),
+		AttrAppAdminUIOutcome.String("success"),
+	)
+
+	rm := metrictest.CollectMetrics(t, metrics.Reader)
+	attrs := map[string]string{
+		"gestaltd.app_admin.ui.app":     "g-issues",
+		"gestaltd.app_admin.ui.surface": "members",
+		"gestaltd.app_admin.ui.action":  "list",
+		"gestaltd.app_admin.ui.outcome": "success",
+	}
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.app_admin.ui.count", 1, attrs)
+	metrictest.RequireNoInt64Sum(t, rm, "gestaltd.app_admin.ui.error_count", attrs)
+	metrictest.RequireFloat64Histogram(t, rm, "gestaltd.app_admin.ui.duration", attrs)
+
+	RecordAppAdminUI(ctx, startedAt, true,
+		AttrAppAdminUIApp.String("g-issues"),
+		AttrAppAdminUISurface.String("members"),
+		AttrAppAdminUIAction.String("grant_add"),
+		AttrAppAdminUIOutcome.String("failure"),
+		AttrAppAdminUIFailureCategory.String("auth_failure"),
+	)
+
+	rm = metrictest.CollectMetrics(t, metrics.Reader)
+	failAttrs := map[string]string{
+		"gestaltd.app_admin.ui.app":              "g-issues",
+		"gestaltd.app_admin.ui.surface":          "members",
+		"gestaltd.app_admin.ui.action":           "grant_add",
+		"gestaltd.app_admin.ui.outcome":          "failure",
+		"gestaltd.app_admin.ui.failure_category": "auth_failure",
+	}
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.app_admin.ui.count", 1, failAttrs)
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.app_admin.ui.error_count", 1, failAttrs)
+}

--- a/gestaltd/services/observability/observability.go
+++ b/gestaltd/services/observability/observability.go
@@ -69,6 +69,7 @@ var (
 	catalogOperationResolveMetrics      metricutil.MeterCache[metricSet]
 	credentialProviderOperationMetrics  metricutil.MeterCache[metricSet]
 	invokeAuthorizationMetrics          metricutil.MeterCache[metricSet]
+	appAdminUIMetrics                   metricutil.MeterCache[metricSet]
 )
 
 var genAIClientOperationDurationBuckets = []float64{0.01, 0.02, 0.04, 0.08, 0.16, 0.32, 0.64, 1.28, 2.56, 5.12, 10.24, 20.48, 40.96, 81.92}

--- a/gestaltd/services/providergateway/authorization_access.go
+++ b/gestaltd/services/providergateway/authorization_access.go
@@ -2,9 +2,15 @@ package providergateway
 
 import (
 	"context"
+	"log/slog"
+	"strings"
+	"time"
 
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
+	"github.com/valon-technologies/gestalt/server/services/observability"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	gproto "google.golang.org/protobuf/proto"
@@ -40,10 +46,10 @@ func (t *ProviderGatewayTransport) enforceAuthorizationPublicAccess(
 	ctx context.Context,
 	subjectID, fullMethod string,
 	req gproto.Message,
-) error {
+) (context.Context, error) {
 	read, write, ok := authorizationMethodAccessClass(fullMethod)
 	if !ok {
-		return status.Error(codes.Internal, "provider gateway: unsupported authorization method")
+		return ctx, status.Error(codes.Internal, "provider gateway: unsupported authorization method")
 	}
 
 	resource := &proto.Resource{Type: authorizationResourceType, Id: authorizationResourceID}
@@ -52,24 +58,29 @@ func (t *ProviderGatewayTransport) enforceAuthorizationPublicAccess(
 		checkReq := invocation.SubjectAccessRequest(subjectID, action, resource)
 		allowed, err := invocation.CheckSubjectAccess(ctx, t.authorization, checkReq)
 		if err != nil {
-			return status.Error(codes.Unavailable, "authorization provider unavailable")
+			return ctx, status.Error(codes.Unavailable, "authorization provider unavailable")
 		}
 		if allowed {
-			return nil
+			return ctx, nil
 		}
 	}
 	if write {
 		if tuple, ok := relationshipTupleFromAuthorizationRequest(fullMethod, req); ok {
 			allowed, err := allowsAppScopedRelationshipMutation(ctx, t.authorization, subjectID, tuple)
 			if err != nil {
-				return status.Error(codes.Unavailable, "authorization provider unavailable")
+				return ctx, status.Error(codes.Unavailable, "authorization provider unavailable")
 			}
 			if allowed {
-				return nil
+				appID := strings.TrimSpace(tuple.GetResource().GetId())
+				action := appScopedRelationshipActionFromMethod(fullMethod)
+				return WithAppScopedRelationshipMutationAuth(ctx, appID, action), nil
+			}
+			if deniedErr := recordAppScopedRelationshipAuthFailure(ctx, tuple, fullMethod, status.Error(codes.PermissionDenied, "access denied")); deniedErr != nil {
+				return ctx, deniedErr
 			}
 		}
 	}
-	return status.Error(codes.PermissionDenied, "access denied")
+	return ctx, status.Error(codes.PermissionDenied, "access denied")
 }
 
 func authorizationPublicActions(read, write bool) []string {
@@ -86,4 +97,57 @@ func authorizationPublicActions(read, write bool) []string {
 func isAuthorizationServiceMethod(fullMethod string) bool {
 	service, _ := splitFullMethod(fullMethod)
 	return service == proto.Authorization_ServiceDesc.ServiceName
+}
+
+const (
+	appAdminUISurfaceMembers = "members"
+
+	appAdminUIOutcomeFailure = "failure"
+
+	appAdminUIFailureAuth = "auth_failure"
+)
+
+func recordAppScopedRelationshipAuthFailure(ctx context.Context, tuple *proto.RelationshipTuple, fullMethod string, err error) error {
+	if tuple == nil || strings.TrimSpace(tuple.GetResource().GetType()) != appAuthorizationResourceType {
+		return err
+	}
+	appID := strings.TrimSpace(tuple.GetResource().GetId())
+	action := appScopedRelationshipActionFromMethod(fullMethod)
+	if appID == "" || action == "" {
+		return err
+	}
+	startedAt := time.Now()
+	attrs := []attribute.KeyValue{
+		observability.AttrAppAdminUIApp.String(appID),
+		observability.AttrAppAdminUISurface.String(appAdminUISurfaceMembers),
+		observability.AttrAppAdminUIAction.String(action),
+		observability.AttrAppAdminUIOutcome.String(appAdminUIOutcomeFailure),
+		observability.AttrAppAdminUIFailureCategory.String(appAdminUIFailureAuth),
+	}
+	observability.RecordAppAdminUI(ctx, startedAt, true, attrs...)
+	logAppScopedRelationshipFailure(ctx, appID, action, appAdminUIFailureAuth, err)
+	return err
+}
+
+func logAppScopedRelationshipFailure(ctx context.Context, appID, action, failureCategory string, err error) {
+	attrs := []any{
+		slog.String("event", "app_admin.ui"),
+		slog.String("app", appID),
+		slog.String("surface", appAdminUISurfaceMembers),
+		slog.String("action", action),
+		slog.String("failure_category", failureCategory),
+	}
+	if err != nil {
+		attrs = append(attrs, slog.String("error", err.Error()))
+	}
+	if meta := invocation.MetaFromContext(ctx); meta != nil {
+		if requestID := strings.TrimSpace(meta.RequestID); requestID != "" {
+			attrs = append(attrs, slog.String("request_id", requestID))
+		}
+	}
+	spanCtx := trace.SpanContextFromContext(ctx)
+	if spanCtx.IsValid() {
+		attrs = append(attrs, slog.String("trace_id", spanCtx.TraceID().String()))
+	}
+	slog.WarnContext(ctx, "app admin ui interaction failed", attrs...)
 }

--- a/gestaltd/services/providergateway/authorization_access.go
+++ b/gestaltd/services/providergateway/authorization_access.go
@@ -2,15 +2,12 @@ package providergateway
 
 import (
 	"context"
-	"log/slog"
 	"strings"
 	"time"
 
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"github.com/valon-technologies/gestalt/server/services/observability"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	gproto "google.golang.org/protobuf/proto"
@@ -75,9 +72,9 @@ func (t *ProviderGatewayTransport) enforceAuthorizationPublicAccess(
 				action := appScopedRelationshipActionFromMethod(fullMethod)
 				return WithAppScopedRelationshipMutationAuth(ctx, appID, action), nil
 			}
-			if deniedErr := recordAppScopedRelationshipAuthFailure(ctx, tuple, fullMethod, status.Error(codes.PermissionDenied, "access denied")); deniedErr != nil {
-				return ctx, deniedErr
-			}
+			deniedErr := status.Error(codes.PermissionDenied, "access denied")
+			recordAppScopedRelationshipAuthFailure(ctx, tuple, fullMethod, deniedErr)
+			return ctx, deniedErr
 		}
 	}
 	return ctx, status.Error(codes.PermissionDenied, "access denied")
@@ -99,55 +96,21 @@ func isAuthorizationServiceMethod(fullMethod string) bool {
 	return service == proto.Authorization_ServiceDesc.ServiceName
 }
 
-const (
-	appAdminUISurfaceMembers = "members"
-
-	appAdminUIOutcomeFailure = "failure"
-
-	appAdminUIFailureAuth = "auth_failure"
-)
-
-func recordAppScopedRelationshipAuthFailure(ctx context.Context, tuple *proto.RelationshipTuple, fullMethod string, err error) error {
+func recordAppScopedRelationshipAuthFailure(ctx context.Context, tuple *proto.RelationshipTuple, fullMethod string, err error) {
 	if tuple == nil || strings.TrimSpace(tuple.GetResource().GetType()) != appAuthorizationResourceType {
-		return err
+		return
 	}
 	appID := strings.TrimSpace(tuple.GetResource().GetId())
 	action := appScopedRelationshipActionFromMethod(fullMethod)
 	if appID == "" || action == "" {
-		return err
+		return
 	}
-	startedAt := time.Now()
-	attrs := []attribute.KeyValue{
-		observability.AttrAppAdminUIApp.String(appID),
-		observability.AttrAppAdminUISurface.String(appAdminUISurfaceMembers),
-		observability.AttrAppAdminUIAction.String(action),
-		observability.AttrAppAdminUIOutcome.String(appAdminUIOutcomeFailure),
-		observability.AttrAppAdminUIFailureCategory.String(appAdminUIFailureAuth),
-	}
-	observability.RecordAppAdminUI(ctx, startedAt, true, attrs...)
-	logAppScopedRelationshipFailure(ctx, appID, action, appAdminUIFailureAuth, err)
-	return err
-}
-
-func logAppScopedRelationshipFailure(ctx context.Context, appID, action, failureCategory string, err error) {
-	attrs := []any{
-		slog.String("event", "app_admin.ui"),
-		slog.String("app", appID),
-		slog.String("surface", appAdminUISurfaceMembers),
-		slog.String("action", action),
-		slog.String("failure_category", failureCategory),
-	}
-	if err != nil {
-		attrs = append(attrs, slog.String("error", err.Error()))
-	}
-	if meta := invocation.MetaFromContext(ctx); meta != nil {
-		if requestID := strings.TrimSpace(meta.RequestID); requestID != "" {
-			attrs = append(attrs, slog.String("request_id", requestID))
-		}
-	}
-	spanCtx := trace.SpanContextFromContext(ctx)
-	if spanCtx.IsValid() {
-		attrs = append(attrs, slog.String("trace_id", spanCtx.TraceID().String()))
-	}
-	slog.WarnContext(ctx, "app admin ui interaction failed", attrs...)
+	observability.RecordAppAdminUIInteraction(ctx, time.Now(), observability.AppAdminUIInteraction{
+		App:             appID,
+		Surface:         observability.AppAdminUISurfaceMembers,
+		Action:          action,
+		Failed:          true,
+		FailureCategory: observability.AppAdminUIFailureAuth,
+		Err:             err,
+	})
 }

--- a/gestaltd/services/providergateway/authorization_app_admin_ui_test.go
+++ b/gestaltd/services/providergateway/authorization_app_admin_ui_test.go
@@ -1,0 +1,73 @@
+package providergateway
+
+import (
+	"context"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/internal/publicrpc"
+	"github.com/valon-technologies/gestalt/server/internal/testutil/metrictest"
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"github.com/valon-technologies/gestalt/server/services/observability/metricutil"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestEnforceAuthorizationPublicAccessRecordsAppScopedAuthFailure(t *testing.T) {
+	t.Parallel()
+
+	metrics := metrictest.NewManualMeterProvider(t)
+	ctx := metricutil.WithMeterProvider(context.Background(), metrics.Provider)
+	ctx = publicrpc.WithPublicOrigin(ctx, proto.Authorization_AddRelationship_FullMethodName)
+
+	provider := &appScopedAuthorizationProvider{
+		stubAuthorizationProvider: &stubAuthorizationProvider{
+			allowedActions: map[string]bool{},
+		},
+		appAdmin: map[string]bool{},
+	}
+	transport := &ProviderGatewayTransport{authorization: provider}
+
+	req := &proto.AddRelationshipRequest{
+		Relationship: &proto.Relationship{
+			Tuple: &proto.RelationshipTuple{
+				Resource: &proto.Resource{Type: "app", Id: "roadmap"},
+				Relation: "viewer",
+				Target: &proto.RelationshipTarget{
+					Kind: &proto.RelationshipTarget_Subject{
+						Subject: &proto.Subject{Type: "subject", Id: "user:viewer@example.com"},
+					},
+				},
+			},
+		},
+	}
+	_, err := transport.enforceAuthorizationPublicAccess(
+		ctx,
+		"user:outsider@example.com",
+		proto.Authorization_AddRelationship_FullMethodName,
+		req,
+	)
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("error = %v, want permission denied", err)
+	}
+
+	rm := metrictest.CollectMetrics(t, metrics.Reader)
+	attrs := map[string]string{
+		"gestaltd.app_admin.ui.app":              "roadmap",
+		"gestaltd.app_admin.ui.surface":          "members",
+		"gestaltd.app_admin.ui.action":           "grant_add",
+		"gestaltd.app_admin.ui.outcome":          "failure",
+		"gestaltd.app_admin.ui.failure_category": "auth_failure",
+	}
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.app_admin.ui.count", 1, attrs)
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.app_admin.ui.error_count", 1, attrs)
+}
+
+func TestWithAppScopedRelationshipMutationAuth(t *testing.T) {
+	t.Parallel()
+
+	ctx := WithAppScopedRelationshipMutationAuth(context.Background(), "roadmap", "grant_remove")
+	appID, action, ok := AppScopedRelationshipMutationFromContext(ctx)
+	if !ok || appID != "roadmap" || action != "grant_remove" {
+		t.Fatalf("context marker = (%q, %q, %v), want (roadmap, grant_remove, true)", appID, action, ok)
+	}
+}

--- a/gestaltd/services/providergateway/authorization_app_scope.go
+++ b/gestaltd/services/providergateway/authorization_app_scope.go
@@ -15,6 +15,50 @@ const (
 	appAdminRelation             = "admin"
 )
 
+type appScopedRelationshipMutationContext struct {
+	appID  string
+	action string
+}
+
+type appScopedRelationshipMutationKey struct{}
+
+func WithAppScopedRelationshipMutationAuth(ctx context.Context, appID, action string) context.Context {
+	appID = strings.TrimSpace(appID)
+	action = strings.TrimSpace(action)
+	if appID == "" || action == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, appScopedRelationshipMutationKey{}, appScopedRelationshipMutationContext{
+		appID:  appID,
+		action: action,
+	})
+}
+
+func AppScopedRelationshipMutationFromContext(ctx context.Context) (appID, action string, ok bool) {
+	value, ok := ctx.Value(appScopedRelationshipMutationKey{}).(appScopedRelationshipMutationContext)
+	if !ok {
+		return "", "", false
+	}
+	appID = strings.TrimSpace(value.appID)
+	action = strings.TrimSpace(value.action)
+	if appID == "" || action == "" {
+		return "", "", false
+	}
+	return appID, action, true
+}
+
+func appScopedRelationshipActionFromMethod(fullMethod string) string {
+	_, method := splitFullMethod(fullMethod)
+	switch method {
+	case "AddRelationship":
+		return "grant_add"
+	case "DeleteRelationship":
+		return "grant_remove"
+	default:
+		return ""
+	}
+}
+
 func relationshipTupleFromAuthorizationRequest(fullMethod string, req gproto.Message) (*proto.RelationshipTuple, bool) {
 	if req == nil {
 		return nil, false

--- a/gestaltd/services/providergateway/authorization_app_scope_test.go
+++ b/gestaltd/services/providergateway/authorization_app_scope_test.go
@@ -147,7 +147,7 @@ func TestEnforceAuthorizationPublicAccessAllowsAppAdminRelationshipWrite(t *test
 			},
 		},
 	}
-	err := transport.enforceAuthorizationPublicAccess(
+	_, err := transport.enforceAuthorizationPublicAccess(
 		context.Background(),
 		"user:admin@example.com",
 		proto.Authorization_AddRelationship_FullMethodName,
@@ -166,7 +166,7 @@ func TestEnforceAuthorizationPublicAccessDeniesAppAdminModelWrite(t *testing.T) 
 	}
 	transport := &ProviderGatewayTransport{authorization: provider}
 
-	err := transport.enforceAuthorizationPublicAccess(
+	_, err := transport.enforceAuthorizationPublicAccess(
 		context.Background(),
 		"user:admin@example.com",
 		proto.Authorization_SetActiveModel_FullMethodName,

--- a/gestaltd/services/providergateway/gateway_test.go
+++ b/gestaltd/services/providergateway/gateway_test.go
@@ -430,7 +430,7 @@ func TestPreparePublicRequest(t *testing.T) {
 			}
 			ctx = metadata.NewIncomingContext(ctx, metadata.Pairs(metadataPairs...))
 
-			p, adapted, err := transport.PreparePublicRequest(ctx, tc.fullMethod, tc.req)
+			ctx, p, adapted, err := transport.PreparePublicRequest(ctx, tc.fullMethod, tc.req)
 			if tc.wantCode != codes.OK {
 				assertGRPCCode(t, err, tc.wantCode)
 				return
@@ -804,7 +804,7 @@ func TestPublicRequestOptionalProviderMatrix(t *testing.T) {
 			}
 			ctx = metadata.NewIncomingContext(ctx, metadata.Pairs(pairs...))
 
-			_, _, err := transport.PreparePublicRequest(ctx, tc.fullMethod, tc.req)
+			_, _, _, err := transport.PreparePublicRequest(ctx, tc.fullMethod, tc.req)
 			if tc.wantCode == codes.OK {
 				if err != nil {
 					t.Fatalf("PreparePublicRequest: %v", err)
@@ -862,7 +862,7 @@ func TestPublicRequestLoginMethodsWithoutAuth(t *testing.T) {
 			} {
 				ctx := publicrpc.WithPublicOrigin(context.Background(), fullMethod)
 				ctx = metadata.NewIncomingContext(ctx, metadata.Pairs())
-				if _, _, err := transport.PreparePublicRequest(ctx, fullMethod, &proto.AuthorizeRequest{
+				if _, _, _, err := transport.PreparePublicRequest(ctx, fullMethod, &proto.AuthorizeRequest{
 					ResponseType: "code",
 					ClientId:     "gestalt-cli",
 					RedirectUri:  "http://localhost:8080/callback",

--- a/gestaltd/services/providergateway/gateway_test.go
+++ b/gestaltd/services/providergateway/gateway_test.go
@@ -430,7 +430,7 @@ func TestPreparePublicRequest(t *testing.T) {
 			}
 			ctx = metadata.NewIncomingContext(ctx, metadata.Pairs(metadataPairs...))
 
-			ctx, p, adapted, err := transport.PreparePublicRequest(ctx, tc.fullMethod, tc.req)
+			_, p, adapted, err := transport.PreparePublicRequest(ctx, tc.fullMethod, tc.req)
 			if tc.wantCode != codes.OK {
 				assertGRPCCode(t, err, tc.wantCode)
 				return

--- a/gestaltd/services/providergateway/public_request.go
+++ b/gestaltd/services/providergateway/public_request.go
@@ -22,53 +22,53 @@ func (t *ProviderGatewayTransport) PreparePublicRequest(
 	ctx context.Context,
 	fullMethod string,
 	req gproto.Message,
-) (*principal.Principal, gproto.Message, error) {
+) (context.Context, *principal.Principal, gproto.Message, error) {
 	if t == nil {
-		return nil, nil, status.Error(codes.Internal, "provider gateway: transport is nil")
+		return ctx, nil, nil, status.Error(codes.Internal, "provider gateway: transport is nil")
 	}
 	if req == nil {
-		return nil, nil, status.Error(codes.InvalidArgument, "request is required")
+		return ctx, nil, nil, status.Error(codes.InvalidArgument, "request is required")
 	}
 	fullMethod = strings.TrimSpace(fullMethod)
 	if fullMethod == "" {
-		return nil, nil, status.Error(codes.Internal, "provider gateway: full method is required")
+		return ctx, nil, nil, status.Error(codes.Internal, "provider gateway: full method is required")
 	}
 	origin, ok := publicrpc.PublicOriginFromContext(ctx)
 	if !ok {
-		return nil, nil, status.Error(codes.Internal, "provider gateway: public origin marker is required")
+		return ctx, nil, nil, status.Error(codes.Internal, "provider gateway: public origin marker is required")
 	}
 	if origin.FullMethod != fullMethod {
-		return nil, nil, status.Errorf(codes.Internal, "provider gateway: public origin method %q does not match %q", origin.FullMethod, fullMethod)
+		return ctx, nil, nil, status.Errorf(codes.Internal, "provider gateway: public origin method %q does not match %q", origin.FullMethod, fullMethod)
 	}
 	if t.publicMethods == nil {
-		return nil, nil, status.Error(codes.NotFound, "method is not public")
+		return ctx, nil, nil, status.Error(codes.NotFound, "method is not public")
 	}
 	policy, ok := t.publicMethods.Lookup(fullMethod)
 	if !ok {
-		return nil, nil, status.Error(codes.NotFound, "method is not public")
+		return ctx, nil, nil, status.Error(codes.NotFound, "method is not public")
 	}
 
 	if publicIdentityLoginMethod(fullMethod) {
 		adapted, err := adaptPublicRequest(ctx, t.publicBaseURL, nil, nil, req, policy, fullMethod)
 		if err != nil {
-			return nil, nil, err
+			return ctx, nil, nil, err
 		}
-		return nil, adapted, nil
+		return ctx, nil, adapted, nil
 	}
 
 	var p *principal.Principal
 	if t.identity != nil {
 		token := bearerTokenFromContext(ctx)
 		if token == "" {
-			return nil, nil, status.Error(codes.Unauthenticated, "bearer token is required")
+			return ctx, nil, nil, status.Error(codes.Unauthenticated, "bearer token is required")
 		}
 		resolved, err := t.resolvePublicPrincipal(ctx, token)
 		if err != nil {
-			return nil, nil, err
+			return ctx, nil, nil, err
 		}
 		p = resolved
 		if err := t.canonicalizePublicCredentialPrincipal(ctx, fullMethod, p); err != nil {
-			return nil, nil, err
+			return ctx, nil, nil, err
 		}
 	} else {
 		// No IdentityProvider: the caller is anonymous. Use a stable anonymous
@@ -77,16 +77,17 @@ func (t *ProviderGatewayTransport) PreparePublicRequest(
 	}
 	resourceID, err := t.publicResourceID(req, fullMethod)
 	if err != nil {
-		return nil, nil, err
+		return ctx, nil, nil, err
 	}
-	if err := t.enforcePublicAuthorization(ctx, p, resourceID, fullMethod, req); err != nil {
-		return nil, nil, err
+	ctx, err = t.enforcePublicAuthorization(ctx, p, resourceID, fullMethod, req)
+	if err != nil {
+		return ctx, nil, nil, err
 	}
 	adapted, err := adaptPublicRequest(ctx, t.publicBaseURL, t.users, p, req, policy, fullMethod)
 	if err != nil {
-		return nil, nil, err
+		return ctx, nil, nil, err
 	}
-	return p, adapted, nil
+	return ctx, p, adapted, nil
 }
 
 func (t *ProviderGatewayTransport) resolvePublicPrincipal(ctx context.Context, token string) (*principal.Principal, error) {
@@ -105,17 +106,17 @@ func (t *ProviderGatewayTransport) enforcePublicAuthorization(
 	p *principal.Principal,
 	providerID, fullMethod string,
 	req gproto.Message,
-) error {
+) (context.Context, error) {
 	service, _ := splitFullMethod(fullMethod)
 	if service == proto.App_ServiceDesc.ServiceName || service == proto.Identity_ServiceDesc.ServiceName || service == proto.RemoteManagement_ServiceDesc.ServiceName {
-		return nil
+		return ctx, nil
 	}
 	if t == nil || t.authorization == nil {
-		return nil
+		return ctx, nil
 	}
 	subjectID, err := principal.ResolveCredentialSubjectID(ctx, t.users, p)
 	if err != nil {
-		return status.Error(codes.Unauthenticated, "authenticated subject is required")
+		return ctx, status.Error(codes.Unauthenticated, "authenticated subject is required")
 	}
 	if isAuthorizationServiceMethod(fullMethod) {
 		return t.enforceAuthorizationPublicAccess(ctx, subjectID, fullMethod, req)
@@ -126,12 +127,12 @@ func (t *ProviderGatewayTransport) enforcePublicAuthorization(
 	checkReq := invocation.SubjectAccessRequest(subjectID, action.GetName(), resource)
 	allowed, err := invocation.CheckSubjectAccess(ctx, t.authorization, checkReq)
 	if err != nil {
-		return status.Error(codes.Unavailable, "authorization provider unavailable")
+		return ctx, status.Error(codes.Unavailable, "authorization provider unavailable")
 	}
 	if !allowed {
-		return status.Error(codes.PermissionDenied, "access denied")
+		return ctx, status.Error(codes.PermissionDenied, "access denied")
 	}
-	return nil
+	return ctx, nil
 }
 
 func bearerTokenFromContext(ctx context.Context) string {


### PR DESCRIPTION
## Summary
- Emit `gestaltd.app_admin.ui.*` metrics on Members and Allowed Operations interactions: HTTP list/save routes plus app-scoped relationship grant_add/grant_remove mutations authorized through app admin delegation.
- Dimensions include `app`, `surface`, `action`, `outcome`, and `failure_category` (`auth_failure` for 401/403 when the caller lacks `app:{app} admin`).
- Failures emit searchable `@event:app_admin.ui` structured logs with correlation fields.

## Test plan
- [x] `go test ./internal/server/... ./services/observability/... ./services/authorization/... ./services/providergateway/...`
- [ ] Merge gestalt, then merge toolshed dashboard PR and push dashboard to Datadog
- [ ] Spot-check metrics on `/apps/{app}/admin/members` and `/apps/{app}/admin/allowed-operations` in production after gestaltd deploy

## Stack
- toolshed: https://github.com/valon-technologies/toolshed/pull/4830 (plan + Datadog dashboard)