### PR TITLE
Authenticate private GCS app registries with ADC

### DIFF
--- a/gestaltd/internal/appregistry/materializer_test.go
+++ b/gestaltd/internal/appregistry/materializer_test.go
@@ -2,9 +2,12 @@ package appregistry_test
 
 import (
 	"context"
+	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"sync"
 	"testing"
 
@@ -14,6 +17,12 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/services/apps/packageio"
 )
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
 
 func TestMaterializer_serializes_same_app(t *testing.T) {
 	t.Parallel()
@@ -134,6 +143,40 @@ func TestMaterializer_downloads_and_extracts_artifact(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(destDir, "manifest.yaml")); err != nil {
 		t.Fatalf("stat manifest.yaml: %v", err)
+	}
+}
+
+func TestMaterializer_downloads_copied_artifact_from_configured_registry(t *testing.T) {
+	t.Parallel()
+
+	fixture := registrytest.NewInstallFixture(t)
+	const targetBucket = "copied-registry"
+	targetRegistry, err := config.NewGCSAppRegistry(targetBucket)
+	if err != nil {
+		t.Fatalf("NewGCSAppRegistry: %v", err)
+	}
+	targetPrefix := "/" + targetBucket + "/"
+	sourcePrefix := "/" + registrytest.Bucket + "/"
+	reader := &appregistry.RegistryReader{HTTPClient: &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		if !strings.HasPrefix(req.URL.Path, targetPrefix) {
+			return nil, fmt.Errorf("unexpected registry path %q", req.URL.Path)
+		}
+		clone := req.Clone(req.Context())
+		clone.URL.Path = sourcePrefix + strings.TrimPrefix(req.URL.Path, targetPrefix)
+		return fixture.Reader.HTTPClient.Transport.RoundTrip(clone)
+	})}}
+	materializer := &appregistry.Materializer{
+		Registries:   map[string]config.AppRegistryConfig{"toolshed": targetRegistry},
+		Reader:       reader,
+		ArtifactsDir: t.TempDir(),
+	}
+
+	if _, err := materializer.Ensure(t.Context(), &core.AppInstallation{
+		AppName:  "g-issues",
+		Version:  fixture.Version,
+		Registry: "toolshed",
+	}); err != nil {
+		t.Fatalf("Ensure: %v", err)
 	}
 }
 

--- a/gestaltd/internal/appregistry/reader_auth.go
+++ b/gestaltd/internal/appregistry/reader_auth.go
@@ -1,0 +1,72 @@
+package appregistry
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/gcsauth"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+)
+
+type gcpADCTokenSourceFactory func(context.Context) (oauth2.TokenSource, error)
+
+// NewRegistryReader creates one reader for all configured app registries.
+func NewRegistryReader(ctx context.Context, registries map[string]config.AppRegistryConfig) (*RegistryReader, error) {
+	return newRegistryReader(ctx, registries, http.DefaultClient, func(ctx context.Context) (oauth2.TokenSource, error) {
+		return google.DefaultTokenSource(ctx, gcsauth.ReadOnlyScope)
+	})
+}
+
+func newRegistryReader(
+	ctx context.Context,
+	registries map[string]config.AppRegistryConfig,
+	baseClient *http.Client,
+	newTokenSource gcpADCTokenSourceFactory,
+) (*RegistryReader, error) {
+	buckets := make(map[string]struct{})
+	for name, registry := range registries {
+		switch registry.Auth {
+		case "":
+			continue
+		case config.AppRegistryAuthGCPADC:
+			storageURL, err := registry.StorageURL()
+			if err != nil {
+				return nil, fmt.Errorf("app registry %q: %w", name, err)
+			}
+			buckets[strings.TrimPrefix(storageURL, "gs://")] = struct{}{}
+		default:
+			return nil, fmt.Errorf("app registry %q has unsupported auth %q", name, registry.Auth)
+		}
+	}
+
+	reader := &RegistryReader{HTTPClient: baseClient}
+	if len(buckets) == 0 {
+		return reader, nil
+	}
+	tokenSource, err := newTokenSource(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("create app registry GCS ADC token source: %w", err)
+	}
+	reader.HTTPClient = gcsauth.NewHTTPClient(baseClient, tokenSource, func(rawURL *url.URL) bool {
+		bucket, ok := gcsBucketFromPublicURL(rawURL)
+		if !ok {
+			return false
+		}
+		_, ok = buckets[bucket]
+		return ok
+	})
+	return reader, nil
+}
+
+func gcsBucketFromPublicURL(rawURL *url.URL) (string, bool) {
+	if !gcsauth.IsStorageURL(rawURL) {
+		return "", false
+	}
+	bucket, _, _ := strings.Cut(strings.TrimPrefix(rawURL.Path, "/"), "/")
+	return bucket, bucket != ""
+}

