### PR TITLE
Emit app-admin UI audit logs on success and failure

### DIFF
--- a/gestaltd/services/observability/app_admin_ui.go
+++ b/gestaltd/services/observability/app_admin_ui.go
@@ -94,7 +94,7 @@ func RecordAppAdminUIInteraction(ctx context.Context, startedAt time.Time, inter
 		)
 	}
 	RecordAppAdminUI(ctx, startedAt, interaction.Failed, attrs...)
-	LogAppAdminUI(ctx, interaction, outcome)
+	LogAppAdminUI(ctx, interaction)
 }
 
 func appendAppAdminUILogSubject(
@@ -111,7 +111,11 @@ func appendAppAdminUILogSubject(
 	)
 }
 
-func LogAppAdminUI(ctx context.Context, interaction AppAdminUIInteraction, outcome string) {
+func LogAppAdminUI(ctx context.Context, interaction AppAdminUIInteraction) {
+	outcome := AppAdminUIOutcomeSuccess
+	if interaction.Failed {
+		outcome = AppAdminUIOutcomeFailure
+	}
 	attrs := []any{
 		slog.String("event", "app_admin.ui"),
 		slog.String("app", interaction.App),

--- a/gestaltd/services/observability/app_admin_ui.go
+++ b/gestaltd/services/observability/app_admin_ui.go
@@ -94,9 +94,7 @@ func RecordAppAdminUIInteraction(ctx context.Context, startedAt time.Time, inter
 		)
 	}
 	RecordAppAdminUI(ctx, startedAt, interaction.Failed, attrs...)
-	if interaction.Failed {
-		LogAppAdminUIFailure(ctx, interaction)
-	}
+	LogAppAdminUI(ctx, interaction, outcome)
 }
 
 func appendAppAdminUILogSubject(
@@ -113,13 +111,13 @@ func appendAppAdminUILogSubject(
 	)
 }
 
-func LogAppAdminUIFailure(ctx context.Context, interaction AppAdminUIInteraction) {
+func LogAppAdminUI(ctx context.Context, interaction AppAdminUIInteraction, outcome string) {
 	attrs := []any{
 		slog.String("event", "app_admin.ui"),
 		slog.String("app", interaction.App),
 		slog.String("surface", interaction.Surface),
 		slog.String("action", interaction.Action),
-		slog.String("failure_category", interaction.FailureCategory),
+		slog.String("outcome", outcome),
 	}
 	attrs = appendAppAdminUILogSubject(
 		attrs,
@@ -135,10 +133,15 @@ func LogAppAdminUIFailure(ctx context.Context, interaction AppAdminUIInteraction
 		interaction.TargetSubjectKind,
 		interaction.TargetSubjectID,
 	)
-	if interaction.Err != nil {
-		attrs = append(attrs, slog.String("error", interaction.Err.Error()))
-	} else if interaction.StatusCode > 0 {
-		attrs = append(attrs, slog.String("error", fmt.Sprintf("HTTP %d", interaction.StatusCode)))
+	if interaction.Failed {
+		if failureCategory := strings.TrimSpace(interaction.FailureCategory); failureCategory != "" {
+			attrs = append(attrs, slog.String("failure_category", failureCategory))
+		}
+		if interaction.Err != nil {
+			attrs = append(attrs, slog.String("error", interaction.Err.Error()))
+		} else if interaction.StatusCode > 0 {
+			attrs = append(attrs, slog.String("error", fmt.Sprintf("HTTP %d", interaction.StatusCode)))
+		}
 	}
 	if requestID := strings.TrimSpace(interaction.RequestID); requestID != "" {
 		attrs = append(attrs, slog.String("request_id", requestID))
@@ -147,7 +150,11 @@ func LogAppAdminUIFailure(ctx context.Context, interaction AppAdminUIInteraction
 	if spanCtx.IsValid() {
 		attrs = append(attrs, slog.String("trace_id", spanCtx.TraceID().String()))
 	}
-	slog.WarnContext(ctx, "app admin ui interaction failed", attrs...)
+	if interaction.Failed {
+		slog.WarnContext(ctx, "app admin ui interaction failed", attrs...)
+		return
+	}
+	slog.InfoContext(ctx, "app admin ui interaction", attrs...)
 }
 
 func AppAdminUIFailureCategoryHTTP(status int) string {

--- a/gestaltd/services/observability/app_admin_ui_test.go
+++ b/gestaltd/services/observability/app_admin_ui_test.go
@@ -59,79 +59,89 @@ func TestRecordAppAdminUI(t *testing.T) {
 	metrictest.RequireInt64Sum(t, rm, "gestaltd.app_admin.ui.error_count", 1, failAttrs)
 }
 
-func TestLogAppAdminUIFailureIncludesPrincipalAndTargetSubjects(t *testing.T) {
+func TestLogAppAdminUI(t *testing.T) {
 	t.Parallel()
 
-	var buf bytes.Buffer
-	previous := slog.Default()
-	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
-	t.Cleanup(func() { slog.SetDefault(previous) })
-
-	LogAppAdminUI(context.Background(), AppAdminUIInteraction{
-		App:                  "g-issues",
-		Surface:              AppAdminUISurfaceMembers,
-		Action:               AppAdminUIActionGrantAdd,
-		Failed:               true,
-		FailureCategory:      AppAdminUIFailureAuth,
-		StatusCode:           http.StatusForbidden,
-		PrincipalSubjectKind: "user",
-		PrincipalSubjectID:   "user:abc",
-		TargetSubjectKind:    "user",
-		TargetSubjectID:      "user:def",
-	}, AppAdminUIOutcomeFailure)
-
-	var record map[string]string
-	if err := json.Unmarshal(buf.Bytes(), &record); err != nil {
-		t.Fatalf("unmarshal log record: %v", err)
+	tests := []struct {
+		name      string
+		interaction AppAdminUIInteraction
+		wantLevel string
+		want      map[string]string
+		omit      []string
+	}{
+		{
+			name: "failure includes principal target and category",
+			interaction: AppAdminUIInteraction{
+				App:                  "g-issues",
+				Surface:              AppAdminUISurfaceMembers,
+				Action:               AppAdminUIActionGrantAdd,
+				Failed:               true,
+				FailureCategory:      AppAdminUIFailureAuth,
+				StatusCode:           http.StatusForbidden,
+				PrincipalSubjectKind: "user",
+				PrincipalSubjectID:   "user:abc",
+				TargetSubjectKind:    "user",
+				TargetSubjectID:      "user:def",
+			},
+			wantLevel: "WARN",
+			want: map[string]string{
+				"event":                  "app_admin.ui",
+				"outcome":                AppAdminUIOutcomeFailure,
+				"principal_subject_kind": "user",
+				"principal_subject_id":   "user:abc",
+				"target_subject_kind":    "user",
+				"target_subject_id":      "user:def",
+				"failure_category":       AppAdminUIFailureAuth,
+			},
+		},
+		{
+			name: "success omits failure category",
+			interaction: AppAdminUIInteraction{
+				App:                  "g-issues",
+				Surface:              AppAdminUISurfaceMembers,
+				Action:               AppAdminUIActionList,
+				PrincipalSubjectKind: "user",
+				PrincipalSubjectID:   "user:abc",
+			},
+			wantLevel: "INFO",
+			want: map[string]string{
+				"event":                  "app_admin.ui",
+				"outcome":                AppAdminUIOutcomeSuccess,
+				"principal_subject_kind": "user",
+				"principal_subject_id":   "user:abc",
+			},
+			omit: []string{"failure_category"},
+		},
 	}
-	for key, want := range map[string]string{
-		"event":                  "app_admin.ui",
-		"outcome":                AppAdminUIOutcomeFailure,
-		"level":                  "WARN",
-		"principal_subject_kind": "user",
-		"principal_subject_id":   "user:abc",
-		"target_subject_kind":    "user",
-		"target_subject_id":      "user:def",
-		"failure_category":       AppAdminUIFailureAuth,
-	} {
-		if got := strings.TrimSpace(record[key]); got != want {
-			t.Fatalf("%s = %q, want %q", key, got, want)
-		}
-	}
-}
 
-func TestLogAppAdminUISuccessIncludesOutcome(t *testing.T) {
-	t.Parallel()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	var buf bytes.Buffer
-	previous := slog.Default()
-	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
-	t.Cleanup(func() { slog.SetDefault(previous) })
+			var buf bytes.Buffer
+			previous := slog.Default()
+			slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+			t.Cleanup(func() { slog.SetDefault(previous) })
 
-	LogAppAdminUI(context.Background(), AppAdminUIInteraction{
-		App:                  "g-issues",
-		Surface:              AppAdminUISurfaceMembers,
-		Action:               AppAdminUIActionList,
-		PrincipalSubjectKind: "user",
-		PrincipalSubjectID:   "user:abc",
-	}, AppAdminUIOutcomeSuccess)
+			LogAppAdminUI(context.Background(), tt.interaction)
 
-	var record map[string]string
-	if err := json.Unmarshal(buf.Bytes(), &record); err != nil {
-		t.Fatalf("unmarshal log record: %v", err)
-	}
-	for key, want := range map[string]string{
-		"event":                  "app_admin.ui",
-		"outcome":                AppAdminUIOutcomeSuccess,
-		"level":                  "INFO",
-		"principal_subject_kind": "user",
-		"principal_subject_id":   "user:abc",
-	} {
-		if got := strings.TrimSpace(record[key]); got != want {
-			t.Fatalf("%s = %q, want %q", key, got, want)
-		}
-	}
-	if _, ok := record["failure_category"]; ok {
-		t.Fatalf("failure_category should be omitted on success logs")
+			var record map[string]string
+			if err := json.Unmarshal(buf.Bytes(), &record); err != nil {
+				t.Fatalf("unmarshal log record: %v", err)
+			}
+			if got := strings.TrimSpace(record["level"]); got != tt.wantLevel {
+				t.Fatalf("level = %q, want %q", got, tt.wantLevel)
+			}
+			for key, want := range tt.want {
+				if got := strings.TrimSpace(record[key]); got != want {
+					t.Fatalf("%s = %q, want %q", key, got, want)
+				}
+			}
+			for _, key := range tt.omit {
+				if _, ok := record[key]; ok {
+					t.Fatalf("%s should be omitted", key)
+				}
+			}
+		})
 	}
 }

--- a/gestaltd/services/observability/app_admin_ui_test.go
+++ b/gestaltd/services/observability/app_admin_ui_test.go
@@ -63,11 +63,11 @@ func TestLogAppAdminUI(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name      string
+		name        string
 		interaction AppAdminUIInteraction
-		wantLevel string
-		want      map[string]string
-		omit      []string
+		wantLevel   string
+		want        map[string]string
+		omit        []string
 	}{
 		{
 			name: "failure includes principal target and category",

--- a/gestaltd/services/observability/app_admin_ui_test.go
+++ b/gestaltd/services/observability/app_admin_ui_test.go
@@ -67,17 +67,18 @@ func TestLogAppAdminUIFailureIncludesPrincipalAndTargetSubjects(t *testing.T) {
 	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
 	t.Cleanup(func() { slog.SetDefault(previous) })
 
-	LogAppAdminUIFailure(context.Background(), AppAdminUIInteraction{
+	LogAppAdminUI(context.Background(), AppAdminUIInteraction{
 		App:                  "g-issues",
 		Surface:              AppAdminUISurfaceMembers,
 		Action:               AppAdminUIActionGrantAdd,
+		Failed:               true,
 		FailureCategory:      AppAdminUIFailureAuth,
 		StatusCode:           http.StatusForbidden,
 		PrincipalSubjectKind: "user",
 		PrincipalSubjectID:   "user:abc",
 		TargetSubjectKind:    "user",
 		TargetSubjectID:      "user:def",
-	})
+	}, AppAdminUIOutcomeFailure)
 
 	var record map[string]string
 	if err := json.Unmarshal(buf.Bytes(), &record); err != nil {
@@ -85,13 +86,52 @@ func TestLogAppAdminUIFailureIncludesPrincipalAndTargetSubjects(t *testing.T) {
 	}
 	for key, want := range map[string]string{
 		"event":                  "app_admin.ui",
+		"outcome":                AppAdminUIOutcomeFailure,
+		"level":                  "WARN",
 		"principal_subject_kind": "user",
 		"principal_subject_id":   "user:abc",
 		"target_subject_kind":    "user",
 		"target_subject_id":      "user:def",
+		"failure_category":       AppAdminUIFailureAuth,
 	} {
 		if got := strings.TrimSpace(record[key]); got != want {
 			t.Fatalf("%s = %q, want %q", key, got, want)
 		}
+	}
+}
+
+func TestLogAppAdminUISuccessIncludesOutcome(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	previous := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+	t.Cleanup(func() { slog.SetDefault(previous) })
+
+	LogAppAdminUI(context.Background(), AppAdminUIInteraction{
+		App:                  "g-issues",
+		Surface:              AppAdminUISurfaceMembers,
+		Action:               AppAdminUIActionList,
+		PrincipalSubjectKind: "user",
+		PrincipalSubjectID:   "user:abc",
+	}, AppAdminUIOutcomeSuccess)
+
+	var record map[string]string
+	if err := json.Unmarshal(buf.Bytes(), &record); err != nil {
+		t.Fatalf("unmarshal log record: %v", err)
+	}
+	for key, want := range map[string]string{
+		"event":                  "app_admin.ui",
+		"outcome":                AppAdminUIOutcomeSuccess,
+		"level":                  "INFO",
+		"principal_subject_kind": "user",
+		"principal_subject_id":   "user:abc",
+	} {
+		if got := strings.TrimSpace(record[key]); got != want {
+			t.Fatalf("%s = %q, want %q", key, got, want)
+		}
+	}
+	if _, ok := record["failure_category"]; ok {
+		t.Fatalf("failure_category should be omitted on success logs")
 	}
 }


### PR DESCRIPTION
## Summary
- Log every app-admin interaction with `@event:app_admin.ui`, not just failures.
- Add an `outcome` field (`success` | `failure`); keep `failure_category` and error details on failures only.
- Success rows use `INFO`; failures stay `WARN`.

## Test plan
- [x] `go test ./services/observability/ -run 'TestLogAppAdminUI|TestRecordAppAdminUI'`

## Stack
- toolshed dashboard follow-up: merge after this ships and bump `GESTALTD_PINNED_SHA`

Made with [Cursor](https://cursor.com)