### PR TITLE
Emit principal and target-subject dims on app-admin UI metrics

### DIFF
--- a/gestaltd/internal/server/app_admin_ui_observability.go
+++ b/gestaltd/internal/server/app_admin_ui_observability.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
+	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 	"github.com/valon-technologies/gestalt/server/services/observability"
 )
 
@@ -50,6 +51,9 @@ func (s *Server) appAdminUIObservabilityMiddleware(next http.Handler) http.Handl
 		if failed {
 			interaction.FailureCategory = observability.AppAdminUIFailureCategoryHTTP(recorder.status)
 		}
+		principalKind, principalID := principal.MetricAuthorizationSubject(PrincipalFromContext(r.Context()))
+		interaction.PrincipalSubjectKind = principalKind
+		interaction.PrincipalSubjectID = principalID
 		observability.RecordAppAdminUIInteraction(r.Context(), startedAt, interaction)
 	})
 }

--- a/gestaltd/internal/server/app_admin_ui_observability.go
+++ b/gestaltd/internal/server/app_admin_ui_observability.go
@@ -6,8 +6,8 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
+	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"github.com/valon-technologies/gestalt/server/services/observability"
 )
 
@@ -40,20 +40,20 @@ func (s *Server) appAdminUIObservabilityMiddleware(next http.Handler) http.Handl
 		recorder := &appAdminUIResponseRecorder{ResponseWriter: w, status: http.StatusOK}
 		next.ServeHTTP(recorder, r)
 		failed := recorder.status >= http.StatusBadRequest
+		principalKind, principalID := principal.MetricAuthorizationSubject(PrincipalFromContext(r.Context()))
 		interaction := observability.AppAdminUIInteraction{
-			App:        appName,
-			Surface:    surface,
-			Action:     action,
-			Failed:     failed,
-			StatusCode: recorder.status,
-			RequestID:  appAdminUIRequestID(r),
+			App:                  appName,
+			Surface:              surface,
+			Action:               action,
+			Failed:               failed,
+			StatusCode:           recorder.status,
+			RequestID:            appAdminUIRequestID(r),
+			PrincipalSubjectKind: principalKind,
+			PrincipalSubjectID:   principalID,
 		}
 		if failed {
 			interaction.FailureCategory = observability.AppAdminUIFailureCategoryHTTP(recorder.status)
 		}
-		principalKind, principalID := principal.MetricAuthorizationSubject(PrincipalFromContext(r.Context()))
-		interaction.PrincipalSubjectKind = principalKind
-		interaction.PrincipalSubjectID = principalID
 		observability.RecordAppAdminUIInteraction(r.Context(), startedAt, interaction)
 	})
 }

--- a/gestaltd/internal/server/app_admin_ui_observability_test.go
+++ b/gestaltd/internal/server/app_admin_ui_observability_test.go
@@ -41,6 +41,8 @@ func TestAppAdminUIObservabilityMiddlewareRecordsSuccess(t *testing.T) {
 		"gestaltd.app_admin.ui.surface": "members",
 		"gestaltd.app_admin.ui.action":  "list",
 		"gestaltd.app_admin.ui.outcome": "success",
+		"gestaltd.subject.kind":         "unknown",
+		"gestaltd.subject.id":           "unknown",
 	}
 	metrictest.RequireInt64Sum(t, rm, "gestaltd.app_admin.ui.count", 1, attrs)
 	metrictest.RequireNoInt64Sum(t, rm, "gestaltd.app_admin.ui.error_count", attrs)
@@ -73,6 +75,8 @@ func TestAppAdminUIObservabilityMiddlewareRecordsValidationFailure(t *testing.T)
 		"gestaltd.app_admin.ui.action":           "save",
 		"gestaltd.app_admin.ui.outcome":          "failure",
 		"gestaltd.app_admin.ui.failure_category": "validation",
+		"gestaltd.subject.kind":                  "unknown",
+		"gestaltd.subject.id":                    "unknown",
 	}
 	metrictest.RequireInt64Sum(t, rm, "gestaltd.app_admin.ui.count", 1, attrs)
 	metrictest.RequireInt64Sum(t, rm, "gestaltd.app_admin.ui.error_count", 1, attrs)
