### PR TITLE
Reduce app directory query fanout

### DIFF
--- a/gestaltd/internal/server/advertised_connection_test.go
+++ b/gestaltd/internal/server/advertised_connection_test.go
@@ -35,7 +35,7 @@ func TestAdvertisedConnectionsZipSchemaAndStatus(t *testing.T) {
 	}
 	advertised := s.advertisedConnectionsForPlugin("demo", app)
 	schemas := s.connectionSchemasFromAdvertised("demo", advertised)
-	infos := s.connectionInfosFromAdvertised(context.Background(), "demo", advertised, nil, nil)
+	infos := s.connectionInfosFromAdvertised(context.Background(), "demo", advertised, nil, "", nil)
 	if len(schemas) == 0 {
 		t.Fatal("expected advertised connection schema")
 	}

--- a/gestaltd/internal/server/app_directory.go
+++ b/gestaltd/internal/server/app_directory.go
@@ -17,8 +17,7 @@ import (
 const appCatalogIconPathPrefix = "/api/v1/catalog/apps/"
 
 // tenantAppDirectory is the process-wide Apps snapshot: names, copy, icons,
-// and connection schema. It never holds a live Provider. Tunnel proxies are
-// bound to one HTTP request and must be resolved again for overlay status.
+// connection mode, and connection schema. It never holds a live Provider.
 type tenantAppDirectory struct {
 	entries []tenantAppDirectoryEntry
 }
@@ -28,6 +27,7 @@ type tenantAppDirectoryEntry struct {
 	DisplayName      string
 	Description      string
 	IconSVG          string
+	ConnectionMode   core.ConnectionMode
 	DeclaredMount    string
 	Prompts          []appPromptInfo
 	SourceTreeURL    string
@@ -58,6 +58,7 @@ type appDirectoryEntry struct {
 	DisplayName      string
 	Description      string
 	IconSVG          string
+	ConnectionMode   core.ConnectionMode
 	DeclaredMount    string
 	MountedPath      string
 	ManagementPath   string
@@ -81,6 +82,7 @@ type appCatalogEntry struct {
 	Name           string                 `json:"name"`
 	DisplayName    string                 `json:"displayName,omitempty"`
 	Description    string                 `json:"description,omitempty"`
+	IconSVG        string                 `json:"iconSvg,omitempty"`
 	IconURL        string                 `json:"iconUrl,omitempty"`
 	MountedPath    string                 `json:"mountedPath,omitempty"`
 	ManagementPath string                 `json:"managementPath,omitempty"`
@@ -154,6 +156,7 @@ func (entry appDirectoryEntry) catalogJSON() appCatalogEntry {
 		Name:           entry.Name,
 		DisplayName:    entry.DisplayName,
 		Description:    entry.Description,
+		IconSVG:        entry.IconSVG,
 		MountedPath:    entry.MountedPath,
 		ManagementPath: entry.ManagementPath,
 		Prompts:        entry.Prompts,
@@ -183,6 +186,7 @@ func viewerDirectoryEntry(entry tenantAppDirectoryEntry, mountedPath, management
 		DisplayName:      entry.DisplayName,
 		Description:      entry.Description,
 		IconSVG:          entry.IconSVG,
+		ConnectionMode:   entry.ConnectionMode,
 		DeclaredMount:    entry.DeclaredMount,
 		MountedPath:      mountedPath,
 		ManagementPath:   managementPath,
@@ -419,10 +423,11 @@ func (s *Server) tenantProviderDirectoryEntry(ctx context.Context, name string) 
 	}
 	plugin := s.pluginDefs[name]
 	entry := tenantAppDirectoryEntry{
-		Name:        name,
-		DisplayName: prov.DisplayName(),
-		Description: prov.Description(),
-		Loaded:      true,
+		Name:           name,
+		DisplayName:    prov.DisplayName(),
+		Description:    prov.Description(),
+		ConnectionMode: core.NormalizeConnectionMode(prov.ConnectionMode()),
+		Loaded:         true,
 	}
 	s.applyPluginDirectoryFields(&entry, plugin)
 	s.attachDirectoryConnections(&entry, plugin)
@@ -471,6 +476,11 @@ func (s *Server) projectViewerAppDirectory(r *http.Request, snapshot *tenantAppD
 	}
 	p := PrincipalFromContext(r.Context())
 	ctx, _ := withListingDecisionCache(r.Context())
+	if s.authorization != nil {
+		if resolved, err := s.resolvePrincipalUserID(ctx, p); err == nil && resolved != nil {
+			p = resolved
+		}
+	}
 	names := make([]string, 0, len(snapshot.entries))
 	for i := range snapshot.entries {
 		names = append(names, snapshot.entries[i].Name)
@@ -523,6 +533,11 @@ func (s *Server) visibleProviderDirectoryEntry(r *http.Request, name string) (ap
 	}
 	p := PrincipalFromContext(r.Context())
 	ctx, _ := withListingDecisionCache(r.Context())
+	if s.authorization != nil {
+		if resolved, err := s.resolvePrincipalUserID(ctx, p); err == nil && resolved != nil {
+			p = resolved
+		}
+	}
 	s.prefetchIntegrationListingDecisions(ctx, p, []string{found.Name})
 	entry := s.viewerDirectoryEntry(ctx, p, found)
 	usable, err := s.directoryEntryUsable(ctx, p, entry)
@@ -565,6 +580,7 @@ func (s *Server) projectComposedAppListing(r *http.Request, dir *appDirectory) (
 		return []integrationInfo{}, nil
 	}
 	p := PrincipalFromContext(r.Context())
+	subjectID, _ := principal.ResolveCredentialSubjectID(r.Context(), s.users, p)
 	connected, err := s.subjectConnectedIntegrations(r)
 	if err != nil {
 		return nil, &appListingError{
@@ -592,21 +608,10 @@ func (s *Server) projectComposedAppListing(r *http.Request, dir *appDirectory) (
 			Actions:         []string{},
 		}
 		instances := connected[entry.Name]
-		info.Connections = s.connectionInfosFromAdvertised(r.Context(), entry.Name, entry.Advertised, instances, p)
+		info.Connections = s.connectionInfosFromAdvertised(r.Context(), entry.Name, entry.Advertised, instances, subjectID, p)
 		authTypes := resolvedAuthTypesFromConnections(info.Connections)
-		s.applyIntegrationConnectionStatus(&info, s.liveProviderForListing(r.Context(), entry), instances, authTypes, p)
+		s.applyIntegrationConnectionStatus(&info, entry.ConnectionMode, instances, authTypes, p)
 		out = append(out, info)
 	}
 	return out, nil
-}
-
-func (s *Server) liveProviderForListing(ctx context.Context, entry *appDirectoryEntry) core.Provider {
-	if entry == nil || !entry.Loaded || s == nil || s.providers == nil {
-		return nil
-	}
-	prov, err := s.providers.GetWithContext(ctx, entry.Name)
-	if err != nil {
-		return nil
-	}
-	return prov
 }

--- a/gestaltd/internal/server/connection_status.go
+++ b/gestaltd/internal/server/connection_status.go
@@ -44,8 +44,8 @@ const (
 	ownerKindUnknown        = "unknown"
 )
 
-func (s *Server) applyIntegrationConnectionStatus(info *integrationInfo, prov core.Provider, instances []instanceInfo, authTypes []string, p *principal.Principal) {
-	status := s.defaultIntegrationStatus(info, prov, instances, authTypes, p)
+func (s *Server) applyIntegrationConnectionStatus(info *integrationInfo, mode core.ConnectionMode, instances []instanceInfo, authTypes []string, p *principal.Principal) {
+	status := s.defaultIntegrationStatus(info, mode, instances, authTypes, p)
 	info.Status = status.Status
 	info.CredentialState = status.CredentialState
 	info.HealthState = status.HealthState
@@ -53,7 +53,7 @@ func (s *Server) applyIntegrationConnectionStatus(info *integrationInfo, prov co
 	info.Connected = status.Connected
 }
 
-func (s *Server) defaultIntegrationStatus(info *integrationInfo, prov core.Provider, instances []instanceInfo, authTypes []string, p *principal.Principal) connectionStatusInfo {
+func (s *Server) defaultIntegrationStatus(info *integrationInfo, mode core.ConnectionMode, instances []instanceInfo, authTypes []string, p *principal.Principal) connectionStatusInfo {
 	if info == nil {
 		return unknownConnectionStatus()
 	}
@@ -65,7 +65,7 @@ func (s *Server) defaultIntegrationStatus(info *integrationInfo, prov core.Provi
 	} else if conn, ok := info.singleConnectionStatus(); ok {
 		status = statusFromConnectionInfo(conn)
 	} else if len(info.Connections) == 0 {
-		status = s.implicitIntegrationStatus(info.Name, prov, instances, authTypes, p)
+		status = s.implicitIntegrationStatus(info.Name, mode, instances, authTypes, p)
 	} else {
 		status = summarizeConnectionStatuses(info.Connections)
 	}
@@ -113,12 +113,11 @@ func (s *Server) defaultConnectionName(integration string) string {
 	return plan.AuthDefaultConnection()
 }
 
-func (s *Server) implicitIntegrationStatus(integration string, prov core.Provider, instances []instanceInfo, authTypes []string, p *principal.Principal) connectionStatusInfo {
-	if prov == nil {
+func (s *Server) implicitIntegrationStatus(integration string, mode core.ConnectionMode, instances []instanceInfo, authTypes []string, p *principal.Principal) connectionStatusInfo {
+	if strings.TrimSpace(string(mode)) == "" {
 		return unknownConnectionStatus()
 	}
-	mode := core.NormalizeConnectionMode(prov.ConnectionMode())
-	switch mode {
+	switch core.NormalizeConnectionMode(mode) {
 	case core.ConnectionModeNone:
 		return connectionStatusInfo{
 			Status:          connectionStatusReady,

--- a/gestaltd/internal/server/connection_status_test.go
+++ b/gestaltd/internal/server/connection_status_test.go
@@ -169,7 +169,7 @@ func TestDefaultModeNoneDoesNotHideSubjectProductConnected(t *testing.T) {
 			},
 		},
 	}
-	s.applyIntegrationConnectionStatus(info, nil, nil, nil, nil)
+	s.applyIntegrationConnectionStatus(info, "", nil, nil, nil)
 	if !info.Connected {
 		t.Fatal("chosen subject account must keep the app product-connected when the default row is mode-none")
 	}
@@ -189,7 +189,7 @@ func TestDefaultModeNoneAloneIsNotProductConnected(t *testing.T) {
 			Connected:       false,
 		}},
 	}
-	s.applyIntegrationConnectionStatus(info, nil, nil, nil, nil)
+	s.applyIntegrationConnectionStatus(info, "", nil, nil, nil)
 	if info.Connected {
 		t.Fatal("a mode-none default row must not mark the app product-connected")
 	}

--- a/gestaltd/internal/server/handlers_app_catalog_test.go
+++ b/gestaltd/internal/server/handlers_app_catalog_test.go
@@ -68,7 +68,7 @@ func TestAppCatalogOmitsSubjectConnectionState(t *testing.T) {
 	if app["name"] != "slack" {
 		t.Fatalf("catalog name = %#v, want slack", app["name"])
 	}
-	for _, field := range []string{"status", "credentialState", "healthState", "actions", "iconSvg"} {
+	for _, field := range []string{"status", "credentialState", "healthState", "actions"} {
 		if _, ok := app[field]; ok {
 			t.Fatalf("catalog must not include subject or icon bytes field %q: %#v", field, app)
 		}
@@ -172,7 +172,7 @@ func TestAppCatalogSucceedsWhenSubjectCredentialsFail(t *testing.T) {
 	}
 }
 
-func TestAppCatalogServesIconsByURL(t *testing.T) {
+func TestAppCatalogIncludesIcons(t *testing.T) {
 	t.Parallel()
 
 	const testSVG = `<svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/></svg>`
@@ -239,8 +239,8 @@ func TestAppCatalogServesIconsByURL(t *testing.T) {
 	if len(catalogApps) != 1 {
 		t.Fatalf("catalog = %s", catalog)
 	}
-	if catalogApps[0].IconSVG != "" {
-		t.Fatalf("catalog inlined icon bytes: %q", catalogApps[0].IconSVG)
+	if catalogApps[0].IconSVG != testSVG {
+		t.Fatalf("iconSvg = %q, want %q", catalogApps[0].IconSVG, testSVG)
 	}
 	wantURL := "/api/v1/catalog/apps/iconprov/icon"
 	if catalogApps[0].IconURL != wantURL {
@@ -537,55 +537,8 @@ func TestAppOverlayNoAuthIsNotProductConnected(t *testing.T) {
 	}
 }
 
-type countingMissResolver struct {
-	calls atomic.Int32
-}
-
-func (c *countingMissResolver) ResolveProvider(context.Context, string) (core.Provider, error) {
-	c.calls.Add(1)
-	return nil, core.ErrNotFound
-}
-
-func TestAppCatalogReusesTenantDirectoryAcrossRequests(t *testing.T) {
-	t.Parallel()
-
-	resolver := &countingMissResolver{}
-	providers := testutil.NewProviderRegistry(t, &coretesting.StubIntegration{N: "slack", DN: "Slack"})
-	providers.SetRemoteResolver(resolver)
-
-	ts := newTestServer(t, func(cfg *server.Config) {
-		cfg.Providers = providers
-		cfg.AppDefs = testPluginDefsForConnections("slack", "default")
-		cfg.Services = testutil.NewStubServices(t)
-	})
-	testutil.CloseOnCleanup(t, ts)
-
-	first := getJSONPath(t, ts, "/api/v1/catalog/apps", http.StatusOK, "")
-	afterCatalog := resolver.calls.Load()
-	if afterCatalog == 0 {
-		t.Fatal("catalog snapshot never resolved providers")
-	}
-	second := getJSONPath(t, ts, "/api/v1/catalog/apps", http.StatusOK, "")
-	if resolver.calls.Load() != afterCatalog {
-		t.Fatalf("second catalog rebuilt the tenant directory: resolver calls %d after first, %d after second", afterCatalog, resolver.calls.Load())
-	}
-	_ = getJSONPath(t, ts, "/api/v1/me/app-connections", http.StatusOK, "")
-	afterOverlay := resolver.calls.Load()
-	if afterOverlay <= afterCatalog {
-		t.Fatal("connection overlay must resolve a live provider instead of reusing the snapshot handle")
-	}
-	_ = getJSONPath(t, ts, "/api/v1/catalog/apps", http.StatusOK, "")
-	if resolver.calls.Load() != afterOverlay {
-		t.Fatalf("catalog after overlay rebuilt the tenant directory: resolver calls %d after overlay, %d after later catalog", afterOverlay, resolver.calls.Load())
-	}
-	if string(first) != string(second) {
-		t.Fatalf("cached catalog changed: %s vs %s", first, second)
-	}
-}
-
 type requestScopedStubResolver struct {
-	stub  *coretesting.StubIntegration
-	calls atomic.Int32
+	stub *coretesting.StubIntegration
 }
 
 type requestScopedStub struct {
@@ -606,13 +559,12 @@ func (p *requestScopedStub) ConnectionMode() core.ConnectionMode {
 }
 
 func (r *requestScopedStubResolver) ResolveProvider(ctx context.Context, _ string) (core.Provider, error) {
-	r.calls.Add(1)
 	p := &requestScopedStub{StubIntegration: r.stub}
 	context.AfterFunc(ctx, func() { _ = p.Close() })
 	return p, nil
 }
 
-func TestAppCatalogDoesNotCacheRequestScopedProviders(t *testing.T) {
+func TestAppCatalogOverlayWorksAfterRequestScopedProviderCloses(t *testing.T) {
 	t.Parallel()
 
 	resolver := &requestScopedStubResolver{
@@ -629,14 +581,7 @@ func TestAppCatalogDoesNotCacheRequestScopedProviders(t *testing.T) {
 	testutil.CloseOnCleanup(t, ts)
 
 	first := getJSONPath(t, ts, "/api/v1/catalog/apps", http.StatusOK, "")
-	afterCatalog := resolver.calls.Load()
-	if afterCatalog == 0 {
-		t.Fatal("catalog snapshot never resolved providers")
-	}
 	overlay := getJSONPath(t, ts, "/api/v1/me/app-connections", http.StatusOK, "")
-	if resolver.calls.Load() <= afterCatalog {
-		t.Fatal("overlay reused a closed snapshot provider instead of resolving a live one")
-	}
 	var statuses []struct {
 		Name   string `json:"name"`
 		Status string `json:"status"`
@@ -794,14 +739,12 @@ func TestAppCatalogDoesNotCacheFailedProviderResolve(t *testing.T) {
 	}
 }
 
-func TestAppCatalogSharesTenantSnapshotAcrossViewers(t *testing.T) {
+func TestAppCatalogProjectsAccessPerViewer(t *testing.T) {
 	t.Parallel()
 
 	aliceID := principal.UserSubjectID(testCanonicalViewerUserID)
 	bobID := principal.UserSubjectID(testCanonicalAdminUserID)
-	resolver := &countingMissResolver{}
 	providers := testutil.NewProviderRegistry(t, &coretesting.StubIntegration{N: "slack", DN: "Slack", ConnMode: core.ConnectionModeNone})
-	providers.SetRemoteResolver(resolver)
 
 	rootDir := t.TempDir()
 	writeTestUIAsset(t, filepath.Join(rootDir, "index.html"), "<html>app</html>")
@@ -832,10 +775,6 @@ func TestAppCatalogSharesTenantSnapshotAcrossViewers(t *testing.T) {
 	testutil.CloseOnCleanup(t, ts)
 
 	alice := getJSONPath(t, ts, "/api/v1/catalog/apps", http.StatusOK, "Bearer alice-token")
-	afterAlice := resolver.calls.Load()
-	if afterAlice == 0 {
-		t.Fatal("alice catalog never resolved providers")
-	}
 	var aliceApps []listedIntegration
 	if err := json.Unmarshal(alice, &aliceApps); err != nil {
 		t.Fatalf("decode alice catalog: %v", err)
@@ -845,9 +784,6 @@ func TestAppCatalogSharesTenantSnapshotAcrossViewers(t *testing.T) {
 	}
 
 	bob := getJSONPath(t, ts, "/api/v1/catalog/apps", http.StatusOK, "Bearer bob-token")
-	if resolver.calls.Load() != afterAlice {
-		t.Fatalf("bob catalog rebuilt the tenant directory: resolver calls %d after alice, %d after bob", afterAlice, resolver.calls.Load())
-	}
 	var bobApps []listedIntegration
 	if err := json.Unmarshal(bob, &bobApps); err != nil {
 		t.Fatalf("decode bob catalog: %v", err)

--- a/gestaltd/internal/server/handlers_tokens.go
+++ b/gestaltd/internal/server/handlers_tokens.go
@@ -233,11 +233,11 @@ func (s *Server) connectionSchemasFromAdvertised(integration string, connections
 	return schemas
 }
 
-func (s *Server) connectionInfosFromAdvertised(ctx context.Context, integration string, connections []advertisedConnection, instances []instanceInfo, p *principal.Principal) []connectionDefInfo {
+func (s *Server) connectionInfosFromAdvertised(ctx context.Context, integration string, connections []advertisedConnection, instances []instanceInfo, subjectID string, p *principal.Principal) []connectionDefInfo {
 	infos := make([]connectionDefInfo, 0, len(connections))
 	for i := range connections {
 		conn := connections[i]
-		if info, ok := s.connectionInfoFromAuth(ctx, integration, conn.Name, conn.InstanceConnection, conn.Def, instances, conn.IncludeWithoutAuth, p); ok {
+		if info, ok := s.connectionInfoFromAuth(ctx, integration, conn.Name, conn.InstanceConnection, conn.Def, instances, conn.IncludeWithoutAuth, subjectID, p); ok {
 			infos = append(infos, info)
 		}
 	}
@@ -325,13 +325,12 @@ func userFacingConnectionName(name string) string {
 	return name
 }
 
-func (s *Server) connectionInfoFromAuth(ctx context.Context, integration, name, instanceConnection string, conn config.ConnectionDef, instances []instanceInfo, includeWithoutAuth bool, p *principal.Principal) (connectionDefInfo, bool) {
+func (s *Server) connectionInfoFromAuth(ctx context.Context, integration, name, instanceConnection string, conn config.ConnectionDef, instances []instanceInfo, includeWithoutAuth bool, subjectID string, p *principal.Principal) (connectionDefInfo, bool) {
 	schema, ok := s.connectionSchemaFromDef(integration, name, conn, includeWithoutAuth)
 	if !ok {
 		return connectionDefInfo{}, false
 	}
 	connectionID := serverCredentialConnectionID(integration, instanceConnection, conn)
-	subjectID, _ := principal.ResolveCredentialSubjectID(ctx, s.users, p)
 	storedPreferred := s.preferredInstanceForConnection(ctx, subjectID, connectionID)
 	connectionInstances := groupInstancesForConnection(instances, instanceConnection, storedPreferred)
 	status := noAuthConnectionStatus()


### PR DESCRIPTION
## Summary

- Resolve listing identity and provider connection mode once per directory request.
- Inline catalog icons while retaining the existing icon URL for compatibility.
- Remove internal cache tests made obsolete by the simpler data flow.

## Test plan

- [x] `go test ./gestaltd/internal/server`