### PR TITLE
Plan 7: group admin HTTP APIs

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -948,6 +948,7 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 	}
 	gatewayTransport := providergateway.NewProviderGatewayTransport()
 	gatewayTransport.SetPublicMethods(registry)
+	gatewayTransport.SetScimManagedGroupIDs(config.ScimManagedGroupIDs(cfg))
 
 	if err := ResolveConfigSecrets(ctx, cfg, factories); err != nil {
 		return nil, err

--- a/gestaltd/internal/config/scim_managed_groups.go
+++ b/gestaltd/internal/config/scim_managed_groups.go
@@ -1,0 +1,40 @@
+package config
+
+import "strings"
+
+// ScimManagedGroupIDs returns group resource ids provisioned by Rippling SCIM
+// plus any bootstrap SCIM groups wired through authorization relationships.
+func ScimManagedGroupIDs(cfg *Config) map[string]struct{} {
+	ids := map[string]struct{}{}
+	if cfg == nil {
+		return ids
+	}
+	for _, client := range cfg.Server.SCIM.Clients {
+		for _, projection := range client.ActiveUserRelationships {
+			if strings.TrimSpace(projection.Resource.Type) != "group" {
+				continue
+			}
+			id := strings.TrimSpace(projection.Resource.ID)
+			if id != "" {
+				ids[id] = struct{}{}
+			}
+		}
+	}
+	for _, relationship := range cfg.Authorization.Relationships {
+		if !hasAuthorizationRelationshipTarget(relationship.Target) {
+			continue
+		}
+		subjectSet := relationship.Target.SubjectSet
+		if subjectSet == nil {
+			continue
+		}
+		if strings.TrimSpace(subjectSet.Resource.Type) != "group" {
+			continue
+		}
+		id := strings.TrimSpace(subjectSet.Resource.ID)
+		if id != "" {
+			ids[id] = struct{}{}
+		}
+	}
+	return ids
+}

--- a/gestaltd/internal/config/scim_managed_groups.go
+++ b/gestaltd/internal/config/scim_managed_groups.go
@@ -21,7 +21,8 @@ func ScimManagedGroupIDs(cfg *Config) map[string]struct{} {
 			}
 		}
 	}
