### PR TITLE
Include subjects in app-admin UI failure logs

### DIFF
--- a/gestaltd/services/observability/app_admin_ui.go
+++ b/gestaltd/services/observability/app_admin_ui.go
@@ -107,6 +107,18 @@ func LogAppAdminUIFailure(ctx context.Context, interaction AppAdminUIInteraction
 		slog.String("action", interaction.Action),
 		slog.String("failure_category", interaction.FailureCategory),
 	}
+	if kind := strings.TrimSpace(interaction.PrincipalSubjectKind); kind != "" {
+		attrs = append(attrs,
+			slog.String("principal_subject_kind", kind),
+			slog.String("principal_subject_id", strings.TrimSpace(interaction.PrincipalSubjectID)),
+		)
+	}
+	if kind := strings.TrimSpace(interaction.TargetSubjectKind); kind != "" {
+		attrs = append(attrs,
+			slog.String("target_subject_kind", kind),
+			slog.String("target_subject_id", strings.TrimSpace(interaction.TargetSubjectID)),
+		)
+	}
 	if interaction.Err != nil {
 		attrs = append(attrs, slog.String("error", interaction.Err.Error()))
 	} else if interaction.StatusCode > 0 {

--- a/gestaltd/services/observability/app_admin_ui.go
+++ b/gestaltd/services/observability/app_admin_ui.go
@@ -99,6 +99,20 @@ func RecordAppAdminUIInteraction(ctx context.Context, startedAt time.Time, inter
 	}
 }
 
+func appendAppAdminUILogSubject(
+	attrs []any,
+	kindKey, idKey, subjectKind, subjectID string,
+) []any {
+	subjectKind = strings.TrimSpace(subjectKind)
+	if subjectKind == "" {
+		return attrs
+	}
+	return append(attrs,
+		slog.String(kindKey, subjectKind),
+		slog.String(idKey, strings.TrimSpace(subjectID)),
+	)
+}
+
 func LogAppAdminUIFailure(ctx context.Context, interaction AppAdminUIInteraction) {
 	attrs := []any{
 		slog.String("event", "app_admin.ui"),
@@ -107,18 +121,20 @@ func LogAppAdminUIFailure(ctx context.Context, interaction AppAdminUIInteraction
 		slog.String("action", interaction.Action),
 		slog.String("failure_category", interaction.FailureCategory),
 	}
-	if kind := strings.TrimSpace(interaction.PrincipalSubjectKind); kind != "" {
-		attrs = append(attrs,
-			slog.String("principal_subject_kind", kind),
-			slog.String("principal_subject_id", strings.TrimSpace(interaction.PrincipalSubjectID)),
-		)
-	}
-	if kind := strings.TrimSpace(interaction.TargetSubjectKind); kind != "" {
-		attrs = append(attrs,
-			slog.String("target_subject_kind", kind),
-			slog.String("target_subject_id", strings.TrimSpace(interaction.TargetSubjectID)),
-		)
-	}
+	attrs = appendAppAdminUILogSubject(
+		attrs,
+		"principal_subject_kind",
+		"principal_subject_id",
+		interaction.PrincipalSubjectKind,
+		interaction.PrincipalSubjectID,
+	)
+	attrs = appendAppAdminUILogSubject(
+		attrs,
+		"target_subject_kind",
+		"target_subject_id",
+		interaction.TargetSubjectKind,
+		interaction.TargetSubjectID,
+	)
 	if interaction.Err != nil {
 		attrs = append(attrs, slog.String("error", interaction.Err.Error()))
 	} else if interaction.StatusCode > 0 {

--- a/gestaltd/services/observability/app_admin_ui_test.go
+++ b/gestaltd/services/observability/app_admin_ui_test.go
@@ -1,7 +1,12 @@
 package observability
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -52,4 +57,41 @@ func TestRecordAppAdminUI(t *testing.T) {
 	}
 	metrictest.RequireInt64Sum(t, rm, "gestaltd.app_admin.ui.count", 1, failAttrs)
 	metrictest.RequireInt64Sum(t, rm, "gestaltd.app_admin.ui.error_count", 1, failAttrs)
+}
+
+func TestLogAppAdminUIFailureIncludesPrincipalAndTargetSubjects(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	previous := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+	t.Cleanup(func() { slog.SetDefault(previous) })
+
+	LogAppAdminUIFailure(context.Background(), AppAdminUIInteraction{
+		App:                  "g-issues",
+		Surface:              AppAdminUISurfaceMembers,
+		Action:               AppAdminUIActionGrantAdd,
+		FailureCategory:      AppAdminUIFailureAuth,
+		StatusCode:           http.StatusForbidden,
+		PrincipalSubjectKind: "user",
+		PrincipalSubjectID:   "user:abc",
+		TargetSubjectKind:    "user",
+		TargetSubjectID:      "user:def",
+	})
+
+	var record map[string]string
+	if err := json.Unmarshal(buf.Bytes(), &record); err != nil {
+		t.Fatalf("unmarshal log record: %v", err)
+	}
+	for key, want := range map[string]string{
+		"event":                  "app_admin.ui",
+		"principal_subject_kind": "user",
+		"principal_subject_id":   "user:abc",
+		"target_subject_kind":    "user",
+		"target_subject_id":      "user:def",
+	} {
+		if got := strings.TrimSpace(record[key]); got != want {
+			t.Fatalf("%s = %q, want %q", key, got, want)
+		}
+	}
 }


### PR DESCRIPTION
## Summary
- Add `principal_subject_kind` and `principal_subject_id` to `@event:app_admin.ui` failure logs.
- Add `target_subject_kind` and `target_subject_id` when present on grant mutations.
- Enables Datadog forensics log stream columns without trace correlation.

## Test plan
- [x] `go test ./services/observability/ -run TestLogAppAdminUIFailure`


Made with [Cursor](https://cursor.com)