### PR TITLE
Fix app-admin target-subject metrics for gestalt:admin grants

### DIFF
--- a/gestaltd/services/providergateway/authorization_access.go
+++ b/gestaltd/services/providergateway/authorization_access.go
@@ -51,35 +51,40 @@ func (t *ProviderGatewayTransport) enforceAuthorizationPublicAccess(
 	}
 
 	resource := &proto.Resource{Type: authorizationResourceType, Id: authorizationResourceID}
-	actions := authorizationPublicActions(read, write)
-	for _, action := range actions {
+	allowed := false
+	for _, action := range authorizationPublicActions(read, write) {
 		checkReq := invocation.SubjectAccessRequest(subjectID, action, resource)
-		allowed, err := invocation.CheckSubjectAccess(ctx, t.authorization, checkReq)
+		accessAllowed, err := invocation.CheckSubjectAccess(ctx, t.authorization, checkReq)
 		if err != nil {
 			return ctx, status.Error(codes.Unavailable, "authorization provider unavailable")
 		}
-		if allowed {
-			if write {
-				return withAppAdminRelationshipMutationAuth(ctx, fullMethod, req), nil
-			}
-			return ctx, nil
+		if accessAllowed {
+			allowed = true
+			break
 		}
 	}
-	if write {
-		if tuple, ok := relationshipTupleFromAuthorizationRequest(fullMethod, req); ok {
-			allowed, err := allowsAppScopedRelationshipMutation(ctx, t.authorization, subjectID, tuple)
+	if !allowed && write {
+		tuple, ok := relationshipTupleFromAuthorizationRequest(fullMethod, req)
+		if ok {
+			var err error
+			allowed, err = allowsAppScopedRelationshipMutation(ctx, t.authorization, subjectID, tuple)
 			if err != nil {
 				return ctx, status.Error(codes.Unavailable, "authorization provider unavailable")
 			}
-			if allowed {
-				return withAppAdminRelationshipMutationAuth(ctx, fullMethod, req), nil
+			if !allowed {
+				deniedErr := status.Error(codes.PermissionDenied, "access denied")
+				recordAppScopedRelationshipAuthFailure(ctx, subjectID, tuple, fullMethod, deniedErr)
+				return ctx, deniedErr
 			}
-			deniedErr := status.Error(codes.PermissionDenied, "access denied")
-			recordAppScopedRelationshipAuthFailure(ctx, subjectID, tuple, fullMethod, deniedErr)
-			return ctx, deniedErr
 		}
 	}
-	return ctx, status.Error(codes.PermissionDenied, "access denied")
+	if !allowed {
+		return ctx, status.Error(codes.PermissionDenied, "access denied")
+	}
+	if write {
+		ctx = withAppScopedRelationshipMutationAuthFromRequest(ctx, fullMethod, req)
+	}
+	return ctx, nil
 }
 
 func authorizationPublicActions(read, write bool) []string {
@@ -121,17 +126,4 @@ func recordAppScopedRelationshipAuthFailure(ctx context.Context, subjectID strin
 		TargetSubjectKind:    targetSubjectKind,
 		TargetSubjectID:      targetSubjectID,
 	})
-}
-
-func withAppAdminRelationshipMutationAuth(ctx context.Context, fullMethod string, req gproto.Message) context.Context {
-	tuple, ok := relationshipTupleFromAuthorizationRequest(fullMethod, req)
-	if !ok || strings.TrimSpace(tuple.GetResource().GetType()) != appAuthorizationResourceType {
-		return ctx
-	}
-	appID := strings.TrimSpace(tuple.GetResource().GetId())
-	action := appScopedRelationshipActionFromMethod(fullMethod)
-	if appID == "" || action == "" {
-		return ctx
-	}
-	return WithAppScopedRelationshipMutationAuth(ctx, appID, action, tuple)
 }

--- a/gestaltd/services/providergateway/authorization_access.go
+++ b/gestaltd/services/providergateway/authorization_access.go
@@ -59,6 +59,9 @@ func (t *ProviderGatewayTransport) enforceAuthorizationPublicAccess(
 			return ctx, status.Error(codes.Unavailable, "authorization provider unavailable")
 		}
 		if allowed {
+			if write {
+				return withAppAdminRelationshipMutationAuth(ctx, fullMethod, req), nil
+			}
 			return ctx, nil
 		}
 	}
@@ -69,9 +72,7 @@ func (t *ProviderGatewayTransport) enforceAuthorizationPublicAccess(
 				return ctx, status.Error(codes.Unavailable, "authorization provider unavailable")
 			}
 			if allowed {
-				appID := strings.TrimSpace(tuple.GetResource().GetId())
-				action := appScopedRelationshipActionFromMethod(fullMethod)
-				return WithAppScopedRelationshipMutationAuth(ctx, appID, action, tuple), nil
+				return withAppAdminRelationshipMutationAuth(ctx, fullMethod, req), nil
 			}
 			deniedErr := status.Error(codes.PermissionDenied, "access denied")
 			recordAppScopedRelationshipAuthFailure(ctx, subjectID, tuple, fullMethod, deniedErr)
@@ -120,4 +121,17 @@ func recordAppScopedRelationshipAuthFailure(ctx context.Context, subjectID strin
 		TargetSubjectKind:    targetSubjectKind,
 		TargetSubjectID:      targetSubjectID,
 	})
+}
+
+func withAppAdminRelationshipMutationAuth(ctx context.Context, fullMethod string, req gproto.Message) context.Context {
+	tuple, ok := relationshipTupleFromAuthorizationRequest(fullMethod, req)
+	if !ok || strings.TrimSpace(tuple.GetResource().GetType()) != appAuthorizationResourceType {
+		return ctx
+	}
+	appID := strings.TrimSpace(tuple.GetResource().GetId())
+	action := appScopedRelationshipActionFromMethod(fullMethod)
+	if appID == "" || action == "" {
+		return ctx
+	}
+	return WithAppScopedRelationshipMutationAuth(ctx, appID, action, tuple)
 }