@@ -110,6 +114,8 @@ func TestAppAdminUIObservabilityMiddlewareRecordsAuthorizationUnavailable(t *tes
 		"gestaltd.app_admin.ui.action":           "list",
 		"gestaltd.app_admin.ui.outcome":          "failure",
 		"gestaltd.app_admin.ui.failure_category": "server",
+		"gestaltd.subject.kind":                  "unknown",
+		"gestaltd.subject.id":                    "unknown",
 	}
 	metrictest.RequireInt64Sum(t, rm, "gestaltd.app_admin.ui.count", 1, attrs)
 	metrictest.RequireInt64Sum(t, rm, "gestaltd.app_admin.ui.error_count", 1, attrs)

--- a/gestaltd/services/authorization/app_admin_ui_test.go
+++ b/gestaltd/services/authorization/app_admin_ui_test.go
@@ -21,7 +21,7 @@ func TestAddRelationshipRecordsAppScopedMutationMetrics(t *testing.T) {
 	metrics := metrictest.NewManualMeterProvider(t)
 	ctx := metricutil.WithMeterProvider(context.Background(), metrics.Provider)
 	ctx = publicrpc.WithPublicOrigin(ctx, proto.Authorization_AddRelationship_FullMethodName)
-	ctx = providergateway.WithAppScopedRelationshipMutationAuth(ctx, "roadmap", "grant_add")
+	ctx = providergateway.WithAppScopedRelationshipMutationAuth(ctx, "roadmap", "grant_add", nil)
 
 	provider := &stubAuthorizationProvider{}
 	server := NewProviderServer(provider)
@@ -74,7 +74,7 @@ func TestDeleteRelationshipRecordsAppScopedMutationFailure(t *testing.T) {
 	metrics := metrictest.NewManualMeterProvider(t)
 	ctx := metricutil.WithMeterProvider(context.Background(), metrics.Provider)
 	ctx = publicrpc.WithPublicOrigin(ctx, proto.Authorization_DeleteRelationship_FullMethodName)
-	ctx = providergateway.WithAppScopedRelationshipMutationAuth(ctx, "roadmap", "grant_remove")
+	ctx = providergateway.WithAppScopedRelationshipMutationAuth(ctx, "roadmap", "grant_remove", nil)
 
 	provider := &stubAuthorizationProvider{
 		deleteErr: status.Error(codes.InvalidArgument, "invalid tuple"),

--- a/gestaltd/services/authorization/server.go
+++ b/gestaltd/services/authorization/server.go
@@ -122,18 +122,18 @@ func recordAppScopedRelationshipMutation(ctx context.Context, startedAt time.Tim
 		return
 	}
 	failed := err != nil
-	interaction := observability.AppAdminUIInteraction{
-		App:               appID,
-		Surface:           observability.AppAdminUISurfaceMembers,
-		Action:            action,
-		Failed:            failed,
-		Err:               err,
-		TargetSubjectKind: targetSubjectKind,
-		TargetSubjectID:   targetSubjectID,
-	}
 	principalKind, principalID := principal.MetricAuthorizationSubject(principal.FromContext(ctx))
-	interaction.PrincipalSubjectKind = principalKind
-	interaction.PrincipalSubjectID = principalID
+	interaction := observability.AppAdminUIInteraction{
+		App:                  appID,
+		Surface:              observability.AppAdminUISurfaceMembers,
+		Action:               action,
+		Failed:               failed,
+		Err:                  err,
+		TargetSubjectKind:    targetSubjectKind,
+		TargetSubjectID:      targetSubjectID,
+		PrincipalSubjectKind: principalKind,
+		PrincipalSubjectID:   principalID,
+	}
 	if failed {
 		interaction.FailureCategory = observability.AppAdminUIFailureCategoryGRPC(err)
 	}

--- a/gestaltd/services/authorization/server.go
+++ b/gestaltd/services/authorization/server.go
@@ -8,6 +8,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/publicrpc"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"github.com/valon-technologies/gestalt/server/services/observability"
 	"github.com/valon-technologies/gestalt/server/services/providergateway"
@@ -116,18 +117,23 @@ func recordAppScopedRelationshipMutation(ctx context.Context, startedAt time.Tim
 	if _, ok := publicrpc.PublicOriginFromContext(ctx); !ok {
 		return
 	}
-	appID, action, ok := providergateway.AppScopedRelationshipMutationFromContext(ctx)
+	appID, action, targetSubjectKind, targetSubjectID, ok := providergateway.AppScopedRelationshipMutationFromContext(ctx)
 	if !ok {
 		return
 	}
 	failed := err != nil
 	interaction := observability.AppAdminUIInteraction{
-		App:     appID,
-		Surface: observability.AppAdminUISurfaceMembers,
-		Action:  action,
-		Failed:  failed,
-		Err:     err,
+		App:               appID,
+		Surface:           observability.AppAdminUISurfaceMembers,
+		Action:            action,
+		Failed:            failed,
+		Err:               err,
+		TargetSubjectKind: targetSubjectKind,
+		TargetSubjectID:   targetSubjectID,
 	}
+	principalKind, principalID := principal.MetricAuthorizationSubject(principal.FromContext(ctx))
+	interaction.PrincipalSubjectKind = principalKind
+	interaction.PrincipalSubjectID = principalID
 	if failed {
 		interaction.FailureCategory = observability.AppAdminUIFailureCategoryGRPC(err)
 	}

--- a/gestaltd/services/observability/app_admin_ui.go
+++ b/gestaltd/services/observability/app_admin_ui.go
@@ -33,22 +33,28 @@ const (
 )
 
 var (
-	AttrAppAdminUIApp             = attribute.Key("gestaltd.app_admin.ui.app")
-	AttrAppAdminUISurface         = attribute.Key("gestaltd.app_admin.ui.surface")
-	AttrAppAdminUIAction          = attribute.Key("gestaltd.app_admin.ui.action")
-	AttrAppAdminUIOutcome         = attribute.Key("gestaltd.app_admin.ui.outcome")
-	AttrAppAdminUIFailureCategory = attribute.Key("gestaltd.app_admin.ui.failure_category")
+	AttrAppAdminUIApp                 = attribute.Key("gestaltd.app_admin.ui.app")
+	AttrAppAdminUISurface             = attribute.Key("gestaltd.app_admin.ui.surface")
+	AttrAppAdminUIAction              = attribute.Key("gestaltd.app_admin.ui.action")
+	AttrAppAdminUIOutcome             = attribute.Key("gestaltd.app_admin.ui.outcome")
+	AttrAppAdminUIFailureCategory     = attribute.Key("gestaltd.app_admin.ui.failure_category")
+	AttrAppAdminUITargetSubjectKind   = attribute.Key("gestaltd.app_admin.ui.target_subject.kind")
+	AttrAppAdminUITargetSubjectID     = attribute.Key("gestaltd.app_admin.ui.target_subject.id")
 )
 
 type AppAdminUIInteraction struct {
-	App             string
-	Surface         string
-	Action          string
-	Failed          bool
-	FailureCategory string
-	StatusCode      int
-	Err             error
-	RequestID       string
+	App                  string
+	Surface              string
+	Action               string
+	Failed               bool
+	FailureCategory      string
+	StatusCode           int
+	Err                  error
+	RequestID            string
+	PrincipalSubjectKind string
+	PrincipalSubjectID   string
+	TargetSubjectKind    string
+	TargetSubjectID      string
 }
 
 func RecordAppAdminUI(ctx context.Context, startedAt time.Time, failed bool, attrs ...attribute.KeyValue) {
@@ -74,6 +80,18 @@ func RecordAppAdminUIInteraction(ctx context.Context, startedAt time.Time, inter
 	}
 	if interaction.Failed && interaction.FailureCategory != "" {
 		attrs = append(attrs, AttrAppAdminUIFailureCategory.String(interaction.FailureCategory))
+	}
+	if kind := strings.TrimSpace(interaction.PrincipalSubjectKind); kind != "" {
+		attrs = append(attrs,
+			AttrSubjectKind.String(kind),
+			AttrSubjectID.String(strings.TrimSpace(interaction.PrincipalSubjectID)),
+		)
+	}
+	if kind := strings.TrimSpace(interaction.TargetSubjectKind); kind != "" {
+		attrs = append(attrs,
+			AttrAppAdminUITargetSubjectKind.String(kind),
+			AttrAppAdminUITargetSubjectID.String(strings.TrimSpace(interaction.TargetSubjectID)),
+		)
 	}
 	RecordAppAdminUI(ctx, startedAt, interaction.Failed, attrs...)
 	if interaction.Failed {

--- a/gestaltd/services/observability/app_admin_ui.go
+++ b/gestaltd/services/observability/app_admin_ui.go
@@ -33,13 +33,13 @@ const (
 )
 
 var (
-	AttrAppAdminUIApp                 = attribute.Key("gestaltd.app_admin.ui.app")
-	AttrAppAdminUISurface             = attribute.Key("gestaltd.app_admin.ui.surface")
-	AttrAppAdminUIAction              = attribute.Key("gestaltd.app_admin.ui.action")
-	AttrAppAdminUIOutcome             = attribute.Key("gestaltd.app_admin.ui.outcome")
-	AttrAppAdminUIFailureCategory     = attribute.Key("gestaltd.app_admin.ui.failure_category")
-	AttrAppAdminUITargetSubjectKind   = attribute.Key("gestaltd.app_admin.ui.target_subject.kind")
-	AttrAppAdminUITargetSubjectID     = attribute.Key("gestaltd.app_admin.ui.target_subject.id")
+	AttrAppAdminUIApp               = attribute.Key("gestaltd.app_admin.ui.app")
+	AttrAppAdminUISurface           = attribute.Key("gestaltd.app_admin.ui.surface")
+	AttrAppAdminUIAction            = attribute.Key("gestaltd.app_admin.ui.action")
+	AttrAppAdminUIOutcome           = attribute.Key("gestaltd.app_admin.ui.outcome")
+	AttrAppAdminUIFailureCategory   = attribute.Key("gestaltd.app_admin.ui.failure_category")
+	AttrAppAdminUITargetSubjectKind = attribute.Key("gestaltd.app_admin.ui.target_subject.kind")
+	AttrAppAdminUITargetSubjectID   = attribute.Key("gestaltd.app_admin.ui.target_subject.id")
 )
 
 type AppAdminUIInteraction struct {

--- a/gestaltd/services/providergateway/authorization_access.go
+++ b/gestaltd/services/providergateway/authorization_access.go
@@ -5,9 +5,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/valon-technologies/gestalt/server/core"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"github.com/valon-technologies/gestalt/server/services/observability"
+	"github.com/valon-technologies/gestalt/server/services/observability/metricutil"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	gproto "google.golang.org/protobuf/proto"
@@ -70,10 +72,10 @@ func (t *ProviderGatewayTransport) enforceAuthorizationPublicAccess(
 			if allowed {
 				appID := strings.TrimSpace(tuple.GetResource().GetId())
 				action := appScopedRelationshipActionFromMethod(fullMethod)
-				return WithAppScopedRelationshipMutationAuth(ctx, appID, action), nil
+				return WithAppScopedRelationshipMutationAuth(ctx, appID, action, tuple), nil
 			}
 			deniedErr := status.Error(codes.PermissionDenied, "access denied")
-			recordAppScopedRelationshipAuthFailure(ctx, tuple, fullMethod, deniedErr)
+			recordAppScopedRelationshipAuthFailure(ctx, subjectID, tuple, fullMethod, deniedErr)
 			return ctx, deniedErr
 		}
 	}
@@ -96,7 +98,7 @@ func isAuthorizationServiceMethod(fullMethod string) bool {
 	return service == proto.Authorization_ServiceDesc.ServiceName
 }
 
-func recordAppScopedRelationshipAuthFailure(ctx context.Context, tuple *proto.RelationshipTuple, fullMethod string, err error) {
+func recordAppScopedRelationshipAuthFailure(ctx context.Context, subjectID string, tuple *proto.RelationshipTuple, fullMethod string, err error) {
 	if tuple == nil || strings.TrimSpace(tuple.GetResource().GetType()) != appAuthorizationResourceType {
 		return
 	}
@@ -105,12 +107,39 @@ func recordAppScopedRelationshipAuthFailure(ctx context.Context, tuple *proto.Re
 	if appID == "" || action == "" {
 		return
 	}
+	targetSubjectKind, targetSubjectID := relationshipTupleTargetSubjectMetric(tuple)
 	observability.RecordAppAdminUIInteraction(ctx, time.Now(), observability.AppAdminUIInteraction{
-		App:             appID,
-		Surface:         observability.AppAdminUISurfaceMembers,
-		Action:          action,
-		Failed:          true,
-		FailureCategory: observability.AppAdminUIFailureAuth,
-		Err:             err,
+		App:                  appID,
+		Surface:              observability.AppAdminUISurfaceMembers,
+		Action:               action,
+		Failed:               true,
+		FailureCategory:      observability.AppAdminUIFailureAuth,
+		Err:                  err,
+		PrincipalSubjectKind: principalSubjectKindFromID(subjectID),
+		PrincipalSubjectID:   principalSubjectIDFromID(subjectID),
+		TargetSubjectKind:    targetSubjectKind,
+		TargetSubjectID:      targetSubjectID,
 	})
+}
+
+func principalSubjectKindFromID(subjectID string) string {
+	subjectKind, parsedID, ok := core.ParseSubjectID(strings.TrimSpace(subjectID))
+	if ok && parsedID != "" {
+		return subjectKind
+	}
+	if strings.TrimSpace(subjectID) != "" {
+		return "subject"
+	}
+	return metricutil.UnknownAttrValue
+}
+
+func principalSubjectIDFromID(subjectID string) string {
+	_, parsedID, ok := core.ParseSubjectID(strings.TrimSpace(subjectID))
+	if ok && parsedID != "" {
+		return parsedID
+	}
+	if trimmed := strings.TrimSpace(subjectID); trimmed != "" {
+		return trimmed
+	}
+	return metricutil.UnknownAttrValue
 }

--- a/gestaltd/services/providergateway/authorization_access.go
+++ b/gestaltd/services/providergateway/authorization_access.go
@@ -5,11 +5,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/valon-technologies/gestalt/server/core"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"github.com/valon-technologies/gestalt/server/services/observability"
-	"github.com/valon-technologies/gestalt/server/services/observability/metricutil"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	gproto "google.golang.org/protobuf/proto"
@@ -108,6 +107,7 @@ func recordAppScopedRelationshipAuthFailure(ctx context.Context, subjectID strin
 		return
 	}
 	targetSubjectKind, targetSubjectID := relationshipTupleTargetSubjectMetric(tuple)
+	principalKind, principalID := principal.MetricAuthorizationSubject(&principal.Principal{SubjectID: subjectID})
 	observability.RecordAppAdminUIInteraction(ctx, time.Now(), observability.AppAdminUIInteraction{
 		App:                  appID,
 		Surface:              observability.AppAdminUISurfaceMembers,
@@ -115,31 +115,9 @@ func recordAppScopedRelationshipAuthFailure(ctx context.Context, subjectID strin
 		Failed:               true,
 		FailureCategory:      observability.AppAdminUIFailureAuth,
 		Err:                  err,
-		PrincipalSubjectKind: principalSubjectKindFromID(subjectID),
-		PrincipalSubjectID:   principalSubjectIDFromID(subjectID),
+		PrincipalSubjectKind: principalKind,
+		PrincipalSubjectID:   principalID,
 		TargetSubjectKind:    targetSubjectKind,
 		TargetSubjectID:      targetSubjectID,
 	})
-}
-
-func principalSubjectKindFromID(subjectID string) string {
-	subjectKind, parsedID, ok := core.ParseSubjectID(strings.TrimSpace(subjectID))
-	if ok && parsedID != "" {
-		return subjectKind
-	}
-	if strings.TrimSpace(subjectID) != "" {
-		return "subject"
-	}
-	return metricutil.UnknownAttrValue
-}
-
-func principalSubjectIDFromID(subjectID string) string {
-	_, parsedID, ok := core.ParseSubjectID(strings.TrimSpace(subjectID))
-	if ok && parsedID != "" {
-		return parsedID
-	}
-	if trimmed := strings.TrimSpace(subjectID); trimmed != "" {
-		return trimmed
-	}
-	return metricutil.UnknownAttrValue
 }

--- a/gestaltd/services/providergateway/authorization_app_admin_ui_test.go
+++ b/gestaltd/services/providergateway/authorization_app_admin_ui_test.go
@@ -57,6 +57,10 @@ func TestEnforceAuthorizationPublicAccessRecordsAppScopedAuthFailure(t *testing.
 		"gestaltd.app_admin.ui.action":           "grant_add",
 		"gestaltd.app_admin.ui.outcome":          "failure",
 		"gestaltd.app_admin.ui.failure_category": "auth_failure",
+		"gestaltd.subject.kind":                  "user",
+		"gestaltd.subject.id":                    "outsider@example.com",
+		"gestaltd.app_admin.ui.target_subject.kind": "user",
+		"gestaltd.app_admin.ui.target_subject.id":   "viewer@example.com",
 	}
 	metrictest.RequireInt64Sum(t, rm, "gestaltd.app_admin.ui.count", 1, attrs)
 	metrictest.RequireInt64Sum(t, rm, "gestaltd.app_admin.ui.error_count", 1, attrs)
@@ -65,9 +69,17 @@ func TestEnforceAuthorizationPublicAccessRecordsAppScopedAuthFailure(t *testing.
 func TestWithAppScopedRelationshipMutationAuth(t *testing.T) {
 	t.Parallel()
 
-	ctx := WithAppScopedRelationshipMutationAuth(context.Background(), "roadmap", "grant_remove")
-	appID, action, ok := AppScopedRelationshipMutationFromContext(ctx)
-	if !ok || appID != "roadmap" || action != "grant_remove" {
-		t.Fatalf("context marker = (%q, %q, %v), want (roadmap, grant_remove, true)", appID, action, ok)
+	ctx := WithAppScopedRelationshipMutationAuth(context.Background(), "roadmap", "grant_remove", &proto.RelationshipTuple{
+		Resource: &proto.Resource{Type: "app", Id: "roadmap"},
+		Relation: "viewer",
+		Target: &proto.RelationshipTarget{
+			Kind: &proto.RelationshipTarget_Subject{
+				Subject: &proto.Subject{Type: "subject", Id: "user:viewer@example.com"},
+			},
+		},
+	})
+	appID, action, targetKind, targetID, ok := AppScopedRelationshipMutationFromContext(ctx)
+	if !ok || appID != "roadmap" || action != "grant_remove" || targetKind != "user" || targetID != "viewer@example.com" {
+		t.Fatalf("context marker = (%q, %q, %q, %q, %v), want (roadmap, grant_remove, user, viewer@example.com, true)", appID, action, targetKind, targetID, ok)
 	}
 }

--- a/gestaltd/services/providergateway/authorization_app_admin_ui_test.go
+++ b/gestaltd/services/providergateway/authorization_app_admin_ui_test.go
@@ -52,13 +52,13 @@ func TestEnforceAuthorizationPublicAccessRecordsAppScopedAuthFailure(t *testing.
 
 	rm := metrictest.CollectMetrics(t, metrics.Reader)
 	attrs := map[string]string{
-		"gestaltd.app_admin.ui.app":              "roadmap",
-		"gestaltd.app_admin.ui.surface":          "members",
-		"gestaltd.app_admin.ui.action":           "grant_add",
-		"gestaltd.app_admin.ui.outcome":          "failure",
-		"gestaltd.app_admin.ui.failure_category": "auth_failure",
-		"gestaltd.subject.kind":                  "user",
-		"gestaltd.subject.id":                    "outsider@example.com",
+		"gestaltd.app_admin.ui.app":                 "roadmap",
+		"gestaltd.app_admin.ui.surface":             "members",
+		"gestaltd.app_admin.ui.action":              "grant_add",
+		"gestaltd.app_admin.ui.outcome":             "failure",
+		"gestaltd.app_admin.ui.failure_category":    "auth_failure",
+		"gestaltd.subject.kind":                     "user",
+		"gestaltd.subject.id":                       "outsider@example.com",
 		"gestaltd.app_admin.ui.target_subject.kind": "user",
 		"gestaltd.app_admin.ui.target_subject.id":   "viewer@example.com",
 	}

--- a/gestaltd/services/providergateway/authorization_app_scope.go
+++ b/gestaltd/services/providergateway/authorization_app_scope.go
@@ -16,35 +16,69 @@ const (
 )
 
 type appScopedRelationshipMutationContext struct {
-	appID  string
-	action string
+	appID             string
+	action            string
+	targetSubjectKind string
+	targetSubjectID   string
 }
 
 type appScopedRelationshipMutationKey struct{}
 
-func WithAppScopedRelationshipMutationAuth(ctx context.Context, appID, action string) context.Context {
+func WithAppScopedRelationshipMutationAuth(ctx context.Context, appID, action string, tuple *proto.RelationshipTuple) context.Context {
 	appID = strings.TrimSpace(appID)
 	action = strings.TrimSpace(action)
 	if appID == "" || action == "" {
 		return ctx
 	}
+	targetSubjectKind, targetSubjectID := relationshipTupleTargetSubjectMetric(tuple)
 	return context.WithValue(ctx, appScopedRelationshipMutationKey{}, appScopedRelationshipMutationContext{
-		appID:  appID,
-		action: action,
+		appID:             appID,
+		action:            action,
+		targetSubjectKind: targetSubjectKind,
+		targetSubjectID:   targetSubjectID,
 	})
 }
 
-func AppScopedRelationshipMutationFromContext(ctx context.Context) (appID, action string, ok bool) {
+func AppScopedRelationshipMutationFromContext(ctx context.Context) (appID, action, targetSubjectKind, targetSubjectID string, ok bool) {
 	value, ok := ctx.Value(appScopedRelationshipMutationKey{}).(appScopedRelationshipMutationContext)
 	if !ok {
-		return "", "", false
+		return "", "", "", "", false
 	}
 	appID = strings.TrimSpace(value.appID)
 	action = strings.TrimSpace(value.action)
 	if appID == "" || action == "" {
-		return "", "", false
+		return "", "", "", "", false
 	}
-	return appID, action, true
+	return appID, action, strings.TrimSpace(value.targetSubjectKind), strings.TrimSpace(value.targetSubjectID), true
+}
+
+func relationshipTupleTargetSubjectMetric(tuple *proto.RelationshipTuple) (kind, id string) {
+	if tuple == nil {
+		return "", ""
+	}
+	switch target := tuple.GetTarget().GetKind().(type) {
+	case *proto.RelationshipTarget_Subject:
+		subjectID := strings.TrimSpace(target.Subject.GetId())
+		if subjectKind, parsedID, ok := core.ParseSubjectID(subjectID); ok && parsedID != "" {
+			return subjectKind, parsedID
+		}
+		if subjectID != "" {
+			return "subject", subjectID
+		}
+	case *proto.RelationshipTarget_SubjectSet:
+		resource := target.SubjectSet.GetResource()
+		relation := strings.TrimSpace(target.SubjectSet.GetRelation())
+		resourceType := strings.TrimSpace(resource.GetType())
+		resourceID := strings.TrimSpace(resource.GetId())
+		if resourceType != "" && resourceID != "" {
+			selector := resourceType + ":" + resourceID
+			if relation != "" {
+				selector += "#" + relation
+			}
+			return "subject_set", selector
+		}
+	}
+	return "", ""
 }
 
 func appScopedRelationshipActionFromMethod(fullMethod string) string {

--- a/gestaltd/services/providergateway/authorization_app_scope_test.go
+++ b/gestaltd/services/providergateway/authorization_app_scope_test.go
@@ -211,6 +211,35 @@ func TestRelationshipTupleFromAuthorizationRequest(t *testing.T) {
 	}
 }
 
+func TestRelationshipTupleTargetSubjectMetric(t *testing.T) {
+	t.Parallel()
+
+	kind, id := relationshipTupleTargetSubjectMetric(&proto.RelationshipTuple{
+		Target: &proto.RelationshipTarget{
+			Kind: &proto.RelationshipTarget_Subject{
+				Subject: &proto.Subject{Type: "subject", Id: "user:viewer@example.com"},
+			},
+		},
+	})
+	if kind != "user" || id != "viewer@example.com" {
+		t.Fatalf("subject target = (%q, %q), want (user, viewer@example.com)", kind, id)
+	}
+
+	kind, id = relationshipTupleTargetSubjectMetric(&proto.RelationshipTuple{
+		Target: &proto.RelationshipTarget{
+			Kind: &proto.RelationshipTarget_SubjectSet{
+				SubjectSet: &proto.SubjectSet{
+					Resource: &proto.Resource{Type: "group", Id: "valon-employees"},
+					Relation: "member",
+				},
+			},
+		},
+	})
+	if kind != "subject_set" || id != "group:valon-employees#member" {
+		t.Fatalf("subject set target = (%q, %q), want (subject_set, group:valon-employees#member)", kind, id)
+	}
+}
+
 func TestAllowsAppScopedRelationshipMutationAllowsSubjectSetTarget(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Tag every `gestaltd.app_admin.ui.*` interaction with caller principal (`gestaltd.subject.kind`, `gestaltd.subject.id`) from the request principal.
- Tag app-scoped grant mutations with grant target subject (`gestaltd.app_admin.ui.target_subject.kind`, `gestaltd.app_admin.ui.target_subject.id`) parsed from the relationship tuple.
- Companion to toolshed#4834 app-admin Datadog dashboard Breakdown panels.

## Test plan
- [x] `go test ./internal/server/... -run AppAdminUI`
- [x] `go test ./services/authorization/... ./services/providergateway/... -run 'AppAdmin|RelationshipTupleTarget|WithAppScoped'`


Made with [Cursor](https://cursor.com)