### PR TITLE
Expose source folders for registry apps

### DIFF
--- a/gestaltd/core/types.go
+++ b/gestaltd/core/types.go
@@ -27,6 +27,7 @@ type ManagedSubject struct {
 type AppInstallation struct {
 	AppName            string
 	Version            string
+	SourceRepository   string
 	SourceRef          string
 	Registry           string
 	ProviderReleaseURL string

--- a/gestaltd/internal/appregistry/installer.go
+++ b/gestaltd/internal/appregistry/installer.go
@@ -237,6 +237,7 @@ func (i *Installer) install(ctx context.Context, input InstallInput, mode instal
 	known := &core.AppInstallation{
 		AppName:            appName,
 		Version:            version,
+		SourceRepository:   entry.Repository,
 		SourceRef:          entry.SourceRef,
 		Registry:           registryName,
 		ProviderReleaseURL: entryURL,

--- a/gestaltd/internal/appregistry/installer_test.go
+++ b/gestaltd/internal/appregistry/installer_test.go
@@ -91,6 +91,13 @@ func TestInstaller_does_not_materialize_locally(t *testing.T) {
 	if err != nil {
 		t.Fatalf("install: %v", err)
 	}
+	known, err := svc.AppVersionChangeRequests.ListKnownVersionsByApp(ctx, "g-issues")
+	if err != nil {
+		t.Fatalf("ListKnownVersionsByApp: %v", err)
+	}
+	if len(known) != 1 || known[0].SourceRepository != "github.com/valon-technologies/valon-tools" {
+		t.Fatalf("known installations = %#v, want published source repository", known)
+	}
 
 	materialized := filepath.Join(artifactsDir, appregistry.RegistryInstallSubdir, "g-issues", fixture.Version)
 	if _, err := os.Stat(materialized); err == nil {

--- a/gestaltd/internal/appregistry/registry.go
+++ b/gestaltd/internal/appregistry/registry.go
@@ -86,7 +86,15 @@ type Entry struct {
 // app name is sufficient to project the source directory from the immutable
 // repository and source ref recorded in the entry.
 func (e Entry) SourceTreeURL() string {
-	repositoryLocation := strings.TrimSpace(e.Repository)
+	return SourceTreeURLForApp(e.Repository, e.App, e.SourceRef)
+}
+
+// SourceTreeURLForApp projects the source directory for a published app from
+// the source identity captured at publication time. The registry contract
+// fixes app sources under apps/{app}, so callers only need the repository,
+// application name, and immutable source ref from the installation record.
+func SourceTreeURLForApp(repositoryLocation, appName, sourceRef string) string {
+	repositoryLocation = strings.TrimSpace(repositoryLocation)
 	if strings.HasPrefix(strings.ToLower(repositoryLocation), "github.com/") {
 		repositoryLocation = "https://" + repositoryLocation
 	}
@@ -94,8 +102,8 @@ func (e Entry) SourceTreeURL() string {
 	if err != nil {
 		return ""
 	}
-	ref := strings.TrimSpace(e.SourceRef)
-	appName := strings.TrimSpace(e.App)
+	ref := strings.TrimSpace(sourceRef)
+	appName = strings.TrimSpace(appName)
 	if ref == "" || appName == "" {
 		return ""
 	}

--- a/gestaltd/internal/appregistry/registry.go
+++ b/gestaltd/internal/appregistry/registry.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"path"
 	"sort"
@@ -14,6 +15,7 @@ import (
 	"time"
 
 	"github.com/valon-technologies/gestalt/server/core/catalog"
+	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/providerregistry"
 	"github.com/valon-technologies/gestalt/server/internal/providerrelease"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
@@ -78,6 +80,29 @@ type Entry struct {
 	Compatibility     Compatibility       `json:"compatibility,omitempty"`
 	PublishedAt       time.Time           `json:"publishedAt"`
 	PublishStartedAt  *time.Time          `json:"publishStartedAt,omitempty"`
+}
+
+// SourceTreeURL is the GitHub tree for the source that produced this
+// published app. Registry app sources are validated as apps/{app}, so the
+// app name is sufficient to project the source directory from the immutable
+// repository and source ref recorded in the entry.
+func (e Entry) SourceTreeURL() string {
+	repositoryLocation := strings.TrimSpace(e.Repository)
+	if strings.HasPrefix(strings.ToLower(repositoryLocation), "github.com/") {
+		repositoryLocation = "https://" + repositoryLocation
+	}
+	repository, err := config.ParseGitHubRepo(repositoryLocation)
+	if err != nil {
+		return ""
+	}
+	ref := strings.TrimSpace(e.SourceRef)
+	appName := strings.TrimSpace(e.App)
+	if ref == "" || appName == "" {
+		return ""
+	}
+	return "https://github.com/" + url.PathEscape(repository.Owner) + "/" +
+		url.PathEscape(repository.Name) + "/tree/" + url.PathEscape(ref) +
+		"/apps/" + url.PathEscape(appName)
 }
 
 type Publication struct {

--- a/gestaltd/internal/appregistry/registry.go
+++ b/gestaltd/internal/appregistry/registry.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/url"
 	"os"
 	"path"
 	"sort"
@@ -100,9 +99,11 @@ func (e Entry) SourceTreeURL() string {
 	if ref == "" || appName == "" {
 		return ""
 	}
-	return "https://github.com/" + url.PathEscape(repository.Owner) + "/" +
-		url.PathEscape(repository.Name) + "/tree/" + url.PathEscape(ref) +
-		"/apps/" + url.PathEscape(appName)
+	return (config.GitSourceIdentity{
+		Repo:   repository,
+		Ref:    ref,
+		AppDir: path.Join(appSourcePathPrefix, appName),
+	}).TreeURL()
 }
 
 type Publication struct {

--- a/gestaltd/internal/appregistry/registry_source_test.go
+++ b/gestaltd/internal/appregistry/registry_source_test.go
@@ -1,0 +1,39 @@
+package appregistry
+
+import "testing"
+
+func TestEntrySourceTreeURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		entry Entry
+		want  string
+	}{
+		{
+			name: "github app",
+			entry: Entry{
+				App:        "g-issues",
+				SourceRef:  "abc123def456abc123def456abc123def456abcd",
+				Repository: "github.com/valon-technologies/valon-tools",
+			},
+			want: "https://github.com/valon-technologies/valon-tools/tree/abc123def456abc123def456abc123def456abcd/apps/g-issues",
+		},
+		{
+			name: "non github repository",
+			entry: Entry{
+				App:        "g-issues",
+				SourceRef:  "main",
+				Repository: "gitlab.example.com/acme/valon-tools",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.entry.SourceTreeURL(); got != tt.want {
+				t.Fatalf("SourceTreeURL = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/gestaltd/internal/appregistry/registry_source_test.go
+++ b/gestaltd/internal/appregistry/registry_source_test.go
@@ -31,6 +31,7 @@ func TestEntrySourceTreeURL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			if got := tt.entry.SourceTreeURL(); got != tt.want {
 				t.Fatalf("SourceTreeURL = %q, want %q", got, tt.want)
 			}

--- a/gestaltd/internal/appregistry/registry_source_test.go
+++ b/gestaltd/internal/appregistry/registry_source_test.go
@@ -27,6 +27,15 @@ func TestEntrySourceTreeURL(t *testing.T) {
 				Repository: "gitlab.example.com/acme/valon-tools",
 			},
 		},
+		{
+			name: "www github repository",
+			entry: Entry{
+				App:        "g-issues",
+				SourceRef:  "release/2026-09",
+				Repository: "https://www.github.com/valon-technologies/valon-tools.git",
+			},
+			want: "https://github.com/valon-technologies/valon-tools/tree/release%2F2026-09/apps/g-issues",
+		},
 	}
 
 	for _, tt := range tests {

--- a/gestaltd/internal/coredata/app_version_change_requests_projection.go
+++ b/gestaltd/internal/coredata/app_version_change_requests_projection.go
@@ -12,6 +12,7 @@ import (
 
 const (
 	appVersionChangeRequestMetaRegistry           = "registry"
+	appVersionChangeRequestMetaSourceRepository   = "source_repository"
 	appVersionChangeRequestMetaSourceRef          = "source_ref"
 	appVersionChangeRequestMetaProviderReleaseURL = "provider_release_url"
 	appVersionChangeRequestMetaArtifactChecksums  = "artifact_checksums"
@@ -24,6 +25,7 @@ func ChangeRequestMetadata(installation *core.AppInstallation) map[string]any {
 	}
 	metadata := map[string]any{
 		appVersionChangeRequestMetaRegistry:           strings.TrimSpace(installation.Registry),
+		appVersionChangeRequestMetaSourceRepository:   strings.TrimSpace(installation.SourceRepository),
 		appVersionChangeRequestMetaSourceRef:          strings.TrimSpace(installation.SourceRef),
 		appVersionChangeRequestMetaProviderReleaseURL: strings.TrimSpace(installation.ProviderReleaseURL),
 	}
@@ -110,6 +112,7 @@ func installationFromChangeRequest(request *core.AppVersionChangeRequest) *core.
 	}
 	if metadata := request.Metadata; metadata != nil {
 		installation.Registry = stringMeta(metadata, appVersionChangeRequestMetaRegistry)
+		installation.SourceRepository = stringMeta(metadata, appVersionChangeRequestMetaSourceRepository)
 		installation.SourceRef = stringMeta(metadata, appVersionChangeRequestMetaSourceRef)
 		installation.ProviderReleaseURL = stringMeta(metadata, appVersionChangeRequestMetaProviderReleaseURL)
 		installation.ArtifactChecksums = stringMapMeta(metadata, appVersionChangeRequestMetaArtifactChecksums)
@@ -128,8 +131,19 @@ func InstallationFromChangeRequest(request *core.AppVersionChangeRequest) *core.
 }
 
 func LatestKnownVersion(installations []*core.AppInstallation) string {
-	if len(installations) == 0 {
+	latest := LatestKnownInstallation(installations)
+	if latest == nil {
 		return ""
+	}
+	return strings.TrimSpace(latest.Version)
+}
+
+// LatestKnownInstallation returns the local installation record that currently
+// represents the desired version. Keeping the full record is important for
+// projections that need immutable publication metadata, not just its version.
+func LatestKnownInstallation(installations []*core.AppInstallation) *core.AppInstallation {
+	if len(installations) == 0 {
+		return nil
 	}
 	latest := installations[0]
 	for _, installation := range installations[1:] {
@@ -143,10 +157,7 @@ func LatestKnownVersion(installations []*core.AppInstallation) string {
 			latest = installation
 		}
 	}
-	if latest == nil {
-		return ""
-	}
-	return strings.TrimSpace(latest.Version)
+	return latest
 }
 
 func stringMeta(metadata map[string]any, key string) string {

--- a/gestaltd/internal/coredata/app_version_change_requests_projection_test.go
+++ b/gestaltd/internal/coredata/app_version_change_requests_projection_test.go
@@ -22,3 +22,26 @@ func TestLatestKnownVersionBreaksTimestampTiesLexicographically(t *testing.T) {
 		}
 	}
 }
+
+func TestInstallationFromChangeRequestPreservesSourceIdentity(t *testing.T) {
+	t.Parallel()
+
+	request := &core.AppVersionChangeRequest{
+		App:       "g-issues",
+		ToVersion: "1.2.3",
+		Metadata: coredata.ChangeRequestMetadata(&core.AppInstallation{
+			AppName:          "g-issues",
+			Version:          "1.2.3",
+			SourceRepository: " github.com/valon-technologies/valon-tools ",
+			SourceRef:        " abc123 ",
+		}),
+	}
+
+	installation := coredata.InstallationFromChangeRequest(request)
+	if installation.SourceRepository != "github.com/valon-technologies/valon-tools" {
+		t.Fatalf("SourceRepository = %q", installation.SourceRepository)
+	}
+	if installation.SourceRef != "abc123" {
+		t.Fatalf("SourceRef = %q", installation.SourceRef)
+	}
+}

--- a/gestaltd/internal/server/app_directory.go
+++ b/gestaltd/internal/server/app_directory.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/coredata"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 )
 
@@ -401,7 +402,7 @@ func (s *Server) buildTenantAppDirectory(ctx context.Context) (*tenantAppDirecto
 		if s.integrationHiddenFromCatalog(app.name) {
 			continue
 		}
-		dir.entries = append(dir.entries, s.tenantRegistryDirectoryEntry(app.name))
+		dir.entries = append(dir.entries, s.tenantRegistryDirectoryEntry(ctx, app.name))
 	}
 	return dir, cacheable, nil
 }
@@ -424,7 +425,7 @@ func (s *Server) tenantProviderDirectoryEntry(ctx context.Context, name string) 
 		Description: prov.Description(),
 		Loaded:      true,
 	}
-	s.applyPluginDirectoryFields(&entry, plugin)
+	s.applyPluginDirectoryFields(ctx, &entry, plugin)
 	s.attachDirectoryConnections(&entry, plugin)
 	if cat := prov.Catalog(); cat != nil {
 		entry.IconSVG = cat.IconSVG
@@ -432,13 +433,13 @@ func (s *Server) tenantProviderDirectoryEntry(ctx context.Context, name string) 
 	return entry, true, nil
 }
 
-func (s *Server) tenantRegistryDirectoryEntry(name string) tenantAppDirectoryEntry {
+func (s *Server) tenantRegistryDirectoryEntry(ctx context.Context, name string) tenantAppDirectoryEntry {
 	plugin := s.pluginDefs[name]
 	entry := tenantAppDirectoryEntry{
 		Name:        name,
 		DisplayName: name,
 	}
-	s.applyPluginDirectoryFields(&entry, plugin)
+	s.applyPluginDirectoryFields(ctx, &entry, plugin)
 	if plugin != nil && strings.TrimSpace(plugin.DisplayName) != "" {
 		entry.DisplayName = strings.TrimSpace(plugin.DisplayName)
 	}
@@ -446,15 +447,15 @@ func (s *Server) tenantRegistryDirectoryEntry(name string) tenantAppDirectoryEnt
 	return entry
 }
 
-func (s *Server) applyPluginDirectoryFields(entry *tenantAppDirectoryEntry, plugin *config.ProviderEntry) {
+func (s *Server) applyPluginDirectoryFields(ctx context.Context, entry *tenantAppDirectoryEntry, plugin *config.ProviderEntry) {
 	if entry == nil {
 		return
 	}
 	entry.Prompts = s.appPrompts[entry.Name]
+	entry.SourceTreeURL = s.appSourceTreeURL(ctx, entry.Name, plugin)
 	if plugin == nil {
 		return
 	}
-	entry.SourceTreeURL = plugin.SourceTreeURL()
 	entry.DeclaredMount = pluginDeclaredMount(plugin)
 }
 
@@ -498,6 +499,61 @@ func (s *Server) viewerDirectoryEntry(ctx context.Context, p *principal.Principa
 		s.integrationMountedPathForPrincipalContext(ctx, p, entry.Name, entry.DeclaredMount),
 		s.integrationManagementPath(ctx, p, entry.Name),
 	)
+}
+
+func (s *Server) appSourceTreeURL(ctx context.Context, appName string, plugin *config.ProviderEntry) string {
+	if plugin != nil {
+		if sourceTreeURL := plugin.SourceTreeURL(); sourceTreeURL != "" {
+			return sourceTreeURL
+		}
+	}
+	app, ok := s.registryApp(appName)
+	if !ok {
+		return ""
+	}
+	return s.registryAppSourceTreeURL(ctx, app)
+}
+
+func (s *Server) registryAppSourceTreeURL(ctx context.Context, app configuredRegistryApp) string {
+	if s == nil || s.appRegistryReader == nil || s.appVersionChanges == nil {
+		return ""
+	}
+	known, err := s.appVersionChanges.ListKnownVersionsByApp(ctx, app.name)
+	if err != nil {
+		return ""
+	}
+	version := coredata.LatestKnownVersion(known)
+	if version == "" {
+		return ""
+	}
+	cacheKey := app.name + "\x00" + version
+	s.appRegistrySourceMu.Lock()
+	if sourceTreeURL := s.appRegistrySourceTreeURLs[cacheKey]; sourceTreeURL != "" {
+		s.appRegistrySourceMu.Unlock()
+		return sourceTreeURL
+	}
+	s.appRegistrySourceMu.Unlock()
+
+	registry, ok := s.appRegistries[app.registry]
+	if !ok {
+		return ""
+	}
+	publicRoot, err := registry.PublicURL()
+	if err != nil {
+		return ""
+	}
+	entry, err := s.appRegistryReader.FetchEntry(ctx, publicRoot, app.name, version)
+	if err != nil || entry == nil {
+		return ""
+	}
+	sourceTreeURL := entry.SourceTreeURL()
+	if sourceTreeURL == "" {
+		return ""
+	}
+	s.appRegistrySourceMu.Lock()
+	s.appRegistrySourceTreeURLs[cacheKey] = sourceTreeURL
+	s.appRegistrySourceMu.Unlock()
+	return sourceTreeURL
 }
 
 func (s *Server) visibleProviderDirectoryEntry(r *http.Request, name string) (appDirectoryEntry, bool, error) {

--- a/gestaltd/internal/server/app_directory.go
+++ b/gestaltd/internal/server/app_directory.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/appregistry"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/coredata"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
@@ -497,9 +498,9 @@ func (s *Server) viewerDirectoryEntry(ctx context.Context, p *principal.Principa
 		s.integrationMountedPathForPrincipalContext(ctx, p, entry.Name, entry.DeclaredMount),
 		s.integrationManagementPath(ctx, p, entry.Name),
 	)
-	// Registry source metadata depends on the installed app version, so resolve
-	// it while projecting the request rather than freezing it in the tenant
-	// snapshot. Successful lookups are still cached by app and version.
+	// Registry source metadata belongs to the installed version, so resolve it
+	// while projecting the request rather than freezing it in the tenant
+	// snapshot.
 	projected.SourceTreeURL = s.appSourceTreeURL(ctx, entry.Name, s.pluginDefs[entry.Name])
 	return projected
 }
@@ -514,28 +515,33 @@ func (s *Server) appSourceTreeURL(ctx context.Context, appName string, plugin *c
 	if !ok {
 		return ""
 	}
-	return s.registryAppSourceTreeURL(ctx, app)
-}
-
-func (s *Server) registryAppSourceTreeURL(ctx context.Context, app configuredRegistryApp) string {
-	if s == nil || s.appRegistryReader == nil || s.appVersionChanges == nil {
+	if s.appVersionChanges == nil {
 		return ""
 	}
 	known, err := s.appVersionChanges.ListKnownVersionsByApp(ctx, app.name)
 	if err != nil {
 		return ""
 	}
-	version := coredata.LatestKnownVersion(known)
+	installation := coredata.LatestKnownInstallation(known)
+	if installation == nil {
+		return ""
+	}
+	if sourceRepository := strings.TrimSpace(installation.SourceRepository); sourceRepository != "" {
+		return appregistry.SourceTreeURLForApp(sourceRepository, installation.AppName, installation.SourceRef)
+	}
+	return s.legacyRegistryAppSourceTreeURL(ctx, app, installation.Version)
+}
+
+// legacyRegistryAppSourceTreeURL supports installations recorded before source
+// repository identity was persisted. New installations never use this remote
+// read path; it can be removed after those historical records are migrated.
+func (s *Server) legacyRegistryAppSourceTreeURL(ctx context.Context, app configuredRegistryApp, version string) string {
+	if s == nil || s.appRegistryReader == nil || s.appVersionChanges == nil {
+		return ""
+	}
 	if version == "" {
 		return ""
 	}
-	cacheKey := app.name + "\x00" + version
-	s.appRegistrySourceMu.Lock()
-	if sourceTreeURL := s.appRegistrySourceTreeURLs[cacheKey]; sourceTreeURL != "" {
-		s.appRegistrySourceMu.Unlock()
-		return sourceTreeURL
-	}
-	s.appRegistrySourceMu.Unlock()
 
 	registry, ok := s.appRegistries[app.registry]
 	if !ok {
@@ -553,9 +559,6 @@ func (s *Server) registryAppSourceTreeURL(ctx context.Context, app configuredReg
 	if sourceTreeURL == "" {
 		return ""
 	}
-	s.appRegistrySourceMu.Lock()
-	s.appRegistrySourceTreeURLs[cacheKey] = sourceTreeURL
-	s.appRegistrySourceMu.Unlock()
 	return sourceTreeURL
 }
 

--- a/gestaltd/internal/server/app_directory.go
+++ b/gestaltd/internal/server/app_directory.go
@@ -381,7 +381,7 @@ func (s *Server) buildTenantAppDirectory(ctx context.Context) (*tenantAppDirecto
 	dir := &tenantAppDirectory{entries: make([]tenantAppDirectoryEntry, 0, len(names)+len(registryApps))}
 	cacheable := true
 	for _, name := range names {
-		entry, ok, err := s.tenantProviderDirectoryEntry(ctx, name)
+		entry, ok, entryCacheable, err := s.tenantProviderDirectoryEntry(ctx, name)
 		if err != nil {
 			if ctx.Err() != nil {
 				return nil, false, err
@@ -392,6 +392,7 @@ func (s *Server) buildTenantAppDirectory(ctx context.Context) (*tenantAppDirecto
 		if !ok {
 			continue
 		}
+		cacheable = cacheable && entryCacheable
 		seen[name] = struct{}{}
 		dir.entries = append(dir.entries, entry)
 	}
@@ -402,21 +403,23 @@ func (s *Server) buildTenantAppDirectory(ctx context.Context) (*tenantAppDirecto
 		if s.integrationHiddenFromCatalog(app.name) {
 			continue
 		}
-		dir.entries = append(dir.entries, s.tenantRegistryDirectoryEntry(ctx, app.name))
+		entry, entryCacheable := s.tenantRegistryDirectoryEntry(ctx, app.name)
+		cacheable = cacheable && entryCacheable
+		dir.entries = append(dir.entries, entry)
 	}
 	return dir, cacheable, nil
 }
 
-func (s *Server) tenantProviderDirectoryEntry(ctx context.Context, name string) (tenantAppDirectoryEntry, bool, error) {
+func (s *Server) tenantProviderDirectoryEntry(ctx context.Context, name string) (tenantAppDirectoryEntry, bool, bool, error) {
 	if s.integrationHiddenFromCatalog(name) {
-		return tenantAppDirectoryEntry{}, false, nil
+		return tenantAppDirectoryEntry{}, false, true, nil
 	}
 	prov, err := s.providers.GetWithContext(ctx, name)
 	if err != nil {
 		if errors.Is(err, core.ErrNotFound) {
-			return tenantAppDirectoryEntry{}, false, nil
+			return tenantAppDirectoryEntry{}, false, true, nil
 		}
-		return tenantAppDirectoryEntry{}, false, fmt.Errorf("resolve app %q: %w", name, err)
+		return tenantAppDirectoryEntry{}, false, false, fmt.Errorf("resolve app %q: %w", name, err)
 	}
 	plugin := s.pluginDefs[name]
 	entry := tenantAppDirectoryEntry{
@@ -425,38 +428,40 @@ func (s *Server) tenantProviderDirectoryEntry(ctx context.Context, name string) 
 		Description: prov.Description(),
 		Loaded:      true,
 	}
-	s.applyPluginDirectoryFields(ctx, &entry, plugin)
+	entryCacheable := s.applyPluginDirectoryFields(ctx, &entry, plugin)
 	s.attachDirectoryConnections(&entry, plugin)
 	if cat := prov.Catalog(); cat != nil {
 		entry.IconSVG = cat.IconSVG
 	}
-	return entry, true, nil
+	return entry, true, entryCacheable, nil
 }
 
-func (s *Server) tenantRegistryDirectoryEntry(ctx context.Context, name string) tenantAppDirectoryEntry {
+func (s *Server) tenantRegistryDirectoryEntry(ctx context.Context, name string) (tenantAppDirectoryEntry, bool) {
 	plugin := s.pluginDefs[name]
 	entry := tenantAppDirectoryEntry{
 		Name:        name,
 		DisplayName: name,
 	}
-	s.applyPluginDirectoryFields(ctx, &entry, plugin)
+	entryCacheable := s.applyPluginDirectoryFields(ctx, &entry, plugin)
 	if plugin != nil && strings.TrimSpace(plugin.DisplayName) != "" {
 		entry.DisplayName = strings.TrimSpace(plugin.DisplayName)
 	}
 	s.attachDirectoryConnections(&entry, plugin)
-	return entry
+	return entry, entryCacheable
 }
 
-func (s *Server) applyPluginDirectoryFields(ctx context.Context, entry *tenantAppDirectoryEntry, plugin *config.ProviderEntry) {
+func (s *Server) applyPluginDirectoryFields(ctx context.Context, entry *tenantAppDirectoryEntry, plugin *config.ProviderEntry) bool {
 	if entry == nil {
-		return
+		return true
 	}
 	entry.Prompts = s.appPrompts[entry.Name]
-	entry.SourceTreeURL = s.appSourceTreeURL(ctx, entry.Name, plugin)
+	sourceTreeURL, sourceCacheable := s.appSourceTreeURL(ctx, entry.Name, plugin)
+	entry.SourceTreeURL = sourceTreeURL
 	if plugin == nil {
-		return
+		return sourceCacheable
 	}
 	entry.DeclaredMount = pluginDeclaredMount(plugin)
+	return sourceCacheable
 }
 
 func pluginDeclaredMount(plugin *config.ProviderEntry) string {
@@ -501,59 +506,59 @@ func (s *Server) viewerDirectoryEntry(ctx context.Context, p *principal.Principa
 	)
 }
 
-func (s *Server) appSourceTreeURL(ctx context.Context, appName string, plugin *config.ProviderEntry) string {
+func (s *Server) appSourceTreeURL(ctx context.Context, appName string, plugin *config.ProviderEntry) (string, bool) {
 	if plugin != nil {
 		if sourceTreeURL := plugin.SourceTreeURL(); sourceTreeURL != "" {
-			return sourceTreeURL
+			return sourceTreeURL, true
 		}
 	}
 	app, ok := s.registryApp(appName)
 	if !ok {
-		return ""
+		return "", true
 	}
 	return s.registryAppSourceTreeURL(ctx, app)
 }
 
-func (s *Server) registryAppSourceTreeURL(ctx context.Context, app configuredRegistryApp) string {
+func (s *Server) registryAppSourceTreeURL(ctx context.Context, app configuredRegistryApp) (string, bool) {
 	if s == nil || s.appRegistryReader == nil || s.appVersionChanges == nil {
-		return ""
+		return "", false
 	}
 	known, err := s.appVersionChanges.ListKnownVersionsByApp(ctx, app.name)
 	if err != nil {
-		return ""
+		return "", false
 	}
 	version := coredata.LatestKnownVersion(known)
 	if version == "" {
-		return ""
+		return "", false
 	}
 	cacheKey := app.name + "\x00" + version
 	s.appRegistrySourceMu.Lock()
 	if sourceTreeURL := s.appRegistrySourceTreeURLs[cacheKey]; sourceTreeURL != "" {
 		s.appRegistrySourceMu.Unlock()
-		return sourceTreeURL
+		return sourceTreeURL, true
 	}
 	s.appRegistrySourceMu.Unlock()
 
 	registry, ok := s.appRegistries[app.registry]
 	if !ok {
-		return ""
+		return "", false
 	}
 	publicRoot, err := registry.PublicURL()
 	if err != nil {
-		return ""
+		return "", false
 	}
 	entry, err := s.appRegistryReader.FetchEntry(ctx, publicRoot, app.name, version)
 	if err != nil || entry == nil {
-		return ""
+		return "", false
 	}
 	sourceTreeURL := entry.SourceTreeURL()
 	if sourceTreeURL == "" {
-		return ""
+		return "", false
 	}
 	s.appRegistrySourceMu.Lock()
 	s.appRegistrySourceTreeURLs[cacheKey] = sourceTreeURL
 	s.appRegistrySourceMu.Unlock()
-	return sourceTreeURL
+	return sourceTreeURL, true
 }
 
 func (s *Server) visibleProviderDirectoryEntry(r *http.Request, name string) (appDirectoryEntry, bool, error) {

--- a/gestaltd/internal/server/app_directory.go
+++ b/gestaltd/internal/server/app_directory.go
@@ -31,7 +31,6 @@ type tenantAppDirectoryEntry struct {
 	IconSVG          string
 	DeclaredMount    string
 	Prompts          []appPromptInfo
-	SourceTreeURL    string
 	Advertised       []advertisedConnection
 	ConnectionSchema []connectionSchemaInfo
 	Loaded           bool
@@ -188,7 +187,6 @@ func viewerDirectoryEntry(entry tenantAppDirectoryEntry, mountedPath, management
 		MountedPath:      mountedPath,
 		ManagementPath:   managementPath,
 		Prompts:          entry.Prompts,
-		SourceTreeURL:    entry.SourceTreeURL,
 		Advertised:       entry.Advertised,
 		ConnectionSchema: entry.ConnectionSchema,
 		Loaded:           entry.Loaded,
@@ -381,7 +379,7 @@ func (s *Server) buildTenantAppDirectory(ctx context.Context) (*tenantAppDirecto
 	dir := &tenantAppDirectory{entries: make([]tenantAppDirectoryEntry, 0, len(names)+len(registryApps))}
 	cacheable := true
 	for _, name := range names {
-		entry, ok, entryCacheable, err := s.tenantProviderDirectoryEntry(ctx, name)
+		entry, ok, err := s.tenantProviderDirectoryEntry(ctx, name)
 		if err != nil {
 			if ctx.Err() != nil {
 				return nil, false, err
@@ -392,7 +390,6 @@ func (s *Server) buildTenantAppDirectory(ctx context.Context) (*tenantAppDirecto
 		if !ok {
 			continue
 		}
-		cacheable = cacheable && entryCacheable
 		seen[name] = struct{}{}
 		dir.entries = append(dir.entries, entry)
 	}
@@ -403,23 +400,22 @@ func (s *Server) buildTenantAppDirectory(ctx context.Context) (*tenantAppDirecto
 		if s.integrationHiddenFromCatalog(app.name) {
 			continue
 		}
-		entry, entryCacheable := s.tenantRegistryDirectoryEntry(ctx, app.name)
-		cacheable = cacheable && entryCacheable
+		entry := s.tenantRegistryDirectoryEntry(app.name)
 		dir.entries = append(dir.entries, entry)
 	}
 	return dir, cacheable, nil
 }
 
-func (s *Server) tenantProviderDirectoryEntry(ctx context.Context, name string) (tenantAppDirectoryEntry, bool, bool, error) {
+func (s *Server) tenantProviderDirectoryEntry(ctx context.Context, name string) (tenantAppDirectoryEntry, bool, error) {
 	if s.integrationHiddenFromCatalog(name) {
-		return tenantAppDirectoryEntry{}, false, true, nil
+		return tenantAppDirectoryEntry{}, false, nil
 	}
 	prov, err := s.providers.GetWithContext(ctx, name)
 	if err != nil {
 		if errors.Is(err, core.ErrNotFound) {
-			return tenantAppDirectoryEntry{}, false, true, nil
+			return tenantAppDirectoryEntry{}, false, nil
 		}
-		return tenantAppDirectoryEntry{}, false, false, fmt.Errorf("resolve app %q: %w", name, err)
+		return tenantAppDirectoryEntry{}, false, fmt.Errorf("resolve app %q: %w", name, err)
 	}
 	plugin := s.pluginDefs[name]
 	entry := tenantAppDirectoryEntry{
@@ -428,40 +424,37 @@ func (s *Server) tenantProviderDirectoryEntry(ctx context.Context, name string) 
 		Description: prov.Description(),
 		Loaded:      true,
 	}
-	entryCacheable := s.applyPluginDirectoryFields(ctx, &entry, plugin)
+	s.applyPluginDirectoryFields(&entry, plugin)
 	s.attachDirectoryConnections(&entry, plugin)
 	if cat := prov.Catalog(); cat != nil {
 		entry.IconSVG = cat.IconSVG
 	}
-	return entry, true, entryCacheable, nil
+	return entry, true, nil
 }
 
-func (s *Server) tenantRegistryDirectoryEntry(ctx context.Context, name string) (tenantAppDirectoryEntry, bool) {
+func (s *Server) tenantRegistryDirectoryEntry(name string) tenantAppDirectoryEntry {
 	plugin := s.pluginDefs[name]
 	entry := tenantAppDirectoryEntry{
 		Name:        name,
 		DisplayName: name,
 	}
-	entryCacheable := s.applyPluginDirectoryFields(ctx, &entry, plugin)
+	s.applyPluginDirectoryFields(&entry, plugin)
 	if plugin != nil && strings.TrimSpace(plugin.DisplayName) != "" {
 		entry.DisplayName = strings.TrimSpace(plugin.DisplayName)
 	}
 	s.attachDirectoryConnections(&entry, plugin)
-	return entry, entryCacheable
+	return entry
 }
 
-func (s *Server) applyPluginDirectoryFields(ctx context.Context, entry *tenantAppDirectoryEntry, plugin *config.ProviderEntry) bool {
+func (s *Server) applyPluginDirectoryFields(entry *tenantAppDirectoryEntry, plugin *config.ProviderEntry) {
 	if entry == nil {
-		return true
+		return
 	}
 	entry.Prompts = s.appPrompts[entry.Name]
-	sourceTreeURL, sourceCacheable := s.appSourceTreeURL(ctx, entry.Name, plugin)
-	entry.SourceTreeURL = sourceTreeURL
 	if plugin == nil {
-		return sourceCacheable
+		return
 	}
 	entry.DeclaredMount = pluginDeclaredMount(plugin)
-	return sourceCacheable
 }
 
 func pluginDeclaredMount(plugin *config.ProviderEntry) string {
@@ -499,66 +492,71 @@ func (s *Server) projectViewerAppDirectory(r *http.Request, snapshot *tenantAppD
 }
 
 func (s *Server) viewerDirectoryEntry(ctx context.Context, p *principal.Principal, entry tenantAppDirectoryEntry) appDirectoryEntry {
-	return viewerDirectoryEntry(
+	projected := viewerDirectoryEntry(
 		entry,
 		s.integrationMountedPathForPrincipalContext(ctx, p, entry.Name, entry.DeclaredMount),
 		s.integrationManagementPath(ctx, p, entry.Name),
 	)
+	// Registry source metadata depends on the installed app version, so resolve
+	// it while projecting the request rather than freezing it in the tenant
+	// snapshot. Successful lookups are still cached by app and version.
+	projected.SourceTreeURL = s.appSourceTreeURL(ctx, entry.Name, s.pluginDefs[entry.Name])
+	return projected
 }
 
-func (s *Server) appSourceTreeURL(ctx context.Context, appName string, plugin *config.ProviderEntry) (string, bool) {
+func (s *Server) appSourceTreeURL(ctx context.Context, appName string, plugin *config.ProviderEntry) string {
 	if plugin != nil {
 		if sourceTreeURL := plugin.SourceTreeURL(); sourceTreeURL != "" {
-			return sourceTreeURL, true
+			return sourceTreeURL
 		}
 	}
 	app, ok := s.registryApp(appName)
 	if !ok {
-		return "", true
+		return ""
 	}
 	return s.registryAppSourceTreeURL(ctx, app)
 }
 
-func (s *Server) registryAppSourceTreeURL(ctx context.Context, app configuredRegistryApp) (string, bool) {
+func (s *Server) registryAppSourceTreeURL(ctx context.Context, app configuredRegistryApp) string {
 	if s == nil || s.appRegistryReader == nil || s.appVersionChanges == nil {
-		return "", false
+		return ""
 	}
 	known, err := s.appVersionChanges.ListKnownVersionsByApp(ctx, app.name)
 	if err != nil {
-		return "", false
+		return ""
 	}
 	version := coredata.LatestKnownVersion(known)
 	if version == "" {
-		return "", false
+		return ""
 	}
 	cacheKey := app.name + "\x00" + version
 	s.appRegistrySourceMu.Lock()
 	if sourceTreeURL := s.appRegistrySourceTreeURLs[cacheKey]; sourceTreeURL != "" {
 		s.appRegistrySourceMu.Unlock()
-		return sourceTreeURL, true
+		return sourceTreeURL
 	}
 	s.appRegistrySourceMu.Unlock()
 
 	registry, ok := s.appRegistries[app.registry]
 	if !ok {
-		return "", false
+		return ""
 	}
 	publicRoot, err := registry.PublicURL()
 	if err != nil {
-		return "", false
+		return ""
 	}
 	entry, err := s.appRegistryReader.FetchEntry(ctx, publicRoot, app.name, version)
 	if err != nil || entry == nil {
-		return "", false
+		return ""
 	}
 	sourceTreeURL := entry.SourceTreeURL()
 	if sourceTreeURL == "" {
-		return "", false
+		return ""
 	}
 	s.appRegistrySourceMu.Lock()
 	s.appRegistrySourceTreeURLs[cacheKey] = sourceTreeURL
 	s.appRegistrySourceMu.Unlock()
-	return sourceTreeURL, true
+	return sourceTreeURL
 }
 
 func (s *Server) visibleProviderDirectoryEntry(r *http.Request, name string) (appDirectoryEntry, bool, error) {

--- a/gestaltd/internal/server/handlers_app_catalog_test.go
+++ b/gestaltd/internal/server/handlers_app_catalog_test.go
@@ -13,7 +13,9 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/core"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+	"github.com/valon-technologies/gestalt/server/internal/appregistry/registrytest"
 	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/coredata"
 	"github.com/valon-technologies/gestalt/server/internal/server"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
@@ -340,6 +342,70 @@ func TestAppCatalogIncludesSourceTreeURL(t *testing.T) {
 	}
 	if _, exists := composedByName["notes"]["sourceTreeUrl"]; exists {
 		t.Fatalf("composed notes sourceTreeUrl = %+v, want omitted", composedByName["notes"]["sourceTreeUrl"])
+	}
+}
+
+func TestAppCatalogIncludesSourceTreeURLForRegistryApp(t *testing.T) {
+	t.Parallel()
+
+	fixture := registrytest.NewInstallFixture(t)
+	services := testutil.NewStubServices(t)
+	_, err := services.AppVersionChangeRequests.AppendRequest(t.Context(), &core.AppVersionChangeRequest{
+		App:         "g-issues",
+		FromVersion: "none",
+		ToVersion:   fixture.Version,
+		Actor:       testCanonicalAdminUserID,
+		Metadata: coredata.ChangeRequestMetadata(&core.AppInstallation{
+			AppName:  "g-issues",
+			Version:  fixture.Version,
+			Registry: "toolshed",
+		}),
+	})
+	if err != nil {
+		t.Fatalf("AppendRequest: %v", err)
+	}
+	subjectID := principal.UserSubjectID(testCanonicalAdminUserID)
+	authz := &serverTestAuthorizationProvider{
+		relationships: []*proto.Relationship{
+			testAuthorizationRelationship(subjectID, "admin", "app", "g-issues"),
+		},
+	}
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = authStubWithSessionTokenIntrospect("alice-token", subjectID, "")
+		cfg.Authorization = authz
+		cfg.Services = services
+		cfg.AppRegistries = map[string]config.AppRegistryConfig{"toolshed": fixture.Registry}
+		cfg.AppRegistryReader = fixture.Reader
+		cfg.AppDefs = map[string]*config.ProviderEntry{
+			"g-issues": {Source: config.ProviderSource{Registry: "toolshed"}},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	request, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/catalog/apps", nil)
+	request.Header.Set("Authorization", "Bearer alice-token")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("GET catalog: %v", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("status = %d: %s", response.StatusCode, body)
+	}
+	var apps []struct {
+		Name          string `json:"name"`
+		SourceTreeURL string `json:"sourceTreeUrl"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&apps); err != nil {
+		t.Fatalf("decode catalog: %v", err)
+	}
+	if len(apps) != 1 || apps[0].Name != "g-issues" {
+		t.Fatalf("apps = %#v", apps)
+	}
+	want := "https://github.com/valon-technologies/valon-tools/tree/abc123def456abc123def456abc123def456abcd/apps/g-issues"
+	if apps[0].SourceTreeURL != want {
+		t.Fatalf("sourceTreeUrl = %q, want %q", apps[0].SourceTreeURL, want)
 	}
 }
 

--- a/gestaltd/internal/server/handlers_app_catalog_test.go
+++ b/gestaltd/internal/server/handlers_app_catalog_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -23,6 +24,18 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/apps/declarative"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 )
+
+type failOnceRegistryEntryTransport struct {
+	base   http.RoundTripper
+	failed atomic.Bool
+}
+
+func (t *failOnceRegistryEntryTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	if strings.Contains(request.URL.Path, "/versions/") && t.failed.CompareAndSwap(false, true) {
+		return nil, fmt.Errorf("temporary registry entry failure")
+	}
+	return t.base.RoundTrip(request)
+}
 
 type errorListCredentials struct {
 	core.ExternalCredentialProvider
@@ -381,25 +394,40 @@ func TestAppCatalogIncludesSourceTreeURLForRegistryApp(t *testing.T) {
 		}
 	})
 	testutil.CloseOnCleanup(t, ts)
+	fixture.Reader.HTTPClient.Transport = &failOnceRegistryEntryTransport{
+		base: fixture.Reader.HTTPClient.Transport,
+	}
 
-	request, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/catalog/apps", nil)
-	request.Header.Set("Authorization", "Bearer alice-token")
-	response, err := http.DefaultClient.Do(request)
-	if err != nil {
-		t.Fatalf("GET catalog: %v", err)
-	}
-	defer func() { _ = response.Body.Close() }()
-	if response.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(response.Body)
-		t.Fatalf("status = %d: %s", response.StatusCode, body)
-	}
-	var apps []struct {
+	getCatalog := func() []struct {
 		Name          string `json:"name"`
 		SourceTreeURL string `json:"sourceTreeUrl"`
+	} {
+		request, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/catalog/apps", nil)
+		request.Header.Set("Authorization", "Bearer alice-token")
+		response, err := http.DefaultClient.Do(request)
+		if err != nil {
+			t.Fatalf("GET catalog: %v", err)
+		}
+		defer func() { _ = response.Body.Close() }()
+		if response.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(response.Body)
+			t.Fatalf("status = %d: %s", response.StatusCode, body)
+		}
+		var apps []struct {
+			Name          string `json:"name"`
+			SourceTreeURL string `json:"sourceTreeUrl"`
+		}
+		if err := json.NewDecoder(response.Body).Decode(&apps); err != nil {
+			t.Fatalf("decode catalog: %v", err)
+		}
+		return apps
 	}
-	if err := json.NewDecoder(response.Body).Decode(&apps); err != nil {
-		t.Fatalf("decode catalog: %v", err)
+
+	first := getCatalog()
+	if len(first) != 1 || first[0].Name != "g-issues" || first[0].SourceTreeURL != "" {
+		t.Fatalf("first apps = %#v, want one app without sourceTreeUrl", first)
 	}
+	apps := getCatalog()
 	if len(apps) != 1 || apps[0].Name != "g-issues" {
 		t.Fatalf("apps = %#v", apps)
 	}

--- a/gestaltd/internal/server/handlers_app_catalog_test.go
+++ b/gestaltd/internal/server/handlers_app_catalog_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
-	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -24,18 +23,6 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/apps/declarative"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 )
-
-type failOnceRegistryEntryTransport struct {
-	base   http.RoundTripper
-	failed atomic.Bool
-}
-
-func (t *failOnceRegistryEntryTransport) RoundTrip(request *http.Request) (*http.Response, error) {
-	if strings.Contains(request.URL.Path, "/versions/") && t.failed.CompareAndSwap(false, true) {
-		return nil, fmt.Errorf("temporary registry entry failure")
-	}
-	return t.base.RoundTrip(request)
-}
 
 type errorListCredentials struct {
 	core.ExternalCredentialProvider
@@ -369,9 +356,11 @@ func TestAppCatalogIncludesSourceTreeURLForRegistryApp(t *testing.T) {
 		ToVersion:   fixture.Version,
 		Actor:       testCanonicalAdminUserID,
 		Metadata: coredata.ChangeRequestMetadata(&core.AppInstallation{
-			AppName:  "g-issues",
-			Version:  fixture.Version,
-			Registry: "toolshed",
+			AppName:          "g-issues",
+			Version:          fixture.Version,
+			SourceRepository: "github.com/valon-technologies/valon-tools",
+			SourceRef:        "abc123def456abc123def456abc123def456abcd",
+			Registry:         "toolshed",
 		}),
 	})
 	if err != nil {
@@ -388,15 +377,11 @@ func TestAppCatalogIncludesSourceTreeURLForRegistryApp(t *testing.T) {
 		cfg.Authorization = authz
 		cfg.Services = services
 		cfg.AppRegistries = map[string]config.AppRegistryConfig{"toolshed": fixture.Registry}
-		cfg.AppRegistryReader = fixture.Reader
 		cfg.AppDefs = map[string]*config.ProviderEntry{
 			"g-issues": {Source: config.ProviderSource{Registry: "toolshed"}},
 		}
 	})
 	testutil.CloseOnCleanup(t, ts)
-	fixture.Reader.HTTPClient.Transport = &failOnceRegistryEntryTransport{
-		base: fixture.Reader.HTTPClient.Transport,
-	}
 
 	getCatalog := func() []struct {
 		Name          string `json:"name"`
@@ -423,10 +408,6 @@ func TestAppCatalogIncludesSourceTreeURLForRegistryApp(t *testing.T) {
 		return apps
 	}
 
-	first := getCatalog()
-	if len(first) != 1 || first[0].Name != "g-issues" || first[0].SourceTreeURL != "" {
-		t.Fatalf("first apps = %#v, want one app without sourceTreeUrl", first)
-	}
 	apps := getCatalog()
 	if len(apps) != 1 || apps[0].Name != "g-issues" {
 		t.Fatalf("apps = %#v", apps)

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -178,7 +178,6 @@ func run(ctx context.Context, cfg *config.Config, result *bootstrap.Result, gest
 	}
 	baseConfig.AppRegistryPublish = publishService
 	baseConfig.AppRegistryPublishAllowedApps = cfg.Server.AppRegistry.Publish.AllowedAppSet()
-
 	result.RegistryAppStartup = registryAppStartup(cfg, result, appRegistryReader)
 	if err := result.Start(ctx); err != nil {
 		return err

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -186,8 +186,6 @@ type Server struct {
 	adminRoute                    AdminRouteConfig
 	appRegistries                 map[string]config.AppRegistryConfig
 	appRegistryReader             *appregistry.RegistryReader
-	appRegistrySourceMu           sync.Mutex
-	appRegistrySourceTreeURLs     map[string]string
 	appRegistryInstaller          *appregistry.Installer
 	appRegistryPublish            *appregistry.StatelessPublishService
 	appRegistryPublishAllowedApps map[string]struct{}
@@ -526,7 +524,6 @@ func New(cfg Config) (*Server, error) {
 		adminRoute:                    adminRoute,
 		appRegistries:                 cloneAppRegistryConfig(cfg.AppRegistries),
 		appRegistryReader:             cfg.AppRegistryReader,
-		appRegistrySourceTreeURLs:     make(map[string]string),
 		appRegistryInstaller:          newAppRegistryInstaller(cfg),
 		appRegistryPublish:            cfg.AppRegistryPublish,
 		appRegistryPublishAllowedApps: cloneStringSet(cfg.AppRegistryPublishAllowedApps),

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -186,6 +186,8 @@ type Server struct {
 	adminRoute                    AdminRouteConfig
 	appRegistries                 map[string]config.AppRegistryConfig
 	appRegistryReader             *appregistry.RegistryReader
+	appRegistrySourceMu           sync.Mutex
+	appRegistrySourceTreeURLs     map[string]string
 	appRegistryInstaller          *appregistry.Installer
 	appRegistryPublish            *appregistry.StatelessPublishService
 	appRegistryPublishAllowedApps map[string]struct{}
@@ -524,6 +526,7 @@ func New(cfg Config) (*Server, error) {
 		adminRoute:                    adminRoute,
 		appRegistries:                 cloneAppRegistryConfig(cfg.AppRegistries),
 		appRegistryReader:             cfg.AppRegistryReader,
+		appRegistrySourceTreeURLs:     make(map[string]string),
 		appRegistryInstaller:          newAppRegistryInstaller(cfg),
 		appRegistryPublish:            cfg.AppRegistryPublish,
 		appRegistryPublishAllowedApps: cloneStringSet(cfg.AppRegistryPublishAllowedApps),


### PR DESCRIPTION
## Summary
- Return commit-pinned GitHub source folders for registry-managed apps in the catalog.
- Resolve source identity from the installed registry version and cache it per app/version without making catalog availability depend on registry metadata.
- Pass the registry reader through the runtime and cover the registry-only catalog path with tests.

## Test plan
- [x] `go test ./gestaltd/internal/appregistry ./gestaltd/internal/server`
- [x] `go test ./...` from `gestaltd` (one unrelated existing failure: Python SDK test requires Python >=3.10, host has 3.9.6)
- [x] `git diff --check`