### PR TITLE
Step 17: cap app-admin UI metric cardinality at subject kinds

### DIFF
--- a/gestaltd/internal/server/app_admin_ui_observability_test.go
+++ b/gestaltd/internal/server/app_admin_ui_observability_test.go
@@ -42,7 +42,6 @@ func TestAppAdminUIObservabilityMiddlewareRecordsSuccess(t *testing.T) {
 		"gestaltd.app_admin.ui.action":  "list",
 		"gestaltd.app_admin.ui.outcome": "success",
 		"gestaltd.subject.kind":         "unknown",
-		"gestaltd.subject.id":           "unknown",
 	}
 	metrictest.RequireInt64Sum(t, rm, "gestaltd.app_admin.ui.count", 1, attrs)
 	metrictest.RequireNoInt64Sum(t, rm, "gestaltd.app_admin.ui.error_count", attrs)
@@ -76,7 +75,6 @@ func TestAppAdminUIObservabilityMiddlewareRecordsValidationFailure(t *testing.T)
 		"gestaltd.app_admin.ui.outcome":          "failure",
 		"gestaltd.app_admin.ui.failure_category": "validation",
 		"gestaltd.subject.kind":                  "unknown",
-		"gestaltd.subject.id":                    "unknown",
 	}
 	metrictest.RequireInt64Sum(t, rm, "gestaltd.app_admin.ui.count", 1, attrs)
 	metrictest.RequireInt64Sum(t, rm, "gestaltd.app_admin.ui.error_count", 1, attrs)
@@ -115,7 +113,6 @@ func TestAppAdminUIObservabilityMiddlewareRecordsAuthorizationUnavailable(t *tes
 		"gestaltd.app_admin.ui.outcome":          "failure",
 		"gestaltd.app_admin.ui.failure_category": "server",
 		"gestaltd.subject.kind":                  "unknown",
-		"gestaltd.subject.id":                    "unknown",
 	}
 	metrictest.RequireInt64Sum(t, rm, "gestaltd.app_admin.ui.count", 1, attrs)
 	metrictest.RequireInt64Sum(t, rm, "gestaltd.app_admin.ui.error_count", 1, attrs)

--- a/gestaltd/services/observability/app_admin_ui.go
+++ b/gestaltd/services/observability/app_admin_ui.go
@@ -82,16 +82,10 @@ func RecordAppAdminUIInteraction(ctx context.Context, startedAt time.Time, inter
 		attrs = append(attrs, AttrAppAdminUIFailureCategory.String(interaction.FailureCategory))
 	}
 	if kind := strings.TrimSpace(interaction.PrincipalSubjectKind); kind != "" {
-		attrs = append(attrs,
-			AttrSubjectKind.String(kind),
-			AttrSubjectID.String(strings.TrimSpace(interaction.PrincipalSubjectID)),
-		)
+		attrs = append(attrs, AttrSubjectKind.String(kind))
 	}
 	if kind := strings.TrimSpace(interaction.TargetSubjectKind); kind != "" {
-		attrs = append(attrs,
-			AttrAppAdminUITargetSubjectKind.String(kind),
-			AttrAppAdminUITargetSubjectID.String(strings.TrimSpace(interaction.TargetSubjectID)),
-		)
+		attrs = append(attrs, AttrAppAdminUITargetSubjectKind.String(kind))
 	}
 	RecordAppAdminUI(ctx, startedAt, interaction.Failed, attrs...)
 	LogAppAdminUI(ctx, interaction)

--- a/gestaltd/services/observability/app_admin_ui_test.go
+++ b/gestaltd/services/observability/app_admin_ui_test.go
@@ -59,6 +59,43 @@ func TestRecordAppAdminUI(t *testing.T) {
 	metrictest.RequireInt64Sum(t, rm, "gestaltd.app_admin.ui.error_count", 1, failAttrs)
 }
 