-	for _, relationship := range cfg.Authorization.Relationships {
+	for i := range cfg.Authorization.Relationships {
+		relationship := &cfg.Authorization.Relationships[i]
 		if strings.TrimSpace(relationship.Resource.Type) == "app" {
 			continue
 		}

--- a/gestaltd/internal/config/scim_managed_groups.go
+++ b/gestaltd/internal/config/scim_managed_groups.go
@@ -2,8 +2,9 @@ package config
 
 import "strings"
 
-// ScimManagedGroupIDs returns group resource ids provisioned by Rippling SCIM
-// plus any bootstrap SCIM groups wired through authorization relationships.
+// ScimManagedGroupIDs returns Rippling-managed group ids: SCIM user
+// projections plus platform subject-set grants (gestalt/authorization).
+// App subject-set grants stay editable so local roster groups are not locked.
 func ScimManagedGroupIDs(cfg *Config) map[string]struct{} {
 	ids := map[string]struct{}{}
 	if cfg == nil {
@@ -21,14 +22,11 @@ func ScimManagedGroupIDs(cfg *Config) map[string]struct{} {
 		}
 	}
 	for _, relationship := range cfg.Authorization.Relationships {
-		if !hasAuthorizationRelationshipTarget(relationship.Target) {
+		if strings.TrimSpace(relationship.Resource.Type) == "app" {
 			continue
 		}
 		subjectSet := relationship.Target.SubjectSet
-		if subjectSet == nil {
-			continue
-		}
-		if strings.TrimSpace(subjectSet.Resource.Type) != "group" {
+		if subjectSet == nil || strings.TrimSpace(subjectSet.Resource.Type) != "group" {
 			continue
 		}
 		id := strings.TrimSpace(subjectSet.Resource.ID)

--- a/gestaltd/internal/config/scim_managed_groups_test.go
+++ b/gestaltd/internal/config/scim_managed_groups_test.go
@@ -1,0 +1,57 @@
+package config
+
+import "testing"
+
+func TestScimManagedGroupIDsUsesActiveUserRelationshipsOnly(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		Server: ServerConfig{
+			SCIM: ServerSCIMConfig{
+				Clients: map[string]SCIMClientConfig{
+					"rippling": {
+						ActiveUserRelationships: []SCIMRelationshipConfig{{
+							Relation: "member",
+							Resource: AuthorizationResourceDef{Type: "group", ID: "valon-employees"},
+						}},
+					},
+				},
+			},
+		},
+		Authorization: AuthorizationConfig{
+			Relationships: []AuthorizationRelationshipDef{
+				{
+					Relation: "admin",
+					Resource: AuthorizationResourceDef{Type: "gestalt", ID: "gestalt"},
+					Target: AuthorizationRelationshipTargetDef{
+						SubjectSet: &AuthorizationSubjectSetDef{
+							Resource: AuthorizationResourceDef{Type: "group", ID: "gestalt-team"},
+							Relation: "member",
+						},
+					},
+				},
+				{
+					Relation: "viewer",
+					Resource: AuthorizationResourceDef{Type: "app", ID: "home"},
+					Target: AuthorizationRelationshipTargetDef{
+						SubjectSet: &AuthorizationSubjectSetDef{
+							Resource: AuthorizationResourceDef{Type: "group", ID: "servicemacusa-employees"},
+							Relation: "member",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ids := ScimManagedGroupIDs(cfg)
+	if _, ok := ids["valon-employees"]; !ok {
+		t.Fatalf("ids = %#v, want valon-employees", ids)
+	}
+	if _, ok := ids["gestalt-team"]; !ok {
+		t.Fatalf("ids = %#v, want gestalt-team", ids)
+	}
+	if _, ok := ids["servicemacusa-employees"]; ok {
+		t.Fatalf("ids = %#v, app subject-set group must not be SCIM-managed", ids)
+	}
+}

--- a/gestaltd/internal/server/handlers_group_admin.go
+++ b/gestaltd/internal/server/handlers_group_admin.go
@@ -50,6 +50,8 @@ func (s *Server) mountGroupAdminRoutes(r chi.Router) {
 		Get("/groups", s.listGroupAdminGroups)
 	r.With(s.pluginRouteAuthMiddleware("group"), s.groupAdminCreateAuthorizationMiddleware).
 		Post("/groups", s.createGroupAdminGroup)
+	r.With(s.pluginRouteAuthMiddleware("group"), s.groupAdminShowAuthorizationMiddleware).
+		Get("/groups/{group}", s.getGroupAdminGroup)
 	r.With(s.pluginRouteAuthMiddleware("group"), s.groupAdminAuthorizationMiddleware).
 		Get("/groups/{group}/admin/members", s.listGroupAdminMembers)
 	r.With(s.pluginRouteAuthMiddleware("group"), s.groupAdminAuthorizationMiddleware).
@@ -254,20 +256,43 @@ func (s *Server) canListGroupAdminGroups(ctx context.Context, subjectID string) 
 	if ok, err := s.hasGestaltAdmin(ctx, subjectID); err != nil || ok {
 		return ok, err
 	}
-	groupIDs, err := s.listGroupIDs(ctx)
+	return s.hasAnyGroupAdmin(ctx, subjectID)
+}
+
+func (s *Server) canViewGroupAdminGroup(ctx context.Context, subjectID, groupID string) (bool, error) {
+	if ok, err := s.hasAuthorizationViewer(ctx, subjectID); err != nil || ok {
+		return ok, err
+	}
+	if ok, err := s.hasGestaltAdmin(ctx, subjectID); err != nil || ok {
+		return ok, err
+	}
+	return s.hasExplicitGroupAdmin(ctx, subjectID, groupID)
+}
+
+func (s *Server) hasAnyGroupAdmin(ctx context.Context, subjectID string) (bool, error) {
+	if s == nil || s.authorization == nil {
+		return false, errors.New("authorization is unavailable")
+	}
+	subjectID = strings.TrimSpace(subjectID)
+	if subjectID == "" {
+		return false, nil
+	}
+	resp, err := s.authorization.ListRelationships(ctx, &proto.ListRelationshipsRequest{
+		Filter: &proto.RelationshipFilter{
+			ResourceType: groupAuthorizationResourceType,
+			Relation:     groupAdminRelation,
+			Target: &proto.RelationshipTarget{
+				Kind: &proto.RelationshipTarget_Subject{
+					Subject: &proto.Subject{Type: "subject", Id: subjectID},
+				},
+			},
+		},
+		PageSize: 1,
+	})
 	if err != nil {
 		return false, err
 	}
-	for _, groupID := range groupIDs {
-		allowed, err := s.hasExplicitGroupAdmin(ctx, subjectID, groupID)
-		if err != nil {
-			return false, err
-		}
-		if allowed {
-			return true, nil
-		}
-	}
-	return false, nil
+	return len(resp.GetRelationships()) > 0, nil
 }
 
 func (s *Server) canCreateGroupAdminGroup(ctx context.Context, subjectID string) (bool, error) {
@@ -335,6 +360,52 @@ func (s *Server) countGroupMembers(ctx context.Context, groupID string) (int, er
 			return count, nil
 		}
 	}
+}
+
+func (s *Server) groupAdminShowAuthorizationMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if s.authorization == nil {
+			writeError(w, http.StatusServiceUnavailable, "authorization is unavailable")
+			return
+		}
+		subjectID, ok := s.resolveGroupAdminSubjectID(w, r)
+		if !ok {
+			return
+		}
+		groupID := strings.TrimSpace(chi.URLParam(r, "group"))
+		if groupID == "" {
+			writeError(w, http.StatusBadRequest, "group is required")
+			return
+		}
+		allowed, err := s.canViewGroupAdminGroup(r.Context(), subjectID, groupID)
+		if err != nil {
+			writeError(w, http.StatusServiceUnavailable, "authorization is unavailable")
+			return
+		}
+		if !allowed {
+			writeError(w, http.StatusForbidden, "group access denied")
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (s *Server) getGroupAdminGroup(w http.ResponseWriter, r *http.Request) {
+	groupID := strings.TrimSpace(chi.URLParam(r, "group"))
+	if groupID == "" {
+		writeError(w, http.StatusBadRequest, "group is required")
+		return
+	}
+	subjectID, ok := s.resolveGroupAdminSubjectID(w, r)
+	if !ok {
+		return
+	}
+	summary, err := s.groupAdminSummary(r.Context(), subjectID, groupID)
+	if err != nil {
+		writeError(w, http.StatusServiceUnavailable, "authorization is unavailable")
+		return
+	}
+	writeJSON(w, http.StatusOK, summary)
 }
 
 func (s *Server) listGroupAdminGroups(w http.ResponseWriter, r *http.Request) {

--- a/gestaltd/internal/server/handlers_group_admin.go
+++ b/gestaltd/internal/server/handlers_group_admin.go
@@ -1,0 +1,549 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/valon-technologies/gestalt/server/services/identity/principal"
+	"github.com/valon-technologies/gestalt/server/services/invocation"
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+)
+
+const (
+	groupAuthorizationResourceType = "group"
+	groupAdminRelation             = "admin"
+	groupMemberRelation            = "member"
+)
+
+type groupAdminSummary struct {
+	ID          string `json:"id"`
+	DisplayName string `json:"displayName"`
+	MemberCount int    `json:"memberCount"`
+	ScimManaged bool   `json:"scimManaged"`
+	Editable    bool   `json:"editable"`
+	CanAdmin    bool   `json:"canAdmin"`
+}
+
+type groupAdminCreateRequest struct {
+	ID          string `json:"id"`
+	DisplayName string `json:"displayName"`
+}
+
+type groupAdminCreateResponse struct {
+	Group groupAdminSummary `json:"group"`
+}
+
+type groupAdminMemberSetRequest struct {
+	SubjectID string `json:"subjectId"`
+}
+
+type groupAdminMemberRemoveRequest struct {
+	SubjectID string `json:"subjectId"`
+}
+
+func (s *Server) mountGroupAdminRoutes(r chi.Router) {
+	r.With(s.pluginRouteAuthMiddleware("group"), s.groupAdminListAuthorizationMiddleware).
+		Get("/groups", s.listGroupAdminGroups)
+	r.With(s.pluginRouteAuthMiddleware("group"), s.groupAdminCreateAuthorizationMiddleware).
+		Post("/groups", s.createGroupAdminGroup)
+	r.With(s.pluginRouteAuthMiddleware("group"), s.groupAdminAuthorizationMiddleware).
+		Get("/groups/{group}/admin/members", s.listGroupAdminMembers)
+	r.With(s.pluginRouteAuthMiddleware("group"), s.groupAdminAuthorizationMiddleware).
+		Post("/groups/{group}/admin/members", s.setGroupAdminMember)
+	r.With(s.pluginRouteAuthMiddleware("group"), s.groupAdminAuthorizationMiddleware).
+		Delete("/groups/{group}/admin/members", s.removeGroupAdminMember)
+}
+
+func (s *Server) groupResource(groupID string) *proto.Resource {
+	return &proto.Resource{Type: groupAuthorizationResourceType, Id: strings.TrimSpace(groupID)}
+}
+
+func (s *Server) isScimManagedGroup(groupID string) bool {
+	if s == nil || s.scimManagedGroupIDs == nil {
+		return false
+	}
+	_, ok := s.scimManagedGroupIDs[strings.TrimSpace(groupID)]
+	return ok
+}
+
+func (s *Server) resolveGroupAdminSubjectID(w http.ResponseWriter, r *http.Request) (string, bool) {
+	p := PrincipalFromContext(r.Context())
+	if p == nil {
+		writeError(w, http.StatusUnauthorized, "missing authorization")
+		return "", false
+	}
+	if err := requireUserCaller(w, p); err != nil {
+		return "", false
+	}
+	subjectID, err := principal.ResolveAuthorizationSubjectID(r.Context(), s.credentialUserResolver(), p)
+	switch {
+	case errors.Is(err, principal.ErrCredentialSubjectRequired):
+		writeError(w, http.StatusUnauthorized, "missing authorization")
+		return "", false
+	case errors.Is(err, principal.ErrOpaqueCredentialSubject):
+		writeError(w, http.StatusForbidden, "group access denied")
+		return "", false
+	case err != nil:
+		writeError(w, http.StatusServiceUnavailable, "authorization is unavailable")
+		return "", false
+	}
+	subjectID = strings.TrimSpace(subjectID)
+	if subjectID == "" {
+		writeError(w, http.StatusUnauthorized, "missing authorization")
+		return "", false
+	}
+	return subjectID, true
+}
+
+func (s *Server) hasExplicitGroupAdmin(ctx context.Context, subjectID, groupID string) (bool, error) {
+	if s == nil || s.authorization == nil {
+		return false, errors.New("authorization is unavailable")
+	}
+	groupID = strings.TrimSpace(groupID)
+	decision, err := s.checkResourceAccess(ctx, invocation.ResourceAccessRequest{
+		SubjectID:    subjectID,
+		Action:       groupID,
+		Resource:     s.groupResource(groupID),
+		AllowedRoles: []string{groupAdminRelation},
+	})
+	if err != nil {
+		return false, err
+	}
+	return decision.Allowed && decision.Role == groupAdminRelation, nil
+}
+
+func (s *Server) hasAuthorizationViewer(ctx context.Context, subjectID string) (bool, error) {
+	if s == nil || s.authorization == nil {
+		return false, errors.New("authorization is unavailable")
+	}
+	allowed, err := invocation.CheckSubjectAccess(ctx, s.authorization, invocation.SubjectAccessRequest(
+		subjectID,
+		"viewer",
+		&proto.Resource{Type: "authorization", Id: "authorization"},
+	))
+	if err != nil {
+		return false, err
+	}
+	return allowed, nil
+}
+
+func (s *Server) hasGestaltAdmin(ctx context.Context, subjectID string) (bool, error) {
+	if s == nil || s.authorization == nil {
+		return false, errors.New("authorization is unavailable")
+	}
+	allowed, err := invocation.CheckSubjectAccess(ctx, s.authorization, invocation.SubjectAccessRequest(
+		subjectID,
+		"admin",
+		&proto.Resource{Type: "gestalt", Id: "gestalt"},
+	))
+	if err != nil {
+		return false, err
+	}
+	return allowed, nil
+}
+
+func (s *Server) hasAuthorizationAdmin(ctx context.Context, subjectID string) (bool, error) {
+	if s == nil || s.authorization == nil {
+		return false, errors.New("authorization is unavailable")
+	}
+	for _, action := range []string{"admin", "authorization"} {
+		allowed, err := invocation.CheckSubjectAccess(ctx, s.authorization, invocation.SubjectAccessRequest(
+			subjectID,
+			action,
+			&proto.Resource{Type: "authorization", Id: "authorization"},
+		))
+		if err != nil {
+			return false, err
+		}
+		if allowed {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (s *Server) groupAdminAuthorizationMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if s.authorization == nil {
+			writeError(w, http.StatusServiceUnavailable, "authorization is unavailable")
+			return
+		}
+		subjectID, ok := s.resolveGroupAdminSubjectID(w, r)
+		if !ok {
+			return
+		}
+		groupID := strings.TrimSpace(chi.URLParam(r, "group"))
+		if groupID == "" {
+			writeError(w, http.StatusBadRequest, "group is required")
+			return
+		}
+		allowed, err := s.hasExplicitGroupAdmin(r.Context(), subjectID, groupID)
+		if err != nil {
+			writeError(w, http.StatusServiceUnavailable, "authorization is unavailable")
+			return
+		}
+		if !allowed {
+			globalAdmin, err := s.hasGestaltAdmin(r.Context(), subjectID)
+			if err != nil {
+				writeError(w, http.StatusServiceUnavailable, "authorization is unavailable")
+				return
+			}
+			if !globalAdmin {
+				writeError(w, http.StatusForbidden, "group access denied")
+				return
+			}
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (s *Server) groupAdminListAuthorizationMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if s.authorization == nil {
+			writeError(w, http.StatusServiceUnavailable, "authorization is unavailable")
+			return
+		}
+		subjectID, ok := s.resolveGroupAdminSubjectID(w, r)
+		if !ok {
+			return
+		}
+		allowed, err := s.canListGroupAdminGroups(r.Context(), subjectID)
+		if err != nil {
+			writeError(w, http.StatusServiceUnavailable, "authorization is unavailable")
+			return
+		}
+		if !allowed {
+			writeError(w, http.StatusForbidden, "group access denied")
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (s *Server) groupAdminCreateAuthorizationMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if s.authorization == nil {
+			writeError(w, http.StatusServiceUnavailable, "authorization is unavailable")
+			return
+		}
+		subjectID, ok := s.resolveGroupAdminSubjectID(w, r)
+		if !ok {
+			return
+		}
+		allowed, err := s.canCreateGroupAdminGroup(r.Context(), subjectID)
+		if err != nil {
+			writeError(w, http.StatusServiceUnavailable, "authorization is unavailable")
+			return
+		}
+		if !allowed {
+			writeError(w, http.StatusForbidden, "group access denied")
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (s *Server) canListGroupAdminGroups(ctx context.Context, subjectID string) (bool, error) {
+	if ok, err := s.hasAuthorizationViewer(ctx, subjectID); err != nil || ok {
+		return ok, err
+	}
+	if ok, err := s.hasGestaltAdmin(ctx, subjectID); err != nil || ok {
+		return ok, err
+	}
+	groupIDs, err := s.listGroupIDs(ctx)
+	if err != nil {
+		return false, err
+	}
+	for _, groupID := range groupIDs {
+		allowed, err := s.hasExplicitGroupAdmin(ctx, subjectID, groupID)
+		if err != nil {
+			return false, err
+		}
+		if allowed {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (s *Server) canCreateGroupAdminGroup(ctx context.Context, subjectID string) (bool, error) {
+	if ok, err := s.hasAuthorizationAdmin(ctx, subjectID); err != nil || ok {
+		return ok, err
+	}
+	return s.hasGestaltAdmin(ctx, subjectID)
+}
+
+func (s *Server) listGroupIDs(ctx context.Context) ([]string, error) {
+	seen := map[string]struct{}{}
+	ids := make([]string, 0)
+	pageToken := ""
+	for {
+		resp, err := s.authorization.ListRelationships(ctx, &proto.ListRelationshipsRequest{
+			Filter: &proto.RelationshipFilter{
+				ResourceType: groupAuthorizationResourceType,
+			},
+			PageSize:  500,
+			PageToken: pageToken,
+		})
+		if err != nil {
+			return nil, err
+		}
+		for _, relationship := range resp.GetRelationships() {
+			if relationship == nil || relationship.GetTuple() == nil {
+				continue
+			}
+			id := strings.TrimSpace(relationship.GetTuple().GetResource().GetId())
+			if id == "" {
+				continue
+			}
+			if _, ok := seen[id]; ok {
+				continue
+			}
+			seen[id] = struct{}{}
+			ids = append(ids, id)
+		}
+		pageToken = strings.TrimSpace(resp.GetNextPageToken())
+		if pageToken == "" {
+			return ids, nil
+		}
+	}
+}
+
+func (s *Server) countGroupMembers(ctx context.Context, groupID string) (int, error) {
+	count := 0
+	pageToken := ""
+	resource := s.groupResource(groupID)
+	for {
+		resp, err := s.authorization.ListRelationships(ctx, &proto.ListRelationshipsRequest{
+			Filter: &proto.RelationshipFilter{
+				Resource: resource,
+				Relation: groupMemberRelation,
+			},
+			PageSize:  500,
+			PageToken: pageToken,
+		})
+		if err != nil {
+			return 0, err
+		}
+		count += len(resp.GetRelationships())
+		pageToken = strings.TrimSpace(resp.GetNextPageToken())
+		if pageToken == "" {
+			return count, nil
+		}
+	}
+}
+
+func (s *Server) listGroupAdminGroups(w http.ResponseWriter, r *http.Request) {
+	subjectID, ok := s.resolveGroupAdminSubjectID(w, r)
+	if !ok {
+		return
+	}
+	groupIDs, err := s.listGroupIDs(r.Context())
+	if err != nil {
+		writeError(w, http.StatusServiceUnavailable, "authorization is unavailable")
+		return
+	}
+	summaries := make([]groupAdminSummary, 0, len(groupIDs))
+	for _, groupID := range groupIDs {
+		summary, err := s.groupAdminSummary(r.Context(), subjectID, groupID)
+		if err != nil {
+			writeError(w, http.StatusServiceUnavailable, "authorization is unavailable")
+			return
+		}
+		summaries = append(summaries, summary)
+	}
+	writeJSON(w, http.StatusOK, summaries)
+}
+
+func (s *Server) groupAdminSummary(ctx context.Context, subjectID, groupID string) (groupAdminSummary, error) {
+	memberCount, err := s.countGroupMembers(ctx, groupID)
+	if err != nil {
+		return groupAdminSummary{}, err
+	}
+	canAdmin, err := s.hasExplicitGroupAdmin(ctx, subjectID, groupID)
+	if err != nil {
+		return groupAdminSummary{}, err
+	}
+	if !canAdmin {
+		globalAdmin, err := s.hasGestaltAdmin(ctx, subjectID)
+		if err != nil {
+			return groupAdminSummary{}, err
+		}
+		canAdmin = globalAdmin
+	}
+	scimManaged := s.isScimManagedGroup(groupID)
+	return groupAdminSummary{
+		ID:          groupID,
+		DisplayName: groupID,
+		MemberCount: memberCount,
+		ScimManaged: scimManaged,
+		Editable:    !scimManaged,
+		CanAdmin:    canAdmin && !scimManaged,
+	}, nil
+}
+
+func (s *Server) createGroupAdminGroup(w http.ResponseWriter, r *http.Request) {
+	subjectID, ok := s.resolveGroupAdminSubjectID(w, r)
+	if !ok {
+		return
+	}
+	var request groupAdminCreateRequest
+	if !decodeStrictJSONBody(w, r, &request) {
+		return
+	}
+	groupID := strings.TrimSpace(request.ID)
+	if groupID == "" {
+		writeError(w, http.StatusBadRequest, "id is required")
+		return
+	}
+	displayName := strings.TrimSpace(request.DisplayName)
+	if displayName == "" {
+		displayName = groupID
+	}
+	if err := s.addGroupAdminMemberRole(r.Context(), groupID, groupAdminRelation, subjectID); err != nil {
+		writeError(w, http.StatusServiceUnavailable, "authorization is unavailable")
+		return
+	}
+	summary, err := s.groupAdminSummary(r.Context(), subjectID, groupID)
+	if err != nil {
+		writeError(w, http.StatusServiceUnavailable, "authorization is unavailable")
+		return
+	}
+	summary.DisplayName = displayName
+	writeJSON(w, http.StatusCreated, groupAdminCreateResponse{Group: summary})
+}
+
+func (s *Server) listGroupAdminMembers(w http.ResponseWriter, r *http.Request) {
+	groupID := strings.TrimSpace(chi.URLParam(r, "group"))
+	if groupID == "" {
+		writeError(w, http.StatusBadRequest, "group is required")
+		return
+	}
+	if s.isScimManagedGroup(groupID) {
+		writeError(w, http.StatusForbidden, "group is read-only")
+		return
+	}
+	rows, err := s.listAuthorizationMemberRows(r.Context(), s.groupResource(groupID))
+	if err != nil {
+		writeError(w, http.StatusServiceUnavailable, "authorization is unavailable")
+		return
+	}
+	filtered := make([]appAdminMemberRow, 0, len(rows))
+	for _, row := range rows {
+		if row.Role != groupMemberRelation {
+			continue
+		}
+		filtered = append(filtered, row)
+	}
+	writeJSON(w, http.StatusOK, s.projectAppAdminHumanMemberRows(r.Context(), filtered))
+}
+
+func (s *Server) setGroupAdminMember(w http.ResponseWriter, r *http.Request) {
+	groupID := strings.TrimSpace(chi.URLParam(r, "group"))
+	if groupID == "" {
+		writeError(w, http.StatusBadRequest, "group is required")
+		return
+	}
+	if s.isScimManagedGroup(groupID) {
+		writeError(w, http.StatusForbidden, "group is read-only")
+		return
+	}
+	var request groupAdminMemberSetRequest
+	if !decodeStrictJSONBody(w, r, &request) {
+		return
+	}
+	subjectID := strings.TrimSpace(request.SubjectID)
+	if subjectID == "" {
+		writeError(w, http.StatusBadRequest, "subjectId is required")
+		return
+	}
+	if err := validateAppAdminMemberSubjectID(subjectID); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	recordAppAdminUITargetSubject(r.Context(), subjectID)
+	if err := s.addGroupAdminMemberRole(r.Context(), groupID, groupMemberRelation, subjectID); err != nil {
+		writeError(w, http.StatusServiceUnavailable, "authorization is unavailable")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{
+		"group":     groupID,
+		"subjectId": subjectID,
+		"role":      groupMemberRelation,
+	})
+}
+
+func (s *Server) removeGroupAdminMember(w http.ResponseWriter, r *http.Request) {
+	groupID := strings.TrimSpace(chi.URLParam(r, "group"))
+	if groupID == "" {
+		writeError(w, http.StatusBadRequest, "group is required")
+		return
+	}
+	if s.isScimManagedGroup(groupID) {
+		writeError(w, http.StatusForbidden, "group is read-only")
+		return
+	}
+	var request groupAdminMemberRemoveRequest
+	if !decodeStrictJSONBody(w, r, &request) {
+		return
+	}
+	subjectID := strings.TrimSpace(request.SubjectID)
+	if subjectID == "" {
+		writeError(w, http.StatusBadRequest, "subjectId is required")
+		return
+	}
+	if err := validateAppAdminMemberSubjectID(subjectID); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	recordAppAdminUITargetSubject(r.Context(), subjectID)
+	if err := s.deleteGroupAdminMemberRole(r.Context(), groupID, groupMemberRelation, subjectID); err != nil {
+		writeError(w, http.StatusServiceUnavailable, "authorization is unavailable")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"group":         groupID,
+		"subjectId":     subjectID,
+		"removedRoles":  []string{groupMemberRelation},
+	})
+}
+
+func (s *Server) addGroupAdminMemberRole(ctx context.Context, groupID, role, subjectID string) error {
+	if s == nil || s.authorization == nil {
+		return errors.New("authorization is unavailable")
+	}
+	_, err := s.authorization.AddRelationship(ctx, &proto.AddRelationshipRequest{
+		Relationship: &proto.Relationship{
+			Tuple:       groupAdminMemberRelationshipTuple(groupID, role, subjectID),
+			SourceLayer: proto.SourceLayer_SOURCE_LAYER_RUNTIME,
+		},
+	})
+	return err
+}
+
+func (s *Server) deleteGroupAdminMemberRole(ctx context.Context, groupID, role, subjectID string) error {
+	if s == nil || s.authorization == nil {
+		return errors.New("authorization is unavailable")
+	}
+	_, err := s.authorization.DeleteRelationship(ctx, &proto.DeleteRelationshipRequest{
+		RelationshipTuple: groupAdminMemberRelationshipTuple(groupID, role, subjectID),
+	})
+	return err
+}
+
+func groupAdminMemberRelationshipTuple(groupID, role, subjectID string) *proto.RelationshipTuple {
+	return &proto.RelationshipTuple{
+		Resource: &proto.Resource{Type: groupAuthorizationResourceType, Id: strings.TrimSpace(groupID)},
+		Relation: strings.TrimSpace(role),
+		Target: &proto.RelationshipTarget{
+			Kind: &proto.RelationshipTarget_Subject{Subject: &proto.Subject{
+				Type: "subject",
+				Id:   strings.TrimSpace(subjectID),
+			}},
+		},
+	}
+}

--- a/gestaltd/internal/server/handlers_group_admin.go
+++ b/gestaltd/internal/server/handlers_group_admin.go
@@ -7,16 +7,18 @@ import (
 	"strings"
 
 	"github.com/go-chi/chi/v5"
+	"google.golang.org/protobuf/types/known/structpb"
 
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
-	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 )
 
 const (
 	groupAuthorizationResourceType = "group"
 	groupAdminRelation             = "admin"
 	groupMemberRelation            = "member"
+	groupDisplayNameProperty       = "displayName"
 )
 
 type groupAdminSummary struct {
@@ -338,26 +340,53 @@ func (s *Server) listGroupIDs(ctx context.Context) ([]string, error) {
 	}
 }
 
-func (s *Server) countGroupMembers(ctx context.Context, groupID string) (int, error) {
-	count := 0
+func (s *Server) groupExists(ctx context.Context, groupID string) (bool, error) {
+	if s == nil || s.authorization == nil {
+		return false, errors.New("authorization is unavailable")
+	}
+	resp, err := s.authorization.ListRelationships(ctx, &proto.ListRelationshipsRequest{
+		Filter: &proto.RelationshipFilter{
+			Resource: s.groupResource(groupID),
+		},
+		PageSize: 1,
+	})
+	if err != nil {
+		return false, err
+	}
+	return len(resp.GetRelationships()) > 0, nil
+}
+
+func (s *Server) groupMetadata(ctx context.Context, groupID string) (int, string, error) {
+	memberCount := 0
+	displayName := ""
 	pageToken := ""
 	resource := s.groupResource(groupID)
 	for {
 		resp, err := s.authorization.ListRelationships(ctx, &proto.ListRelationshipsRequest{
 			Filter: &proto.RelationshipFilter{
 				Resource: resource,
-				Relation: groupMemberRelation,
 			},
 			PageSize:  500,
 			PageToken: pageToken,
 		})
 		if err != nil {
-			return 0, err
+			return 0, "", err
 		}
-		count += len(resp.GetRelationships())
+		for _, relationship := range resp.GetRelationships() {
+			tuple := relationship.GetTuple()
+			if tuple == nil {
+				continue
+			}
+			if strings.TrimSpace(tuple.GetRelation()) == groupMemberRelation {
+				memberCount++
+			}
+			if displayName == "" {
+				displayName = strings.TrimSpace(relationship.GetProperties().GetFields()[groupDisplayNameProperty].GetStringValue())
+			}
+		}
 		pageToken = strings.TrimSpace(resp.GetNextPageToken())
 		if pageToken == "" {
-			return count, nil
+			return memberCount, displayName, nil
 		}
 	}
 }
@@ -431,9 +460,12 @@ func (s *Server) listGroupAdminGroups(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) groupAdminSummary(ctx context.Context, subjectID, groupID string) (groupAdminSummary, error) {
-	memberCount, err := s.countGroupMembers(ctx, groupID)
+	memberCount, displayName, err := s.groupMetadata(ctx, groupID)
 	if err != nil {
 		return groupAdminSummary{}, err
+	}
+	if displayName == "" {
+		displayName = groupID
 	}
 	canAdmin, err := s.hasExplicitGroupAdmin(ctx, subjectID, groupID)
 	if err != nil {
@@ -449,7 +481,7 @@ func (s *Server) groupAdminSummary(ctx context.Context, subjectID, groupID strin
 	scimManaged := s.isScimManagedGroup(groupID)
 	return groupAdminSummary{
 		ID:          groupID,
-		DisplayName: groupID,
+		DisplayName: displayName,
 		MemberCount: memberCount,
 		ScimManaged: scimManaged,
 		Editable:    !scimManaged,
@@ -475,7 +507,16 @@ func (s *Server) createGroupAdminGroup(w http.ResponseWriter, r *http.Request) {
 	if displayName == "" {
 		displayName = groupID
 	}
-	if err := s.addGroupAdminMemberRole(r.Context(), groupID, groupAdminRelation, subjectID); err != nil {
+	exists, err := s.groupExists(r.Context(), groupID)
+	if err != nil {
+		writeError(w, http.StatusServiceUnavailable, "authorization is unavailable")
+		return
+	}
+	if exists {
+		writeError(w, http.StatusConflict, "group already exists")
+		return
+	}
+	if err := s.addGroupAdminMemberRole(r.Context(), groupID, groupAdminRelation, subjectID, displayName); err != nil {
 		writeError(w, http.StatusServiceUnavailable, "authorization is unavailable")
 		return
 	}
@@ -577,19 +618,31 @@ func (s *Server) removeGroupAdminMember(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]interface{}{
-		"group":         groupID,
-		"subjectId":     subjectID,
-		"removedRoles":  []string{groupMemberRelation},
+		"group":        groupID,
+		"subjectId":    subjectID,
+		"removedRoles": []string{groupMemberRelation},
 	})
 }
 
-func (s *Server) addGroupAdminMemberRole(ctx context.Context, groupID, role, subjectID string) error {
+func (s *Server) addGroupAdminMemberRole(ctx context.Context, groupID, role, subjectID string, displayName ...string) error {
 	if s == nil || s.authorization == nil {
 		return errors.New("authorization is unavailable")
+	}
+	var properties *structpb.Struct
+	if len(displayName) > 0 {
+		name := strings.TrimSpace(displayName[0])
+		if name != "" {
+			var err error
+			properties, err = structpb.NewStruct(map[string]any{groupDisplayNameProperty: name})
+			if err != nil {
+				return err
+			}
+		}
 	}
 	_, err := s.authorization.AddRelationship(ctx, &proto.AddRelationshipRequest{
 		Relationship: &proto.Relationship{
 			Tuple:       groupAdminMemberRelationshipTuple(groupID, role, subjectID),
+			Properties:  properties,
 			SourceLayer: proto.SourceLayer_SOURCE_LAYER_RUNTIME,
 		},
 	})

--- a/gestaltd/internal/server/handlers_group_admin.go
+++ b/gestaltd/internal/server/handlers_group_admin.go
@@ -48,17 +48,17 @@ type groupAdminMemberRemoveRequest struct {
 }
 
 func (s *Server) mountGroupAdminRoutes(r chi.Router) {
-	r.With(s.pluginRouteAuthMiddleware("group"), s.groupAdminListAuthorizationMiddleware).
+	r.With(s.authMiddleware, s.groupAdminListAuthorizationMiddleware).
 		Get("/groups", s.listGroupAdminGroups)
-	r.With(s.pluginRouteAuthMiddleware("group"), s.groupAdminCreateAuthorizationMiddleware).
+	r.With(s.authMiddleware, s.groupAdminCreateAuthorizationMiddleware).
 		Post("/groups", s.createGroupAdminGroup)
-	r.With(s.pluginRouteAuthMiddleware("group"), s.groupAdminShowAuthorizationMiddleware).
+	r.With(s.authMiddleware, s.groupAdminShowAuthorizationMiddleware).
 		Get("/groups/{group}", s.getGroupAdminGroup)
-	r.With(s.pluginRouteAuthMiddleware("group"), s.groupAdminAuthorizationMiddleware).
+	r.With(s.authMiddleware, s.groupAdminShowAuthorizationMiddleware).
 		Get("/groups/{group}/admin/members", s.listGroupAdminMembers)
-	r.With(s.pluginRouteAuthMiddleware("group"), s.groupAdminAuthorizationMiddleware).
+	r.With(s.authMiddleware, s.groupAdminAuthorizationMiddleware).
 		Post("/groups/{group}/admin/members", s.setGroupAdminMember)
-	r.With(s.pluginRouteAuthMiddleware("group"), s.groupAdminAuthorizationMiddleware).
+	r.With(s.authMiddleware, s.groupAdminAuthorizationMiddleware).
 		Delete("/groups/{group}/admin/members", s.removeGroupAdminMember)
 }
 
@@ -255,46 +255,34 @@ func (s *Server) canListGroupAdminGroups(ctx context.Context, subjectID string) 
 	if ok, err := s.hasAuthorizationViewer(ctx, subjectID); err != nil || ok {
 		return ok, err
 	}
+	if ok, err := s.hasAuthorizationAdmin(ctx, subjectID); err != nil || ok {
+		return ok, err
+	}
 	if ok, err := s.hasGestaltAdmin(ctx, subjectID); err != nil || ok {
 		return ok, err
 	}
 	return s.hasAnyGroupAdmin(ctx, subjectID)
 }
 
-func (s *Server) canViewGroupAdminGroup(ctx context.Context, subjectID, groupID string) (bool, error) {
-	if ok, err := s.hasAuthorizationViewer(ctx, subjectID); err != nil || ok {
-		return ok, err
-	}
-	if ok, err := s.hasGestaltAdmin(ctx, subjectID); err != nil || ok {
-		return ok, err
-	}
-	return s.hasExplicitGroupAdmin(ctx, subjectID, groupID)
+func (s *Server) canViewGroupAdminGroup(ctx context.Context, subjectID, _ string) (bool, error) {
+	return s.canListGroupAdminGroups(ctx, subjectID)
 }
 
 func (s *Server) hasAnyGroupAdmin(ctx context.Context, subjectID string) (bool, error) {
-	if s == nil || s.authorization == nil {
-		return false, errors.New("authorization is unavailable")
-	}
-	subjectID = strings.TrimSpace(subjectID)
-	if subjectID == "" {
-		return false, nil
-	}
-	resp, err := s.authorization.ListRelationships(ctx, &proto.ListRelationshipsRequest{
-		Filter: &proto.RelationshipFilter{
-			ResourceType: groupAuthorizationResourceType,
-			Relation:     groupAdminRelation,
-			Target: &proto.RelationshipTarget{
-				Kind: &proto.RelationshipTarget_Subject{
-					Subject: &proto.Subject{Type: "subject", Id: subjectID},
-				},
-			},
-		},
-		PageSize: 1,
-	})
+	groupIDs, err := s.listGroupIDs(ctx)
 	if err != nil {
 		return false, err
 	}
-	return len(resp.GetRelationships()) > 0, nil
+	for _, groupID := range groupIDs {
+		ok, err := s.hasExplicitGroupAdmin(ctx, subjectID, groupID)
+		if err != nil {
+			return false, err
+		}
+		if ok {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func (s *Server) canCreateGroupAdminGroup(ctx context.Context, subjectID string) (bool, error) {
@@ -533,10 +521,6 @@ func (s *Server) listGroupAdminMembers(w http.ResponseWriter, r *http.Request) {
 	groupID := strings.TrimSpace(chi.URLParam(r, "group"))
 	if groupID == "" {
 		writeError(w, http.StatusBadRequest, "group is required")
-		return
-	}
-	if s.isScimManagedGroup(groupID) {
-		writeError(w, http.StatusForbidden, "group is read-only")
 		return
 	}
 	rows, err := s.listAuthorizationMemberRows(r.Context(), s.groupResource(groupID))

--- a/gestaltd/internal/server/handlers_group_admin.go
+++ b/gestaltd/internal/server/handlers_group_admin.go
@@ -529,11 +529,11 @@ func (s *Server) listGroupAdminMembers(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	filtered := make([]appAdminMemberRow, 0, len(rows))
-	for _, row := range rows {
-		if row.Role != groupMemberRelation {
+	for i := range rows {
+		if rows[i].Role != groupMemberRelation {
 			continue
 		}
-		filtered = append(filtered, row)
+		filtered = append(filtered, rows[i])
 	}
 	writeJSON(w, http.StatusOK, s.projectAppAdminHumanMemberRows(r.Context(), filtered))
 }

--- a/gestaltd/internal/server/handlers_group_admin_test.go
+++ b/gestaltd/internal/server/handlers_group_admin_test.go
@@ -1,0 +1,284 @@
+package server_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/internal/server"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"github.com/valon-technologies/gestalt/server/services/identity/principal"
+)
+
+func TestGroupAdminListAndGet(t *testing.T) {
+	t.Parallel()
+
+	adminID := principal.UserSubjectID(testCanonicalAdminUserID)
+	memberID := principal.UserSubjectID(testCanonicalViewerUserID)
+	groupID := "servicemacusa-employees"
+	authz := &serverTestAuthorizationProvider{
+		relationships: []*proto.Relationship{
+			testAuthorizationRelationship(adminID, "admin", "group", groupID),
+			{
+				Tuple: &proto.RelationshipTuple{
+					Target: &proto.RelationshipTarget{
+						Kind: &proto.RelationshipTarget_Subject{Subject: &proto.Subject{
+							Type: "subject",
+							Id:   memberID,
+						}},
+					},
+					Relation: "member",
+					Resource: &proto.Resource{Type: "group", Id: groupID},
+				},
+				SourceLayer: proto.SourceLayer_SOURCE_LAYER_RUNTIME,
+			},
+		},
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = authStubWithSessionTokenIntrospect("alice-token", adminID, "")
+		cfg.Authorization = authz
+		cfg.AppDefs = appAdminTestAppDefs()
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	listRequest, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/groups", nil)
+	listRequest.Header.Set("Authorization", "Bearer alice-token")
+	listResponse, err := http.DefaultClient.Do(listRequest)
+	if err != nil {
+		t.Fatalf("GET groups: %v", err)
+	}
+	defer func() { _ = listResponse.Body.Close() }()
+	if listResponse.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(listResponse.Body)
+		t.Fatalf("GET groups status = %d: %s", listResponse.StatusCode, body)
+	}
+
+	var groups []struct {
+		ID          string `json:"id"`
+		MemberCount int    `json:"memberCount"`
+		ScimManaged bool   `json:"scimManaged"`
+		Editable    bool   `json:"editable"`
+		CanAdmin    bool   `json:"canAdmin"`
+	}
+	if err := json.NewDecoder(listResponse.Body).Decode(&groups); err != nil {
+		t.Fatalf("decode groups: %v", err)
+	}
+	if len(groups) != 1 || groups[0].ID != groupID || groups[0].MemberCount != 1 || !groups[0].CanAdmin {
+		t.Fatalf("groups = %#v", groups)
+	}
+
+	getRequest, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/groups/"+groupID, nil)
+	getRequest.Header.Set("Authorization", "Bearer alice-token")
+	getResponse, err := http.DefaultClient.Do(getRequest)
+	if err != nil {
+		t.Fatalf("GET group: %v", err)
+	}
+	defer func() { _ = getResponse.Body.Close() }()
+	if getResponse.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(getResponse.Body)
+		t.Fatalf("GET group status = %d: %s", getResponse.StatusCode, body)
+	}
+
+	var summary struct {
+		ID          string `json:"id"`
+		MemberCount int    `json:"memberCount"`
+		CanAdmin    bool   `json:"canAdmin"`
+	}
+	if err := json.NewDecoder(getResponse.Body).Decode(&summary); err != nil {
+		t.Fatalf("decode group: %v", err)
+	}
+	if summary.ID != groupID || summary.MemberCount != 1 || !summary.CanAdmin {
+		t.Fatalf("summary = %#v", summary)
+	}
+}
+
+func TestGroupAdminMembersMutations(t *testing.T) {
+	t.Parallel()
+
+	adminID := principal.UserSubjectID(testCanonicalAdminUserID)
+	memberID := principal.UserSubjectID(testCanonicalViewerUserID)
+	groupID := "servicemacusa-employees"
+	authz := &serverTestAuthorizationProvider{
+		relationships: []*proto.Relationship{
+			testAuthorizationRelationship(adminID, "admin", "group", groupID),
+		},
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = authStubWithSessionTokenIntrospect("alice-token", adminID, "")
+		cfg.Authorization = authz
+		cfg.AppDefs = appAdminTestAppDefs()
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	addRequest, _ := http.NewRequest(
+		http.MethodPost,
+		ts.URL+"/api/v1/groups/"+groupID+"/admin/members",
+		bytes.NewBufferString(`{"subjectId":"`+memberID+`"}`),
+	)
+	addRequest.Header.Set("Authorization", "Bearer alice-token")
+	addRequest.Header.Set("Content-Type", "application/json")
+	addResponse, err := http.DefaultClient.Do(addRequest)
+	if err != nil {
+		t.Fatalf("POST member: %v", err)
+	}
+	defer func() { _ = addResponse.Body.Close() }()
+	if addResponse.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(addResponse.Body)
+		t.Fatalf("POST member status = %d: %s", addResponse.StatusCode, body)
+	}
+
+	listRequest, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/groups/"+groupID+"/admin/members", nil)
+	listRequest.Header.Set("Authorization", "Bearer alice-token")
+	listResponse, err := http.DefaultClient.Do(listRequest)
+	if err != nil {
+		t.Fatalf("GET members: %v", err)
+	}
+	defer func() { _ = listResponse.Body.Close() }()
+	if listResponse.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(listResponse.Body)
+		t.Fatalf("GET members status = %d: %s", listResponse.StatusCode, body)
+	}
+
+	var rows []struct {
+		SubjectID string `json:"subjectId"`
+		Role      string `json:"role"`
+	}
+	if err := json.NewDecoder(listResponse.Body).Decode(&rows); err != nil {
+		t.Fatalf("decode members: %v", err)
+	}
+	if len(rows) != 1 || rows[0].SubjectID != memberID || rows[0].Role != "member" {
+		t.Fatalf("members = %#v", rows)
+	}
+
+	deleteRequest, _ := http.NewRequest(
+		http.MethodDelete,
+		ts.URL+"/api/v1/groups/"+groupID+"/admin/members",
+		bytes.NewBufferString(`{"subjectId":"`+memberID+`"}`),
+	)
+	deleteRequest.Header.Set("Authorization", "Bearer alice-token")
+	deleteRequest.Header.Set("Content-Type", "application/json")
+	deleteResponse, err := http.DefaultClient.Do(deleteRequest)
+	if err != nil {
+		t.Fatalf("DELETE member: %v", err)
+	}
+	defer func() { _ = deleteResponse.Body.Close() }()
+	if deleteResponse.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(deleteResponse.Body)
+		t.Fatalf("DELETE member status = %d: %s", deleteResponse.StatusCode, body)
+	}
+}
+
+func TestGroupAdminScimGroupIsReadOnly(t *testing.T) {
+	t.Parallel()
+
+	adminID := principal.UserSubjectID(testCanonicalAdminUserID)
+	groupID := "e7dce358-8291-431f-baf0-fdb8a10b4252"
+	authz := &serverTestAuthorizationProvider{
+		relationships: []*proto.Relationship{
+			testAuthorizationRelationship(adminID, "admin", "group", groupID),
+		},
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = authStubWithSessionTokenIntrospect("alice-token", adminID, "")
+		cfg.Authorization = authz
+		cfg.AppDefs = appAdminTestAppDefs()
+		cfg.ScimManagedGroupIDs = map[string]struct{}{groupID: {}}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	getRequest, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/groups/"+groupID, nil)
+	getRequest.Header.Set("Authorization", "Bearer alice-token")
+	getResponse, err := http.DefaultClient.Do(getRequest)
+	if err != nil {
+		t.Fatalf("GET group: %v", err)
+	}
+	defer func() { _ = getResponse.Body.Close() }()
+	if getResponse.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(getResponse.Body)
+		t.Fatalf("GET group status = %d: %s", getResponse.StatusCode, body)
+	}
+
+	var summary struct {
+		ScimManaged bool `json:"scimManaged"`
+		Editable    bool `json:"editable"`
+		CanAdmin    bool `json:"canAdmin"`
+	}
+	if err := json.NewDecoder(getResponse.Body).Decode(&summary); err != nil {
+		t.Fatalf("decode group: %v", err)
+	}
+	if !summary.ScimManaged || summary.Editable || summary.CanAdmin {
+		t.Fatalf("summary = %#v", summary)
+	}
+
+	addRequest, _ := http.NewRequest(
+		http.MethodPost,
+		ts.URL+"/api/v1/groups/"+groupID+"/admin/members",
+		bytes.NewBufferString(`{"subjectId":"`+principal.UserSubjectID(testCanonicalViewerUserID)+`"}`),
+	)
+	addRequest.Header.Set("Authorization", "Bearer alice-token")
+	addRequest.Header.Set("Content-Type", "application/json")
+	addResponse, err := http.DefaultClient.Do(addRequest)
+	if err != nil {
+		t.Fatalf("POST member: %v", err)
+	}
+	defer func() { _ = addResponse.Body.Close() }()
+	if addResponse.StatusCode != http.StatusForbidden {
+		body, _ := io.ReadAll(addResponse.Body)
+		t.Fatalf("POST member status = %d: %s", addResponse.StatusCode, body)
+	}
+}
+
+func TestGroupAdminListAllowsDelegatedAdmin(t *testing.T) {
+	t.Parallel()
+
+	adminID := principal.UserSubjectID(testCanonicalAdminUserID)
+	viewerID := principal.UserSubjectID(testCanonicalViewerUserID)
+	groupID := "servicemacusa-employees"
+	authz := &serverTestAuthorizationProvider{
+		relationships: []*proto.Relationship{
+			testAuthorizationRelationship(adminID, "admin", "group", groupID),
+			testAuthorizationRelationship(viewerID, "viewer", "app", "g-issues"),
+		},
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = authStubWithSessionTokenIntrospect("viewer-token", viewerID, "")
+		cfg.Authorization = authz
+		cfg.AppDefs = appAdminTestAppDefs()
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	request, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/groups", nil)
+	request.Header.Set("Authorization", "Bearer viewer-token")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("GET groups: %v", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusForbidden {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("GET groups status = %d: %s", response.StatusCode, body)
+	}
+
+	authz.relationships = append(authz.relationships,
+		testAuthorizationRelationship(viewerID, "admin", "group", groupID),
+	)
+
+	request, _ = http.NewRequest(http.MethodGet, ts.URL+"/api/v1/groups", nil)
+	request.Header.Set("Authorization", "Bearer viewer-token")
+	response, err = http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("GET groups after grant: %v", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("GET groups status = %d: %s", response.StatusCode, body)
+	}
+}

--- a/gestaltd/internal/server/handlers_group_admin_test.go
+++ b/gestaltd/internal/server/handlers_group_admin_test.go
@@ -347,6 +347,18 @@ func TestGroupAdminScimGroupIsReadOnly(t *testing.T) {
 		body, _ := io.ReadAll(addResponse.Body)
 		t.Fatalf("POST member status = %d: %s", addResponse.StatusCode, body)
 	}
+
+	listRequest, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/groups/"+groupID+"/admin/members", nil)
+	listRequest.Header.Set("Authorization", "Bearer alice-token")
+	listResponse, err := http.DefaultClient.Do(listRequest)
+	if err != nil {
+		t.Fatalf("GET members: %v", err)
+	}
+	defer func() { _ = listResponse.Body.Close() }()
+	if listResponse.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(listResponse.Body)
+		t.Fatalf("GET members status = %d: %s", listResponse.StatusCode, body)
+	}
 }
 
 func TestGroupAdminListAllowsDelegatedAdmin(t *testing.T) {
@@ -390,6 +402,82 @@ func TestGroupAdminListAllowsDelegatedAdmin(t *testing.T) {
 	response, err = http.DefaultClient.Do(request)
 	if err != nil {
 		t.Fatalf("GET groups after grant: %v", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("GET groups status = %d: %s", response.StatusCode, body)
+	}
+}
+
+func TestGroupAdminListAllowsSubjectSetAdmin(t *testing.T) {
+	t.Parallel()
+
+	viewerID := principal.UserSubjectID(testCanonicalViewerUserID)
+	groupID := "servicemacusa-employees"
+	adminsGroupID := "group-admins"
+	authz := &serverTestAuthorizationProvider{
+		relationships: []*proto.Relationship{
+			{
+				Tuple: &proto.RelationshipTuple{
+					Resource: &proto.Resource{Type: "group", Id: groupID},
+					Relation: "admin",
+					Target: &proto.RelationshipTarget{
+						Kind: &proto.RelationshipTarget_SubjectSet{
+							SubjectSet: &proto.SubjectSet{
+								Resource: &proto.Resource{Type: "group", Id: adminsGroupID},
+								Relation: "member",
+							},
+						},
+					},
+				},
+			},
+			testAuthorizationRelationship(viewerID, "member", "group", adminsGroupID),
+		},
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = authStubWithSessionTokenIntrospect("viewer-token", viewerID, "")
+		cfg.Authorization = authz
+		cfg.AppDefs = appAdminTestAppDefs()
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	request, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/groups", nil)
+	request.Header.Set("Authorization", "Bearer viewer-token")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("GET groups: %v", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("GET groups status = %d: %s", response.StatusCode, body)
+	}
+}
+
+func TestGroupAdminListAllowsAuthorizationAdmin(t *testing.T) {
+	t.Parallel()
+
+	adminID := principal.UserSubjectID(testCanonicalAdminUserID)
+	authz := &serverTestAuthorizationProvider{
+		relationships: []*proto.Relationship{
+			testAuthorizationRelationship(adminID, "admin", "authorization", "authorization"),
+		},
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = authStubWithSessionTokenIntrospect("alice-token", adminID, "")
+		cfg.Authorization = authz
+		cfg.AppDefs = appAdminTestAppDefs()
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	request, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/groups", nil)
+	request.Header.Set("Authorization", "Bearer alice-token")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("GET groups: %v", err)
 	}
 	defer func() { _ = response.Body.Close() }()
 	if response.StatusCode != http.StatusOK {

--- a/gestaltd/internal/server/handlers_group_admin_test.go
+++ b/gestaltd/internal/server/handlers_group_admin_test.go
@@ -173,6 +173,121 @@ func TestGroupAdminMembersMutations(t *testing.T) {
 	}
 }
 
+func TestGroupAdminCreatePersistsDisplayName(t *testing.T) {
+	t.Parallel()
+
+	adminID := principal.UserSubjectID(testCanonicalAdminUserID)
+	groupID := "servicemacusa-employees"
+	authz := &serverTestAuthorizationProvider{
+		relationships: []*proto.Relationship{
+			testAuthorizationRelationship(adminID, "admin", "authorization", "authorization"),
+		},
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = authStubWithSessionTokenIntrospect("alice-token", adminID, "")
+		cfg.Authorization = authz
+		cfg.AppDefs = appAdminTestAppDefs()
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	createRequest, _ := http.NewRequest(
+		http.MethodPost,
+		ts.URL+"/api/v1/groups",
+		bytes.NewBufferString(`{"id":"`+groupID+`","displayName":"ServiceMac employees"}`),
+	)
+	createRequest.Header.Set("Authorization", "Bearer alice-token")
+	createRequest.Header.Set("Content-Type", "application/json")
+	createResponse, err := http.DefaultClient.Do(createRequest)
+	if err != nil {
+		t.Fatalf("POST group: %v", err)
+	}
+	defer func() { _ = createResponse.Body.Close() }()
+	if createResponse.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(createResponse.Body)
+		t.Fatalf("POST group status = %d: %s", createResponse.StatusCode, body)
+	}
+
+	var created struct {
+		Group struct {
+			ID          string `json:"id"`
+			DisplayName string `json:"displayName"`
+			CanAdmin    bool   `json:"canAdmin"`
+		} `json:"group"`
+	}
+	if err := json.NewDecoder(createResponse.Body).Decode(&created); err != nil {
+		t.Fatalf("decode created group: %v", err)
+	}
+	if created.Group.ID != groupID || created.Group.DisplayName != "ServiceMac employees" || !created.Group.CanAdmin {
+		t.Fatalf("created group = %#v", created.Group)
+	}
+	if got := authz.relationships[len(authz.relationships)-1].GetProperties().GetFields()["displayName"].GetStringValue(); got != "ServiceMac employees" {
+		t.Fatalf("stored displayName = %q", got)
+	}
+
+	getRequest, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/groups/"+groupID, nil)
+	getRequest.Header.Set("Authorization", "Bearer alice-token")
+	getResponse, err := http.DefaultClient.Do(getRequest)
+	if err != nil {
+		t.Fatalf("GET group: %v", err)
+	}
+	defer func() { _ = getResponse.Body.Close() }()
+	if getResponse.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(getResponse.Body)
+		t.Fatalf("GET group status = %d: %s", getResponse.StatusCode, body)
+	}
+
+	var summary struct {
+		DisplayName string `json:"displayName"`
+	}
+	if err := json.NewDecoder(getResponse.Body).Decode(&summary); err != nil {
+		t.Fatalf("decode group: %v", err)
+	}
+	if summary.DisplayName != "ServiceMac employees" {
+		t.Fatalf("GET group displayName = %q", summary.DisplayName)
+	}
+}
+
+func TestGroupAdminCreateRejectsExistingGroup(t *testing.T) {
+	t.Parallel()
+
+	adminID := principal.UserSubjectID(testCanonicalAdminUserID)
+	groupID := "servicemacusa-employees"
+	authz := &serverTestAuthorizationProvider{
+		relationships: []*proto.Relationship{
+			testAuthorizationRelationship(adminID, "admin", "authorization", "authorization"),
+			testAuthorizationRelationship("user:existing@example.com", "member", "group", groupID),
+		},
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = authStubWithSessionTokenIntrospect("alice-token", adminID, "")
+		cfg.Authorization = authz
+		cfg.AppDefs = appAdminTestAppDefs()
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	createRequest, _ := http.NewRequest(
+		http.MethodPost,
+		ts.URL+"/api/v1/groups",
+		bytes.NewBufferString(`{"id":"`+groupID+`","displayName":"ServiceMac employees"}`),
+	)
+	createRequest.Header.Set("Authorization", "Bearer alice-token")
+	createRequest.Header.Set("Content-Type", "application/json")
+	createResponse, err := http.DefaultClient.Do(createRequest)
+	if err != nil {
+		t.Fatalf("POST group: %v", err)
+	}
+	defer func() { _ = createResponse.Body.Close() }()
+	if createResponse.StatusCode != http.StatusConflict {
+		body, _ := io.ReadAll(createResponse.Body)
+		t.Fatalf("POST existing group status = %d, want 409: %s", createResponse.StatusCode, body)
+	}
+	if len(authz.addRelationshipRequests) != 0 {
+		t.Fatalf("add relationship requests = %d, want 0", len(authz.addRelationshipRequests))
+	}
+}
+
 func TestGroupAdminScimGroupIsReadOnly(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/server/routes_user.go
+++ b/gestaltd/internal/server/routes_user.go
@@ -8,6 +8,7 @@ import (
 func (s *Server) mountAuthenticatedRoutes(r chi.Router) {
 	s.mountAppAdminRegistryRoutes(r)
 	s.mountAppAdminMembersRoutes(r)
+	s.mountGroupAdminRoutes(r)
 	s.mountAppAdminIdentitiesRoutes(r)
 	s.mountAppAdminAllowedOperationsRoutes(r)
 	s.mountAppAdminMetricsRoutes(r)

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -132,6 +132,7 @@ func run(ctx context.Context, cfg *config.Config, result *bootstrap.Result, gest
 		CatalogConnection:      httpCatalogConnectionMap(connMaps),
 		MCPConnection:          connMaps.MCPConnection,
 		SCIMHandler:            result.SCIMHandler,
+		ScimManagedGroupIDs:    config.ScimManagedGroupIDs(cfg),
 		ConnectionAuth:         result.ConnectionAuth,
 		ManualConnectionAuth:   result.ManualConnectionAuth,
 		AppDefs:                cfg.Apps,

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -206,6 +206,7 @@ type Server struct {
 	appRegistryRolloutMode        config.AppRegistryRolloutMode
 	appRuntimeState               AppRuntimeState
 	routeProfile                  RouteProfile
+	scimManagedGroupIDs           map[string]struct{}
 	activateAppProviders          func(context.Context)
 	appProviderRestarter          interface {
 		RestartApp(context.Context, string) error
@@ -264,6 +265,7 @@ type Config struct {
 	PrometheusMetrics             http.Handler
 	MCPHandler                    http.Handler
 	SCIMHandler                   http.Handler
+	ScimManagedGroupIDs           map[string]struct{}
 	PublicHostServices            *runtimehost.PublicHostServiceRegistry
 	PublicGatewayTransport        *providergateway.ProviderGatewayTransport
 	S3                            map[string]s3sdk.S3
@@ -517,6 +519,7 @@ func New(cfg Config) (*Server, error) {
 		prometheusMetrics:             cfg.PrometheusMetrics,
 		mcpHandler:                    cfg.MCPHandler,
 		scimHandler:                   cfg.SCIMHandler,
+		scimManagedGroupIDs:           cfg.ScimManagedGroupIDs,
 		hostServiceRelayTokens:        hostServiceRelayTokens,
 		publicHostServices:            cfg.PublicHostServices,
 		s3:                            cfg.S3,

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -3111,6 +3111,9 @@ func relationshipMatchesFilter(relationship *proto.Relationship, filter *proto.R
 	if relation := strings.TrimSpace(filter.GetRelation()); relation != "" && tuple.GetRelation() != relation {
 		return false
 	}
+	if resourceType := strings.TrimSpace(filter.GetResourceType()); resourceType != "" && tuple.GetResource().GetType() != resourceType {
+		return false
+	}
 	if target := filter.GetTarget().GetSubject(); target != nil {
 		subject := tuple.GetTarget().GetSubject()
 		if subject.GetType() != target.GetType() || subject.GetId() != target.GetId() {

--- a/gestaltd/services/providergateway/authorization_access.go
+++ b/gestaltd/services/providergateway/authorization_access.go
@@ -148,6 +148,9 @@ func (t *ProviderGatewayTransport) allowsRelationshipTupleWrite(
 	tuple *proto.RelationshipTuple,
 	globalAdmin bool,
 ) (bool, error) {
+	if isGroupMemberRelationshipTuple(tuple) {
+		return allowsGroupScopedRelationshipMutation(ctx, t.authorization, subjectID, tuple)
+	}
 	if !isAppScopedRelationshipTuple(tuple) {
 		return globalAdmin, nil
 	}

--- a/gestaltd/services/providergateway/authorization_access.go
+++ b/gestaltd/services/providergateway/authorization_access.go
@@ -149,7 +149,7 @@ func (t *ProviderGatewayTransport) allowsRelationshipTupleWrite(
 	globalAdmin bool,
 ) (bool, error) {
 	if isGroupMemberRelationshipTuple(tuple) {
-		return allowsGroupScopedRelationshipMutation(ctx, t.authorization, subjectID, tuple)
+		return t.allowsGroupScopedRelationshipMutation(ctx, subjectID, tuple)
 	}
 	if !isAppScopedRelationshipTuple(tuple) {
 		return globalAdmin, nil

--- a/gestaltd/services/providergateway/authorization_app_scope.go
+++ b/gestaltd/services/providergateway/authorization_app_scope.go
@@ -13,6 +13,9 @@ import (
 const (
 	appAuthorizationResourceType = "app"
 	appAdminRelation             = "admin"
+	groupAuthorizationResourceType = "group"
+	groupAdminRelation             = "admin"
+	groupMemberRelation            = "member"
 )
 
 type appScopedRelationshipMutationContext struct {
@@ -163,6 +166,39 @@ func withAppScopedRelationshipMutationAuthFromRequest(ctx context.Context, fullM
 		return ctx
 	}
 	return WithAppScopedRelationshipMutationAuth(ctx, appID, action, tuple)
+}
+
+func allowsGroupScopedRelationshipMutation(
+	ctx context.Context,
+	authorization core.AuthorizationProvider,
+	subjectID string,
+	tuple *proto.RelationshipTuple,
+) (bool, error) {
+	if authorization == nil || tuple == nil || !isGroupMemberRelationshipTuple(tuple) {
+		return false, nil
+	}
+	groupID := strings.TrimSpace(tuple.GetResource().GetId())
+	if groupID == "" {
+		return false, nil
+	}
+	decision, err := invocation.CheckResourceAccess(ctx, authorization, invocation.ResourceAccessRequest{
+		SubjectID:    subjectID,
+		Action:       groupID,
+		Resource:     &proto.Resource{Type: groupAuthorizationResourceType, Id: groupID},
+		AllowedRoles: []string{groupAdminRelation},
+	})
+	if err != nil {
+		return false, err
+	}
+	return decision.Allowed && decision.Role == groupAdminRelation, nil
+}
+
+func isGroupMemberRelationshipTuple(tuple *proto.RelationshipTuple) bool {
+	if tuple == nil {
+		return false
+	}
+	return strings.TrimSpace(tuple.GetResource().GetType()) == groupAuthorizationResourceType &&
+		strings.TrimSpace(tuple.GetRelation()) == groupMemberRelation
 }
 
 func allowsAppScopedRelationshipMutation(

--- a/gestaltd/services/providergateway/authorization_app_scope.go
+++ b/gestaltd/services/providergateway/authorization_app_scope.go
@@ -11,8 +11,8 @@ import (
 )
 
 const (
-	appAuthorizationResourceType = "app"
-	appAdminRelation             = "admin"
+	appAuthorizationResourceType   = "app"
+	appAdminRelation               = "admin"
 	groupAuthorizationResourceType = "group"
 	groupAdminRelation             = "admin"
 	groupMemberRelation            = "member"
@@ -177,6 +177,9 @@ func allowsGroupScopedRelationshipMutation(
 	if authorization == nil || tuple == nil || !isGroupMemberRelationshipTuple(tuple) {
 		return false, nil
 	}
+	if !relationshipTupleHasDirectSubjectTarget(tuple) {
+		return false, nil
+	}
 	groupID := strings.TrimSpace(tuple.GetResource().GetId())
 	if groupID == "" {
 		return false, nil
@@ -238,7 +241,7 @@ func allowsAppScopedRelationshipMutation(
 func relationshipTupleHasDelegableTarget(tuple *proto.RelationshipTuple) bool {
 	switch tuple.GetTarget().GetKind().(type) {
 	case *proto.RelationshipTarget_Subject:
-		return strings.TrimSpace(tuple.GetTarget().GetSubject().GetId()) != ""
+		return relationshipTupleHasDirectSubjectTarget(tuple)
 	case *proto.RelationshipTarget_SubjectSet:
 		subjectSet := tuple.GetTarget().GetSubjectSet()
 		return strings.TrimSpace(subjectSet.GetResource().GetType()) != "" &&
@@ -246,4 +249,9 @@ func relationshipTupleHasDelegableTarget(tuple *proto.RelationshipTuple) bool {
 	default:
 		return false
 	}
+}
+
+func relationshipTupleHasDirectSubjectTarget(tuple *proto.RelationshipTuple) bool {
+	subject := tuple.GetTarget().GetSubject()
+	return subject != nil && strings.TrimSpace(subject.GetId()) != ""
 }

--- a/gestaltd/services/providergateway/authorization_app_scope.go
+++ b/gestaltd/services/providergateway/authorization_app_scope.go
@@ -168,13 +168,20 @@ func withAppScopedRelationshipMutationAuthFromRequest(ctx context.Context, fullM
 	return WithAppScopedRelationshipMutationAuth(ctx, appID, action, tuple)
 }
 
-func allowsGroupScopedRelationshipMutation(
+func (t *ProviderGatewayTransport) isScimManagedGroup(groupID string) bool {
+	if t == nil || t.scimManagedGroupIDs == nil {
+		return false
+	}
+	_, ok := t.scimManagedGroupIDs[strings.TrimSpace(groupID)]
+	return ok
+}
+
+func (t *ProviderGatewayTransport) allowsGroupScopedRelationshipMutation(
 	ctx context.Context,
-	authorization core.AuthorizationProvider,
 	subjectID string,
 	tuple *proto.RelationshipTuple,
 ) (bool, error) {
-	if authorization == nil || tuple == nil || !isGroupMemberRelationshipTuple(tuple) {
+	if t == nil || t.authorization == nil || tuple == nil || !isGroupMemberRelationshipTuple(tuple) {
 		return false, nil
 	}
 	if !relationshipTupleHasDirectSubjectTarget(tuple) {
@@ -184,7 +191,10 @@ func allowsGroupScopedRelationshipMutation(
 	if groupID == "" {
 		return false, nil
 	}
-	decision, err := invocation.CheckResourceAccess(ctx, authorization, invocation.ResourceAccessRequest{
+	if t.isScimManagedGroup(groupID) {
+		return false, nil
+	}
+	decision, err := invocation.CheckResourceAccess(ctx, t.authorization, invocation.ResourceAccessRequest{
 		SubjectID:    subjectID,
 		Action:       groupID,
 		Resource:     &proto.Resource{Type: groupAuthorizationResourceType, Id: groupID},

--- a/gestaltd/services/providergateway/authorization_app_scope_test.go
+++ b/gestaltd/services/providergateway/authorization_app_scope_test.go
@@ -165,9 +165,9 @@ func TestAllowsGroupScopedRelationshipMutation(t *testing.T) {
 		groupAdmin: map[string]bool{"servicemacusa-employees": true},
 	}
 
-	allowed, err := allowsGroupScopedRelationshipMutation(
+	transport := &ProviderGatewayTransport{authorization: provider}
+	allowed, err := transport.allowsGroupScopedRelationshipMutation(
 		context.Background(),
-		provider,
 		"user:admin@example.com",
 		tuple,
 	)
@@ -198,9 +198,9 @@ func TestAllowsGroupScopedRelationshipMutationRejectsSubjectSets(t *testing.T) {
 		groupAdmin: map[string]bool{"servicemacusa-employees": true},
 	}
 
-	allowed, err := allowsGroupScopedRelationshipMutation(
+	transport := &ProviderGatewayTransport{authorization: provider}
+	allowed, err := transport.allowsGroupScopedRelationshipMutation(
 		context.Background(),
-		provider,
 		"user:admin@example.com",
 		tuple,
 	)
@@ -209,6 +209,38 @@ func TestAllowsGroupScopedRelationshipMutationRejectsSubjectSets(t *testing.T) {
 	}
 	if allowed {
 		t.Fatal("allowsGroupScopedRelationshipMutation allowed = true for subject_set target, want false")
+	}
+}
+
+func TestAllowsGroupScopedRelationshipMutationRejectsScimManagedGroups(t *testing.T) {
+	t.Parallel()
+
+	tuple := &proto.RelationshipTuple{
+		Resource: &proto.Resource{Type: "group", Id: "e7dce358-8291-431f-baf0-fdb8a10b4252"},
+		Relation: "member",
+		Target: &proto.RelationshipTarget{
+			Kind: &proto.RelationshipTarget_Subject{
+				Subject: &proto.Subject{Type: "subject", Id: "user:viewer@example.com"},
+			},
+		},
+	}
+	transport := &ProviderGatewayTransport{
+		authorization: &groupScopedAuthorizationProvider{
+			groupAdmin: map[string]bool{"e7dce358-8291-431f-baf0-fdb8a10b4252": true},
+		},
+		scimManagedGroupIDs: map[string]struct{}{"e7dce358-8291-431f-baf0-fdb8a10b4252": {}},
+	}
+
+	allowed, err := transport.allowsGroupScopedRelationshipMutation(
+		context.Background(),
+		"user:admin@example.com",
+		tuple,
+	)
+	if err != nil {
+		t.Fatalf("allowsGroupScopedRelationshipMutation error = %v", err)
+	}
+	if allowed {
+		t.Fatal("allowsGroupScopedRelationshipMutation allowed = true for SCIM group, want false")
 	}
 }
 

--- a/gestaltd/services/providergateway/authorization_app_scope_test.go
+++ b/gestaltd/services/providergateway/authorization_app_scope_test.go
@@ -33,6 +33,32 @@ func (p *appScopedAuthorizationProvider) CheckAccess(
 	return &proto.CheckAccessResponse{Allowed: false}, nil
 }
 
+type groupScopedAuthorizationProvider struct {
+	*stubAuthorizationProvider
+	groupAdmin map[string]bool
+}
+
+func (p *groupScopedAuthorizationProvider) CheckAccess(
+	ctx context.Context,
+	req *proto.CheckAccessRequest,
+) (*proto.CheckAccessResponse, error) {
+	resource := req.GetResource()
+	if resource.GetType() == groupAuthorizationResourceType {
+		groupID := resource.GetId()
+		if p.groupAdmin[groupID] && req.GetAction().GetName() == groupID {
+			return &proto.CheckAccessResponse{
+				Allowed:          true,
+				MatchedRelations: []string{groupAdminRelation},
+			}, nil
+		}
+		return &proto.CheckAccessResponse{Allowed: false}, nil
+	}
+	if p.stubAuthorizationProvider != nil {
+		return p.stubAuthorizationProvider.CheckAccess(ctx, req)
+	}
+	return &proto.CheckAccessResponse{Allowed: false}, nil
+}
+
 func TestAllowsAppScopedRelationshipMutation(t *testing.T) {
 	t.Parallel()
 
@@ -120,6 +146,69 @@ func TestAllowsAppScopedRelationshipMutationRejectsGlobalResources(t *testing.T)
 	}
 	if allowed {
 		t.Fatal("allowsAppScopedRelationshipMutation allowed = true for gestalt tuple, want false")
+	}
+}
+
+func TestAllowsGroupScopedRelationshipMutation(t *testing.T) {
+	t.Parallel()
+
+	tuple := &proto.RelationshipTuple{
+		Resource: &proto.Resource{Type: "group", Id: "servicemacusa-employees"},
+		Relation: "member",
+		Target: &proto.RelationshipTarget{
+			Kind: &proto.RelationshipTarget_Subject{
+				Subject: &proto.Subject{Type: "subject", Id: "user:viewer@example.com"},
+			},
+		},
+	}
+	provider := &groupScopedAuthorizationProvider{
+		groupAdmin: map[string]bool{"servicemacusa-employees": true},
+	}
+
+	allowed, err := allowsGroupScopedRelationshipMutation(
+		context.Background(),
+		provider,
+		"user:admin@example.com",
+		tuple,
+	)
+	if err != nil {
+		t.Fatalf("allowsGroupScopedRelationshipMutation error = %v", err)
+	}
+	if !allowed {
+		t.Fatal("allowsGroupScopedRelationshipMutation allowed = false, want true")
+	}
+}
+
+func TestAllowsGroupScopedRelationshipMutationRejectsSubjectSets(t *testing.T) {
+	t.Parallel()
+
+	tuple := &proto.RelationshipTuple{
+		Resource: &proto.Resource{Type: "group", Id: "servicemacusa-employees"},
+		Relation: "member",
+		Target: &proto.RelationshipTarget{
+			Kind: &proto.RelationshipTarget_SubjectSet{
+				SubjectSet: &proto.SubjectSet{
+					Resource: &proto.Resource{Type: "group", Id: "valon-employees"},
+					Relation: "member",
+				},
+			},
+		},
+	}
+	provider := &groupScopedAuthorizationProvider{
+		groupAdmin: map[string]bool{"servicemacusa-employees": true},
+	}
+
+	allowed, err := allowsGroupScopedRelationshipMutation(
+		context.Background(),
+		provider,
+		"user:admin@example.com",
+		tuple,
+	)
+	if err != nil {
+		t.Fatalf("allowsGroupScopedRelationshipMutation error = %v", err)
+	}
+	if allowed {
+		t.Fatal("allowsGroupScopedRelationshipMutation allowed = true for subject_set target, want false")
 	}
 }
 

--- a/gestaltd/services/providergateway/gateway.go
+++ b/gestaltd/services/providergateway/gateway.go
@@ -19,12 +19,13 @@ type UserStore interface {
 }
 
 type ProviderGatewayTransport struct {
-	authorization core.AuthorizationProvider
-	identity      core.IdentityProvider
-	users         UserStore
-	publicMethods *publicrpc.Registry
-	publicBaseURL string
-	registry      *LocalRegistry
+	authorization       core.AuthorizationProvider
+	identity            core.IdentityProvider
+	users               UserStore
+	publicMethods       *publicrpc.Registry
+	publicBaseURL       string
+	registry            *LocalRegistry
+	scimManagedGroupIDs map[string]struct{}
 }
 
 func NewProviderGatewayTransport() *ProviderGatewayTransport {
@@ -36,6 +37,13 @@ func (t *ProviderGatewayTransport) SetAuthorizationProvider(authorization core.A
 		return
 	}
 	t.authorization = authorization
+}
+
+func (t *ProviderGatewayTransport) SetScimManagedGroupIDs(ids map[string]struct{}) {
+	if t == nil {
+		return
+	}
+	t.scimManagedGroupIDs = ids
 }
 
 func (t *ProviderGatewayTransport) SetIdentityProvider(identity core.IdentityProvider) {


### PR DESCRIPTION
## Summary
- Add `/api/v1/groups` list and create endpoints with SCIM-managed read-only marking from deploy config.
- Add `/api/v1/groups/{group}/admin/members` roster mutations gated on `group:{group} admin`.
- Allow group admins to add/remove `member` tuples through the authorization relationship write path.

## Test plan
- [ ] `go test ./internal/server/... ./services/providergateway/...`
- [ ] Group admin without `gestalt:admin` can list editable groups and mutate members
- [ ] Rippling SCIM group ids return `scimManaged: true` and reject member mutations


Made with [Cursor](https://cursor.com)