--- a/gestaltd/internal/appregistry/registry_source.go
+++ b/gestaltd/internal/appregistry/registry_source.go
@@ -3,6 +3,8 @@ package appregistry
 import (
 	"context"
 	"fmt"
+	"net/url"
+	"path"
 	"strings"
 
 	"github.com/valon-technologies/gestalt/server/internal/config"
@@ -48,7 +50,28 @@ func fetchConfiguredRegistryEntry(
 	if entry.Version != version {
 		return nil, fmt.Errorf("registry entry version %q does not match requested version %q", entry.Version, version)
 	}
+	if err := relocateGCSArtifactURLs(entry, publicRoot); err != nil {
+		return nil, err
+	}
 	return &configuredRegistryEntry{PublicRoot: publicRoot, Entry: entry}, nil
+}
+
+func relocateGCSArtifactURLs(entry *Entry, publicRoot string) error {
+	for platform, artifact := range entry.Artifacts {
+		storageURL := strings.TrimSpace(artifact.URL)
+		parsed, err := url.Parse(storageURL)
+		if err != nil || !strings.EqualFold(parsed.Scheme, "gs") {
+			continue
+		}
+		objectPath := strings.TrimPrefix(parsed.Path, "/")
+		expectedPrefix := AppArtifactPrefix(entry.App, entry.Version) + "/"
+		if parsed.Host == "" || path.Clean(objectPath) != objectPath || !strings.HasPrefix(objectPath, expectedPrefix) {
+			return fmt.Errorf("registry entry artifact for platform %q has invalid GCS URL", platform)
+		}
+		artifact.PublicURL = PublicURL(publicRoot, objectPath)
+		entry.Artifacts[platform] = artifact
+	}
+	return nil
 }
 
 func resolveRegistryArtifact(entry *Entry, platform string) (*registryArtifact, error) {

--- a/gestaltd/internal/config/app_registry_config.go
+++ b/gestaltd/internal/config/app_registry_config.go
@@ -10,6 +10,10 @@ import (
 
 const AppRegistryKindGCS = "gcs"
 
+type AppRegistryAuth string
+
+const AppRegistryAuthGCPADC AppRegistryAuth = "gcpADC"
+
 const (
 	defaultGCSAppRegistryPublicURLPrefix = "https://storage.googleapis.com/"
 	defaultAppRegistryUnusedRetention    = 72 * time.Hour
@@ -18,6 +22,7 @@ const (
 
 type AppRegistryConfig struct {
 	Kind      string                      `yaml:"kind,omitempty"`
+	Auth      AppRegistryAuth             `yaml:"auth,omitempty"`
 	GCS       *AppRegistryGCSConfig       `yaml:"gcs,omitempty"`
 	Retention *AppRegistryRetentionConfig `yaml:"retention,omitempty"`
 }
@@ -36,6 +41,7 @@ type AppRegistryGCSConfig struct {
 
 type appRegistryConfigYAML struct {
 	Kind      string                      `yaml:"kind,omitempty"`
+	Auth      AppRegistryAuth             `yaml:"auth,omitempty"`
 	GCS       *AppRegistryGCSConfig       `yaml:"gcs,omitempty"`
 	Retention *AppRegistryRetentionConfig `yaml:"retention,omitempty"`
 }
@@ -61,6 +67,7 @@ func (c *AppRegistryConfig) UnmarshalYAML(value *yaml.Node) error {
 		return err
 	}
 	c.Kind = raw.Kind
+	c.Auth = raw.Auth
 	c.GCS = raw.GCS
 	c.Retention = raw.Retention
 	return nil

--- a/gestaltd/internal/config/app_registry_step12_test.go
+++ b/gestaltd/internal/config/app_registry_step12_test.go
@@ -66,6 +66,40 @@ server: {}
 	}
 }
 
+func TestAppRegistryAuthValidation(t *testing.T) {
+	t.Parallel()
+
+	path := mustWriteConfigFile(t, `
+appRegistries:
+  toolshed:
+    kind: gcs
+    auth: gcpADC
+    gcs:
+      bucket: private-registry
+server: {}
+`)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := cfg.AppRegistries["toolshed"].Auth; got != AppRegistryAuthGCPADC {
+		t.Fatalf("auth = %q, want %q", got, AppRegistryAuthGCPADC)
+	}
+
+	path = mustWriteConfigFile(t, `
+appRegistries:
+  toolshed:
+    kind: gcs
+    auth: signedUrl
+    gcs:
+      bucket: private-registry
+server: {}
+`)
+	if _, err := Load(path); err == nil || !strings.Contains(err.Error(), `auth must be "gcpADC" when set`) {
+		t.Fatalf("Load error = %v, want unsupported auth error", err)
+	}
+}
+
 func TestAppRegistryMaxReconcileAttemptsValidation(t *testing.T) {
 	t.Parallel()
 	for _, value := range []string{"0", "-1"} {

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -377,6 +377,11 @@ func validateAppRegistries(cfg *Config) error {
 		if err := validateAppRegistryLocation("appRegistries", name, registry); err != nil {
 			return err
 		}
+		switch registry.Auth {
+		case "", AppRegistryAuthGCPADC:
+		default:
+			return fmt.Errorf("config validation: appRegistries.%s.auth must be %q when set", name, AppRegistryAuthGCPADC)
+		}
 	}
 	return nil
 }

--- a/gestaltd/internal/gcsauth/http.go
+++ b/gestaltd/internal/gcsauth/http.go
@@ -1,0 +1,57 @@
+package gcsauth
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/oauth2"
+)
+
+const ReadOnlyScope = "https://www.googleapis.com/auth/devstorage.read_only"
+
+// NewHTTPClient returns a copy of base that authenticates matching requests.
+func NewHTTPClient(base *http.Client, tokenSource oauth2.TokenSource, authenticate func(*url.URL) bool) *http.Client {
+	if base == nil {
+		base = http.DefaultClient
+	}
+	client := *base
+	client.Transport = &roundTripper{
+		base:         base.Transport,
+		tokenSource:  oauth2.ReuseTokenSource(nil, tokenSource),
+		authenticate: authenticate,
+	}
+	return &client
+}
+
+type roundTripper struct {
+	base         http.RoundTripper
+	tokenSource  oauth2.TokenSource
+	authenticate func(*url.URL) bool
+}
+
+func (t *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	base := t.base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	if t.authenticate == nil || !t.authenticate(req.URL) {
+		return base.RoundTrip(req)
+	}
+	token, err := t.tokenSource.Token()
+	if err != nil {
+		return nil, fmt.Errorf("get GCS ADC token: %w", err)
+	}
+	clone := req.Clone(req.Context())
+	clone.Header = req.Header.Clone()
+	token.SetAuthHeader(clone)
+	return base.RoundTrip(clone)
+}
+
+func IsStorageURL(u *url.URL) bool {
+	if u == nil || u.Scheme != "https" || !strings.EqualFold(u.Hostname(), "storage.googleapis.com") {
+		return false
+	}
+	return u.Port() == "" || u.Port() == "443"
+}

--- a/gestaltd/internal/operator/snapshot_repository_auth.go
+++ b/gestaltd/internal/operator/snapshot_repository_auth.go
@@ -4,15 +4,13 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"net/url"
 	"strings"
 
 	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/gcsauth"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 )
-
-const snapshotGCSReadOnlyScope = "https://www.googleapis.com/auth/devstorage.read_only"
 
 func (l *Lifecycle) snapshotRepositoryHTTPClient(ctx context.Context, cfg *config.Config, entry *config.ProviderEntry) (*http.Client, error) {
 	client := l.metadataHTTPClient()
@@ -36,44 +34,9 @@ func (l *Lifecycle) snapshotRepositoryHTTPClient(ctx context.Context, cfg *confi
 	if err != nil {
 		return nil, fmt.Errorf("create provider snapshot GCS ADC token source: %w", err)
 	}
-	clone := *client
-	clone.Transport = &gcsADCRoundTripper{
-		base:        client.Transport,
-		tokenSource: oauth2.ReuseTokenSource(nil, tokenSource),
-	}
-	return &clone, nil
+	return gcsauth.NewHTTPClient(client, tokenSource, gcsauth.IsStorageURL), nil
 }
 
 func googleSnapshotTokenSource(ctx context.Context) (oauth2.TokenSource, error) {
-	return google.DefaultTokenSource(ctx, snapshotGCSReadOnlyScope)
-}
-
-type gcsADCRoundTripper struct {
-	base        http.RoundTripper
-	tokenSource oauth2.TokenSource
-}
-
-func (t *gcsADCRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	base := t.base
-	if base == nil {
-		base = http.DefaultTransport
-	}
-	if !isGoogleCloudStorageURL(req.URL) {
-		return base.RoundTrip(req)
-	}
-	token, err := t.tokenSource.Token()
-	if err != nil {
-		return nil, fmt.Errorf("get provider snapshot GCS ADC token: %w", err)
-	}
-	clone := req.Clone(req.Context())
-	clone.Header = req.Header.Clone()
-	token.SetAuthHeader(clone)
-	return base.RoundTrip(clone)
-}
-
-func isGoogleCloudStorageURL(u *url.URL) bool {
-	if u == nil || u.Scheme != "https" || !strings.EqualFold(u.Hostname(), "storage.googleapis.com") {
-		return false
-	}
-	return u.Port() == "" || u.Port() == "443"
+	return google.DefaultTokenSource(ctx, gcsauth.ReadOnlyScope)
 }

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -58,6 +58,10 @@ func run(ctx context.Context, cfg *config.Config, result *bootstrap.Result, gest
 	if err != nil {
 		return err
 	}
+	appRegistryReader, err := appregistry.NewRegistryReader(ctx, cfg.AppRegistries)
+	if err != nil {
+		return fmt.Errorf("configure app registry reader: %w", err)
+	}
 
 	if cfg.Server.BaseURL != "" {
 		slog.Debug("gestaltd base URL configured",
@@ -158,6 +162,7 @@ func run(ctx context.Context, cfg *config.Config, result *bootstrap.Result, gest
 		},
 		OperationAccessChecker:  operationAccessChecker(result.Invoker),
 		AppRegistries:           cfg.AppRegistries,
+		AppRegistryReader:       appRegistryReader,
 		AppRegistryHeartbeatTTL: heartbeatTTL,
 		AppRegistryRolloutMode:  cfg.Server.AppRegistry.RolloutMode,
 		ArtifactsDir:            cfg.Server.ArtifactsDir,
@@ -174,11 +179,11 @@ func run(ctx context.Context, cfg *config.Config, result *bootstrap.Result, gest
 	baseConfig.AppRegistryPublish = publishService
 	baseConfig.AppRegistryPublishAllowedApps = cfg.Server.AppRegistry.Publish.AllowedAppSet()
 
-	result.RegistryAppStartup = registryAppStartup(cfg, result, nil)
+	result.RegistryAppStartup = registryAppStartup(cfg, result, appRegistryReader)
 	if err := result.Start(ctx); err != nil {
 		return err
 	}
-	autoDeployController, err := startAppRegistryAutoDeployController(ctx, cfg, result, gestaltdVersion)
+	autoDeployController, err := startAppRegistryAutoDeployController(ctx, cfg, result, gestaltdVersion, appRegistryReader)
 	if err != nil {
 		return err
 	}
@@ -190,7 +195,7 @@ func run(ctx context.Context, cfg *config.Config, result *bootstrap.Result, gest
 		onRolloutTerminal = autoDeployController.Notify
 		baseConfig.AppAutoDeployNotify = autoDeployController.Notify
 	}
-	catalogPoller := startAppRegistryCatalogPoller(ctx, cfg, result, restartDelay, disableRestartDelay, onRolloutTerminal)
+	catalogPoller := startAppRegistryCatalogPoller(ctx, cfg, result, restartDelay, disableRestartDelay, onRolloutTerminal, appRegistryReader)
 	if catalogPoller != nil {
 		defer catalogPoller.Stop()
 		baseConfig.AppRegistryReconcileNotify = catalogPoller.Notify
@@ -567,6 +572,7 @@ func startAppRegistryCatalogPoller(
 	restartDelay time.Duration,
 	disableRestartDelay bool,
 	onRolloutTerminal func(string),
+	reader *appregistry.RegistryReader,
 ) *appregistry.CatalogPoller {
 	if result == nil || result.Services == nil {
 		return nil
@@ -584,6 +590,7 @@ func startAppRegistryCatalogPoller(
 			materializer = &appregistry.Materializer{
 				Registries:   cfg.AppRegistries,
 				ArtifactsDir: artifactsDir,
+				Reader:       reader,
 			}
 		}
 	}
@@ -714,6 +721,7 @@ func startAppRegistryAutoDeployController(
 	cfg *config.Config,
 	result *bootstrap.Result,
 	gestaltdVersion string,
+	reader *appregistry.RegistryReader,
 ) (*autodeploy.Controller, error) {
 	if cfg == nil || result == nil || result.Services == nil {
 		return nil, nil
@@ -749,7 +757,6 @@ func startAppRegistryAutoDeployController(
 	if err != nil {
 		return nil, fmt.Errorf("server.appRegistry.autoDeployPollInterval: %w", err)
 	}
-	reader := &appregistry.RegistryReader{}
 	installer := &appregistry.Installer{
 		Registries:       cfg.AppRegistries,
 		ConfigApps:       cfg.Apps,

--- a/gestaltd/internal/server/runtime_app_registry_test.go
+++ b/gestaltd/internal/server/runtime_app_registry_test.go
@@ -61,7 +61,7 @@ func TestServerInstallerWiringPreservesConfiguredRolloutMode(t *testing.T) {
 			cfg.Server.AppRegistry.RolloutMode = mode
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
-			controller, err := startAppRegistryAutoDeployController(ctx, cfg, &bootstrap.Result{Services: services}, "0.1.0")
+			controller, err := startAppRegistryAutoDeployController(ctx, cfg, &bootstrap.Result{Services: services}, "0.1.0", fixture.Reader)
 			if err != nil {
 				t.Fatalf("startAppRegistryAutoDeployController: %v", err)
 			}
@@ -91,6 +91,7 @@ func TestCatalogPollerWiringPreservesIndependentCadences(t *testing.T) {
 		&bootstrap.Result{Services: testutil.NewStubServices(t)},
 		0,
 		false,
+		nil,
 		nil,
 	)
 	if poller == nil {


### PR DESCRIPTION
## Problem Statement

Private GCS app registries reject unsigned reads, and copied registry entries keep artifact downloads tied to the source bucket.

## Solution

Add opt-in GCP ADC authentication per registry, reuse one reader across every runtime path, and send credentials only to explicitly configured GCS buckets. Resolve copied GCS artifacts from the configured registry bucket while preserving non-GCS URLs.

### App Operations

- Add appRegistries.<name>.auth: gcpADC.
- Authenticate registry metadata and artifact reads with the runtime service account.

### Workflows

None.