### PR TITLE
Remove legacy Valon Tools chart readers

### DIFF
--- a/gestaltd/terraform/README.md
+++ b/gestaltd/terraform/README.md
@@ -14,10 +14,6 @@ It creates:
 - CI image publisher service account
 - Artifact Registry writer access for the publisher service account
 - Artifact Registry writer access for the CI image publisher service account
-- Artifact Registry reader access for configured `valon-tools` Terraform and
-  GitHub deploy service accounts
-- Artifact Registry reader access for the `valon-tools` GitHub Actions service
-  account that pulls pinned `gestaltd` CI images during Docker builds
 
 The release workflow consumes the `github_actions_variables` output. Copy those
 values into the `valon-technologies/gestalt` repository variables:
@@ -64,13 +60,6 @@ counterpart to the semver GitHub Release binaries, and the only SHA-addressed
 artifact carrying a native macOS binary (the CI and alpine images are
 linux-only). Consumers fetch them over plain public HTTPS by commit SHA, with no
 authentication.
-
-`valon-tools` environments should consume the chart repository location as input
-variables instead of creating their own per-environment chart repository.
-The `gestaltd_chart_reader_service_accounts` variable controls which
-environment Terraform and GitHub deploy service accounts can read the chart
-repository. By default this grants read access to the dev and stage
-`valon-tools` Terraform and GitHub deploy service accounts.
 
 ## Continuous Deployment
 

--- a/gestaltd/terraform/variables.tf
+++ b/gestaltd/terraform/variables.tf
@@ -36,14 +36,7 @@ variable "ci_binary_bucket_location" {
 variable "gestaltd_chart_reader_service_accounts" {
   description = "Service account emails allowed to read gestaltd Helm charts from Artifact Registry."
   type        = set(string)
-  default = [
-    "github-deploy-dev@valon-tools-dev.iam.gserviceaccount.com",
-    "github-deploy-stage@valon-tools-stage.iam.gserviceaccount.com",
-    "terraform-dev@valon-tools-dev.iam.gserviceaccount.com",
-    "terraform-stage@valon-tools-stage.iam.gserviceaccount.com",
-    "tools-dev-nodes@valon-tools-dev.iam.gserviceaccount.com",
-    "tools-stage-nodes@valon-tools-stage.iam.gserviceaccount.com",
-  ]
+  default     = []
 }
 
 variable "gestaltd_ci_image_reader_service_accounts" {


### PR DESCRIPTION
## Summary

- remove the retired valon-tools-dev chart reader service accounts
- remove the retired valon-tools-stage chart reader service accounts
- leave the chart reader allowlist empty now that no active deployment uses those identities
- delete stale README claims about default dev and stage reader grants, leaving the Terraform variable as the source of truth

Companion stack cleanup: https://github.com/valon-technologies/valon-tools/pull/592

## Validation

- terraform fmt -check -recursive gestaltd/terraform
- terraform validate
- git diff --check