### PR TITLE
Step 18: rename app-admin metrics and add client kind

### DIFF
--- a/gestaltd/internal/server/app_admin_ui_observability_test.go
+++ b/gestaltd/internal/server/app_admin_ui_observability_test.go
@@ -37,15 +37,14 @@ func TestAppAdminUIObservabilityMiddlewareRecordsSuccess(t *testing.T) {
 
 	rm := metrictest.CollectMetrics(t, metrics.Reader)
 	attrs := map[string]string{
-		"gestaltd.app_admin.ui.app":     "g-issues",
-		"gestaltd.app_admin.ui.surface": "members",
-		"gestaltd.app_admin.ui.action":  "list",
-		"gestaltd.app_admin.ui.outcome": "success",
-		"gestaltd.subject.kind":         "unknown",
+		"gestaltd.app_admin.app":       "g-issues",
+		"gestaltd.app_admin.operation": "members_list",
+		"gestaltd.app_admin.outcome":   "success",
+		"gestaltd.subject.kind":        "unknown",
 	}
-	metrictest.RequireInt64Sum(t, rm, "gestaltd.app_admin.ui.count", 1, attrs)
-	metrictest.RequireNoInt64Sum(t, rm, "gestaltd.app_admin.ui.error_count", attrs)
-	metrictest.RequireFloat64Histogram(t, rm, "gestaltd.app_admin.ui.duration", attrs)
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.app_admin.count", 1, attrs)
+	metrictest.RequireNoInt64Sum(t, rm, "gestaltd.app_admin.error_count", attrs)
+	metrictest.RequireFloat64Histogram(t, rm, "gestaltd.app_admin.duration", attrs)
 }
 
 func TestAppAdminUIObservabilityMiddlewareRecordsValidationFailure(t *testing.T) {
@@ -69,16 +68,15 @@ func TestAppAdminUIObservabilityMiddlewareRecordsValidationFailure(t *testing.T)
 
 	rm := metrictest.CollectMetrics(t, metrics.Reader)
 	attrs := map[string]string{
-		"gestaltd.app_admin.ui.app":              "g-issues",
-		"gestaltd.app_admin.ui.surface":          "allowed_operations",
-		"gestaltd.app_admin.ui.action":           "save",
-		"gestaltd.app_admin.ui.outcome":          "failure",
-		"gestaltd.app_admin.ui.failure_category": "validation",
-		"gestaltd.subject.kind":                  "unknown",
+		"gestaltd.app_admin.app":              "g-issues",
+		"gestaltd.app_admin.operation":        "allowed_operations_save",
+		"gestaltd.app_admin.outcome":          "failure",
+		"gestaltd.app_admin.failure_category": "validation",
+		"gestaltd.subject.kind":               "unknown",
 	}
-	metrictest.RequireInt64Sum(t, rm, "gestaltd.app_admin.ui.count", 1, attrs)
-	metrictest.RequireInt64Sum(t, rm, "gestaltd.app_admin.ui.error_count", 1, attrs)
-	metrictest.RequireFloat64Histogram(t, rm, "gestaltd.app_admin.ui.duration", attrs)
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.app_admin.count", 1, attrs)
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.app_admin.error_count", 1, attrs)
+	metrictest.RequireFloat64Histogram(t, rm, "gestaltd.app_admin.duration", attrs)
 }
 
 func TestAppAdminUIObservabilityMiddlewareRecordsAuthorizationUnavailable(t *testing.T) {
@@ -107,16 +105,15 @@ func TestAppAdminUIObservabilityMiddlewareRecordsAuthorizationUnavailable(t *tes
 
 	rm := metrictest.CollectMetrics(t, metrics.Reader)
 	attrs := map[string]string{
-		"gestaltd.app_admin.ui.app":              "g-issues",
-		"gestaltd.app_admin.ui.surface":          "members",
-		"gestaltd.app_admin.ui.action":           "list",
-		"gestaltd.app_admin.ui.outcome":          "failure",
-		"gestaltd.app_admin.ui.failure_category": "server",
-		"gestaltd.subject.kind":                  "unknown",
+		"gestaltd.app_admin.app":              "g-issues",
+		"gestaltd.app_admin.operation":        "members_list",
+		"gestaltd.app_admin.outcome":          "failure",
+		"gestaltd.app_admin.failure_category": "server",
+		"gestaltd.subject.kind":               "unknown",
 	}
-	metrictest.RequireInt64Sum(t, rm, "gestaltd.app_admin.ui.count", 1, attrs)
-	metrictest.RequireInt64Sum(t, rm, "gestaltd.app_admin.ui.error_count", 1, attrs)
-	metrictest.RequireFloat64Histogram(t, rm, "gestaltd.app_admin.ui.duration", attrs)
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.app_admin.count", 1, attrs)
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.app_admin.error_count", 1, attrs)
+	metrictest.RequireFloat64Histogram(t, rm, "gestaltd.app_admin.duration", attrs)
 }
 
 func TestAppAdminUIFailureCategoryFromStatus(t *testing.T) {

--- a/gestaltd/services/authorization/app_admin_ui_test.go
+++ b/gestaltd/services/authorization/app_admin_ui_test.go
@@ -40,13 +40,12 @@ func TestAddRelationshipRecordsAppScopedMutationMetrics(t *testing.T) {
 
 	rm := metrictest.CollectMetrics(t, metrics.Reader)
 	attrs := map[string]string{
-		"gestaltd.app_admin.ui.app":     "roadmap",
-		"gestaltd.app_admin.ui.surface": "members",
-		"gestaltd.app_admin.ui.action":  "grant_add",
-		"gestaltd.app_admin.ui.outcome": "success",
+		"gestaltd.app_admin.app":       "roadmap",
+		"gestaltd.app_admin.operation": "members_grant_add",
+		"gestaltd.app_admin.outcome":   "success",
 	}
-	metrictest.RequireInt64Sum(t, rm, "gestaltd.app_admin.ui.count", 1, attrs)
-	metrictest.RequireNoInt64Sum(t, rm, "gestaltd.app_admin.ui.error_count", attrs)
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.app_admin.count", 1, attrs)
+	metrictest.RequireNoInt64Sum(t, rm, "gestaltd.app_admin.error_count", attrs)
 }
 
 func TestAddRelationshipSkipsMetricsWithoutAppScopedMarker(t *testing.T) {
@@ -65,7 +64,7 @@ func TestAddRelationshipSkipsMetricsWithoutAppScopedMarker(t *testing.T) {
 	}
 
 	rm := metrictest.CollectMetrics(t, metrics.Reader)
-	metrictest.RequireNoMetric(t, rm, "gestaltd.app_admin.ui.count")
+	metrictest.RequireNoMetric(t, rm, "gestaltd.app_admin.count")
 }
 
 func TestDeleteRelationshipRecordsAppScopedMutationFailure(t *testing.T) {
@@ -88,14 +87,13 @@ func TestDeleteRelationshipRecordsAppScopedMutationFailure(t *testing.T) {
 
 	rm := metrictest.CollectMetrics(t, metrics.Reader)
 	attrs := map[string]string{
-		"gestaltd.app_admin.ui.app":              "roadmap",
-		"gestaltd.app_admin.ui.surface":          "members",
-		"gestaltd.app_admin.ui.action":           "grant_remove",
-		"gestaltd.app_admin.ui.outcome":          "failure",
-		"gestaltd.app_admin.ui.failure_category": "validation",
+		"gestaltd.app_admin.app":              "roadmap",
+		"gestaltd.app_admin.operation":        "members_grant_remove",
+		"gestaltd.app_admin.outcome":          "failure",
+		"gestaltd.app_admin.failure_category": "validation",
 	}
-	metrictest.RequireInt64Sum(t, rm, "gestaltd.app_admin.ui.count", 1, attrs)
-	metrictest.RequireInt64Sum(t, rm, "gestaltd.app_admin.ui.error_count", 1, attrs)
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.app_admin.count", 1, attrs)
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.app_admin.error_count", 1, attrs)
 }
 
 type stubAuthorizationProvider struct {

--- a/gestaltd/services/observability/app_admin_ui.go
+++ b/gestaltd/services/observability/app_admin_ui.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/valon-technologies/gestalt/server/services/observability/metricutil"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc/codes"
@@ -33,19 +34,19 @@ const (
 )
 
 var (
-	AttrAppAdminUIApp               = attribute.Key("gestaltd.app_admin.ui.app")
-	AttrAppAdminUISurface           = attribute.Key("gestaltd.app_admin.ui.surface")
-	AttrAppAdminUIAction            = attribute.Key("gestaltd.app_admin.ui.action")
-	AttrAppAdminUIOutcome           = attribute.Key("gestaltd.app_admin.ui.outcome")
-	AttrAppAdminUIFailureCategory   = attribute.Key("gestaltd.app_admin.ui.failure_category")
-	AttrAppAdminUITargetSubjectKind = attribute.Key("gestaltd.app_admin.ui.target_subject.kind")
-	AttrAppAdminUITargetSubjectID   = attribute.Key("gestaltd.app_admin.ui.target_subject.id")
+	AttrAppAdminApp               = attribute.Key("gestaltd.app_admin.app")
+	AttrAppAdminOperation         = attribute.Key("gestaltd.app_admin.operation")
+	AttrAppAdminOutcome           = attribute.Key("gestaltd.app_admin.outcome")
+	AttrAppAdminFailureCategory   = attribute.Key("gestaltd.app_admin.failure_category")
+	AttrAppAdminTargetSubjectKind = attribute.Key("gestaltd.app_admin.target_subject.kind")
+	AttrAppAdminUITargetSubjectID = attribute.Key("gestaltd.app_admin.ui.target_subject.id")
 )
 
 type AppAdminUIInteraction struct {
 	App                  string
 	Surface              string
 	Action               string
+	ClientKind           string
 	Failed               bool
 	FailureCategory      string
 	StatusCode           int
@@ -57,15 +58,25 @@ type AppAdminUIInteraction struct {
 	TargetSubjectID      string
 }
 
+func AppAdminOperation(surface, action string) string {
+	surface = strings.TrimSpace(surface)
+	action = strings.TrimSpace(action)
+	if surface == "" || action == "" {
+		return ""
+	}
+	return surface + "_" + action
+}
+
 func RecordAppAdminUI(ctx context.Context, startedAt time.Time, failed bool, attrs ...attribute.KeyValue) {
-	record(ctx, &appAdminUIMetrics, "gestaltd.app_admin.ui", "gestaltd app admin UI interactions", startedAt, failed, attrs...)
+	record(ctx, &appAdminUIMetrics, "gestaltd.app_admin", "gestaltd app admin interactions", startedAt, failed, attrs...)
 }
 
 func RecordAppAdminUIInteraction(ctx context.Context, startedAt time.Time, interaction AppAdminUIInteraction) {
 	interaction.App = strings.TrimSpace(interaction.App)
 	interaction.Surface = strings.TrimSpace(interaction.Surface)
 	interaction.Action = strings.TrimSpace(interaction.Action)
-	if interaction.App == "" || interaction.Surface == "" || interaction.Action == "" {
+	operation := AppAdminOperation(interaction.Surface, interaction.Action)
+	if interaction.App == "" || operation == "" {
 		return
 	}
 	outcome := AppAdminUIOutcomeSuccess
@@ -73,22 +84,35 @@ func RecordAppAdminUIInteraction(ctx context.Context, startedAt time.Time, inter
 		outcome = AppAdminUIOutcomeFailure
 	}
 	attrs := []attribute.KeyValue{
-		AttrAppAdminUIApp.String(interaction.App),
-		AttrAppAdminUISurface.String(interaction.Surface),
-		AttrAppAdminUIAction.String(interaction.Action),
-		AttrAppAdminUIOutcome.String(outcome),
+		AttrAppAdminApp.String(interaction.App),
+		AttrAppAdminOperation.String(operation),
+		AttrAppAdminOutcome.String(outcome),
 	}
 	if interaction.Failed && interaction.FailureCategory != "" {
-		attrs = append(attrs, AttrAppAdminUIFailureCategory.String(interaction.FailureCategory))
+		attrs = append(attrs, AttrAppAdminFailureCategory.String(interaction.FailureCategory))
 	}
 	if kind := strings.TrimSpace(interaction.PrincipalSubjectKind); kind != "" {
 		attrs = append(attrs, AttrSubjectKind.String(kind))
 	}
 	if kind := strings.TrimSpace(interaction.TargetSubjectKind); kind != "" {
-		attrs = append(attrs, AttrAppAdminUITargetSubjectKind.String(kind))
+		attrs = append(attrs, AttrAppAdminTargetSubjectKind.String(kind))
+	}
+	if clientKindAttr, ok := appAdminClientKindAttr(ctx, interaction.ClientKind); ok {
+		attrs = append(attrs, clientKindAttr)
 	}
 	RecordAppAdminUI(ctx, startedAt, interaction.Failed, attrs...)
 	LogAppAdminUI(ctx, interaction)
+}
+
+func appAdminClientKindAttr(ctx context.Context, explicit string) (attribute.KeyValue, bool) {
+	kind := strings.TrimSpace(explicit)
+	if kind == "" {
+		kind = metricutil.ClientKindFromContext(ctx)
+	}
+	if kind != metricutil.ClientKindWeb && kind != metricutil.ClientKindCLI {
+		return attribute.KeyValue{}, false
+	}
+	return attribute.String("gestaltd.client.kind", kind), true
 }
 
 func appendAppAdminUILogSubject(

--- a/gestaltd/services/observability/app_admin_ui_test.go
+++ b/gestaltd/services/observability/app_admin_ui_test.go
@@ -12,7 +12,20 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/internal/testutil/metrictest"
 	"github.com/valon-technologies/gestalt/server/services/observability/metricutil"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel/attribute"
 )
+
+func TestAppAdminOperation(t *testing.T) {
+	t.Parallel()
+
+	if got := AppAdminOperation(AppAdminUISurfaceMembers, AppAdminUIActionList); got != "members_list" {
+		t.Fatalf("AppAdminOperation() = %q, want members_list", got)
+	}
+	if got := AppAdminOperation(" ", AppAdminUIActionList); got != "" {
+		t.Fatalf("AppAdminOperation() = %q, want empty", got)
+	}
+}
 
 func TestRecordAppAdminUI(t *testing.T) {
 	t.Parallel()
@@ -22,41 +35,37 @@ func TestRecordAppAdminUI(t *testing.T) {
 	startedAt := time.Now()
 
 	RecordAppAdminUI(ctx, startedAt, false,
-		AttrAppAdminUIApp.String("g-issues"),
-		AttrAppAdminUISurface.String("members"),
-		AttrAppAdminUIAction.String("list"),
-		AttrAppAdminUIOutcome.String("success"),
+		AttrAppAdminApp.String("g-issues"),
+		AttrAppAdminOperation.String("members_list"),
+		AttrAppAdminOutcome.String("success"),
 	)
 
 	rm := metrictest.CollectMetrics(t, metrics.Reader)
 	attrs := map[string]string{
-		"gestaltd.app_admin.ui.app":     "g-issues",
-		"gestaltd.app_admin.ui.surface": "members",
-		"gestaltd.app_admin.ui.action":  "list",
-		"gestaltd.app_admin.ui.outcome": "success",
+		"gestaltd.app_admin.app":       "g-issues",
+		"gestaltd.app_admin.operation": "members_list",
+		"gestaltd.app_admin.outcome":   "success",
 	}
-	metrictest.RequireInt64Sum(t, rm, "gestaltd.app_admin.ui.count", 1, attrs)
-	metrictest.RequireNoInt64Sum(t, rm, "gestaltd.app_admin.ui.error_count", attrs)
-	metrictest.RequireFloat64Histogram(t, rm, "gestaltd.app_admin.ui.duration", attrs)
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.app_admin.count", 1, attrs)
+	metrictest.RequireNoInt64Sum(t, rm, "gestaltd.app_admin.error_count", attrs)
+	metrictest.RequireFloat64Histogram(t, rm, "gestaltd.app_admin.duration", attrs)
 
 	RecordAppAdminUI(ctx, startedAt, true,
-		AttrAppAdminUIApp.String("g-issues"),
-		AttrAppAdminUISurface.String("members"),
-		AttrAppAdminUIAction.String("grant_add"),
-		AttrAppAdminUIOutcome.String("failure"),
-		AttrAppAdminUIFailureCategory.String("auth_failure"),
+		AttrAppAdminApp.String("g-issues"),
+		AttrAppAdminOperation.String("members_grant_add"),
+		AttrAppAdminOutcome.String("failure"),
+		AttrAppAdminFailureCategory.String("auth_failure"),
 	)
 
 	rm = metrictest.CollectMetrics(t, metrics.Reader)
 	failAttrs := map[string]string{
-		"gestaltd.app_admin.ui.app":              "g-issues",
-		"gestaltd.app_admin.ui.surface":          "members",
-		"gestaltd.app_admin.ui.action":           "grant_add",
-		"gestaltd.app_admin.ui.outcome":          "failure",
-		"gestaltd.app_admin.ui.failure_category": "auth_failure",
+		"gestaltd.app_admin.app":              "g-issues",
+		"gestaltd.app_admin.operation":        "members_grant_add",
+		"gestaltd.app_admin.outcome":          "failure",
+		"gestaltd.app_admin.failure_category": "auth_failure",
 	}
-	metrictest.RequireInt64Sum(t, rm, "gestaltd.app_admin.ui.count", 1, failAttrs)
-	metrictest.RequireInt64Sum(t, rm, "gestaltd.app_admin.ui.error_count", 1, failAttrs)
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.app_admin.count", 1, failAttrs)
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.app_admin.error_count", 1, failAttrs)
 }
 
 func TestRecordAppAdminUIInteractionOmitsSubjectIDsFromMetrics(t *testing.T) {
@@ -69,6 +78,7 @@ func TestRecordAppAdminUIInteractionOmitsSubjectIDsFromMetrics(t *testing.T) {
 		App:                  "g-issues",
 		Surface:              AppAdminUISurfaceMembers,
 		Action:               AppAdminUIActionGrantAdd,
+		ClientKind:           metricutil.ClientKindCLI,
 		PrincipalSubjectKind: "user",
 		PrincipalSubjectID:   "user:abc",
 		TargetSubjectKind:    "user",
@@ -77,23 +87,47 @@ func TestRecordAppAdminUIInteractionOmitsSubjectIDsFromMetrics(t *testing.T) {
 
 	rm := metrictest.CollectMetrics(t, metrics.Reader)
 	attrs := map[string]string{
-		"gestaltd.app_admin.ui.app":                 "g-issues",
-		"gestaltd.app_admin.ui.surface":             "members",
-		"gestaltd.app_admin.ui.action":              "grant_add",
-		"gestaltd.app_admin.ui.outcome":             "success",
-		"gestaltd.subject.kind":                     "user",
-		"gestaltd.app_admin.ui.target_subject.kind": "user",
+		"gestaltd.app_admin.app":                 "g-issues",
+		"gestaltd.app_admin.operation":           "members_grant_add",
+		"gestaltd.app_admin.outcome":             "success",
+		"gestaltd.client.kind":                   metricutil.ClientKindCLI,
+		"gestaltd.subject.kind":                  "user",
+		"gestaltd.app_admin.target_subject.kind": "user",
 	}
-	metrictest.RequireInt64Sum(t, rm, "gestaltd.app_admin.ui.count", 1, attrs)
-	metrictest.RequireNoInt64Sum(t, rm, "gestaltd.app_admin.ui.count", map[string]string{
-		"gestaltd.app_admin.ui.app":                 "g-issues",
-		"gestaltd.app_admin.ui.surface":             "members",
-		"gestaltd.app_admin.ui.action":              "grant_add",
-		"gestaltd.app_admin.ui.outcome":             "success",
-		"gestaltd.subject.kind":                     "user",
-		"gestaltd.subject.id":                       "user:abc",
-		"gestaltd.app_admin.ui.target_subject.kind": "user",
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.app_admin.count", 1, attrs)
+	metrictest.RequireNoInt64Sum(t, rm, "gestaltd.app_admin.count", map[string]string{
+		"gestaltd.app_admin.app":                 "g-issues",
+		"gestaltd.app_admin.operation":           "members_grant_add",
+		"gestaltd.app_admin.outcome":             "success",
+		"gestaltd.subject.kind":                  "user",
+		"gestaltd.subject.id":                    "user:abc",
+		"gestaltd.app_admin.target_subject.kind": "user",
 	})
+}
+
+func TestRecordAppAdminUIInteractionClientKindFromContext(t *testing.T) {
+	t.Parallel()
+
+	metrics := metrictest.NewManualMeterProvider(t)
+	labeler := &otelhttp.Labeler{}
+	labeler.Add(attribute.String("gestaltd.client.kind", metricutil.ClientKindWeb))
+	ctx := otelhttp.ContextWithLabeler(context.Background(), labeler)
+	ctx = metricutil.WithMeterProvider(ctx, metrics.Provider)
+
+	RecordAppAdminUIInteraction(ctx, time.Now(), AppAdminUIInteraction{
+		App:     "g-issues",
+		Surface: AppAdminUISurfaceMembers,
+		Action:  AppAdminUIActionList,
+	})
+
+	rm := metrictest.CollectMetrics(t, metrics.Reader)
+	attrs := map[string]string{
+		"gestaltd.app_admin.app":       "g-issues",
+		"gestaltd.app_admin.operation": "members_list",
+		"gestaltd.app_admin.outcome":   "success",
+		"gestaltd.client.kind":         metricutil.ClientKindWeb,
+	}
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.app_admin.count", 1, attrs)
 }
 
 func TestLogAppAdminUI(t *testing.T) { //nolint:paralleltest // mutates slog.Default()

--- a/gestaltd/services/observability/metricutil/attrs.go
+++ b/gestaltd/services/observability/metricutil/attrs.go
@@ -188,6 +188,19 @@ func DBClientAttrs(dims DBMetricDims) []attribute.KeyValue {
 	return attrs
 }
 
+func ClientKindFromContext(ctx context.Context) string {
+	labeler, ok := otelhttp.LabelerFromContext(ctx)
+	if !ok {
+		return ""
+	}
+	for _, attr := range labeler.Get() {
+		if attr.Key == attrGestaltdClientKind {
+			return attr.Value.AsString()
+		}
+	}
+	return ""
+}
+
 func appendStringAttr(attrs []attribute.KeyValue, key attribute.Key, value string) []attribute.KeyValue {
 	value = strings.TrimSpace(value)
 	if value == "" {

--- a/gestaltd/services/observability/metricutil/attrs_test.go
+++ b/gestaltd/services/observability/metricutil/attrs_test.go
@@ -71,6 +71,21 @@ func containsAttr(attrs []attribute.KeyValue, key, value string) bool {
 	return false
 }
 
+func TestClientKindFromContext(t *testing.T) {
+	t.Parallel()
+
+	if got := metricutil.ClientKindFromContext(context.Background()); got != "" {
+		t.Fatalf("ClientKindFromContext() = %q, want empty", got)
+	}
+
+	labeler := &otelhttp.Labeler{}
+	labeler.Add(attribute.String("gestaltd.client.kind", metricutil.ClientKindCLI))
+	ctx := otelhttp.ContextWithLabeler(context.Background(), labeler)
+	if got := metricutil.ClientKindFromContext(ctx); got != metricutil.ClientKindCLI {
+		t.Fatalf("ClientKindFromContext() = %q, want %q", got, metricutil.ClientKindCLI)
+	}
+}
+
 func TestHTTPServerAttrsOmitsUnsetDimensions(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/services/providergateway/authorization_app_admin_ui_test.go
+++ b/gestaltd/services/providergateway/authorization_app_admin_ui_test.go
@@ -52,16 +52,15 @@ func TestEnforceAuthorizationPublicAccessRecordsAppScopedAuthFailure(t *testing.
 
 	rm := metrictest.CollectMetrics(t, metrics.Reader)
 	attrs := map[string]string{
-		"gestaltd.app_admin.ui.app":                 "roadmap",
-		"gestaltd.app_admin.ui.surface":             "members",
-		"gestaltd.app_admin.ui.action":              "grant_add",
-		"gestaltd.app_admin.ui.outcome":             "failure",
-		"gestaltd.app_admin.ui.failure_category":    "auth_failure",
-		"gestaltd.subject.kind":                     "user",
-		"gestaltd.app_admin.ui.target_subject.kind": "user",
+		"gestaltd.app_admin.app":                 "roadmap",
+		"gestaltd.app_admin.operation":           "members_grant_add",
+		"gestaltd.app_admin.outcome":             "failure",
+		"gestaltd.app_admin.failure_category":    "auth_failure",
+		"gestaltd.subject.kind":                  "user",
+		"gestaltd.app_admin.target_subject.kind": "user",
 	}
-	metrictest.RequireInt64Sum(t, rm, "gestaltd.app_admin.ui.count", 1, attrs)
-	metrictest.RequireInt64Sum(t, rm, "gestaltd.app_admin.ui.error_count", 1, attrs)
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.app_admin.count", 1, attrs)
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.app_admin.error_count", 1, attrs)
 }
 
 func TestWithAppScopedRelationshipMutationAuth(t *testing.T) {


### PR DESCRIPTION
## Summary
- Rename `gestaltd.app_admin.ui.*` metrics to `gestaltd.app_admin.*`.
- Collapse `surface` and `action` metric tags into `gestaltd.app_admin.operation` (for example `members_list`, `members_grant_add`).
- Tag `gestaltd.client.kind` (`web` | `cli`) from caller context via the existing ingress client-kind telemetry.

## Test plan
- [x] `go test ./services/observability/... ./internal/server/... ./services/authorization/... ./services/providergateway/...`
- [ ] Pair with toolshed dashboard PR after merge; bump `GESTALTD_PINNED_SHA` and deploy in a follow-up


Made with [Cursor](https://cursor.com)