+func TestRecordAppAdminUIInteractionOmitsSubjectIDsFromMetrics(t *testing.T) {
+	t.Parallel()
+
+	metrics := metrictest.NewManualMeterProvider(t)
+	ctx := metricutil.WithMeterProvider(context.Background(), metrics.Provider)
+
+	RecordAppAdminUIInteraction(ctx, time.Now(), AppAdminUIInteraction{
+		App:                  "g-issues",
+		Surface:              AppAdminUISurfaceMembers,
+		Action:               AppAdminUIActionGrantAdd,
+		PrincipalSubjectKind: "user",
+		PrincipalSubjectID:   "user:abc",
+		TargetSubjectKind:    "user",
+		TargetSubjectID:      "user:def",
+	})
+
+	rm := metrictest.CollectMetrics(t, metrics.Reader)
+	attrs := map[string]string{
+		"gestaltd.app_admin.ui.app":                 "g-issues",
+		"gestaltd.app_admin.ui.surface":             "members",
+		"gestaltd.app_admin.ui.action":              "grant_add",
+		"gestaltd.app_admin.ui.outcome":             "success",
+		"gestaltd.subject.kind":                     "user",
+		"gestaltd.app_admin.ui.target_subject.kind": "user",
+	}
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.app_admin.ui.count", 1, attrs)
+	metrictest.RequireNoInt64Sum(t, rm, "gestaltd.app_admin.ui.count", map[string]string{
+		"gestaltd.app_admin.ui.app":                 "g-issues",
+		"gestaltd.app_admin.ui.surface":             "members",
+		"gestaltd.app_admin.ui.action":              "grant_add",
+		"gestaltd.app_admin.ui.outcome":             "success",
+		"gestaltd.subject.kind":                     "user",
+		"gestaltd.subject.id":                       "user:abc",
+		"gestaltd.app_admin.ui.target_subject.kind": "user",
+	})
+}
+
 func TestLogAppAdminUI(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/services/observability/app_admin_ui_test.go
+++ b/gestaltd/services/observability/app_admin_ui_test.go
@@ -96,7 +96,7 @@ func TestRecordAppAdminUIInteractionOmitsSubjectIDsFromMetrics(t *testing.T) {
 	})
 }
 
-func TestLogAppAdminUI(t *testing.T) {
+func TestLogAppAdminUI(t *testing.T) { //nolint:paralleltest // mutates slog.Default()
 	tests := []struct {
 		name        string
 		interaction AppAdminUIInteraction
@@ -149,7 +149,7 @@ func TestLogAppAdminUI(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
+	for _, tt := range tests { //nolint:paralleltest // mutates slog.Default()
 		t.Run(tt.name, func(t *testing.T) {
 			var buf bytes.Buffer
 			previous := slog.Default()

--- a/gestaltd/services/observability/app_admin_ui_test.go
+++ b/gestaltd/services/observability/app_admin_ui_test.go
@@ -97,8 +97,6 @@ func TestRecordAppAdminUIInteractionOmitsSubjectIDsFromMetrics(t *testing.T) {
 }
 
 func TestLogAppAdminUI(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		name        string
 		interaction AppAdminUIInteraction
@@ -153,8 +151,6 @@ func TestLogAppAdminUI(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
 			var buf bytes.Buffer
 			previous := slog.Default()
 			slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})))

--- a/gestaltd/services/providergateway/authorization_app_admin_ui_test.go
+++ b/gestaltd/services/providergateway/authorization_app_admin_ui_test.go
@@ -58,9 +58,7 @@ func TestEnforceAuthorizationPublicAccessRecordsAppScopedAuthFailure(t *testing.
 		"gestaltd.app_admin.ui.outcome":             "failure",
 		"gestaltd.app_admin.ui.failure_category":    "auth_failure",
 		"gestaltd.subject.kind":                     "user",
-		"gestaltd.subject.id":                       "outsider@example.com",
 		"gestaltd.app_admin.ui.target_subject.kind": "user",
-		"gestaltd.app_admin.ui.target_subject.id":   "viewer@example.com",
 	}
 	metrictest.RequireInt64Sum(t, rm, "gestaltd.app_admin.ui.count", 1, attrs)
 	metrictest.RequireInt64Sum(t, rm, "gestaltd.app_admin.ui.error_count", 1, attrs)


### PR DESCRIPTION
## Summary
- Stop emitting `gestaltd.subject.id` and `gestaltd.app_admin.ui.target_subject.id` on `gestaltd.app_admin.ui.*` metrics.
- Keep principal and grant-target **kinds** on metrics; full subject IDs remain on `@event:app_admin.ui` audit logs (gestalt#3189).

## Test plan
- [x] `go test ./services/observability/ ./services/providergateway/ -run 'AppAdmin|RecordAppAdmin'`
- [x] `go test ./internal/server/ -run AppAdminUI`

## Stack
- toolshed: https://github.com/valon-technologies/toolshed/pull/4863 — merge after gestaltd deploy; push dashboard
- Bump `GESTALTD_PINNED_SHA` on merge