### PR TITLE
[authz] constrain authorization-admin app grants to bootstrap

### DIFF
--- a/gestaltd/internal/server/handlers_app_admin_authz_boundary_test.go
+++ b/gestaltd/internal/server/handlers_app_admin_authz_boundary_test.go
@@ -1,0 +1,76 @@
+package server_test
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/internal/server"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
+	"github.com/valon-technologies/gestalt/server/services/identity/principal"
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+)
+
+func TestAppAdminMembersForbiddenForAuthorizationAdminOnly(t *testing.T) {
+	t.Parallel()
+
+	globalAdminID := principal.UserSubjectID(testCanonicalAdminUserID)
+	authz := &serverTestAuthorizationProvider{
+		relationships: []*proto.Relationship{
+			testAuthorizationRelationship(globalAdminID, "admin", "authorization", "authorization"),
+		},
+	}
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = authStubWithSessionTokenIntrospect("global-admin-token", globalAdminID, "")
+		cfg.Authorization = authz
+		cfg.AppDefs = appAdminTestAppDefs()
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	request, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/apps/g-issues/admin/members", nil)
+	request.Header.Set("Authorization", "Bearer global-admin-token")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("GET members: %v", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusForbidden {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("GET status = %d, want 403: %s", response.StatusCode, body)
+	}
+}
+
+func TestAppAdminAllowedOperationsForbiddenForAuthorizationAdminOnly(t *testing.T) {
+	t.Parallel()
+
+	globalAdminID := principal.UserSubjectID(testCanonicalAdminUserID)
+	authz := &serverTestAuthorizationProvider{
+		relationships: []*proto.Relationship{
+			testAuthorizationRelationship(globalAdminID, "admin", "authorization", "authorization"),
+		},
+	}
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = authStubWithSessionTokenIntrospect("global-admin-token", globalAdminID, "")
+		cfg.Authorization = authz
+		cfg.AppDefs = appAdminTestAppDefs()
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	request, _ := http.NewRequest(
+		http.MethodPut,
+		ts.URL+"/api/v1/apps/g-issues/admin/allowed-operations",
+		bytes.NewBufferString(`{"operations":{}}`),
+	)
+	request.Header.Set("Authorization", "Bearer global-admin-token")
+	request.Header.Set("Content-Type", "application/json")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("PUT allowed-operations: %v", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusForbidden {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("PUT status = %d, want 403: %s", response.StatusCode, body)
+	}
+}

--- a/gestaltd/internal/server/handlers_app_admin_authz_boundary_test.go
+++ b/gestaltd/internal/server/handlers_app_admin_authz_boundary_test.go
@@ -12,7 +12,7 @@ import (
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 )
 
-func TestAppAdminMembersForbiddenForAuthorizationAdminOnly(t *testing.T) {
+func TestAppAdminSurfacesForbiddenForAuthorizationAdminOnly(t *testing.T) {
 	t.Parallel()
 
 	globalAdminID := principal.UserSubjectID(testCanonicalAdminUserID)
@@ -28,49 +28,47 @@ func TestAppAdminMembersForbiddenForAuthorizationAdminOnly(t *testing.T) {
 	})
 	testutil.CloseOnCleanup(t, ts)
 
-	request, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/apps/g-issues/admin/members", nil)
-	request.Header.Set("Authorization", "Bearer global-admin-token")
-	response, err := http.DefaultClient.Do(request)
-	if err != nil {
-		t.Fatalf("GET members: %v", err)
-	}
-	defer func() { _ = response.Body.Close() }()
-	if response.StatusCode != http.StatusForbidden {
-		body, _ := io.ReadAll(response.Body)
-		t.Fatalf("GET status = %d, want 403: %s", response.StatusCode, body)
-	}
-}
-
-func TestAppAdminAllowedOperationsForbiddenForAuthorizationAdminOnly(t *testing.T) {
-	t.Parallel()
-
-	globalAdminID := principal.UserSubjectID(testCanonicalAdminUserID)
-	authz := &serverTestAuthorizationProvider{
-		relationships: []*proto.Relationship{
-			testAuthorizationRelationship(globalAdminID, "admin", "authorization", "authorization"),
+	tests := []struct {
+		name   string
+		method string
+		path   string
+		body   string
+	}{
+		{
+			name:   "members",
+			method: http.MethodGet,
+			path:   "/api/v1/apps/g-issues/admin/members",
+		},
+		{
+			name:   "allowed_operations",
+			method: http.MethodPut,
+			path:   "/api/v1/apps/g-issues/admin/allowed-operations",
+			body:   `{"operations":{}}`,
 		},
 	}
-	ts := newTestServer(t, func(cfg *server.Config) {
-		cfg.Auth = authStubWithSessionTokenIntrospect("global-admin-token", globalAdminID, "")
-		cfg.Authorization = authz
-		cfg.AppDefs = appAdminTestAppDefs()
-	})
-	testutil.CloseOnCleanup(t, ts)
 
-	request, _ := http.NewRequest(
-		http.MethodPut,
-		ts.URL+"/api/v1/apps/g-issues/admin/allowed-operations",
-		bytes.NewBufferString(`{"operations":{}}`),
-	)
-	request.Header.Set("Authorization", "Bearer global-admin-token")
-	request.Header.Set("Content-Type", "application/json")
-	response, err := http.DefaultClient.Do(request)
-	if err != nil {
-		t.Fatalf("PUT allowed-operations: %v", err)
-	}
-	defer func() { _ = response.Body.Close() }()
-	if response.StatusCode != http.StatusForbidden {
-		body, _ := io.ReadAll(response.Body)
-		t.Fatalf("PUT status = %d, want 403: %s", response.StatusCode, body)
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var body io.Reader
+			if tc.body != "" {
+				body = bytes.NewBufferString(tc.body)
+			}
+			request, _ := http.NewRequest(tc.method, ts.URL+tc.path, body)
+			request.Header.Set("Authorization", "Bearer global-admin-token")
+			if tc.body != "" {
+				request.Header.Set("Content-Type", "application/json")
+			}
+			response, err := http.DefaultClient.Do(request)
+			if err != nil {
+				t.Fatalf("%s %s: %v", tc.method, tc.path, err)
+			}
+			defer func() { _ = response.Body.Close() }()
+			if response.StatusCode != http.StatusForbidden {
+				respBody, _ := io.ReadAll(response.Body)
+				t.Fatalf("status = %d, want 403: %s", response.StatusCode, respBody)
+			}
+		})
 	}
 }

--- a/gestaltd/internal/server/handlers_app_admin_authz_boundary_test.go
+++ b/gestaltd/internal/server/handlers_app_admin_authz_boundary_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/internal/server"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
-	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 )
 
 func TestAppAdminSurfacesForbiddenForAuthorizationAdminOnly(t *testing.T) {

--- a/gestaltd/services/providergateway/authorization_access.go
+++ b/gestaltd/services/providergateway/authorization_access.go
@@ -20,7 +20,16 @@ const (
 	legacyAuthorizationAction = "authorization"
 )
 
-func authorizationMethodAccessClass(fullMethod string) (read bool, write bool, ok bool) {
+type authorizationEnforcementPolicy int
+
+const (
+	authorizationPolicyUnsupported authorizationEnforcementPolicy = iota
+	authorizationPolicyGlobalRead
+	authorizationPolicyGlobalAdminWrite
+	authorizationPolicyRelationshipWrite
+)
+
+func authorizationMethodEnforcementPolicy(fullMethod string) (authorizationEnforcementPolicy, bool) {
 	_, method := splitFullMethod(fullMethod)
 	switch method {
 	case "GetActiveModelRef",
@@ -28,12 +37,25 @@ func authorizationMethodAccessClass(fullMethod string) (read bool, write bool, o
 		"ListRelationships",
 		"CheckAccess",
 		"CheckAccessMany":
+		return authorizationPolicyGlobalRead, true
+	case "SetActiveModel", "SetAuthorizationState":
+		return authorizationPolicyGlobalAdminWrite, true
+	case "AddRelationship", "DeleteRelationship", "WriteRelationships":
+		return authorizationPolicyRelationshipWrite, true
+	default:
+		return authorizationPolicyUnsupported, false
+	}
+}
+
+func authorizationMethodAccessClass(fullMethod string) (read bool, write bool, ok bool) {
+	policy, ok := authorizationMethodEnforcementPolicy(fullMethod)
+	if !ok {
+		return false, false, false
+	}
+	switch policy {
+	case authorizationPolicyGlobalRead:
 		return true, false, true
-	case "SetActiveModel",
-		"SetAuthorizationState",
-		"AddRelationship",
-		"DeleteRelationship",
-		"WriteRelationships":
+	case authorizationPolicyGlobalAdminWrite, authorizationPolicyRelationshipWrite:
 		return false, true, true
 	default:
 		return false, false, false
@@ -45,30 +67,25 @@ func (t *ProviderGatewayTransport) enforceAuthorizationPublicAccess(
 	subjectID, fullMethod string,
 	req gproto.Message,
 ) (context.Context, error) {
-	read, write, ok := authorizationMethodAccessClass(fullMethod)
+	policy, ok := authorizationMethodEnforcementPolicy(fullMethod)
 	if !ok {
 		return ctx, status.Error(codes.Internal, "provider gateway: unsupported authorization method")
 	}
 
+	read := policy == authorizationPolicyGlobalRead
+	write := policy == authorizationPolicyGlobalAdminWrite || policy == authorizationPolicyRelationshipWrite
 	globalAdmin, err := t.hasAuthorizationPublicAdminAccess(ctx, subjectID, read, write)
 	if err != nil {
 		return ctx, status.Error(codes.Unavailable, "authorization provider unavailable")
 	}
-	if read {
-		if !globalAdmin {
-			return ctx, status.Error(codes.PermissionDenied, "access denied")
-		}
-		return ctx, nil
-	}
 
-	_, method := splitFullMethod(fullMethod)
-	switch method {
-	case "SetAuthorizationState", "SetActiveModel":
+	switch policy {
+	case authorizationPolicyGlobalRead, authorizationPolicyGlobalAdminWrite:
 		if !globalAdmin {
 			return ctx, status.Error(codes.PermissionDenied, "access denied")
 		}
 		return ctx, nil
-	case "AddRelationship", "DeleteRelationship", "WriteRelationships":
+	case authorizationPolicyRelationshipWrite:
 		allowed, err := t.allowsRelationshipWriteAccess(ctx, subjectID, fullMethod, req, globalAdmin)
 		if err != nil {
 			return ctx, status.Error(codes.Unavailable, "authorization provider unavailable")
@@ -79,10 +96,7 @@ func (t *ProviderGatewayTransport) enforceAuthorizationPublicAccess(
 		ctx = withAppScopedRelationshipMutationAuthFromRequest(ctx, fullMethod, req)
 		return ctx, nil
 	default:
-		if !globalAdmin {
-			return ctx, status.Error(codes.PermissionDenied, "access denied")
-		}
-		return ctx, nil
+		return ctx, status.Error(codes.Internal, "provider gateway: unsupported authorization method")
 	}
 }
 

--- a/gestaltd/services/providergateway/authorization_access.go
+++ b/gestaltd/services/providergateway/authorization_access.go
@@ -50,41 +50,97 @@ func (t *ProviderGatewayTransport) enforceAuthorizationPublicAccess(
 		return ctx, status.Error(codes.Internal, "provider gateway: unsupported authorization method")
 	}
 
+	globalAdmin, err := t.hasAuthorizationPublicAdminAccess(ctx, subjectID, read, write)
+	if err != nil {
+		return ctx, status.Error(codes.Unavailable, "authorization provider unavailable")
+	}
+	if read {
+		if !globalAdmin {
+			return ctx, status.Error(codes.PermissionDenied, "access denied")
+		}
+		return ctx, nil
+	}
+
+	_, method := splitFullMethod(fullMethod)
+	switch method {
+	case "SetAuthorizationState", "SetActiveModel":
+		if !globalAdmin {
+			return ctx, status.Error(codes.PermissionDenied, "access denied")
+		}
+		return ctx, nil
+	case "AddRelationship", "DeleteRelationship", "WriteRelationships":
+		allowed, err := t.allowsRelationshipWriteAccess(ctx, subjectID, fullMethod, req, globalAdmin)
+		if err != nil {
+			return ctx, status.Error(codes.Unavailable, "authorization provider unavailable")
+		}
+		if !allowed {
+			return ctx, status.Error(codes.PermissionDenied, "access denied")
+		}
+		ctx = withAppScopedRelationshipMutationAuthFromRequest(ctx, fullMethod, req)
+		return ctx, nil
+	default:
+		if !globalAdmin {
+			return ctx, status.Error(codes.PermissionDenied, "access denied")
+		}
+		return ctx, nil
+	}
+}
+
+func (t *ProviderGatewayTransport) hasAuthorizationPublicAdminAccess(
+	ctx context.Context,
+	subjectID string,
+	read, write bool,
+) (bool, error) {
 	resource := &proto.Resource{Type: authorizationResourceType, Id: authorizationResourceID}
-	allowed := false
 	for _, action := range authorizationPublicActions(read, write) {
 		checkReq := invocation.SubjectAccessRequest(subjectID, action, resource)
 		accessAllowed, err := invocation.CheckSubjectAccess(ctx, t.authorization, checkReq)
 		if err != nil {
-			return ctx, status.Error(codes.Unavailable, "authorization provider unavailable")
+			return false, err
 		}
 		if accessAllowed {
-			allowed = true
-			break
+			return true, nil
 		}
 	}
-	if !allowed && write {
-		tuple, ok := relationshipTupleFromAuthorizationRequest(fullMethod, req)
-		if ok {
-			var err error
-			allowed, err = allowsAppScopedRelationshipMutation(ctx, t.authorization, subjectID, tuple)
-			if err != nil {
-				return ctx, status.Error(codes.Unavailable, "authorization provider unavailable")
-			}
-			if !allowed {
-				deniedErr := status.Error(codes.PermissionDenied, "access denied")
-				recordAppScopedRelationshipAuthFailure(ctx, subjectID, tuple, fullMethod, deniedErr)
-				return ctx, deniedErr
-			}
+	return false, nil
+}
+
+func (t *ProviderGatewayTransport) allowsRelationshipWriteAccess(
+	ctx context.Context,
+	subjectID, fullMethod string,
+	req gproto.Message,
+	globalAdmin bool,
+) (bool, error) {
+	tuples := relationshipTuplesFromAuthorizationRequest(fullMethod, req)
+	if len(tuples) == 0 {
+		return globalAdmin, nil
+	}
+	for _, tuple := range tuples {
+		allowed, err := t.allowsRelationshipTupleWrite(ctx, subjectID, tuple, globalAdmin)
+		if err != nil {
+			return false, err
+		}
+		if !allowed {
+			recordAppScopedRelationshipAuthFailure(ctx, subjectID, tuple, fullMethod, status.Error(codes.PermissionDenied, "access denied"))
+			return false, nil
 		}
 	}
-	if !allowed {
-		return ctx, status.Error(codes.PermissionDenied, "access denied")
+	return true, nil
+}
+
+func (t *ProviderGatewayTransport) allowsRelationshipTupleWrite(
+	ctx context.Context,
+	subjectID string,
+	tuple *proto.RelationshipTuple,
+	globalAdmin bool,
+) (bool, error) {
+	if !isAppScopedRelationshipTuple(tuple) {
+		return globalAdmin, nil
 	}
-	if write {
-		ctx = withAppScopedRelationshipMutationAuthFromRequest(ctx, fullMethod, req)
+	if globalAdmin && isAppBootstrapRelationshipTuple(tuple) {
+		return true, nil
 	}
-	return ctx, nil
+	return allowsAppScopedRelationshipMutation(ctx, t.authorization, subjectID, tuple)
 }
 
 func authorizationPublicActions(read, write bool) []string {

--- a/gestaltd/services/providergateway/authorization_access_test.go
+++ b/gestaltd/services/providergateway/authorization_access_test.go
@@ -20,6 +20,7 @@ func TestAuthorizationMethodAccessClass(t *testing.T) {
 		{method: "SetAuthorizationState", write: true, ok: true},
 		{method: "AddRelationship", write: true, ok: true},
 		{method: "DeleteRelationship", write: true, ok: true},
+		{method: "WriteRelationships", write: true, ok: true},
 		{method: "Ping", ok: false},
 	}
 

--- a/gestaltd/services/providergateway/authorization_app_scope.go
+++ b/gestaltd/services/providergateway/authorization_app_scope.go
@@ -93,26 +93,62 @@ func appScopedRelationshipActionFromMethod(fullMethod string) string {
 	}
 }
 
+func isAppBootstrapRelationshipTuple(tuple *proto.RelationshipTuple) bool {
+	if tuple == nil {
+		return false
+	}
+	return strings.TrimSpace(tuple.GetResource().GetType()) == appAuthorizationResourceType &&
+		strings.TrimSpace(tuple.GetRelation()) == appAdminRelation
+}
+
+func isAppScopedRelationshipTuple(tuple *proto.RelationshipTuple) bool {
+	if tuple == nil {
+		return false
+	}
+	return strings.TrimSpace(tuple.GetResource().GetType()) == appAuthorizationResourceType
+}
+
 func relationshipTupleFromAuthorizationRequest(fullMethod string, req gproto.Message) (*proto.RelationshipTuple, bool) {
-	if req == nil {
+	tuples := relationshipTuplesFromAuthorizationRequest(fullMethod, req)
+	if len(tuples) != 1 {
 		return nil, false
+	}
+	return tuples[0], true
+}
+
+func relationshipTuplesFromAuthorizationRequest(fullMethod string, req gproto.Message) []*proto.RelationshipTuple {
+	if req == nil {
+		return nil
 	}
 	_, method := splitFullMethod(fullMethod)
 	switch method {
 	case "AddRelationship":
 		addReq, ok := req.(*proto.AddRelationshipRequest)
 		if !ok || addReq.GetRelationship() == nil {
-			return nil, false
+			return nil
 		}
-		return addReq.GetRelationship().GetTuple(), true
+		return []*proto.RelationshipTuple{addReq.GetRelationship().GetTuple()}
 	case "DeleteRelationship":
 		deleteReq, ok := req.(*proto.DeleteRelationshipRequest)
-		if !ok {
-			return nil, false
+		if !ok || deleteReq.GetRelationshipTuple() == nil {
+			return nil
 		}
-		return deleteReq.GetRelationshipTuple(), true
+		return []*proto.RelationshipTuple{deleteReq.GetRelationshipTuple()}
+	case "WriteRelationships":
+		writeReq, ok := req.(*proto.WriteRelationshipsRequest)
+		if !ok {
+			return nil
+		}
+		tuples := make([]*proto.RelationshipTuple, 0, len(writeReq.GetUpdates()))
+		for _, update := range writeReq.GetUpdates() {
+			if update == nil || update.GetRelationship() == nil || update.GetRelationship().GetTuple() == nil {
+				continue
+			}
+			tuples = append(tuples, update.GetRelationship().GetTuple())
+		}
+		return tuples
 	default:
-		return nil, false
+		return nil
 	}
 }
 

--- a/gestaltd/services/providergateway/authorization_app_scope_test.go
+++ b/gestaltd/services/providergateway/authorization_app_scope_test.go
@@ -140,49 +140,134 @@ func TestEnforceAuthorizationPublicAccessMarksAppRelationshipWrite(t *testing.T)
 		},
 	}
 
-	tests := []struct {
-		name      string
-		transport *ProviderGatewayTransport
-	}{
-		{
-			name: "app_admin",
-			transport: &ProviderGatewayTransport{
-				authorization: &appScopedAuthorizationProvider{
-					stubAuthorizationProvider: &stubAuthorizationProvider{
-						allowedActions: map[string]bool{"viewer": true},
-					},
-					appAdmin: map[string]bool{"roadmap": true},
-				},
+	transport := &ProviderGatewayTransport{
+		authorization: &appScopedAuthorizationProvider{
+			stubAuthorizationProvider: &stubAuthorizationProvider{
+				allowedActions: map[string]bool{"viewer": true},
 			},
+			appAdmin: map[string]bool{"roadmap": true},
 		},
-		{
-			name: "global_admin",
-			transport: &ProviderGatewayTransport{
-				authorization: &stubAuthorizationProvider{
-					allowedActions: map[string]bool{"admin": true},
+	}
+
+	ctx, err := transport.enforceAuthorizationPublicAccess(
+		context.Background(),
+		"user:admin@example.com",
+		proto.Authorization_AddRelationship_FullMethodName,
+		addViewerReq,
+	)
+	if err != nil {
+		t.Fatalf("enforceAuthorizationPublicAccess error = %v, want nil", err)
+	}
+	appID, action, targetKind, targetID, ok := AppScopedRelationshipMutationFromContext(ctx)
+	if !ok || appID != "roadmap" || action != "grant_add" || targetKind != "user" || targetID != "viewer@example.com" {
+		t.Fatalf("context marker = (%q, %q, %q, %q, %v), want (roadmap, grant_add, user, viewer@example.com, true)", appID, action, targetKind, targetID, ok)
+	}
+}
+
+func TestEnforceAuthorizationPublicAccessDeniesGlobalAdminAppViewerGrant(t *testing.T) {
+	t.Parallel()
+
+	addViewerReq := &proto.AddRelationshipRequest{
+		Relationship: &proto.Relationship{
+			Tuple: &proto.RelationshipTuple{
+				Resource: &proto.Resource{Type: "app", Id: "roadmap"},
+				Relation: "viewer",
+				Target: &proto.RelationshipTarget{
+					Kind: &proto.RelationshipTarget_Subject{
+						Subject: &proto.Subject{Type: "subject", Id: "user:viewer@example.com"},
+					},
 				},
 			},
 		},
 	}
 
-	for _, tc := range tests {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			ctx, err := tc.transport.enforceAuthorizationPublicAccess(
-				context.Background(),
-				"user:admin@example.com",
-				proto.Authorization_AddRelationship_FullMethodName,
-				addViewerReq,
-			)
-			if err != nil {
-				t.Fatalf("enforceAuthorizationPublicAccess error = %v, want nil", err)
-			}
-			appID, action, targetKind, targetID, ok := AppScopedRelationshipMutationFromContext(ctx)
-			if !ok || appID != "roadmap" || action != "grant_add" || targetKind != "user" || targetID != "viewer@example.com" {
-				t.Fatalf("context marker = (%q, %q, %q, %q, %v), want (roadmap, grant_add, user, viewer@example.com, true)", appID, action, targetKind, targetID, ok)
-			}
-		})
+	transport := &ProviderGatewayTransport{
+		authorization: &stubAuthorizationProvider{
+			allowedActions: map[string]bool{"admin": true},
+		},
+	}
+
+	_, err := transport.enforceAuthorizationPublicAccess(
+		context.Background(),
+		"user:global-admin@example.com",
+		proto.Authorization_AddRelationship_FullMethodName,
+		addViewerReq,
+	)
+	if err == nil {
+		t.Fatal("enforceAuthorizationPublicAccess error = nil, want permission denied")
+	}
+}
+
+func TestEnforceAuthorizationPublicAccessAllowsGlobalAdminAppAdminBootstrap(t *testing.T) {
+	t.Parallel()
+
+	addAdminReq := &proto.AddRelationshipRequest{
+		Relationship: &proto.Relationship{
+			Tuple: &proto.RelationshipTuple{
+				Resource: &proto.Resource{Type: "app", Id: "roadmap"},
+				Relation: "admin",
+				Target: &proto.RelationshipTarget{
+					Kind: &proto.RelationshipTarget_Subject{
+						Subject: &proto.Subject{Type: "subject", Id: "user:operator@example.com"},
+					},
+				},
+			},
+		},
+	}
+
+	transport := &ProviderGatewayTransport{
+		authorization: &stubAuthorizationProvider{
+			allowedActions: map[string]bool{"admin": true},
+		},
+	}
+
+	ctx, err := transport.enforceAuthorizationPublicAccess(
+		context.Background(),
+		"user:global-admin@example.com",
+		proto.Authorization_AddRelationship_FullMethodName,
+		addAdminReq,
+	)
+	if err != nil {
+		t.Fatalf("enforceAuthorizationPublicAccess error = %v, want nil", err)
+	}
+	appID, action, targetKind, targetID, ok := AppScopedRelationshipMutationFromContext(ctx)
+	if !ok || appID != "roadmap" || action != "grant_add" || targetKind != "user" || targetID != "operator@example.com" {
+		t.Fatalf("context marker = (%q, %q, %q, %q, %v), want (roadmap, grant_add, user, operator@example.com, true)", appID, action, targetKind, targetID, ok)
+	}
+}
+
+func TestEnforceAuthorizationPublicAccessDeniesGlobalAdminAppViewerWriteRelationships(t *testing.T) {
+	t.Parallel()
+
+	transport := &ProviderGatewayTransport{
+		authorization: &stubAuthorizationProvider{
+			allowedActions: map[string]bool{"admin": true},
+		},
+	}
+
+	_, err := transport.enforceAuthorizationPublicAccess(
+		context.Background(),
+		"user:global-admin@example.com",
+		proto.Authorization_WriteRelationships_FullMethodName,
+		&proto.WriteRelationshipsRequest{
+			Updates: []*proto.RelationshipUpdate{{
+				Operation: proto.RelationshipUpdate_OPERATION_TOUCH,
+				Relationship: &proto.Relationship{
+					Tuple: &proto.RelationshipTuple{
+						Resource: &proto.Resource{Type: "app", Id: "roadmap"},
+						Relation: "viewer",
+						Target: &proto.RelationshipTarget{
+							Kind: &proto.RelationshipTarget_Subject{
+								Subject: &proto.Subject{Type: "subject", Id: "user:viewer@example.com"},
+							},
+						},
+					},
+				},
+			}},
+		},
+	)
+	if err == nil {
+		t.Fatal("enforceAuthorizationPublicAccess error = nil, want permission denied")
 	}
 }
 
@@ -203,7 +288,7 @@ func TestEnforceAuthorizationPublicAccessSkipsMalformedAppRelationshipWriteMarke
 			Relationship: &proto.Relationship{
 				Tuple: &proto.RelationshipTuple{
 					Resource: &proto.Resource{Type: "app", Id: "roadmap"},
-					Relation: "viewer",
+					Relation: "admin",
 				},
 			},
 		},


### PR DESCRIPTION
## Summary
- Restrict global `authorization:admin` relationship writes on `app:{app}` to bootstrap `admin` grants only; viewer and editor grants require `app:{app} admin` through app-admin HTTP/CLI surfaces.
- Preserve unrestricted `SetAuthorizationState` for reviewed break-glass full-state restore.
- Add provider-gateway and app-admin HTTP tests that `gestalt:admin` cannot bypass app-admin checks for member or allowed-operation management.

## Test plan
- [x] `go test ./services/providergateway/... ./internal/server/... -run 'TestEnforceAuthorization|TestAllowsAppScoped|TestAppAdminMembersForbiddenForAuthorization|TestAppAdminAllowedOperationsForbiddenForAuthorization'`

Made with [Cursor](https://cursor.com)