--- a/gestaltd/services/providergateway/authorization_app_scope.go
+++ b/gestaltd/services/providergateway/authorization_app_scope.go
@@ -116,6 +116,19 @@ func relationshipTupleFromAuthorizationRequest(fullMethod string, req gproto.Mes
 	}
 }
 
+func withAppScopedRelationshipMutationAuthFromRequest(ctx context.Context, fullMethod string, req gproto.Message) context.Context {
+	tuple, ok := relationshipTupleFromAuthorizationRequest(fullMethod, req)
+	if !ok || strings.TrimSpace(tuple.GetResource().GetType()) != appAuthorizationResourceType {
+		return ctx
+	}
+	appID := strings.TrimSpace(tuple.GetResource().GetId())
+	action := appScopedRelationshipActionFromMethod(fullMethod)
+	if appID == "" || action == "" {
+		return ctx
+	}
+	return WithAppScopedRelationshipMutationAuth(ctx, appID, action, tuple)
+}
+
 func allowsAppScopedRelationshipMutation(
 	ctx context.Context,
 	authorization core.AuthorizationProvider,

--- a/gestaltd/services/providergateway/authorization_app_scope.go
+++ b/gestaltd/services/providergateway/authorization_app_scope.go
@@ -123,7 +123,7 @@ func withAppScopedRelationshipMutationAuthFromRequest(ctx context.Context, fullM
 	}
 	appID := strings.TrimSpace(tuple.GetResource().GetId())
 	action := appScopedRelationshipActionFromMethod(fullMethod)
-	if appID == "" || action == "" {
+	if appID == "" || action == "" || strings.TrimSpace(tuple.GetRelation()) == "" || !relationshipTupleHasDelegableTarget(tuple) {
 		return ctx
 	}
 	return WithAppScopedRelationshipMutationAuth(ctx, appID, action, tuple)

--- a/gestaltd/services/providergateway/authorization_app_scope_test.go
+++ b/gestaltd/services/providergateway/authorization_app_scope_test.go
@@ -186,6 +186,36 @@ func TestEnforceAuthorizationPublicAccessMarksAppRelationshipWrite(t *testing.T)
 	}
 }
 
