### PR TITLE
Step 19: app-admin allowed-operations CLI parity

### DIFF
--- a/gestalt/cli/src/cli.rs
+++ b/gestalt/cli/src/cli.rs
@@ -254,6 +254,12 @@ pub enum AuthorizationAppsCommands {
         #[command(subcommand)]
         command: AuthorizationAppsMembersCommands,
     },
+    /// Manage allowed operation exposure for an app
+    #[command(name = "allowed-operations")]
+    AllowedOperations {
+        #[command(subcommand)]
+        command: AuthorizationAppsAllowedOperationsCommands,
+    },
 }
 
 #[derive(Subcommand)]
@@ -303,6 +309,38 @@ pub struct AuthorizationAppsMembersRemoveArgs {
     /// Relationship role to remove; when omitted, removes all mutable grants for the subject
     #[arg(long)]
     pub role: Option<String>,
+}
+
+#[derive(Subcommand)]
+pub enum AuthorizationAppsAllowedOperationsCommands {
+    /// List allowed operation exposure for an app
+    List(AuthorizationAppsAllowedOperationsListArgs),
+    /// Update allowed operation exposure for an app
+    Set(AuthorizationAppsAllowedOperationsSetArgs),
+}
+
+#[derive(Args)]
+pub struct AuthorizationAppsAllowedOperationsListArgs {
+    /// App name
+    pub app: String,
+}
+
+#[derive(Args)]
+pub struct AuthorizationAppsAllowedOperationsSetArgs {
+    /// App name
+    pub app: String,
+    /// JSON file with {"operations": {...}, "removed": [...]} in app-admin shape
+    #[arg(
+        long = "input-file",
+        conflicts_with_all = ["set", "remove"]
+    )]
+    pub input_file: Option<String>,
+    /// Operation override as id=viewer,editor (repeatable)
+    #[arg(long, action = clap::ArgAction::Append, conflicts_with = "input_file")]
+    pub set: Vec<String>,
+    /// Operation id to remove from the runtime overlay (repeatable)
+    #[arg(long, action = clap::ArgAction::Append, conflicts_with = "input_file")]
+    pub remove: Vec<String>,
 }
 
 #[derive(Subcommand)]

--- a/gestalt/cli/src/commands/authorization.rs
+++ b/gestalt/cli/src/commands/authorization.rs
@@ -176,24 +176,6 @@ pub(crate) fn build_relationship_from_args(
     })
 }
 
