### PR TITLE
Add authorization apps members CLI (0.0.2-alpha.18)

### DIFF
--- a/gestalt/Cargo.toml
+++ b/gestalt/Cargo.toml
@@ -3,5 +3,5 @@ resolver = "2"
 members = ["cli"]
 
 [workspace.package]
-version = "0.0.2-alpha.17"
+version = "0.0.2-alpha.18"
 edition = "2024"

--- a/gestalt/cli/src/cli.rs
+++ b/gestalt/cli/src/cli.rs
@@ -292,7 +292,14 @@ pub struct AuthorizationAppsMembersRemoveArgs {
     /// App name
     pub app: String,
     /// Member subject id, such as user:abc
-    pub subject: String,
+    #[arg(conflicts_with_all = ["email", "subject_id"], required_unless_present_any = ["email", "subject_id"])]
+    pub subject: Option<String>,
+    /// Member email address
+    #[arg(long, conflicts_with_all = ["subject", "subject_id"])]
+    pub email: Option<String>,
+    /// Member subject id, such as user:abc or service_account:bot
+    #[arg(long = "subject-id", conflicts_with_all = ["subject", "email"])]
+    pub subject_id: Option<String>,
     /// Relationship role to remove; when omitted, removes all mutable grants for the subject
     #[arg(long)]
     pub role: Option<String>,

--- a/gestalt/cli/src/cli.rs
+++ b/gestalt/cli/src/cli.rs
@@ -238,6 +238,64 @@ pub enum AuthorizationCommands {
         #[command(subcommand)]
         command: AuthorizationSubjectCommands,
     },
+    /// Inspect and manage app-scoped authorization grants
+    Apps {
+        #[command(subcommand)]
+        command: AuthorizationAppsCommands,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum AuthorizationAppsCommands {
+    /// List apps in the catalog
+    List,
+    /// Manage member grants for an app
+    Members {
+        #[command(subcommand)]
+        command: AuthorizationAppsMembersCommands,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum AuthorizationAppsMembersCommands {
+    /// List member grants for an app
+    List(AuthorizationAppsMembersListArgs),
+    /// Grant or change a member role on an app
+    Set(AuthorizationAppsMembersSetArgs),
+    /// Remove a member grant from an app
+    Remove(AuthorizationAppsMembersRemoveArgs),
+}
+
+#[derive(Args)]
+pub struct AuthorizationAppsMembersListArgs {
+    /// App name
+    pub app: String,
+}
+
+#[derive(Args)]
+pub struct AuthorizationAppsMembersSetArgs {
+    /// App name
+    pub app: String,
+    /// Member email address
+    #[arg(long, conflicts_with = "subject_id")]
+    pub email: Option<String>,
+    /// Member subject id, such as user:abc or service_account:bot
+    #[arg(long = "subject-id", conflicts_with = "email")]
+    pub subject_id: Option<String>,
+    /// App role to grant, such as viewer, editor, or admin
+    #[arg(long)]
+    pub role: String,
+}
+
+#[derive(Args)]
+pub struct AuthorizationAppsMembersRemoveArgs {
+    /// App name
+    pub app: String,
+    /// Member subject id, such as user:abc
+    pub subject: String,
+    /// Relationship role to remove; when omitted, removes all mutable grants for the subject
+    #[arg(long)]
+    pub role: Option<String>,
 }
 
 #[derive(Subcommand)]

--- a/gestalt/cli/src/cli.rs
+++ b/gestalt/cli/src/cli.rs
@@ -276,7 +276,7 @@ pub struct AuthorizationAppsMembersListArgs {
 pub struct AuthorizationAppsMembersSetArgs {
     /// App name
     pub app: String,
-    /// Member email address
+    /// Existing roster member email address
     #[arg(long, conflicts_with = "subject_id")]
     pub email: Option<String>,
     /// Member subject id, such as user:abc or service_account:bot
@@ -294,7 +294,7 @@ pub struct AuthorizationAppsMembersRemoveArgs {
     /// Member subject id, such as user:abc
     #[arg(conflicts_with_all = ["email", "subject_id"], required_unless_present_any = ["email", "subject_id"])]
     pub subject: Option<String>,
-    /// Member email address
+    /// Existing roster member email address
     #[arg(long, conflicts_with_all = ["subject", "subject_id"])]
     pub email: Option<String>,
     /// Member subject id, such as user:abc or service_account:bot

--- a/gestalt/cli/src/commands/authorization.rs
+++ b/gestalt/cli/src/commands/authorization.rs
@@ -11,6 +11,7 @@ use crate::cli::{
 use crate::output::{self, Format};
 
 use crate::api::ApiClient;
+use crate::commands::authorization_apps;
 use crate::commands::authorization_subjects;
 
 use gestalt_sdk::authorization::source_layer::{
@@ -130,6 +131,9 @@ pub fn dispatch(
         AuthorizationCommands::Subjects { command } => {
             authorization_subjects::dispatch(api, command, format)
         }
+        AuthorizationCommands::Apps { command } => {
+            authorization_apps::dispatch(api, authz, command, format)
+        }
         AuthorizationCommands::State { command } => match command {
             AuthorizationStateCommands::Apply(args) => apply_state(api, &args, format),
         },
@@ -156,7 +160,7 @@ fn apply_state(
     Ok(())
 }
 
-fn build_relationship_from_args(
+pub(crate) fn build_relationship_from_args(
     args: &crate::cli::AuthorizationRelationshipMutationArgs,
 ) -> Result<Relationship> {
     Ok(Relationship {
@@ -172,7 +176,25 @@ fn build_relationship_from_args(
     })
 }
 
-fn relationship_tuple_from_parts(
+pub(crate) fn build_app_member_relationship(
+    app: &str,
+    role: &str,
+    subject_id: &str,
+) -> Result<Relationship> {
+    Ok(Relationship {
+        tuple: Some(relationship_tuple_from_parts(
+            "app",
+            app,
+            role,
+            Some(subject_id),
+            None,
+        )?),
+        properties: None,
+        source_layer: SOURCE_LAYER_RUNTIME,
+    })
+}
+
+pub(crate) fn relationship_tuple_from_parts(
     resource_type: &str,
     resource_id: &str,
     relation: &str,

--- a/gestalt/cli/src/commands/authorization_apps.rs
+++ b/gestalt/cli/src/commands/authorization_apps.rs
@@ -1,0 +1,367 @@
+use anyhow::{Context, Result, bail};
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::api::{ApiClient, encode_path_segment};
+use crate::cli::{
+    AuthorizationAppsCommands, AuthorizationAppsMembersCommands,
+    AuthorizationAppsMembersListArgs, AuthorizationAppsMembersRemoveArgs,
+    AuthorizationAppsMembersSetArgs,
+};
+use crate::commands::authorization::{
+    build_app_member_relationship, relationship_tuple_from_parts,
+};
+use crate::output::{self, Format};
+
+use gestalt_sdk::authorization::{AddRelationshipRequest, DeleteRelationshipRequest};
+use gestalt_sdk::public::generated::app_client::AuthorizationClient;
+use gestalt_sdk::public::rest_transport::SyncRestTransport;
+
+pub fn dispatch(
+    api: &ApiClient,
+    authz: &AuthorizationClient<SyncRestTransport>,
+    command: AuthorizationAppsCommands,
+    format: Format,
+) -> Result<()> {
+    match command {
+        AuthorizationAppsCommands::List => list_apps(api, format),
+        AuthorizationAppsCommands::Members { command } => match command {
+            AuthorizationAppsMembersCommands::List(args) => list_members(api, &args, format),
+            AuthorizationAppsMembersCommands::Set(args) => set_member(authz, api, &args, format),
+            AuthorizationAppsMembersCommands::Remove(args) => remove_member(authz, api, &args, format),
+        },
+    }
+}
+
+fn list_apps(api: &ApiClient, format: Format) -> Result<()> {
+    let resp = api
+        .get("/api/v1/apps")
+        .context("failed to list apps")?;
+    match format {
+        Format::Json => output::print_json(&resp),
+        Format::Table => {
+            let rows: Vec<Vec<String>> = resp
+                .as_array()
+                .unwrap_or(&Vec::new())
+                .iter()
+                .map(|item| {
+                    vec![
+                        item.get("name")
+                            .and_then(Value::as_str)
+                            .unwrap_or("")
+                            .to_string(),
+                        item.get("displayName")
+                            .or_else(|| item.get("display_name"))
+                            .and_then(Value::as_str)
+                            .unwrap_or("")
+                            .to_string(),
+                    ]
+                })
+                .collect();
+            println!("{}", output::render_table(&["Name", "Display Name"], &rows));
+        }
+    }
+    Ok(())
+}
+
+fn list_members(
+    api: &ApiClient,
+    args: &AuthorizationAppsMembersListArgs,
+    format: Format,
+) -> Result<()> {
+    let app = require_app_name(&args.app)?;
+    let path = format!(
+        "/api/v1/apps/{}/admin/members",
+        encode_path_segment(&app)
+    );
+    let resp = api
+        .get(&path)
+        .with_context(|| format!("failed to list members for app {app}"))?;
+    match format {
+        Format::Json => output::print_json(&resp),
+        Format::Table => {
+            let rows: Vec<Vec<String>> = resp
+                .as_array()
+                .unwrap_or(&Vec::new())
+                .iter()
+                .map(member_row)
+                .collect();
+            println!(
+                "{}",
+                output::render_table(
+                    &["Role", "Source", "Mutable", "Subject", "Email"],
+                    &rows
+                )
+            );
+        }
+    }
+    Ok(())
+}
+
+fn set_member(
+    authz: &AuthorizationClient<SyncRestTransport>,
+    api: &ApiClient,
+    args: &AuthorizationAppsMembersSetArgs,
+    format: Format,
+) -> Result<()> {
+    let app = require_app_name(&args.app)?;
+    let role = require_role(&args.role)?;
+    let subject_id = member_subject_id(args.email.as_deref(), args.subject_id.as_deref())?;
+
+    for existing in mutable_member_roles_for_subject(api, &app, &subject_id)? {
+        if existing == role {
+            match format {
+                Format::Json => output::print_json(&serde_json::json!({
+                    "app": app,
+                    "subjectId": subject_id,
+                    "role": role,
+                    "changed": false,
+                })),
+                Format::Table => output::print_success(&format!(
+                    "{subject_id} already has {role} on {app}."
+                )),
+            }
+            return Ok(());
+        }
+        delete_member_tuple(authz, &app, &existing, &subject_id)?;
+    }
+
+    let relationship = build_app_member_relationship(&app, &role, &subject_id)?;
+    authz
+        .add_relationship_sync(AddRelationshipRequest {
+            relationship: Some(relationship),
+        })
+        .context("failed to grant app member access")?;
+    match format {
+        Format::Json => output::print_json(&serde_json::json!({
+            "app": app,
+            "subjectId": subject_id,
+            "role": role,
+            "changed": true,
+        })),
+        Format::Table => output::print_success(&format!(
+            "Granted {role} on {app} to {subject_id}."
+        )),
+    }
+    Ok(())
+}
+
+fn remove_member(
+    authz: &AuthorizationClient<SyncRestTransport>,
+    api: &ApiClient,
+    args: &AuthorizationAppsMembersRemoveArgs,
+    format: Format,
+) -> Result<()> {
+    let app = require_app_name(&args.app)?;
+    let subject = normalize_subject_id(&args.subject)?;
+    let roles = match args.role.as_deref().map(str::trim).filter(|v| !v.is_empty()) {
+        Some(role) => vec![require_role(role)?],
+        None => mutable_member_roles_for_subject(api, &app, &subject)?,
+    };
+    if roles.is_empty() {
+        bail!("no mutable member grants found for {subject} on {app}");
+    }
+    for role in &roles {
+        delete_member_tuple(authz, &app, role, &subject)?;
+    }
+    match format {
+        Format::Json => output::print_json(&serde_json::json!({
+            "app": app,
+            "subjectId": subject,
+            "removedRoles": roles,
+        })),
+        Format::Table => output::print_success(&format!(
+            "Removed {} grant(s) for {subject} on {app}.",
+            roles.len()
+        )),
+    }
+    Ok(())
+}
+
+fn delete_member_tuple(
+    authz: &AuthorizationClient<SyncRestTransport>,
+    app: &str,
+    role: &str,
+    subject_id: &str,
+) -> Result<()> {
+    let tuple = relationship_tuple_from_parts("app", app, role, Some(subject_id), None)?;
+    authz
+        .delete_relationship_sync(DeleteRelationshipRequest {
+            relationship_tuple: Some(tuple),
+        })
+        .with_context(|| format!("failed to remove {role} grant for {subject_id} on {app}"))?;
+    Ok(())
+}
+
+fn mutable_member_roles_for_subject(
+    api: &ApiClient,
+    app: &str,
+    subject_id: &str,
+) -> Result<Vec<String>> {
+    let path = format!(
+        "/api/v1/apps/{}/admin/members",
+        encode_path_segment(app)
+    );
+    let resp = api
+        .get(&path)
+        .with_context(|| format!("failed to list members for app {app}"))?;
+    let members: Vec<AppAdminMember> = serde_json::from_value(resp)
+        .context("failed to parse app admin members response")?;
+    Ok(members
+        .into_iter()
+        .filter(|member| member.mutable && subject_matches_member(subject_id, member))
+        .map(|member| member.role)
+        .collect())
+}
+
+fn subject_matches_member(subject_id: &str, member: &AppAdminMember) -> bool {
+    let normalized = normalize_subject_id(subject_id).unwrap_or_default();
+    if let Some(subject) = member.subject_id.as_deref() {
+        if normalize_subject_id(subject).ok().as_deref() == Some(normalized.as_str()) {
+            return true;
+        }
+    }
+    member
+        .selector_value
+        .as_deref()
+        .and_then(|value| normalize_subject_id(value).ok())
+        .as_deref()
+        == Some(normalized.as_str())
+}
+
+fn member_row(value: &Value) -> Vec<String> {
+    vec![
+        value
+            .get("role")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string(),
+        value
+            .get("source")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string(),
+        value
+            .get("mutable")
+            .and_then(Value::as_bool)
+            .map(|mutable| mutable.to_string())
+            .unwrap_or_default(),
+        value
+            .get("subjectId")
+            .or_else(|| value.get("selectorValue"))
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string(),
+        value
+            .get("email")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string(),
+    ]
+}
+
+fn member_subject_id(email: Option<&str>, subject_id: Option<&str>) -> Result<String> {
+    if let Some(email) = email.map(str::trim).filter(|value| !value.is_empty()) {
+        return normalize_user_email_subject(email);
+    }
+    if let Some(subject_id) = subject_id.map(str::trim).filter(|value| !value.is_empty()) {
+        return normalize_subject_id(subject_id);
+    }
+    bail!("either --email or --subject-id is required")
+}
+
+fn normalize_user_email_subject(email: &str) -> Result<String> {
+    let trimmed = email.trim();
+    if trimmed.is_empty() {
+        bail!("email is required");
+    }
+    if trimmed.to_lowercase().starts_with("user:") {
+        Ok(trimmed.to_string())
+    } else {
+        Ok(format!("user:{trimmed}"))
+    }
+}
+
+fn normalize_subject_id(raw: &str) -> Result<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        bail!("subject id is required");
+    }
+    if trimmed.contains(':') {
+        Ok(trimmed.to_string())
+    } else {
+        Ok(format!("user:{trimmed}"))
+    }
+}
+
+fn require_app_name(app: &str) -> Result<String> {
+    let trimmed = app.trim();
+    if trimmed.is_empty() {
+        bail!("app name is required");
+    }
+    Ok(trimmed.to_string())
+}
+
+fn require_role(role: &str) -> Result<String> {
+    let trimmed = role.trim();
+    if trimmed.is_empty() {
+        bail!("role is required");
+    }
+    Ok(trimmed.to_string())
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AppAdminMember {
+    role: String,
+    #[serde(default)]
+    mutable: bool,
+    #[serde(default)]
+    subject_id: Option<String>,
+    #[serde(default)]
+    selector_value: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        member_subject_id, normalize_subject_id, normalize_user_email_subject, subject_matches_member,
+        AppAdminMember,
+    };
+
+    #[test]
+    fn normalize_user_email_subject_prefixes_user() {
+        assert_eq!(
+            normalize_user_email_subject("alice@example.com").unwrap(),
+            "user:alice@example.com"
+        );
+    }
+
+    #[test]
+    fn normalize_subject_id_prefixes_bare_ids() {
+        assert_eq!(
+            normalize_subject_id("user_123").unwrap(),
+            "user:user_123"
+        );
+    }
+
+    #[test]
+    fn member_subject_id_prefers_email() {
+        assert_eq!(
+            member_subject_id(Some("alice@example.com"), Some("user:other")).unwrap(),
+            "user:alice@example.com"
+        );
+    }
+
+    #[test]
+    fn subject_matches_member_compares_subject_id() {
+        let member = AppAdminMember {
+            role: "viewer".to_string(),
+            mutable: true,
+            subject_id: Some("user:abc".to_string()),
+            selector_value: None,
+        };
+        assert!(subject_matches_member("user:abc", &member));
+        assert!(!subject_matches_member("user:def", &member));
+    }
+}

--- a/gestalt/cli/src/commands/authorization_apps.rs
+++ b/gestalt/cli/src/commands/authorization_apps.rs
@@ -399,12 +399,7 @@ fn subject_matches_member(subject_id: &str, member: &AppAdminMember) -> bool {
             return true;
         }
     }
-    member
-        .selector_value
-        .as_deref()
-        .and_then(|value| normalize_subject_id(value).ok())
-        .as_deref()
-        == Some(normalized.as_str())
+    false
 }
 
 fn member_row(value: &Value) -> Vec<String> {
@@ -449,6 +444,11 @@ fn normalize_subject_id(raw: &str) -> Result<String> {
     let trimmed = raw.trim();
     if trimmed.is_empty() {
         bail!("subject id is required");
+    }
+    if trimmed.contains('#') {
+        bail!(
+            "subject id must be a direct subject, not a subject-set selector; use `authorization relationships` for group grants"
+        );
     }
     if trimmed.contains(':') {
         Ok(trimmed.to_string())
@@ -501,8 +501,6 @@ struct AppAdminMember {
     #[serde(default)]
     subject_id: Option<String>,
     #[serde(default)]
-    selector_value: Option<String>,
-    #[serde(default)]
     email: Option<String>,
 }
 
@@ -525,12 +523,34 @@ mod tests {
             role: "viewer".to_string(),
             mutable: true,
             subject_id: Some("user:abc".to_string()),
-            selector_value: None,
             email: Some("alice@example.com".to_string()),
         };
         assert!(subject_matches_member("user:abc", &member));
         assert!(subject_matches_member("user:alice@example.com", &member));
         assert!(!subject_matches_member("user:def", &member));
+    }
+
+    #[test]
+    fn subject_matches_member_ignores_subject_set_selectors() {
+        let member = AppAdminMember {
+            role: "viewer".to_string(),
+            mutable: true,
+            subject_id: None,
+            email: None,
+        };
+        assert!(!subject_matches_member(
+            "group:valon-employees#member",
+            &member
+        ));
+    }
+
+    #[test]
+    fn normalize_subject_id_rejects_subject_set_selectors() {
+        let err = normalize_subject_id("group:valon-employees#member").unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("subject id must be a direct subject")
+        );
     }
 
     #[test]
@@ -545,7 +565,6 @@ mod tests {
             role: "viewer".to_string(),
             mutable: true,
             subject_id: Some("user:canonical-id".to_string()),
-            selector_value: None,
             email: Some("alice@example.com".to_string()),
         }];
         assert_eq!(
@@ -560,7 +579,6 @@ mod tests {
             role: "viewer".to_string(),
             mutable: true,
             subject_id: Some("user:canonical-id".to_string()),
-            selector_value: None,
             email: Some("Alice@Example.com".to_string()),
         }];
         assert_eq!(

--- a/gestalt/cli/src/commands/authorization_apps.rs
+++ b/gestalt/cli/src/commands/authorization_apps.rs
@@ -159,7 +159,12 @@ fn remove_member(
     format: Format,
 ) -> Result<()> {
     let app = require_app_name(&args.app)?;
-    let subject = normalize_subject_id(&args.subject)?;
+    let subject = resolve_member_subject_id(
+        api,
+        &app,
+        args.email.as_deref(),
+        args.subject_id.as_deref().or(args.subject.as_deref()),
+    )?;
     let mutable_roles = mutable_roles_for_subject(authz, api, &app, &subject)?;
     let roles = match args
         .role

--- a/gestalt/cli/src/commands/authorization_apps.rs
+++ b/gestalt/cli/src/commands/authorization_apps.rs
@@ -558,7 +558,7 @@ mod tests {
 
     #[test]
     fn canonical_subject_id_prefers_roster_subject_id() {
-        let members = vec![AppAdminMember {
+        let members = [AppAdminMember {
             role: "viewer".to_string(),
             mutable: true,
             subject_id: Some("user:canonical-id".to_string()),

--- a/gestalt/cli/src/commands/authorization_apps.rs
+++ b/gestalt/cli/src/commands/authorization_apps.rs
@@ -106,6 +106,7 @@ fn set_member(
     let role = require_role(&args.role)?;
     let subject_id =
         resolve_member_subject_id(api, &app, args.email.as_deref(), args.subject_id.as_deref())?;
+    let subject_id = canonical_subject_id_from_roster(api, &app, &subject_id)?;
 
     let existing = mutable_roles_for_subject(authz, api, &app, &subject_id)?;
     let other_roles: Vec<String> = existing
@@ -165,6 +166,7 @@ fn remove_member(
         args.email.as_deref(),
         args.subject_id.as_deref().or(args.subject.as_deref()),
     )?;
+    let subject = canonical_subject_id_from_roster(api, &app, &subject)?;
     let mutable_roles = mutable_roles_for_subject(authz, api, &app, &subject)?;
     let roles = match args
         .role
@@ -333,6 +335,31 @@ fn resolve_member_subject_id(
     bail!(
         "could not resolve {email} to a canonical user id; pass --subject-id user:<uuid> from `members list`"
     )
+}
+
+fn canonical_subject_id_from_roster(
+    api: &ApiClient,
+    app: &str,
+    subject_id: &str,
+) -> Result<String> {
+    let normalized = normalize_subject_id(subject_id)?;
+    if is_service_account_subject(&normalized) {
+        return Ok(normalized);
+    }
+    for member in load_app_admin_members(api, app)? {
+        if !subject_matches_member(&normalized, &member) {
+            continue;
+        }
+        if let Some(canonical) = member
+            .subject_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            return Ok(canonical.to_string());
+        }
+    }
+    Ok(normalized)
 }
 
 fn subject_id_for_email_in_members(
@@ -527,5 +554,23 @@ mod tests {
     fn service_account_subject_detection() {
         assert!(is_service_account_subject("service_account:bot"));
         assert!(!is_service_account_subject("user:abc"));
+    }
+
+    #[test]
+    fn canonical_subject_id_prefers_roster_subject_id() {
+        let members = vec![AppAdminMember {
+            role: "viewer".to_string(),
+            mutable: true,
+            subject_id: Some("user:canonical-id".to_string()),
+            selector_value: None,
+            email: Some("alice@example.com".to_string()),
+        }];
+        let normalized = normalize_subject_id("user:alice@example.com").unwrap();
+        let canonical = members
+            .iter()
+            .find(|member| subject_matches_member(&normalized, member))
+            .and_then(|member| member.subject_id.clone())
+            .unwrap();
+        assert_eq!(canonical, "user:canonical-id");
     }
 }

--- a/gestalt/cli/src/commands/authorization_apps.rs
+++ b/gestalt/cli/src/commands/authorization_apps.rs
@@ -12,8 +12,13 @@ use crate::commands::authorization::{
 };
 use crate::output::{self, Format};
 
-use gestalt_sdk::authorization::{AddRelationshipRequest, DeleteRelationshipRequest};
-use gestalt_sdk::public::generated::app_client::AuthorizationClient;
+use gestalt_sdk::authorization::source_layer::SOURCE_LAYER_RUNTIME;
+use gestalt_sdk::authorization::{
+    AddRelationshipRequest, DeleteRelationshipRequest, ListRelationshipsRequest, Relationship,
+    RelationshipFilter, RelationshipTargetKind, Resource,
+};
+use gestalt_sdk::public::generated::app::AppInvokeRequest;
+use gestalt_sdk::public::generated::app_client::{AppClient, AuthorizationClient};
 use gestalt_sdk::public::rest_transport::SyncRestTransport;
 
 pub fn dispatch(
@@ -99,24 +104,32 @@ fn set_member(
 ) -> Result<()> {
     let app = require_app_name(&args.app)?;
     let role = require_role(&args.role)?;
-    let subject_id = member_subject_id(args.email.as_deref(), args.subject_id.as_deref())?;
+    let subject_id =
+        resolve_member_subject_id(api, &app, args.email.as_deref(), args.subject_id.as_deref())?;
 
-    for existing in mutable_member_roles_for_subject(api, &app, &subject_id)? {
-        if existing == role {
-            match format {
-                Format::Json => output::print_json(&serde_json::json!({
-                    "app": app,
-                    "subjectId": subject_id,
-                    "role": role,
-                    "changed": false,
-                })),
-                Format::Table => {
-                    output::print_success(&format!("{subject_id} already has {role} on {app}."))
-                }
+    let existing = mutable_roles_for_subject(authz, api, &app, &subject_id)?;
+    let other_roles: Vec<String> = existing
+        .iter()
+        .filter(|existing_role| existing_role.as_str() != role)
+        .cloned()
+        .collect();
+    for existing_role in &other_roles {
+        delete_member_tuple(authz, &app, existing_role, &subject_id)?;
+    }
+
+    if existing.iter().any(|existing_role| existing_role == &role) {
+        match format {
+            Format::Json => output::print_json(&serde_json::json!({
+                "app": app,
+                "subjectId": subject_id,
+                "role": role,
+                "changed": false,
+            })),
+            Format::Table => {
+                output::print_success(&format!("{subject_id} already has {role} on {app}."))
             }
-            return Ok(());
         }
-        delete_member_tuple(authz, &app, &existing, &subject_id)?;
+        return Ok(());
     }
 
     let relationship = build_app_member_relationship(&app, &role, &subject_id)?;
@@ -147,14 +160,24 @@ fn remove_member(
 ) -> Result<()> {
     let app = require_app_name(&args.app)?;
     let subject = normalize_subject_id(&args.subject)?;
+    let mutable_roles = mutable_roles_for_subject(authz, api, &app, &subject)?;
     let roles = match args
         .role
         .as_deref()
         .map(str::trim)
-        .filter(|v| !v.is_empty())
+        .filter(|value| !value.is_empty())
     {
-        Some(role) => vec![require_role(role)?],
-        None => mutable_member_roles_for_subject(api, &app, &subject)?,
+        Some(role) => {
+            let role = require_role(role)?;
+            if !mutable_roles
+                .iter()
+                .any(|mutable_role| mutable_role == &role)
+            {
+                bail!("no mutable {role} grant found for {subject} on {app}");
+            }
+            vec![role]
+        }
+        None => mutable_roles,
     };
     if roles.is_empty() {
         bail!("no mutable member grants found for {subject} on {app}");
@@ -191,28 +214,194 @@ fn delete_member_tuple(
     Ok(())
 }
 
-fn mutable_member_roles_for_subject(
+fn mutable_roles_for_subject(
+    authz: &AuthorizationClient<SyncRestTransport>,
     api: &ApiClient,
     app: &str,
     subject_id: &str,
 ) -> Result<Vec<String>> {
+    if is_service_account_subject(subject_id) {
+        return runtime_roles_for_subject(authz, app, subject_id);
+    }
+
+    let members = load_app_admin_members(api, app)?;
+    let roster_roles: Vec<String> = members
+        .iter()
+        .filter(|member| member.mutable && subject_matches_member(subject_id, member))
+        .map(|member| member.role.clone())
+        .collect();
+    if !roster_roles.is_empty()
+        || members
+            .iter()
+            .any(|member| subject_matches_member(subject_id, member))
+    {
+        return Ok(roster_roles);
+    }
+
+    runtime_roles_for_subject(authz, app, subject_id)
+}
+
+fn runtime_roles_for_subject(
+    authz: &AuthorizationClient<SyncRestTransport>,
+    app: &str,
+    subject_id: &str,
+) -> Result<Vec<String>> {
+    let normalized = normalize_subject_id(subject_id)?;
+    let mut roles = Vec::new();
+    let mut page_token = String::new();
+    loop {
+        let resp = authz
+            .list_relationships_sync(ListRelationshipsRequest {
+                filter: Some(RelationshipFilter {
+                    resource: Some(Resource {
+                        r#type: "app".to_string(),
+                        id: app.to_string(),
+                        properties: None,
+                    }),
+                    ..Default::default()
+                }),
+                page_size: 500,
+                page_token: page_token.clone(),
+            })
+            .context("failed to list app relationships")?;
+        for relationship in resp.relationships {
+            if relationship.source_layer != SOURCE_LAYER_RUNTIME {
+                continue;
+            }
+            let Some(role) = runtime_role_for_subject(&relationship, &normalized) else {
+                continue;
+            };
+            roles.push(role);
+        }
+        page_token = resp.next_page_token.trim().to_string();
+        if page_token.is_empty() {
+            return Ok(roles);
+        }
+    }
+}
+
+fn runtime_role_for_subject(relationship: &Relationship, subject_id: &str) -> Option<String> {
+    let tuple = relationship.tuple.as_ref()?;
+    let target = tuple.target.as_ref()?.kind.as_ref()?;
+    let target_subject = match target {
+        RelationshipTargetKind::Subject(subject) => subject,
+        _ => return None,
+    };
+    if normalize_subject_id(&target_subject.id).ok().as_deref() != Some(subject_id) {
+        return None;
+    }
+    let role = tuple.relation.trim();
+    if role.is_empty() {
+        return None;
+    }
+    Some(role.to_string())
+}
+
+fn load_app_admin_members(api: &ApiClient, app: &str) -> Result<Vec<AppAdminMember>> {
     let path = format!("/api/v1/apps/{}/admin/members", encode_path_segment(app));
     let resp = api
         .get(&path)
         .with_context(|| format!("failed to list members for app {app}"))?;
-    let members: Vec<AppAdminMember> =
-        serde_json::from_value(resp).context("failed to parse app admin members response")?;
-    Ok(members
-        .into_iter()
-        .filter(|member| member.mutable && subject_matches_member(subject_id, member))
-        .map(|member| member.role)
-        .collect())
+    serde_json::from_value(resp).context("failed to parse app admin members response")
+}
+
+fn resolve_member_subject_id(
+    api: &ApiClient,
+    app: &str,
+    email: Option<&str>,
+    subject_id: Option<&str>,
+) -> Result<String> {
+    if let Some(subject_id) = subject_id.map(str::trim).filter(|value| !value.is_empty()) {
+        return normalize_subject_id(subject_id);
+    }
+    let email = email
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .context("either --email or --subject-id is required")?;
+
+    if let Some(subject_id) = subject_id_for_email_in_members(api, app, email)? {
+        return Ok(subject_id);
+    }
+    if let Some(user_id) = lookup_user_id_by_email(api, email)? {
+        return Ok(format!("user:{user_id}"));
+    }
+    bail!(
+        "could not resolve {email} to a canonical user id; pass --subject-id user:<uuid> from `members list`"
+    )
+}
+
+fn subject_id_for_email_in_members(
+    api: &ApiClient,
+    app: &str,
+    email: &str,
+) -> Result<Option<String>> {
+    let normalized_email = email.trim().to_lowercase();
+    for member in load_app_admin_members(api, app)? {
+        let Some(member_email) = member.email.as_deref() else {
+            continue;
+        };
+        if member_email.trim().eq_ignore_ascii_case(&normalized_email)
+            && let Some(subject_id) = member
+                .subject_id
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+        {
+            return Ok(Some(subject_id.to_string()));
+        }
+    }
+    Ok(None)
+}
+
+fn lookup_user_id_by_email(api: &ApiClient, email: &str) -> Result<Option<String>> {
+    let transport = api.sync_rest_transport(std::time::Duration::from_secs(30));
+    let app_client = AppClient::new(transport);
+    let resp = match app_client.invoke_sync(AppInvokeRequest {
+        app: "home".to_string(),
+        operation: "users.list".to_string(),
+        ..Default::default()
+    }) {
+        Ok(resp) => resp,
+        Err(_) => return Ok(None),
+    };
+    let users = resp
+        .get("users")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let normalized_email = email.trim().to_lowercase();
+    for user in users {
+        let user_email = user
+            .get("email")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .trim()
+            .to_lowercase();
+        if user_email != normalized_email {
+            continue;
+        }
+        if let Some(id) = user
+            .get("id")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            return Ok(Some(id.to_string()));
+        }
+    }
+    Ok(None)
 }
 
 fn subject_matches_member(subject_id: &str, member: &AppAdminMember) -> bool {
     let normalized = normalize_subject_id(subject_id).unwrap_or_default();
-    if let Some(subject) = member.subject_id.as_deref() {
-        if normalize_subject_id(subject).ok().as_deref() == Some(normalized.as_str()) {
+    if let Some(subject) = member.subject_id.as_deref()
+        && normalize_subject_id(subject).ok().as_deref() == Some(normalized.as_str())
+    {
+        return true;
+    }
+    if let Some(email) = member.email.as_deref() {
+        let email_subject = format!("user:{}", email.trim().to_lowercase());
+        if normalize_subject_id(&email_subject).ok().as_deref() == Some(normalized.as_str()) {
             return true;
         }
     }
@@ -255,26 +444,11 @@ fn member_row(value: &Value) -> Vec<String> {
     ]
 }
 
-fn member_subject_id(email: Option<&str>, subject_id: Option<&str>) -> Result<String> {
-    if let Some(email) = email.map(str::trim).filter(|value| !value.is_empty()) {
-        return normalize_user_email_subject(email);
-    }
-    if let Some(subject_id) = subject_id.map(str::trim).filter(|value| !value.is_empty()) {
-        return normalize_subject_id(subject_id);
-    }
-    bail!("either --email or --subject-id is required")
-}
-
-fn normalize_user_email_subject(email: &str) -> Result<String> {
-    let trimmed = email.trim();
-    if trimmed.is_empty() {
-        bail!("email is required");
-    }
-    if trimmed.to_lowercase().starts_with("user:") {
-        Ok(trimmed.to_string())
-    } else {
-        Ok(format!("user:{trimmed}"))
-    }
+fn is_service_account_subject(subject_id: &str) -> bool {
+    subject_id
+        .trim()
+        .to_ascii_lowercase()
+        .starts_with("service_account:")
 }
 
 fn normalize_subject_id(raw: &str) -> Result<String> {
@@ -315,22 +489,15 @@ struct AppAdminMember {
     subject_id: Option<String>,
     #[serde(default)]
     selector_value: Option<String>,
+    #[serde(default)]
+    email: Option<String>,
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
-        AppAdminMember, member_subject_id, normalize_subject_id, normalize_user_email_subject,
-        subject_matches_member,
+        AppAdminMember, is_service_account_subject, normalize_subject_id, subject_matches_member,
     };
-
-    #[test]
-    fn normalize_user_email_subject_prefixes_user() {
-        assert_eq!(
-            normalize_user_email_subject("alice@example.com").unwrap(),
-            "user:alice@example.com"
-        );
-    }
 
     #[test]
     fn normalize_subject_id_prefixes_bare_ids() {
@@ -338,22 +505,22 @@ mod tests {
     }
 
     #[test]
-    fn member_subject_id_prefers_email() {
-        assert_eq!(
-            member_subject_id(Some("alice@example.com"), Some("user:other")).unwrap(),
-            "user:alice@example.com"
-        );
-    }
-
-    #[test]
-    fn subject_matches_member_compares_subject_id() {
+    fn subject_matches_member_compares_subject_id_and_email() {
         let member = AppAdminMember {
             role: "viewer".to_string(),
             mutable: true,
             subject_id: Some("user:abc".to_string()),
             selector_value: None,
+            email: Some("alice@example.com".to_string()),
         };
         assert!(subject_matches_member("user:abc", &member));
+        assert!(subject_matches_member("user:alice@example.com", &member));
         assert!(!subject_matches_member("user:def", &member));
+    }
+
+    #[test]
+    fn service_account_subject_detection() {
+        assert!(is_service_account_subject("service_account:bot"));
+        assert!(!is_service_account_subject("user:abc"));
     }
 }

--- a/gestalt/cli/src/commands/authorization_apps.rs
+++ b/gestalt/cli/src/commands/authorization_apps.rs
@@ -4,9 +4,8 @@ use serde_json::Value;
 
 use crate::api::{ApiClient, encode_path_segment};
 use crate::cli::{
-    AuthorizationAppsCommands, AuthorizationAppsMembersCommands,
-    AuthorizationAppsMembersListArgs, AuthorizationAppsMembersRemoveArgs,
-    AuthorizationAppsMembersSetArgs,
+    AuthorizationAppsCommands, AuthorizationAppsMembersCommands, AuthorizationAppsMembersListArgs,
+    AuthorizationAppsMembersRemoveArgs, AuthorizationAppsMembersSetArgs,
 };
 use crate::commands::authorization::{
     build_app_member_relationship, relationship_tuple_from_parts,
@@ -28,15 +27,15 @@ pub fn dispatch(
         AuthorizationAppsCommands::Members { command } => match command {
             AuthorizationAppsMembersCommands::List(args) => list_members(api, &args, format),
             AuthorizationAppsMembersCommands::Set(args) => set_member(authz, api, &args, format),
-            AuthorizationAppsMembersCommands::Remove(args) => remove_member(authz, api, &args, format),
+            AuthorizationAppsMembersCommands::Remove(args) => {
+                remove_member(authz, api, &args, format)
+            }
         },
     }
 }
 
 fn list_apps(api: &ApiClient, format: Format) -> Result<()> {
-    let resp = api
-        .get("/api/v1/apps")
-        .context("failed to list apps")?;
+    let resp = api.get("/api/v1/apps").context("failed to list apps")?;
     match format {
         Format::Json => output::print_json(&resp),
         Format::Table => {
@@ -70,10 +69,7 @@ fn list_members(
     format: Format,
 ) -> Result<()> {
     let app = require_app_name(&args.app)?;
-    let path = format!(
-        "/api/v1/apps/{}/admin/members",
-        encode_path_segment(&app)
-    );
+    let path = format!("/api/v1/apps/{}/admin/members", encode_path_segment(&app));
     let resp = api
         .get(&path)
         .with_context(|| format!("failed to list members for app {app}"))?;
@@ -88,10 +84,7 @@ fn list_members(
                 .collect();
             println!(
                 "{}",
-                output::render_table(
-                    &["Role", "Source", "Mutable", "Subject", "Email"],
-                    &rows
-                )
+                output::render_table(&["Role", "Source", "Mutable", "Subject", "Email"], &rows)
             );
         }
     }
@@ -117,9 +110,9 @@ fn set_member(
                     "role": role,
                     "changed": false,
                 })),
-                Format::Table => output::print_success(&format!(
-                    "{subject_id} already has {role} on {app}."
-                )),
+                Format::Table => {
+                    output::print_success(&format!("{subject_id} already has {role} on {app}."))
+                }
             }
             return Ok(());
         }
@@ -139,9 +132,9 @@ fn set_member(
             "role": role,
             "changed": true,
         })),
-        Format::Table => output::print_success(&format!(
-            "Granted {role} on {app} to {subject_id}."
-        )),
+        Format::Table => {
+            output::print_success(&format!("Granted {role} on {app} to {subject_id}."))
+        }
     }
     Ok(())
 }
@@ -154,7 +147,12 @@ fn remove_member(
 ) -> Result<()> {
     let app = require_app_name(&args.app)?;
     let subject = normalize_subject_id(&args.subject)?;
-    let roles = match args.role.as_deref().map(str::trim).filter(|v| !v.is_empty()) {
+    let roles = match args
+        .role
+        .as_deref()
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+    {
         Some(role) => vec![require_role(role)?],
         None => mutable_member_roles_for_subject(api, &app, &subject)?,
     };
@@ -198,15 +196,12 @@ fn mutable_member_roles_for_subject(
     app: &str,
     subject_id: &str,
 ) -> Result<Vec<String>> {
-    let path = format!(
-        "/api/v1/apps/{}/admin/members",
-        encode_path_segment(app)
-    );
+    let path = format!("/api/v1/apps/{}/admin/members", encode_path_segment(app));
     let resp = api
         .get(&path)
         .with_context(|| format!("failed to list members for app {app}"))?;
-    let members: Vec<AppAdminMember> = serde_json::from_value(resp)
-        .context("failed to parse app admin members response")?;
+    let members: Vec<AppAdminMember> =
+        serde_json::from_value(resp).context("failed to parse app admin members response")?;
     Ok(members
         .into_iter()
         .filter(|member| member.mutable && subject_matches_member(subject_id, member))
@@ -325,8 +320,8 @@ struct AppAdminMember {
 #[cfg(test)]
 mod tests {
     use super::{
-        member_subject_id, normalize_subject_id, normalize_user_email_subject, subject_matches_member,
-        AppAdminMember,
+        AppAdminMember, member_subject_id, normalize_subject_id, normalize_user_email_subject,
+        subject_matches_member,
     };
 
     #[test]
@@ -339,10 +334,7 @@ mod tests {
 
     #[test]
     fn normalize_subject_id_prefixes_bare_ids() {
-        assert_eq!(
-            normalize_subject_id("user_123").unwrap(),
-            "user:user_123"
-        );
+        assert_eq!(normalize_subject_id("user_123").unwrap(), "user:user_123");
     }
 
     #[test]

--- a/gestalt/cli/src/commands/authorization_apps.rs
+++ b/gestalt/cli/src/commands/authorization_apps.rs
@@ -104,21 +104,16 @@ fn set_member(
 ) -> Result<()> {
     let app = require_app_name(&args.app)?;
     let role = require_role(&args.role)?;
-    let subject_id =
-        resolve_member_subject_id(api, &app, args.email.as_deref(), args.subject_id.as_deref())?;
-    let subject_id = canonical_subject_id_from_roster(api, &app, &subject_id)?;
+    let subject_id = resolve_canonical_member_subject_id(
+        api,
+        &app,
+        args.email.as_deref(),
+        args.subject_id.as_deref(),
+    )?;
 
     let existing = mutable_roles_for_subject(authz, api, &app, &subject_id)?;
-    let other_roles: Vec<String> = existing
-        .iter()
-        .filter(|existing_role| existing_role.as_str() != role)
-        .cloned()
-        .collect();
-    for existing_role in &other_roles {
-        delete_member_tuple(authz, &app, existing_role, &subject_id)?;
-    }
-
-    if existing.iter().any(|existing_role| existing_role == &role) {
+    let plan = plan_role_set(&existing, &role);
+    if plan.roles_to_remove.is_empty() && !plan.add_role {
         match format {
             Format::Json => output::print_json(&serde_json::json!({
                 "app": app,
@@ -133,12 +128,19 @@ fn set_member(
         return Ok(());
     }
 
-    let relationship = build_app_member_relationship(&app, &role, &subject_id)?;
-    authz
-        .add_relationship_sync(AddRelationshipRequest {
-            relationship: Some(relationship),
-        })
-        .context("failed to grant app member access")?;
+    for existing_role in &plan.roles_to_remove {
+        delete_member_tuple(authz, &app, existing_role, &subject_id)?;
+    }
+
+    if plan.add_role {
+        let relationship = build_app_member_relationship(&app, &role, &subject_id)?;
+        authz
+            .add_relationship_sync(AddRelationshipRequest {
+                relationship: Some(relationship),
+            })
+            .context("failed to grant app member access")?;
+    }
+
     match format {
         Format::Json => output::print_json(&serde_json::json!({
             "app": app,
@@ -147,7 +149,11 @@ fn set_member(
             "changed": true,
         })),
         Format::Table => {
-            output::print_success(&format!("Granted {role} on {app} to {subject_id}."))
+            if plan.add_role {
+                output::print_success(&format!("Granted {role} on {app} to {subject_id}."))
+            } else {
+                output::print_success(&format!("Updated {subject_id} on {app} to only {role}."))
+            }
         }
     }
     Ok(())
@@ -160,13 +166,12 @@ fn remove_member(
     format: Format,
 ) -> Result<()> {
     let app = require_app_name(&args.app)?;
-    let subject = resolve_member_subject_id(
+    let subject = resolve_canonical_member_subject_id(
         api,
         &app,
         args.email.as_deref(),
         args.subject_id.as_deref().or(args.subject.as_deref()),
     )?;
-    let subject = canonical_subject_id_from_roster(api, &app, &subject)?;
     let mutable_roles = mutable_roles_for_subject(authz, api, &app, &subject)?;
     let roles = match args
         .role
@@ -312,21 +317,26 @@ fn load_app_admin_members(api: &ApiClient, app: &str) -> Result<Vec<AppAdminMemb
     serde_json::from_value(resp).context("failed to parse app admin members response")
 }
 
-fn resolve_member_subject_id(
+fn resolve_canonical_member_subject_id(
     api: &ApiClient,
     app: &str,
     email: Option<&str>,
     subject_id: Option<&str>,
 ) -> Result<String> {
     if let Some(subject_id) = subject_id.map(str::trim).filter(|value| !value.is_empty()) {
-        return normalize_subject_id(subject_id);
+        let normalized = normalize_subject_id(subject_id)?;
+        if is_service_account_subject(&normalized) {
+            return Ok(normalized);
+        }
+        return canonical_subject_id_from_members(&load_app_admin_members(api, app)?, &normalized);
     }
+
     let email = email
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .context("either --email or --subject-id is required")?;
-
-    if let Some(subject_id) = subject_id_for_email_in_members(api, app, email)? {
+    let members = load_app_admin_members(api, app)?;
+    if let Some(subject_id) = subject_id_for_email_in_members(&members, email)? {
         return Ok(subject_id);
     }
     if let Some(user_id) = lookup_user_id_by_email(api, email)? {
@@ -337,17 +347,16 @@ fn resolve_member_subject_id(
     )
 }
 
-fn canonical_subject_id_from_roster(
-    api: &ApiClient,
-    app: &str,
+fn canonical_subject_id_from_members(
+    members: &[AppAdminMember],
     subject_id: &str,
 ) -> Result<String> {
     let normalized = normalize_subject_id(subject_id)?;
     if is_service_account_subject(&normalized) {
         return Ok(normalized);
     }
-    for member in load_app_admin_members(api, app)? {
-        if !subject_matches_member(&normalized, &member) {
+    for member in members {
+        if !subject_matches_member(&normalized, member) {
             continue;
         }
         if let Some(canonical) = member
@@ -363,12 +372,11 @@ fn canonical_subject_id_from_roster(
 }
 
 fn subject_id_for_email_in_members(
-    api: &ApiClient,
-    app: &str,
+    members: &[AppAdminMember],
     email: &str,
 ) -> Result<Option<String>> {
     let normalized_email = email.trim().to_lowercase();
-    for member in load_app_admin_members(api, app)? {
+    for member in members {
         let Some(member_email) = member.email.as_deref() else {
             continue;
         };
@@ -388,14 +396,13 @@ fn subject_id_for_email_in_members(
 fn lookup_user_id_by_email(api: &ApiClient, email: &str) -> Result<Option<String>> {
     let transport = api.sync_rest_transport(std::time::Duration::from_secs(30));
     let app_client = AppClient::new(transport);
-    let resp = match app_client.invoke_sync(AppInvokeRequest {
-        app: "home".to_string(),
-        operation: "users.list".to_string(),
-        ..Default::default()
-    }) {
-        Ok(resp) => resp,
-        Err(_) => return Ok(None),
-    };
+    let resp = app_client
+        .invoke_sync(AppInvokeRequest {
+            app: "home".to_string(),
+            operation: "users.list".to_string(),
+            ..Default::default()
+        })
+        .context("failed to list users while resolving email to canonical user id")?;
     let users = resp
         .get("users")
         .and_then(Value::as_array)
@@ -511,6 +518,25 @@ fn require_role(role: &str) -> Result<String> {
     Ok(trimmed.to_string())
 }
 
+#[derive(Debug, PartialEq, Eq)]
+struct RoleSetPlan {
+    roles_to_remove: Vec<String>,
+    add_role: bool,
+}
+
+fn plan_role_set(existing_roles: &[String], role: &str) -> RoleSetPlan {
+    let already_has_role = existing_roles.iter().any(|existing| existing == role);
+    let roles_to_remove = existing_roles
+        .iter()
+        .filter(|existing| existing.as_str() != role)
+        .cloned()
+        .collect();
+    RoleSetPlan {
+        roles_to_remove,
+        add_role: !already_has_role,
+    }
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct AppAdminMember {
@@ -528,7 +554,8 @@ struct AppAdminMember {
 #[cfg(test)]
 mod tests {
     use super::{
-        AppAdminMember, is_service_account_subject, normalize_subject_id, subject_matches_member,
+        AppAdminMember, RoleSetPlan, canonical_subject_id_from_members, is_service_account_subject,
+        normalize_subject_id, plan_role_set, subject_matches_member,
     };
 
     #[test]
@@ -565,12 +592,42 @@ mod tests {
             selector_value: None,
             email: Some("alice@example.com".to_string()),
         }];
-        let normalized = normalize_subject_id("user:alice@example.com").unwrap();
-        let canonical = members
-            .iter()
-            .find(|member| subject_matches_member(&normalized, member))
-            .and_then(|member| member.subject_id.clone())
-            .unwrap();
-        assert_eq!(canonical, "user:canonical-id");
+        assert_eq!(
+            canonical_subject_id_from_members(&members, "user:alice@example.com").unwrap(),
+            "user:canonical-id"
+        );
+    }
+
+    #[test]
+    fn plan_role_set_noop_when_only_requested_role_present() {
+        assert_eq!(
+            plan_role_set(&["viewer".to_string()], "viewer"),
+            RoleSetPlan {
+                roles_to_remove: vec![],
+                add_role: false,
+            }
+        );
+    }
+
+    #[test]
+    fn plan_role_set_removes_extra_roles_without_readding() {
+        assert_eq!(
+            plan_role_set(&["viewer".to_string(), "editor".to_string()], "viewer"),
+            RoleSetPlan {
+                roles_to_remove: vec!["editor".to_string()],
+                add_role: false,
+            }
+        );
+    }
+
+    #[test]
+    fn plan_role_set_replaces_existing_role() {
+        assert_eq!(
+            plan_role_set(&["editor".to_string()], "viewer"),
+            RoleSetPlan {
+                roles_to_remove: vec!["editor".to_string()],
+                add_role: true,
+            }
+        );
     }
 }

--- a/gestalt/cli/src/commands/authorization_apps.rs
+++ b/gestalt/cli/src/commands/authorization_apps.rs
@@ -17,8 +17,7 @@ use gestalt_sdk::authorization::{
     AddRelationshipRequest, DeleteRelationshipRequest, ListRelationshipsRequest, Relationship,
     RelationshipFilter, RelationshipTargetKind, Resource,
 };
-use gestalt_sdk::public::generated::app::AppInvokeRequest;
-use gestalt_sdk::public::generated::app_client::{AppClient, AuthorizationClient};
+use gestalt_sdk::public::generated::app_client::AuthorizationClient;
 use gestalt_sdk::public::rest_transport::SyncRestTransport;
 
 pub fn dispatch(
@@ -336,14 +335,11 @@ fn resolve_canonical_member_subject_id(
         .filter(|value| !value.is_empty())
         .context("either --email or --subject-id is required")?;
     let members = load_app_admin_members(api, app)?;
-    if let Some(subject_id) = subject_id_for_email_in_members(&members, email)? {
+    if let Some(subject_id) = subject_id_for_email_in_members(&members, email) {
         return Ok(subject_id);
     }
-    if let Some(user_id) = lookup_user_id_by_email(api, email)? {
-        return Ok(format!("user:{user_id}"));
-    }
     bail!(
-        "could not resolve {email} to a canonical user id; pass --subject-id user:<uuid> from `members list`"
+        "could not resolve {email} from the app member roster; pass --subject-id user:<uuid> from `members list`"
     )
 }
 
@@ -371,10 +367,7 @@ fn canonical_subject_id_from_members(
     Ok(normalized)
 }
 
-fn subject_id_for_email_in_members(
-    members: &[AppAdminMember],
-    email: &str,
-) -> Result<Option<String>> {
+fn subject_id_for_email_in_members(members: &[AppAdminMember], email: &str) -> Option<String> {
     let normalized_email = email.trim().to_lowercase();
     for member in members {
         let Some(member_email) = member.email.as_deref() else {
@@ -387,48 +380,10 @@ fn subject_id_for_email_in_members(
                 .map(str::trim)
                 .filter(|value| !value.is_empty())
         {
-            return Ok(Some(subject_id.to_string()));
+            return Some(subject_id.to_string());
         }
     }
-    Ok(None)
-}
-
-fn lookup_user_id_by_email(api: &ApiClient, email: &str) -> Result<Option<String>> {
-    let transport = api.sync_rest_transport(std::time::Duration::from_secs(30));
-    let app_client = AppClient::new(transport);
-    let resp = app_client
-        .invoke_sync(AppInvokeRequest {
-            app: "home".to_string(),
-            operation: "users.list".to_string(),
-            ..Default::default()
-        })
-        .context("failed to list users while resolving email to canonical user id")?;
-    let users = resp
-        .get("users")
-        .and_then(Value::as_array)
-        .cloned()
-        .unwrap_or_default();
-    let normalized_email = email.trim().to_lowercase();
-    for user in users {
-        let user_email = user
-            .get("email")
-            .and_then(Value::as_str)
-            .unwrap_or("")
-            .trim()
-            .to_lowercase();
-        if user_email != normalized_email {
-            continue;
-        }
-        if let Some(id) = user
-            .get("id")
-            .and_then(Value::as_str)
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-        {
-            return Ok(Some(id.to_string()));
-        }
-    }
-    Ok(None)
+    None
 }
 
 fn subject_matches_member(subject_id: &str, member: &AppAdminMember) -> bool {
@@ -555,7 +510,8 @@ struct AppAdminMember {
 mod tests {
     use super::{
         AppAdminMember, RoleSetPlan, canonical_subject_id_from_members, is_service_account_subject,
-        normalize_subject_id, plan_role_set, subject_matches_member,
+        normalize_subject_id, plan_role_set, subject_id_for_email_in_members,
+        subject_matches_member,
     };
 
     #[test]
@@ -595,6 +551,25 @@ mod tests {
         assert_eq!(
             canonical_subject_id_from_members(&members, "user:alice@example.com").unwrap(),
             "user:canonical-id"
+        );
+    }
+
+    #[test]
+    fn subject_id_for_email_uses_roster_only() {
+        let members = [AppAdminMember {
+            role: "viewer".to_string(),
+            mutable: true,
+            subject_id: Some("user:canonical-id".to_string()),
+            selector_value: None,
+            email: Some("Alice@Example.com".to_string()),
+        }];
+        assert_eq!(
+            subject_id_for_email_in_members(&members, "alice@example.com"),
+            Some("user:canonical-id".to_string())
+        );
+        assert_eq!(
+            subject_id_for_email_in_members(&members, "bob@example.com"),
+            None
         );
     }
 

--- a/gestalt/cli/src/commands/mod.rs
+++ b/gestalt/cli/src/commands/mod.rs
@@ -3,6 +3,7 @@ mod app_errors;
 pub mod apps;
 pub mod auth;
 pub mod authorization;
+pub mod authorization_apps;
 pub mod authorization_subjects;
 pub mod config;
 pub mod describe;


### PR DESCRIPTION
## Summary
- Add `gestalt authorization apps list` and `gestalt authorization apps members list|set|remove`
- Wire member mutations through the public authorization API with runtime source layer, matching the Members UI
- Bump gestalt CLI to `0.0.2-alpha.18` (also includes `authorization relationships add|delete` from #3166 since alpha.17)

## Test plan
- [x] `cargo test -p gestalt`
- [x] `gestalt authorization apps members --help`
- [ ] Tag `gestalt/v0.0.2-alpha.18` after merge to publish Homebrew release


Made with [Cursor](https://cursor.com)