+func TestEnforceAuthorizationPublicAccessSkipsMalformedAppRelationshipWriteMarker(t *testing.T) {
+	t.Parallel()
+
+	transport := &ProviderGatewayTransport{
+		authorization: &stubAuthorizationProvider{
+			allowedActions: map[string]bool{"admin": true},
+		},
+	}
+
+	ctx, err := transport.enforceAuthorizationPublicAccess(
+		context.Background(),
+		"user:admin@example.com",
+		proto.Authorization_AddRelationship_FullMethodName,
+		&proto.AddRelationshipRequest{
+			Relationship: &proto.Relationship{
+				Tuple: &proto.RelationshipTuple{
+					Resource: &proto.Resource{Type: "app", Id: "roadmap"},
+					Relation: "viewer",
+				},
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("enforceAuthorizationPublicAccess error = %v, want nil", err)
+	}
+	if _, _, _, _, ok := AppScopedRelationshipMutationFromContext(ctx); ok {
+		t.Fatal("context marker present for malformed app relationship tuple, want absent")
+	}
+}
+
 func TestEnforceAuthorizationPublicAccessDeniesAppAdminModelWrite(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/services/providergateway/authorization_app_scope_test.go
+++ b/gestaltd/services/providergateway/authorization_app_scope_test.go
@@ -123,18 +123,10 @@ func TestAllowsAppScopedRelationshipMutationRejectsGlobalResources(t *testing.T)
 	}
 }
 
-func TestEnforceAuthorizationPublicAccessAllowsAppAdminRelationshipWrite(t *testing.T) {
+func TestEnforceAuthorizationPublicAccessMarksAppRelationshipWrite(t *testing.T) {
 	t.Parallel()
 
-	provider := &appScopedAuthorizationProvider{
-		stubAuthorizationProvider: &stubAuthorizationProvider{
-			allowedActions: map[string]bool{"viewer": true},
-		},
-		appAdmin: map[string]bool{"roadmap": true},
-	}
-	transport := &ProviderGatewayTransport{authorization: provider}
-
-	req := &proto.AddRelationshipRequest{
+	addViewerReq := &proto.AddRelationshipRequest{
 		Relationship: &proto.Relationship{
 			Tuple: &proto.RelationshipTuple{
 				Resource: &proto.Resource{Type: "app", Id: "roadmap"},
@@ -147,54 +139,50 @@ func TestEnforceAuthorizationPublicAccessAllowsAppAdminRelationshipWrite(t *test
 			},
 		},
 	}
-	ctx, err := transport.enforceAuthorizationPublicAccess(
-		context.Background(),
-		"user:admin@example.com",
-		proto.Authorization_AddRelationship_FullMethodName,
-		req,
-	)
-	if err != nil {
-		t.Fatalf("enforceAuthorizationPublicAccess error = %v, want nil", err)
-	}
-	appID, action, targetKind, targetID, ok := AppScopedRelationshipMutationFromContext(ctx)
-	if !ok || appID != "roadmap" || action != "grant_add" || targetKind != "user" || targetID != "viewer@example.com" {
-		t.Fatalf("context marker = (%q, %q, %q, %q, %v), want (roadmap, grant_add, user, viewer@example.com, true)", appID, action, targetKind, targetID, ok)
-	}
-}
 
-func TestEnforceAuthorizationPublicAccessMarksGestaltAdminAppRelationshipWrite(t *testing.T) {
-	t.Parallel()
-
-	transport := &ProviderGatewayTransport{
-		authorization: &stubAuthorizationProvider{
-			allowedActions: map[string]bool{"admin": true},
-		},
-	}
-	req := &proto.AddRelationshipRequest{
-		Relationship: &proto.Relationship{
-			Tuple: &proto.RelationshipTuple{
-				Resource: &proto.Resource{Type: "app", Id: "doc-walkthrough-test"},
-				Relation: "viewer",
-				Target: &proto.RelationshipTarget{
-					Kind: &proto.RelationshipTarget_Subject{
-						Subject: &proto.Subject{Type: "subject", Id: "user:griffin.ansel@valon.com"},
+	tests := []struct {
+		name      string
+		transport *ProviderGatewayTransport
+	}{
+		{
+			name: "app_admin",
+			transport: &ProviderGatewayTransport{
+				authorization: &appScopedAuthorizationProvider{
+					stubAuthorizationProvider: &stubAuthorizationProvider{
+						allowedActions: map[string]bool{"viewer": true},
 					},
+					appAdmin: map[string]bool{"roadmap": true},
+				},
+			},
+		},
+		{
+			name: "global_admin",
+			transport: &ProviderGatewayTransport{
+				authorization: &stubAuthorizationProvider{
+					allowedActions: map[string]bool{"admin": true},
 				},
 			},
 		},
 	}
-	ctx, err := transport.enforceAuthorizationPublicAccess(
-		context.Background(),
-		"user:michael.wang@valon.com",
-		proto.Authorization_AddRelationship_FullMethodName,
-		req,
-	)
-	if err != nil {
-		t.Fatalf("enforceAuthorizationPublicAccess error = %v, want nil", err)
-	}
-	appID, action, targetKind, targetID, ok := AppScopedRelationshipMutationFromContext(ctx)
-	if !ok || appID != "doc-walkthrough-test" || action != "grant_add" || targetKind != "user" || targetID != "griffin.ansel@valon.com" {
-		t.Fatalf("context marker = (%q, %q, %q, %q, %v), want (doc-walkthrough-test, grant_add, user, griffin.ansel@valon.com, true)", appID, action, targetKind, targetID, ok)
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctx, err := tc.transport.enforceAuthorizationPublicAccess(
+				context.Background(),
+				"user:admin@example.com",
+				proto.Authorization_AddRelationship_FullMethodName,
+				addViewerReq,
+			)
+			if err != nil {
+				t.Fatalf("enforceAuthorizationPublicAccess error = %v, want nil", err)
+			}
+			appID, action, targetKind, targetID, ok := AppScopedRelationshipMutationFromContext(ctx)
+			if !ok || appID != "roadmap" || action != "grant_add" || targetKind != "user" || targetID != "viewer@example.com" {
+				t.Fatalf("context marker = (%q, %q, %q, %q, %v), want (roadmap, grant_add, user, viewer@example.com, true)", appID, action, targetKind, targetID, ok)
+			}
+		})
 	}
 }
 

--- a/gestaltd/services/providergateway/authorization_app_scope_test.go
+++ b/gestaltd/services/providergateway/authorization_app_scope_test.go
@@ -147,7 +147,7 @@ func TestEnforceAuthorizationPublicAccessAllowsAppAdminRelationshipWrite(t *test
 			},
 		},
 	}
-	_, err := transport.enforceAuthorizationPublicAccess(
+	ctx, err := transport.enforceAuthorizationPublicAccess(
 		context.Background(),
 		"user:admin@example.com",
 		proto.Authorization_AddRelationship_FullMethodName,
@@ -155,6 +155,46 @@ func TestEnforceAuthorizationPublicAccessAllowsAppAdminRelationshipWrite(t *test
 	)
 	if err != nil {
 		t.Fatalf("enforceAuthorizationPublicAccess error = %v, want nil", err)
+	}
+	appID, action, targetKind, targetID, ok := AppScopedRelationshipMutationFromContext(ctx)
+	if !ok || appID != "roadmap" || action != "grant_add" || targetKind != "user" || targetID != "viewer@example.com" {
+		t.Fatalf("context marker = (%q, %q, %q, %q, %v), want (roadmap, grant_add, user, viewer@example.com, true)", appID, action, targetKind, targetID, ok)
+	}
+}
+
+func TestEnforceAuthorizationPublicAccessMarksGestaltAdminAppRelationshipWrite(t *testing.T) {
+	t.Parallel()
+
+	transport := &ProviderGatewayTransport{
+		authorization: &stubAuthorizationProvider{
+			allowedActions: map[string]bool{"admin": true},
+		},
+	}
+	req := &proto.AddRelationshipRequest{
+		Relationship: &proto.Relationship{
+			Tuple: &proto.RelationshipTuple{
+				Resource: &proto.Resource{Type: "app", Id: "doc-walkthrough-test"},
+				Relation: "viewer",
+				Target: &proto.RelationshipTarget{
+					Kind: &proto.RelationshipTarget_Subject{
+						Subject: &proto.Subject{Type: "subject", Id: "user:griffin.ansel@valon.com"},
+					},
+				},
+			},
+		},
+	}
+	ctx, err := transport.enforceAuthorizationPublicAccess(
+		context.Background(),
+		"user:michael.wang@valon.com",
+		proto.Authorization_AddRelationship_FullMethodName,
+		req,
+	)
+	if err != nil {
+		t.Fatalf("enforceAuthorizationPublicAccess error = %v, want nil", err)
+	}
+	appID, action, targetKind, targetID, ok := AppScopedRelationshipMutationFromContext(ctx)
+	if !ok || appID != "doc-walkthrough-test" || action != "grant_add" || targetKind != "user" || targetID != "griffin.ansel@valon.com" {
+		t.Fatalf("context marker = (%q, %q, %q, %q, %v), want (doc-walkthrough-test, grant_add, user, griffin.ansel@valon.com, true)", appID, action, targetKind, targetID, ok)
 	}
 }
 


### PR DESCRIPTION
## Summary
- When a `gestalt:admin` (or `authorization:admin`) adds/removes an `app:{app}` relationship, the provider gateway returned early without setting the app-scoped mutation context marker.
- `recordAppScopedRelationshipMutation` therefore never ran for those grants, so the dashboard's target-subject breakdown stayed empty while principal volume still showed `list` traffic from the members page middleware.
- Annotate app-scoped `AddRelationship` / `DeleteRelationship` requests with mutation auth context for both global-admin and app-admin authorization paths.

## Test plan
- [x] `go test ./services/providergateway/... -run EnforceAuthorizationPublicAccess`
- [x] `go test ./services/authorization/... -run AppAdmin`
- [ ] After merge + deploy: grant a viewer on `/apps/{app}/admin/members` as `gestalt:admin` and confirm `gestaltd.app_admin.ui.target_subject.*` appears on the dashboard.


Made with [Cursor](https://cursor.com)