-pub(crate) fn build_app_member_relationship(
-    app: &str,
-    role: &str,
-    subject_id: &str,
-) -> Result<Relationship> {
-    Ok(Relationship {
-        tuple: Some(relationship_tuple_from_parts(
-            "app",
-            app,
-            role,
-            Some(subject_id),
-            None,
-        )?),
-        properties: None,
-        source_layer: SOURCE_LAYER_RUNTIME,
-    })
-}
-
 pub(crate) fn relationship_tuple_from_parts(
     resource_type: &str,
     resource_id: &str,

--- a/gestalt/cli/src/commands/authorization_apps.rs
+++ b/gestalt/cli/src/commands/authorization_apps.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result, bail};
-use serde::Deserialize;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::collections::HashMap;
 
 use crate::api::{ApiClient, encode_path_segment};
 use crate::cli::{
@@ -227,12 +227,8 @@ fn list_allowed_operations(
     format: Format,
 ) -> Result<()> {
     let app = require_app_name(&args.app)?;
-    let path = format!(
-        "/api/v1/apps/{}/admin/allowed-operations",
-        encode_path_segment(&app)
-    );
     let resp = api
-        .get(&path)
+        .get(&app_admin_allowed_operations_path(&app))
         .with_context(|| format!("failed to list allowed operations for app {app}"))?;
     match format {
         Format::Json => output::print_json(&resp),
@@ -260,12 +256,8 @@ fn set_allowed_operations(
 ) -> Result<()> {
     let app = require_app_name(&args.app)?;
     let body = build_allowed_operations_update_request(args)?;
-    let path = format!(
-        "/api/v1/apps/{}/admin/allowed-operations",
-        encode_path_segment(&app)
-    );
     let resp = api
-        .put(&path, &body)
+        .put(&app_admin_allowed_operations_path(&app), &body)
         .with_context(|| format!("failed to update allowed operations for app {app}"))?;
     match format {
         Format::Json => output::print_json(&resp),
@@ -295,7 +287,7 @@ fn build_allowed_operations_update_request(
         bail!("pass --set id=viewer,editor and/or --remove id, or use --input-file");
     }
 
-    let mut operations = std::collections::HashMap::new();
+    let mut operations = HashMap::new();
     for entry in &args.set {
         let (operation_id, roles) = parse_operation_roles_assignment(entry)?;
         operations.insert(
@@ -306,22 +298,26 @@ fn build_allowed_operations_update_request(
         );
     }
 
-    let removed: Vec<String> = args
-        .remove
-        .iter()
-        .map(|id| {
-            let trimmed = id.trim();
-            if trimmed.is_empty() {
-                bail!("operation id is required");
-            }
-            Ok(trimmed.to_string())
-        })
-        .collect::<Result<_>>()?;
+    let mut removed = Vec::with_capacity(args.remove.len());
+    for id in &args.remove {
+        let trimmed = id.trim();
+        if trimmed.is_empty() {
+            bail!("operation id is required");
+        }
+        removed.push(trimmed.to_string());
+    }
 
     Ok(AllowedOperationsUpdateRequest {
         operations,
         removed,
     })
+}
+
+fn app_admin_allowed_operations_path(app: &str) -> String {
+    format!(
+        "/api/v1/apps/{}/admin/allowed-operations",
+        encode_path_segment(app)
+    )
 }
 
 fn parse_operation_roles_assignment(raw: &str) -> Result<(String, Vec<String>)> {
@@ -653,7 +649,7 @@ fn plan_role_set(existing_roles: &[String], role: &str) -> RoleSetPlan {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct AppAdminMember {
     role: String,
@@ -668,7 +664,7 @@ struct AppAdminMember {
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct AllowedOperationsUpdateRequest {
-    operations: std::collections::HashMap<String, OperationOverrideBody>,
+    operations: HashMap<String, OperationOverrideBody>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     removed: Vec<String>,
 }

--- a/gestalt/cli/src/commands/authorization_apps.rs
+++ b/gestalt/cli/src/commands/authorization_apps.rs
@@ -10,22 +10,14 @@ use crate::cli::{
     AuthorizationAppsMembersCommands, AuthorizationAppsMembersListArgs,
     AuthorizationAppsMembersRemoveArgs, AuthorizationAppsMembersSetArgs,
 };
-use crate::commands::authorization::{
-    build_app_member_relationship, relationship_tuple_from_parts,
-};
 use crate::output::{self, Format};
 
-use gestalt_sdk::authorization::source_layer::SOURCE_LAYER_RUNTIME;
-use gestalt_sdk::authorization::{
-    AddRelationshipRequest, DeleteRelationshipRequest, ListRelationshipsRequest, Relationship,
-    RelationshipFilter, RelationshipTargetKind, Resource,
-};
 use gestalt_sdk::public::generated::app_client::AuthorizationClient;
 use gestalt_sdk::public::rest_transport::SyncRestTransport;
 
 pub fn dispatch(
     api: &ApiClient,
-    authz: &AuthorizationClient<SyncRestTransport>,
+    _authz: &AuthorizationClient<SyncRestTransport>,
     command: AuthorizationAppsCommands,
     format: Format,
 ) -> Result<()> {
@@ -33,10 +25,8 @@ pub fn dispatch(
         AuthorizationAppsCommands::List => list_apps(api, format),
         AuthorizationAppsCommands::Members { command } => match command {
             AuthorizationAppsMembersCommands::List(args) => list_members(api, &args, format),
-            AuthorizationAppsMembersCommands::Set(args) => set_member(authz, api, &args, format),
-            AuthorizationAppsMembersCommands::Remove(args) => {
-                remove_member(authz, api, &args, format)
-            }
+            AuthorizationAppsMembersCommands::Set(args) => set_member(api, &args, format),
+            AuthorizationAppsMembersCommands::Remove(args) => remove_member(api, &args, format),
         },
         AuthorizationAppsCommands::AllowedOperations { command } => match command {
             AuthorizationAppsAllowedOperationsCommands::List(args) => {
@@ -107,7 +97,6 @@ fn list_members(
 }
 
 fn set_member(
-    authz: &AuthorizationClient<SyncRestTransport>,
     api: &ApiClient,
     args: &AuthorizationAppsMembersSetArgs,
     format: Format,
@@ -121,48 +110,23 @@ fn set_member(
         args.subject_id.as_deref(),
     )?;
 
-    let existing = mutable_roles_for_subject(authz, api, &app, &subject_id)?;
-    let plan = plan_role_set(&existing, &role);
-    if plan.roles_to_remove.is_empty() && !plan.add_role {
-        match format {
-            Format::Json => output::print_json(&serde_json::json!({
-                "app": app,
-                "subjectId": subject_id,
-                "role": role,
-                "changed": false,
-            })),
-            Format::Table => {
-                output::print_success(&format!("{subject_id} already has {role} on {app}."))
-            }
-        }
-        return Ok(());
-    }
-
-    for existing_role in &plan.roles_to_remove {
-        delete_member_tuple(authz, &app, existing_role, &subject_id)?;
-    }
-
-    if plan.add_role {
-        let relationship = build_app_member_relationship(&app, &role, &subject_id)?;
-        authz
-            .add_relationship_sync(AddRelationshipRequest {
-                relationship: Some(relationship),
-            })
-            .context("failed to grant app member access")?;
-    }
+    let resp = api
+        .post(
+            &app_admin_members_path(&app),
+            &AppAdminMemberSetRequest {
+                subject_id: subject_id.clone(),
+                role: role.clone(),
+            },
+        )
+        .with_context(|| format!("failed to grant app member access for {subject_id} on {app}"))?;
 
     match format {
-        Format::Json => output::print_json(&serde_json::json!({
-            "app": app,
-            "subjectId": subject_id,
-            "role": role,
-            "changed": true,
-        })),
+        Format::Json => output::print_json(&resp),
         Format::Table => {
-            if plan.add_role {
-                output::print_success(&format!("Granted {role} on {app} to {subject_id}."))
+            if resp.get("changed").and_then(Value::as_bool) == Some(false) {
+                output::print_success(&format!("{subject_id} already has {role} on {app}."))
             } else {
-                output::print_success(&format!("Updated {subject_id} on {app} to only {role}."))
+                output::print_success(&format!("Granted {role} on {app} to {subject_id}."))
             }
         }
     }
@@ -170,7 +134,6 @@ fn set_member(
 }
 
 fn remove_member(
-    authz: &AuthorizationClient<SyncRestTransport>,
     api: &ApiClient,
     args: &AuthorizationAppsMembersRemoveArgs,
     format: Format,
@@ -182,40 +145,30 @@ fn remove_member(
         args.email.as_deref(),
         args.subject_id.as_deref().or(args.subject.as_deref()),
     )?;
-    let mutable_roles = mutable_roles_for_subject(authz, api, &app, &subject)?;
-    let roles = match args
+    let role = args
         .role
         .as_deref()
         .map(str::trim)
         .filter(|value| !value.is_empty())
-    {
-        Some(role) => {
-            let role = require_role(role)?;
-            if !mutable_roles
-                .iter()
-                .any(|mutable_role| mutable_role == &role)
-            {
-                bail!("no mutable {role} grant found for {subject} on {app}");
-            }
-            vec![role]
-        }
-        None => mutable_roles,
-    };
-    if roles.is_empty() {
-        bail!("no mutable member grants found for {subject} on {app}");
-    }
-    for role in &roles {
-        delete_member_tuple(authz, &app, role, &subject)?;
-    }
+        .map(require_role)
+        .transpose()?;
+    let resp = api
+        .delete_json(
+            &app_admin_members_path(&app),
+            &AppAdminMemberRemoveRequest {
+                subject_id: subject.clone(),
+                role,
+            },
+        )
+        .with_context(|| format!("failed to remove app member access for {subject} on {app}"))?;
     match format {
-        Format::Json => output::print_json(&serde_json::json!({
-            "app": app,
-            "subjectId": subject,
-            "removedRoles": roles,
-        })),
+        Format::Json => output::print_json(&resp),
         Format::Table => output::print_success(&format!(
             "Removed {} grant(s) for {subject} on {app}.",
-            roles.len()
+            resp.get("removedRoles")
+                .and_then(Value::as_array)
+                .map(Vec::len)
+                .unwrap_or_default()
         )),
     }
     Ok(())
@@ -261,9 +214,7 @@ fn set_allowed_operations(
         .with_context(|| format!("failed to update allowed operations for app {app}"))?;
     match format {
         Format::Json => output::print_json(&resp),
-        Format::Table => {
-            output::print_success(&format!("Updated allowed operations for {app}."))
-        }
+        Format::Table => output::print_success(&format!("Updated allowed operations for {app}.")),
     }
     Ok(())
 }
@@ -320,6 +271,10 @@ fn app_admin_allowed_operations_path(app: &str) -> String {
     )
 }
 
+fn app_admin_members_path(app: &str) -> String {
+    format!("/api/v1/apps/{}/admin/members", encode_path_segment(app))
+}
+
 fn parse_operation_roles_assignment(raw: &str) -> Result<(String, Vec<String>)> {
     let (operation_id, roles_raw) = raw
         .split_once('=')
@@ -367,108 +322,9 @@ fn allowed_operation_row(value: &Value) -> Vec<String> {
     ]
 }
 
-fn delete_member_tuple(
-    authz: &AuthorizationClient<SyncRestTransport>,
-    app: &str,
-    role: &str,
-    subject_id: &str,
-) -> Result<()> {
-    let tuple = relationship_tuple_from_parts("app", app, role, Some(subject_id), None)?;
-    authz
-        .delete_relationship_sync(DeleteRelationshipRequest {
-            relationship_tuple: Some(tuple),
-        })
-        .with_context(|| format!("failed to remove {role} grant for {subject_id} on {app}"))?;
-    Ok(())
-}
-
-fn mutable_roles_for_subject(
-    authz: &AuthorizationClient<SyncRestTransport>,
-    api: &ApiClient,
-    app: &str,
-    subject_id: &str,
-) -> Result<Vec<String>> {
-    if is_service_account_subject(subject_id) {
-        return runtime_roles_for_subject(authz, app, subject_id);
-    }
-
-    let members = load_app_admin_members(api, app)?;
-    let roster_roles: Vec<String> = members
-        .iter()
-        .filter(|member| member.mutable && subject_matches_member(subject_id, member))
-        .map(|member| member.role.clone())
-        .collect();
-    if !roster_roles.is_empty()
-        || members
-            .iter()
-            .any(|member| subject_matches_member(subject_id, member))
-    {
-        return Ok(roster_roles);
-    }
-
-    runtime_roles_for_subject(authz, app, subject_id)
-}
-
-fn runtime_roles_for_subject(
-    authz: &AuthorizationClient<SyncRestTransport>,
-    app: &str,
-    subject_id: &str,
-) -> Result<Vec<String>> {
-    let normalized = normalize_subject_id(subject_id)?;
-    let mut roles = Vec::new();
-    let mut page_token = String::new();
-    loop {
-        let resp = authz
-            .list_relationships_sync(ListRelationshipsRequest {
-                filter: Some(RelationshipFilter {
-                    resource: Some(Resource {
-                        r#type: "app".to_string(),
-                        id: app.to_string(),
-                        properties: None,
-                    }),
-                    ..Default::default()
-                }),
-                page_size: 500,
-                page_token: page_token.clone(),
-            })
-            .context("failed to list app relationships")?;
-        for relationship in resp.relationships {
-            if relationship.source_layer != SOURCE_LAYER_RUNTIME {
-                continue;
-            }
-            let Some(role) = runtime_role_for_subject(&relationship, &normalized) else {
-                continue;
-            };
-            roles.push(role);
-        }
-        page_token = resp.next_page_token.trim().to_string();
-        if page_token.is_empty() {
-            return Ok(roles);
-        }
-    }
-}
-
-fn runtime_role_for_subject(relationship: &Relationship, subject_id: &str) -> Option<String> {
-    let tuple = relationship.tuple.as_ref()?;
-    let target = tuple.target.as_ref()?.kind.as_ref()?;
-    let target_subject = match target {
-        RelationshipTargetKind::Subject(subject) => subject,
-        _ => return None,
-    };
-    if normalize_subject_id(&target_subject.id).ok().as_deref() != Some(subject_id) {
-        return None;
-    }
-    let role = tuple.relation.trim();
-    if role.is_empty() {
-        return None;
-    }
-    Some(role.to_string())
-}
-
 fn load_app_admin_members(api: &ApiClient, app: &str) -> Result<Vec<AppAdminMember>> {
-    let path = format!("/api/v1/apps/{}/admin/members", encode_path_segment(app));
     let resp = api
-        .get(&path)
+        .get(&app_admin_members_path(app))
         .with_context(|| format!("failed to list members for app {app}"))?;
     serde_json::from_value(resp).context("failed to parse app admin members response")
 }
@@ -627,38 +483,34 @@ fn require_role(role: &str) -> Result<String> {
     if trimmed.is_empty() {
         bail!("role is required");
     }
-    Ok(trimmed.to_string())
-}
-
-#[derive(Debug, PartialEq, Eq)]
-struct RoleSetPlan {
-    roles_to_remove: Vec<String>,
-    add_role: bool,
-}
-
-fn plan_role_set(existing_roles: &[String], role: &str) -> RoleSetPlan {
-    let already_has_role = existing_roles.iter().any(|existing| existing == role);
-    let roles_to_remove = existing_roles
-        .iter()
-        .filter(|existing| existing.as_str() != role)
-        .cloned()
-        .collect();
-    RoleSetPlan {
-        roles_to_remove,
-        add_role: !already_has_role,
+    if !matches!(trimmed, "admin" | "viewer" | "editor") {
+        bail!("role must be admin, viewer, or editor");
     }
+    Ok(trimmed.to_string())
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct AppAdminMember {
-    role: String,
-    #[serde(default)]
-    mutable: bool,
     #[serde(default)]
     subject_id: Option<String>,
     #[serde(default)]
     email: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AppAdminMemberSetRequest {
+    subject_id: String,
+    role: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AppAdminMemberRemoveRequest {
+    subject_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    role: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -678,10 +530,9 @@ struct OperationOverrideBody {
 #[cfg(test)]
 mod tests {
     use super::{
-        AppAdminMember, AuthorizationAppsAllowedOperationsSetArgs, RoleSetPlan,
+        AppAdminMember, AuthorizationAppsAllowedOperationsSetArgs,
         canonical_subject_id_from_members, is_service_account_subject, normalize_subject_id,
-        parse_operation_roles_assignment, plan_role_set, subject_id_for_email_in_members,
-        subject_matches_member,
+        parse_operation_roles_assignment, subject_id_for_email_in_members, subject_matches_member,
     };
 
     #[test]
@@ -692,8 +543,6 @@ mod tests {
     #[test]
     fn subject_matches_member_compares_subject_id_and_email() {
         let member = AppAdminMember {
-            role: "viewer".to_string(),
-            mutable: true,
             subject_id: Some("user:abc".to_string()),
             email: Some("alice@example.com".to_string()),
         };
@@ -705,8 +554,6 @@ mod tests {
     #[test]
     fn subject_matches_member_ignores_subject_set_selectors() {
         let member = AppAdminMember {
-            role: "viewer".to_string(),
-            mutable: true,
             subject_id: None,
             email: None,
         };
@@ -734,8 +581,6 @@ mod tests {
     #[test]
     fn canonical_subject_id_prefers_roster_subject_id() {
         let members = [AppAdminMember {
-            role: "viewer".to_string(),
-            mutable: true,
             subject_id: Some("user:canonical-id".to_string()),
             email: Some("alice@example.com".to_string()),
         }];
@@ -748,8 +593,6 @@ mod tests {
     #[test]
     fn subject_id_for_email_uses_roster_only() {
         let members = [AppAdminMember {
-            role: "viewer".to_string(),
-            mutable: true,
             subject_id: Some("user:canonical-id".to_string()),
             email: Some("Alice@Example.com".to_string()),
         }];
@@ -764,43 +607,13 @@ mod tests {
     }
 
     #[test]
-    fn plan_role_set_noop_when_only_requested_role_present() {
-        assert_eq!(
-            plan_role_set(&["viewer".to_string()], "viewer"),
-            RoleSetPlan {
-                roles_to_remove: vec![],
-                add_role: false,
-            }
-        );
-    }
-
-    #[test]
-    fn plan_role_set_removes_extra_roles_without_readding() {
-        assert_eq!(
-            plan_role_set(&["viewer".to_string(), "editor".to_string()], "viewer"),
-            RoleSetPlan {
-                roles_to_remove: vec!["editor".to_string()],
-                add_role: false,
-            }
-        );
-    }
-
-    #[test]
-    fn plan_role_set_replaces_existing_role() {
-        assert_eq!(
-            plan_role_set(&["editor".to_string()], "viewer"),
-            RoleSetPlan {
-                roles_to_remove: vec!["editor".to_string()],
-                add_role: true,
-            }
-        );
-    }
-
-    #[test]
     fn parse_operation_roles_assignment_splits_roles() {
         assert_eq!(
             parse_operation_roles_assignment("get_item=viewer,editor").unwrap(),
-            ("get_item".to_string(), vec!["viewer".to_string(), "editor".to_string()])
+            (
+                "get_item".to_string(),
+                vec!["viewer".to_string(), "editor".to_string()]
+            )
         );
     }
 

--- a/gestalt/cli/src/commands/authorization_apps.rs
+++ b/gestalt/cli/src/commands/authorization_apps.rs
@@ -1,10 +1,13 @@
 use anyhow::{Context, Result, bail};
 use serde::Deserialize;
+use serde::Serialize;
 use serde_json::Value;
 
 use crate::api::{ApiClient, encode_path_segment};
 use crate::cli::{
-    AuthorizationAppsCommands, AuthorizationAppsMembersCommands, AuthorizationAppsMembersListArgs,
+    AuthorizationAppsAllowedOperationsCommands, AuthorizationAppsAllowedOperationsListArgs,
+    AuthorizationAppsAllowedOperationsSetArgs, AuthorizationAppsCommands,
+    AuthorizationAppsMembersCommands, AuthorizationAppsMembersListArgs,
     AuthorizationAppsMembersRemoveArgs, AuthorizationAppsMembersSetArgs,
 };
 use crate::commands::authorization::{
@@ -33,6 +36,14 @@ pub fn dispatch(
             AuthorizationAppsMembersCommands::Set(args) => set_member(authz, api, &args, format),
             AuthorizationAppsMembersCommands::Remove(args) => {
                 remove_member(authz, api, &args, format)
+            }
+        },
+        AuthorizationAppsCommands::AllowedOperations { command } => match command {
+            AuthorizationAppsAllowedOperationsCommands::List(args) => {
+                list_allowed_operations(api, &args, format)
+            }
+            AuthorizationAppsAllowedOperationsCommands::Set(args) => {
+                set_allowed_operations(api, &args, format)
             }
         },
     }
@@ -208,6 +219,156 @@ fn remove_member(
         )),
     }
     Ok(())
+}
+
+fn list_allowed_operations(
+    api: &ApiClient,
+    args: &AuthorizationAppsAllowedOperationsListArgs,
+    format: Format,
+) -> Result<()> {
+    let app = require_app_name(&args.app)?;
+    let path = format!(
+        "/api/v1/apps/{}/admin/allowed-operations",
+        encode_path_segment(&app)
+    );
+    let resp = api
+        .get(&path)
+        .with_context(|| format!("failed to list allowed operations for app {app}"))?;
+    match format {
+        Format::Json => output::print_json(&resp),
+        Format::Table => {
+            let rows: Vec<Vec<String>> = resp
+                .get("operations")
+                .and_then(Value::as_array)
+                .unwrap_or(&Vec::new())
+                .iter()
+                .map(allowed_operation_row)
+                .collect();
+            println!(
+                "{}",
+                output::render_table(&["ID", "Source", "Allowed Roles"], &rows)
+            );
+        }
+    }
+    Ok(())
+}
+
+fn set_allowed_operations(
+    api: &ApiClient,
+    args: &AuthorizationAppsAllowedOperationsSetArgs,
+    format: Format,
+) -> Result<()> {
+    let app = require_app_name(&args.app)?;
+    let body = build_allowed_operations_update_request(args)?;
+    let path = format!(
+        "/api/v1/apps/{}/admin/allowed-operations",
+        encode_path_segment(&app)
+    );
+    let resp = api
+        .put(&path, &body)
+        .with_context(|| format!("failed to update allowed operations for app {app}"))?;
+    match format {
+        Format::Json => output::print_json(&resp),
+        Format::Table => {
+            output::print_success(&format!("Updated allowed operations for {app}."))
+        }
+    }
+    Ok(())
+}
+
+fn build_allowed_operations_update_request(
+    args: &AuthorizationAppsAllowedOperationsSetArgs,
+) -> Result<AllowedOperationsUpdateRequest> {
+    if let Some(path) = args
+        .input_file
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        let raw = std::fs::read_to_string(path)
+            .with_context(|| format!("failed to read allowed operations file {path}"))?;
+        return serde_json::from_str(&raw)
+            .with_context(|| format!("failed to parse allowed operations file {path}"));
+    }
+
+    if args.set.is_empty() && args.remove.is_empty() {
+        bail!("pass --set id=viewer,editor and/or --remove id, or use --input-file");
+    }
+
+    let mut operations = std::collections::HashMap::new();
+    for entry in &args.set {
+        let (operation_id, roles) = parse_operation_roles_assignment(entry)?;
+        operations.insert(
+            operation_id,
+            OperationOverrideBody {
+                allowed_roles: roles,
+            },
+        );
+    }
+
+    let removed: Vec<String> = args
+        .remove
+        .iter()
+        .map(|id| {
+            let trimmed = id.trim();
+            if trimmed.is_empty() {
+                bail!("operation id is required");
+            }
+            Ok(trimmed.to_string())
+        })
+        .collect::<Result<_>>()?;
+
+    Ok(AllowedOperationsUpdateRequest {
+        operations,
+        removed,
+    })
+}
+
+fn parse_operation_roles_assignment(raw: &str) -> Result<(String, Vec<String>)> {
+    let (operation_id, roles_raw) = raw
+        .split_once('=')
+        .with_context(|| format!("expected operation override as id=viewer,editor, got {raw:?}"))?;
+    let operation_id = operation_id.trim();
+    if operation_id.is_empty() {
+        bail!("operation id is required");
+    }
+    let roles: Vec<String> = roles_raw
+        .split(',')
+        .map(str::trim)
+        .filter(|role| !role.is_empty())
+        .map(str::to_string)
+        .collect();
+    if roles.is_empty() {
+        bail!("allowed roles are required for operation {operation_id}");
+    }
+    Ok((operation_id.to_string(), roles))
+}
+
+fn allowed_operation_row(value: &Value) -> Vec<String> {
+    let roles = value
+        .get("allowedRoles")
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(Value::as_str)
+                .collect::<Vec<_>>()
+                .join(", ")
+        })
+        .unwrap_or_default();
+    vec![
+        value
+            .get("id")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string(),
+        value
+            .get("source")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string(),
+        roles,
+    ]
 }
 
 fn delete_member_tuple(
@@ -492,7 +653,7 @@ fn plan_role_set(existing_roles: &[String], role: &str) -> RoleSetPlan {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct AppAdminMember {
     role: String,
@@ -504,11 +665,26 @@ struct AppAdminMember {
     email: Option<String>,
 }
 
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AllowedOperationsUpdateRequest {
+    operations: std::collections::HashMap<String, OperationOverrideBody>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    removed: Vec<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct OperationOverrideBody {
+    allowed_roles: Vec<String>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        AppAdminMember, RoleSetPlan, canonical_subject_id_from_members, is_service_account_subject,
-        normalize_subject_id, plan_role_set, subject_id_for_email_in_members,
+        AppAdminMember, AuthorizationAppsAllowedOperationsSetArgs, RoleSetPlan,
+        canonical_subject_id_from_members, is_service_account_subject, normalize_subject_id,
+        parse_operation_roles_assignment, plan_role_set, subject_id_for_email_in_members,
         subject_matches_member,
     };
 
@@ -622,5 +798,33 @@ mod tests {
                 add_role: true,
             }
         );
+    }
+
+    #[test]
+    fn parse_operation_roles_assignment_splits_roles() {
+        assert_eq!(
+            parse_operation_roles_assignment("get_item=viewer,editor").unwrap(),
+            ("get_item".to_string(), vec!["viewer".to_string(), "editor".to_string()])
+        );
+    }
+
+    #[test]
+    fn parse_operation_roles_assignment_rejects_missing_roles() {
+        assert!(parse_operation_roles_assignment("get_item=").is_err());
+    }
+
+    #[test]
+    fn build_allowed_operations_update_request_supports_remove_only() {
+        let body = super::build_allowed_operations_update_request(
+            &AuthorizationAppsAllowedOperationsSetArgs {
+                app: "home".to_string(),
+                input_file: None,
+                set: vec![],
+                remove: vec!["legacy_op".to_string()],
+            },
+        )
+        .unwrap();
+        assert!(body.operations.is_empty());
+        assert_eq!(body.removed, vec!["legacy_op".to_string()]);
     }
 }

--- a/gestaltd/internal/server/app_admin_ui_observability.go
+++ b/gestaltd/internal/server/app_admin_ui_observability.go
@@ -1,11 +1,13 @@
 package server
 
 import (
+	"context"
 	"net/http"
 	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"github.com/valon-technologies/gestalt/server/services/observability"
@@ -15,6 +17,13 @@ type appAdminUIResponseRecorder struct {
 	http.ResponseWriter
 	status int
 }
+
+type appAdminUITargetSubject struct {
+	kind string
+	id   string
+}
+
+type appAdminUITargetSubjectKey struct{}
 
 func (w *appAdminUIResponseRecorder) WriteHeader(statusCode int) {
 	w.status = statusCode
@@ -37,6 +46,8 @@ func (s *Server) appAdminUIObservabilityMiddleware(next http.Handler) http.Handl
 		}
 		appName := strings.TrimSpace(chi.URLParam(r, "app"))
 		startedAt := time.Now()
+		target := &appAdminUITargetSubject{}
+		r = r.WithContext(context.WithValue(r.Context(), appAdminUITargetSubjectKey{}, target))
 		recorder := &appAdminUIResponseRecorder{ResponseWriter: w, status: http.StatusOK}
 		next.ServeHTTP(recorder, r)
 		failed := recorder.status >= http.StatusBadRequest
@@ -50,12 +61,31 @@ func (s *Server) appAdminUIObservabilityMiddleware(next http.Handler) http.Handl
 			RequestID:            appAdminUIRequestID(r),
 			PrincipalSubjectKind: principalKind,
 			PrincipalSubjectID:   principalID,
+			TargetSubjectKind:    target.kind,
+			TargetSubjectID:      target.id,
 		}
 		if failed {
 			interaction.FailureCategory = observability.AppAdminUIFailureCategoryHTTP(recorder.status)
 		}
 		observability.RecordAppAdminUIInteraction(r.Context(), startedAt, interaction)
 	})
+}
+
+func recordAppAdminUITargetSubject(ctx context.Context, subjectID string) {
+	target, ok := ctx.Value(appAdminUITargetSubjectKey{}).(*appAdminUITargetSubject)
+	if !ok || target == nil {
+		return
+	}
+	subjectID = strings.TrimSpace(subjectID)
+	if kind, id, ok := core.ParseSubjectID(subjectID); ok {
+		target.kind = kind
+		target.id = id
+		return
+	}
+	if subjectID != "" {
+		target.kind = "subject"
+		target.id = subjectID
+	}
 }
 
 func appAdminUIRouteSpecForRequest(r *http.Request) (surface, action string, ok bool) {
@@ -70,6 +100,14 @@ func appAdminUIRouteSpecForRequest(r *http.Request) (surface, action string, ok 
 			return observability.AppAdminUISurfaceMembers, observability.AppAdminUIActionList, true
 		case strings.HasSuffix(path, "/admin/allowed-operations"):
 			return observability.AppAdminUISurfaceAllowedOperations, observability.AppAdminUIActionList, true
+		}
+	case http.MethodPost:
+		if strings.HasSuffix(path, "/admin/members") {
+			return observability.AppAdminUISurfaceMembers, observability.AppAdminUIActionGrantAdd, true
+		}
+	case http.MethodDelete:
+		if strings.HasSuffix(path, "/admin/members") {
+			return observability.AppAdminUISurfaceMembers, observability.AppAdminUIActionGrantRemove, true
 		}
 	case http.MethodPut:
 		if strings.HasSuffix(path, "/admin/allowed-operations") {

--- a/gestaltd/internal/server/app_admin_ui_observability_test.go
+++ b/gestaltd/internal/server/app_admin_ui_observability_test.go
@@ -147,6 +147,8 @@ func TestAppAdminUIRouteSpecForRequest(t *testing.T) {
 		ok      bool
 	}{
 		{method: http.MethodGet, path: "/api/v1/apps/demo/admin/members", surface: "members", action: "list", ok: true},
+		{method: http.MethodPost, path: "/api/v1/apps/demo/admin/members", surface: "members", action: "grant_add", ok: true},
+		{method: http.MethodDelete, path: "/api/v1/apps/demo/admin/members", surface: "members", action: "grant_remove", ok: true},
 		{method: http.MethodGet, path: "/api/v1/apps/demo/admin/allowed-operations", surface: "allowed_operations", action: "list", ok: true},
 		{method: http.MethodPut, path: "/api/v1/apps/demo/admin/allowed-operations", surface: "allowed_operations", action: "save", ok: true},
 		{method: http.MethodGet, path: "/api/v1/apps/demo/admin/registry", ok: false},

--- a/gestaltd/internal/server/handlers_app_admin_members.go
+++ b/gestaltd/internal/server/handlers_app_admin_members.go
@@ -2,7 +2,11 @@ package server
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
+	"log/slog"
 	"net/http"
 	"strings"
 
@@ -31,6 +35,33 @@ type appAdminMemberRow struct {
 func (s *Server) mountAppAdminMembersRoutes(r chi.Router) {
 	r.With(s.pluginRouteAuthMiddleware("app"), s.appAdminUIObservabilityMiddleware, s.appAdminAuthorizationMiddleware).
 		Get("/apps/{app}/admin/members", s.listAppAdminMembers)
+	r.With(s.pluginRouteAuthMiddleware("app"), s.appAdminUIObservabilityMiddleware, s.appAdminAuthorizationMiddleware).
+		Post("/apps/{app}/admin/members", s.setAppAdminMember)
+	r.With(s.pluginRouteAuthMiddleware("app"), s.appAdminUIObservabilityMiddleware, s.appAdminAuthorizationMiddleware).
+		Delete("/apps/{app}/admin/members", s.removeAppAdminMember)
+}
+
+type appAdminMemberSetRequest struct {
+	SubjectID string `json:"subjectId"`
+	Role      string `json:"role"`
+}
+
+type appAdminMemberRemoveRequest struct {
+	SubjectID string `json:"subjectId"`
+	Role      string `json:"role,omitempty"`
+}
+
+type appAdminMemberSetResponse struct {
+	App       string `json:"app"`
+	SubjectID string `json:"subjectId"`
+	Role      string `json:"role"`
+	Changed   bool   `json:"changed"`
+}
+
+type appAdminMemberRemoveResponse struct {
+	App          string   `json:"app"`
+	SubjectID    string   `json:"subjectId"`
+	RemovedRoles []string `json:"removedRoles"`
 }
 
 func (s *Server) listAppAdminMembers(w http.ResponseWriter, r *http.Request) {
@@ -52,6 +83,131 @@ func (s *Server) listAppAdminMembers(w http.ResponseWriter, r *http.Request) {
 	// Members is the human/group access roster. Service-account grants are
 	// owned by GET /apps/{app}/admin/identities.
 	writeJSON(w, http.StatusOK, s.projectAppAdminHumanMemberRows(r.Context(), rows))
+}
+
+func (s *Server) setAppAdminMember(w http.ResponseWriter, r *http.Request) {
+	appName := strings.TrimSpace(chi.URLParam(r, "app"))
+	if appName == "" {
+		writeError(w, http.StatusBadRequest, "app is required")
+		return
+	}
+	request, ok := decodeAppAdminMemberSetRequest(w, r)
+	if !ok {
+		return
+	}
+	subjectID := strings.TrimSpace(request.SubjectID)
+	role := strings.TrimSpace(request.Role)
+	if subjectID == "" {
+		writeError(w, http.StatusBadRequest, "subjectId is required")
+		return
+	}
+	if err := validateAppAdminMemberSubjectID(subjectID); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	recordAppAdminUITargetSubject(r.Context(), subjectID)
+	if role == "" {
+		writeError(w, http.StatusBadRequest, "role is required")
+		return
+	}
+	if err := validateAppAdminMemberRole(role); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	existing, err := s.mutableAppAdminMemberRoles(r.Context(), appName, subjectID)
+	if err != nil {
+		slog.Error("app admin member roles load failed", "app", appName, "subject_id", subjectID, "error", err)
+		writeError(w, http.StatusServiceUnavailable, "authorization is unavailable")
+		return
+	}
+	addRole := true
+	for _, existingRole := range existing {
+		if existingRole == role {
+			addRole = false
+			continue
+		}
+		if err := s.deleteAppAdminMemberRole(r.Context(), appName, existingRole, subjectID); err != nil {
+			slog.Error("app admin member grant remove failed", "app", appName, "subject_id", subjectID, "role", existingRole, "error", err)
+			writeError(w, http.StatusServiceUnavailable, "authorization is unavailable")
+			return
+		}
+	}
+	if addRole {
+		if err := s.addAppAdminMemberRole(r.Context(), appName, role, subjectID); err != nil {
+			slog.Error("app admin member grant add failed", "app", appName, "subject_id", subjectID, "role", role, "error", err)
+			writeError(w, http.StatusServiceUnavailable, "authorization is unavailable")
+			return
+		}
+	}
+	writeJSON(w, http.StatusOK, appAdminMemberSetResponse{
+		App:       appName,
+		SubjectID: subjectID,
+		Role:      role,
+		Changed:   addRole || len(existing) > 1,
+	})
+}
+
+func (s *Server) removeAppAdminMember(w http.ResponseWriter, r *http.Request) {
+	appName := strings.TrimSpace(chi.URLParam(r, "app"))
+	if appName == "" {
+		writeError(w, http.StatusBadRequest, "app is required")
+		return
+	}
+	request, ok := decodeAppAdminMemberRemoveRequest(w, r)
+	if !ok {
+		return
+	}
+	subjectID := strings.TrimSpace(request.SubjectID)
+	if subjectID == "" {
+		writeError(w, http.StatusBadRequest, "subjectId is required")
+		return
+	}
+	if err := validateAppAdminMemberSubjectID(subjectID); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	recordAppAdminUITargetSubject(r.Context(), subjectID)
+	existing, err := s.mutableAppAdminMemberRoles(r.Context(), appName, subjectID)
+	if err != nil {
+		slog.Error("app admin member roles load failed", "app", appName, "subject_id", subjectID, "error", err)
+		writeError(w, http.StatusServiceUnavailable, "authorization is unavailable")
+		return
+	}
+	roles := existing
+	if role := strings.TrimSpace(request.Role); role != "" {
+		if err := validateAppAdminMemberRole(role); err != nil {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		found := false
+		for _, existingRole := range existing {
+			if existingRole == role {
+				found = true
+				break
+			}
+		}
+		if !found {
+			writeError(w, http.StatusBadRequest, "no mutable "+role+" grant found for "+subjectID+" on "+appName)
+			return
+		}
+		roles = []string{role}
+	}
+	if len(roles) == 0 {
+		writeError(w, http.StatusBadRequest, "no mutable member grants found for "+subjectID+" on "+appName)
+		return
+	}
+	for _, role := range roles {
+		if err := s.deleteAppAdminMemberRole(r.Context(), appName, role, subjectID); err != nil {
+			slog.Error("app admin member grant remove failed", "app", appName, "subject_id", subjectID, "role", role, "error", err)
+			writeError(w, http.StatusServiceUnavailable, "authorization is unavailable")
+			return
+		}
+	}
+	writeJSON(w, http.StatusOK, appAdminMemberRemoveResponse{
+		App:          appName,
+		SubjectID:    subjectID,
+		RemovedRoles: roles,
+	})
 }
 
 // isAppAdminServiceAccountRow partitions the shared app authorization grant
@@ -119,6 +275,111 @@ func (s *Server) listAuthorizationMemberRows(ctx context.Context, resource *prot
 		if pageToken == "" {
 			return projectAppAdminMemberRoster(rows), nil
 		}
+	}
+}
+
+func decodeAppAdminMemberSetRequest(w http.ResponseWriter, r *http.Request) (appAdminMemberSetRequest, bool) {
+	var request appAdminMemberSetRequest
+	if !decodeStrictJSONBody(w, r, &request) {
+		return appAdminMemberSetRequest{}, false
+	}
+	return request, true
+}
+
+func decodeAppAdminMemberRemoveRequest(w http.ResponseWriter, r *http.Request) (appAdminMemberRemoveRequest, bool) {
+	var request appAdminMemberRemoveRequest
+	if !decodeStrictJSONBody(w, r, &request) {
+		return appAdminMemberRemoveRequest{}, false
+	}
+	return request, true
+}
+
+func decodeStrictJSONBody(w http.ResponseWriter, r *http.Request, out any) bool {
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(out); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return false
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return false
+	}
+	return true
+}
+
+func (s *Server) mutableAppAdminMemberRoles(ctx context.Context, appName, subjectID string) ([]string, error) {
+	rows, err := s.listAppAuthorizationMemberRows(ctx, appName)
+	if err != nil {
+		return nil, err
+	}
+	roles := make([]string, 0)
+	for _, row := range rows {
+		if !row.Mutable || !appAdminMemberRowMatchesSubject(row, subjectID) {
+			continue
+		}
+		roles = append(roles, row.Role)
+	}
+	return roles, nil
+}
+
+func appAdminMemberRowMatchesSubject(row appAdminMemberRow, subjectID string) bool {
+	subjectID = strings.TrimSpace(subjectID)
+	return subjectID != "" && row.SelectorKind == "subject_id" && strings.TrimSpace(row.SubjectID) == subjectID
+}
+
+func (s *Server) addAppAdminMemberRole(ctx context.Context, appName, role, subjectID string) error {
+	if s == nil || s.authorization == nil {
+		return errors.New("authorization is unavailable")
+	}
+	_, err := s.authorization.AddRelationship(ctx, &proto.AddRelationshipRequest{
+		Relationship: &proto.Relationship{
+			Tuple:       appAdminMemberRelationshipTuple(appName, role, subjectID),
+			SourceLayer: proto.SourceLayer_SOURCE_LAYER_RUNTIME,
+		},
+	})
+	return err
+}
+
+func (s *Server) deleteAppAdminMemberRole(ctx context.Context, appName, role, subjectID string) error {
+	if s == nil || s.authorization == nil {
+		return errors.New("authorization is unavailable")
+	}
+	_, err := s.authorization.DeleteRelationship(ctx, &proto.DeleteRelationshipRequest{
+		RelationshipTuple: appAdminMemberRelationshipTuple(appName, role, subjectID),
+	})
+	return err
+}
+
+func appAdminMemberRelationshipTuple(appName, role, subjectID string) *proto.RelationshipTuple {
+	return &proto.RelationshipTuple{
+		Resource: &proto.Resource{Type: "app", Id: strings.TrimSpace(appName)},
+		Relation: strings.TrimSpace(role),
+		Target: &proto.RelationshipTarget{
+			Kind: &proto.RelationshipTarget_Subject{Subject: &proto.Subject{
+				Type: "subject",
+				Id:   strings.TrimSpace(subjectID),
+			}},
+		},
+	}
+}
+
+func validateAppAdminMemberSubjectID(subjectID string) error {
+	if strings.Contains(subjectID, "#") {
+		return errors.New("subjectId must be a direct subject, not a subject-set selector")
+	}
+	if _, _, ok := core.ParseSubjectID(subjectID); !ok {
+		return errors.New("subjectId must include a subject kind prefix")
+	}
+	return nil
+}
+
+func validateAppAdminMemberRole(role string) error {
+	switch strings.TrimSpace(role) {
+	case "admin", "viewer", "editor":
+		return nil
+	default:
+		return errors.New("role must be admin, viewer, or editor")
 	}
 }
 

--- a/gestaltd/internal/server/handlers_app_admin_members_test.go
+++ b/gestaltd/internal/server/handlers_app_admin_members_test.go
@@ -1,6 +1,7 @@
 package server_test
 
 import (
+	"bytes"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -300,5 +301,116 @@ func TestAppAdminMembersListForbiddenWithoutAdmin(t *testing.T) {
 	if response.StatusCode != http.StatusForbidden {
 		body, _ := io.ReadAll(response.Body)
 		t.Fatalf("GET status = %d, want 403: %s", response.StatusCode, body)
+	}
+}
+
+func TestAppAdminMembersSetAddsRuntimeGrant(t *testing.T) {
+	t.Parallel()
+
+	adminID := principal.UserSubjectID(testCanonicalAdminUserID)
+	viewerID := principal.UserSubjectID(testCanonicalViewerUserID)
+	authz := &serverTestAuthorizationProvider{
+		relationships: []*proto.Relationship{
+			testAuthorizationRelationship(adminID, "admin", "app", "g-issues"),
+		},
+	}
+	authz.relationships[0].SourceLayer = proto.SourceLayer_SOURCE_LAYER_STATIC_CONFIG
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = authStubWithSessionTokenIntrospect("alice-token", adminID, "")
+		cfg.Authorization = authz
+		cfg.AppDefs = appAdminTestAppDefs()
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	request, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/apps/g-issues/admin/members", bytes.NewBufferString(`{"subjectId":"`+viewerID+`","role":"viewer"}`))
+	request.Header.Set("Authorization", "Bearer alice-token")
+	request.Header.Set("Content-Type", "application/json")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("POST members: %v", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("POST status = %d: %s", response.StatusCode, body)
+	}
+
+	var body struct {
+		Changed bool `json:"changed"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !body.Changed {
+		t.Fatal("changed = false, want true")
+	}
+	authz.mu.Lock()
+	defer authz.mu.Unlock()
+	if len(authz.addRelationshipRequests) != 1 {
+		t.Fatalf("AddRelationship calls = %d, want 1", len(authz.addRelationshipRequests))
+	}
+	added := authz.addRelationshipRequests[0].GetRelationship()
+	if added.GetSourceLayer() != proto.SourceLayer_SOURCE_LAYER_RUNTIME {
+		t.Fatalf("source layer = %v, want runtime", added.GetSourceLayer())
+	}
+	if tuple := added.GetTuple(); tuple.GetResource().GetId() != "g-issues" || tuple.GetRelation() != "viewer" || tuple.GetTarget().GetSubject().GetId() != viewerID {
+		t.Fatalf("added tuple = %#v", tuple)
+	}
+}
+
+func TestAppAdminMembersRemoveDeletesRuntimeGrants(t *testing.T) {
+	t.Parallel()
+
+	adminID := principal.UserSubjectID(testCanonicalAdminUserID)
+	viewerID := principal.UserSubjectID(testCanonicalViewerUserID)
+	authz := &serverTestAuthorizationProvider{
+		relationships: []*proto.Relationship{
+			testAuthorizationRelationship(adminID, "admin", "app", "g-issues"),
+			testAuthorizationRelationship(viewerID, "viewer", "app", "g-issues"),
+			testAuthorizationRelationship(viewerID, "editor", "app", "g-issues"),
+		},
+	}
+	for i := range authz.relationships {
+		authz.relationships[i].SourceLayer = proto.SourceLayer_SOURCE_LAYER_RUNTIME
+	}
+	authz.relationships[0].SourceLayer = proto.SourceLayer_SOURCE_LAYER_STATIC_CONFIG
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = authStubWithSessionTokenIntrospect("alice-token", adminID, "")
+		cfg.Authorization = authz
+		cfg.AppDefs = appAdminTestAppDefs()
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	request, _ := http.NewRequest(http.MethodDelete, ts.URL+"/api/v1/apps/g-issues/admin/members", bytes.NewBufferString(`{"subjectId":"`+viewerID+`"}`))
+	request.Header.Set("Authorization", "Bearer alice-token")
+	request.Header.Set("Content-Type", "application/json")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("DELETE members: %v", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("DELETE status = %d: %s", response.StatusCode, body)
+	}
+
+	var body struct {
+		RemovedRoles []string `json:"removedRoles"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(body.RemovedRoles) != 2 {
+		t.Fatalf("removedRoles = %#v, want two roles", body.RemovedRoles)
+	}
+	authz.mu.Lock()
+	defer authz.mu.Unlock()
+	if len(authz.deleteRelationshipRequests) != 2 {
+		t.Fatalf("DeleteRelationship calls = %d, want 2", len(authz.deleteRelationshipRequests))
+	}
+	if len(authz.relationships) != 1 || authz.relationships[0].GetTuple().GetTarget().GetSubject().GetId() != adminID {
+		t.Fatalf("remaining relationships = %#v", authz.relationships)
 	}
 }

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -2771,13 +2771,15 @@ type serverTestAuthorizationProvider struct {
 
 	mu sync.Mutex
 
-	resourceTypes            []*proto.AuthorizationModelResourceType
-	relationships            []*proto.Relationship
-	listRelationshipRequests []*proto.ListRelationshipsRequest
-	checkAccessRequests      []*proto.CheckAccessRequest
-	checkAccessManyRequests  []*proto.CheckAccessManyRequest
-	checkAccessErr           error
-	checkAccessManyErr       error
+	resourceTypes              []*proto.AuthorizationModelResourceType
+	relationships              []*proto.Relationship
+	listRelationshipRequests   []*proto.ListRelationshipsRequest
+	addRelationshipRequests    []*proto.AddRelationshipRequest
+	deleteRelationshipRequests []*proto.DeleteRelationshipRequest
+	checkAccessRequests        []*proto.CheckAccessRequest
+	checkAccessManyRequests    []*proto.CheckAccessManyRequest
+	checkAccessErr             error
+	checkAccessManyErr         error
 }
 
 // CheckAccess models the provider-owned evaluator: it expands subject sets so a
@@ -2904,6 +2906,32 @@ func (p *serverTestAuthorizationProvider) ListRelationships(_ context.Context, r
 		out = append(out, relationship)
 	}
 	return &proto.ListRelationshipsResponse{Relationships: out}, nil
+}
+
+func (p *serverTestAuthorizationProvider) AddRelationship(_ context.Context, req *proto.AddRelationshipRequest) (*proto.AddRelationshipResponse, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.addRelationshipRequests = append(p.addRelationshipRequests, req)
+	relationship := req.GetRelationship()
+	if relationship != nil {
+		p.relationships = append(p.relationships, relationship)
+	}
+	return &proto.AddRelationshipResponse{Relationship: relationship}, nil
+}
+
+func (p *serverTestAuthorizationProvider) DeleteRelationship(_ context.Context, req *proto.DeleteRelationshipRequest) (*proto.DeleteRelationshipResponse, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.deleteRelationshipRequests = append(p.deleteRelationshipRequests, req)
+	tuple := req.GetRelationshipTuple()
+	next := p.relationships[:0]
+	for _, relationship := range p.relationships {
+		if !relationshipTupleEqual(relationship.GetTuple(), tuple) {
+			next = append(next, relationship)
+		}
+	}
+	p.relationships = next
+	return &proto.DeleteRelationshipResponse{}, nil
 }
 
 type serviceAccountCredentialAuthorizationProvider struct {
@@ -3039,6 +3067,31 @@ func relationshipMatchesFilter(relationship *proto.Relationship, filter *proto.R
 		}
 	}
 	return true
+}
+
+func relationshipTupleEqual(left, right *proto.RelationshipTuple) bool {
+	if left == nil || right == nil {
+		return left == right
+	}
+	if left.GetResource().GetType() != right.GetResource().GetType() || left.GetResource().GetId() != right.GetResource().GetId() {
+		return false
+	}
+	if strings.TrimSpace(left.GetRelation()) != strings.TrimSpace(right.GetRelation()) {
+		return false
+	}
+	leftSubject := left.GetTarget().GetSubject()
+	rightSubject := right.GetTarget().GetSubject()
+	if leftSubject != nil || rightSubject != nil {
+		return leftSubject.GetType() == rightSubject.GetType() && leftSubject.GetId() == rightSubject.GetId()
+	}
+	leftSet := left.GetTarget().GetSubjectSet()
+	rightSet := right.GetTarget().GetSubjectSet()
+	if leftSet == nil || rightSet == nil {
+		return leftSet == rightSet
+	}
+	return leftSet.GetResource().GetType() == rightSet.GetResource().GetType() &&
+		leftSet.GetResource().GetId() == rightSet.GetResource().GetId() &&
+		strings.TrimSpace(leftSet.GetRelation()) == strings.TrimSpace(rightSet.GetRelation())
 }
 
 // appAdminTestAppDefs registers the apps used by app-admin tests so the shared


### PR DESCRIPTION
## Summary
- Add `gestalt authorization apps allowed-operations list <app>` and `set <app>` against the existing app-admin HTTP routes.
- Support inline `--set id=viewer,editor` / `--remove id` flags and `--input-file` for larger updates.
- `members list` already covered `members_list`; grant mutations continue to use `members set` / `remove` with `gestaltd.client.kind:cli` via existing CLI headers.

## Test plan
- [x] `cargo test authorization_apps`
- [ ] Pair with toolshed docs PR
- [ ] Bump `GESTALTD_PINNED_SHA` and publish gestalt CLI after merge


Made with [Cursor](https://cursor.com)