### PR TITLE
Allow SCIM clients without active user projections

### DIFF
--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -213,9 +213,6 @@ func validateSCIMConfig(cfg *Config) error {
 		if len(client.Credentials) == 0 || len(client.Credentials) > 2 {
 			return fmt.Errorf("config validation: %s.credentials must contain one or two credentials", path)
 		}
-		if len(client.ActiveUserRelationships) == 0 {
-			return fmt.Errorf("config validation: %s.activeUserRelationships must contain at least one relationship", path)
-		}
 		for i, credential := range client.Credentials {
 			credentialPath := fmt.Sprintf("%s.credentials[%d]", path, i)
 			id := strings.TrimSpace(credential.ID)

--- a/gestaltd/internal/config/scim_load_test.go
+++ b/gestaltd/internal/config/scim_load_test.go
@@ -127,6 +127,15 @@ authorization:
 	if got := cfg.Server.SCIM.Clients["rippling"].AuthoritativeUserDomains[0]; got != "valon.com" {
 		t.Fatalf("normalized domain = %q", got)
 	}
+	withoutProjection := strings.Replace(validAuthorization, `        activeUserRelationships:
+          - relation: member
+            resource:
+              type: group
+              id: valon-employees
+`, "", 1)
+	if _, err := config.Load(writeSCIMConfig(t, "apiVersion: gestaltd.config/v8\n"+withoutProjection)); err != nil {
+		t.Fatalf("configuration without active-user projection should be valid: %v", err)
+	}
 	withoutAuthorization := strings.Replace(validAuthorization, `  authorization:
     authz:
       source:


### PR DESCRIPTION
## Summary

- Make `server.scim.clients.<id>.activeUserRelationships` optional instead of requiring at least one synthetic active-user projection.
- Preserve every substantive SCIM invariant: configured credentials, the SCIM `group.member` model, dynamic group membership writes, unique authoritative domains, and a selected AuthorizationProvider.
- Add a config-boundary contract proving an authoritative SCIM client can load with zero active-user projections.

## Interface conformance

SCIM defines user lifecycle through the User resource and group membership through the Group resource's `members` attribute; it does not require provisioning servers to synthesize every active user into an application-defined authorization roster. Allowing an empty projection list lets deployments consume the SCIM Group directly while retaining Gestalt's optional extension for deployments that still want projections.

- [RFC 7643 §4.1.2 — User Resource](https://www.rfc-editor.org/rfc/rfc7643#section-4.1.2)
- [RFC 7643 §4.2 — Group Resource and `members`](https://www.rfc-editor.org/rfc/rfc7643#section-4.2)
- [RFC 7644 §3.3 — Creating Resources](https://www.rfc-editor.org/rfc/rfc7644#section-3.3)

There are no HTTP, protobuf, SDK, or provider interface changes. This only removes a non-SCIM configuration restriction from Gestalt's optional `activeUserRelationships` extension.

## Root cause

The SCIM runtime already treats active-user projections as optional: user and group operations iterate an empty projection list safely, and group memberships remain stored through AuthorizationProvider. Configuration validation contradicted that runtime contract by rejecting every SCIM client whose projection list was empty. That forced deployments to maintain a duplicate roster even when a SCIM Group was the intended authorization subject set.

## Test plan

- [x] `go test ./internal/config ./internal/scim`
- [x] Verify the new contract test loads an authoritative SCIM client without `activeUserRelationships`.