### PR TITLE
Separate live fleet health from rollout history

### DIFF
--- a/gestaltd/core/types.go
+++ b/gestaltd/core/types.go
@@ -199,12 +199,21 @@ type AppAutoDeploySettings struct {
 	App                 string
 	Enabled             bool
 	Paused              bool
-	PauseReason         string
+	PauseReason         AppAutoDeployPauseReason
 	PendingVersion      string
 	LastSeenVersion     string
 	LastError           string
 	LastFailedRolloutAt time.Time
 }
+
+// AppAutoDeployPauseReason identifies why the controller stopped automatic
+// admissions. It is intentionally separate from the user-controlled Enabled
+// setting.
+type AppAutoDeployPauseReason string
+
+const (
+	AppAutoDeployPauseReasonRolloutFailed AppAutoDeployPauseReason = "rollout_failed"
+)
 
 type AppVersionRolloutOutcome struct {
 	ID          string

--- a/gestaltd/core/types.go
+++ b/gestaltd/core/types.go
@@ -113,6 +113,7 @@ type AppFleetReplicaClass string
 
 const (
 	AppFleetReplicaClassOnDesired  AppFleetReplicaClass = "on_desired"
+	AppFleetReplicaClassNotRunning AppFleetReplicaClass = "not_running"
 	AppFleetReplicaClassMismatched AppFleetReplicaClass = "mismatched"
 	AppFleetReplicaClassError      AppFleetReplicaClass = "error"
 )
@@ -141,6 +142,7 @@ type AppFleetProjection struct {
 	MinimumHealthyInstances int
 	LiveInstances           int
 	RunningDesiredVersion   int
+	NotRunning              int
 	Mismatched              int
 	Errors                  int
 	HeartbeatTTL            time.Duration
@@ -168,6 +170,7 @@ type AppRolloutFailureSummary struct {
 	LiveInstances           int       `json:"live_instances"`
 	MinimumHealthyInstances int       `json:"minimum_healthy_instances"`
 	RunningDesiredVersion   int       `json:"running_desired_version"`
+	NotRunning              int       `json:"not_running"`
 	Mismatched              int       `json:"mismatched"`
 	Errors                  int       `json:"errors"`
 	SourceVersion           string    `json:"source_version"`
@@ -195,6 +198,8 @@ type AppRollout struct {
 type AppAutoDeploySettings struct {
 	App                 string
 	Enabled             bool
+	Paused              bool
+	PauseReason         string
 	PendingVersion      string
 	LastSeenVersion     string
 	LastError           string

--- a/gestaltd/internal/appregistry/autodeploy/controller.go
+++ b/gestaltd/internal/appregistry/autodeploy/controller.go
@@ -240,7 +240,7 @@ func (c *Controller) Reconcile(ctx context.Context, appName string) error {
 		if len(versions) > 0 {
 			newest := versions[0].Version
 			settings, err = c.Settings.Update(ctx, appName, func(current *core.AppAutoDeploySettings) error {
-				if !current.Enabled {
+				if !current.Enabled || current.Paused {
 					return nil
 				}
 				if current.LastSeenVersion != newest {

--- a/gestaltd/internal/appregistry/autodeploy/controller.go
+++ b/gestaltd/internal/appregistry/autodeploy/controller.go
@@ -188,7 +188,7 @@ func (c *Controller) Reconcile(ctx context.Context, appName string) error {
 		return err
 	}
 	if !settings.Enabled {
-		return c.repairLegacyPause(ctx, settings, rollout)
+		return nil
 	}
 	if settings.Paused {
 		return nil
@@ -211,7 +211,7 @@ func (c *Controller) Reconcile(ctx context.Context, appName string) error {
 				} else {
 					current.Paused = true
 					current.PauseReason = "rollout_failed"
-					current.LastError = fmt.Sprintf("rollout for %s failed", rollout.Version)
+					current.LastError = fmt.Sprintf("automatic deployment paused after rollout for %s failed; retry the version to resume", rollout.Version)
 				}
 				return nil
 			})
@@ -329,8 +329,11 @@ func (c *Controller) validate() error {
 }
 
 func (c *Controller) failedRolloutIsHealthy(ctx context.Context, app string, rollout *core.AppRollout) (bool, error) {
-	if c.Fleet == nil || rollout == nil {
-		return false, nil
+	if rollout == nil {
+		return false, fmt.Errorf("check failed rollout health: rollout is required")
+	}
+	if c.Fleet == nil {
+		return false, fmt.Errorf("check failed rollout health: fleet health reader is not configured")
 	}
 	projection, err := c.Fleet.Project(ctx, app)
 	if err != nil {
@@ -338,25 +341,6 @@ func (c *Controller) failedRolloutIsHealthy(ctx context.Context, app string, rol
 	}
 	return projection != nil && projection.State == core.AppFleetStateHealthy &&
 		strings.TrimSpace(projection.DesiredVersion) == strings.TrimSpace(rollout.Version), nil
-}
-
-func (c *Controller) repairLegacyPause(ctx context.Context, settings *core.AppAutoDeploySettings, rollout *core.AppRollout) error {
-	if settings == nil || rollout == nil || rollout.State != core.AppRolloutStateFailed || c.Fleet == nil ||
-		!strings.HasPrefix(settings.LastError, "rollout for ") {
-		return nil
-	}
-	healthy, err := c.failedRolloutIsHealthy(ctx, settings.App, rollout)
-	if err != nil || !healthy {
-		return err
-	}
-	_, err = c.Settings.Update(ctx, settings.App, func(current *core.AppAutoDeploySettings) error {
-		current.Enabled = true
-		current.Paused = false
-		current.PauseReason = ""
-		current.LastError = ""
-		return nil
-	})
-	return err
 }
 
 func isCandidateRejection(err error) bool {

--- a/gestaltd/internal/appregistry/autodeploy/controller.go
+++ b/gestaltd/internal/appregistry/autodeploy/controller.go
@@ -30,7 +30,7 @@ type Installer interface {
 }
 
 type FleetHealthReader interface {
-	Project(ctx context.Context, app string) (*core.AppFleetProjection, error)
+	ProjectForRollout(ctx context.Context, rollout *core.AppRollout) (*core.AppFleetProjection, error)
 }
 
 type Controller struct {
@@ -57,6 +57,7 @@ func New(
 	changeRequests *coredata.AppVersionChangeRequestService,
 	reader RegistryReader,
 	installer Installer,
+	fleet FleetHealthReader,
 	apps map[string]AppConfig,
 	interval time.Duration,
 ) *Controller {
@@ -72,6 +73,7 @@ func New(
 		ChangeRequests: changeRequests,
 		Reader:         reader,
 		Installer:      installer,
+		Fleet:          fleet,
 		Apps:           cloneApps(apps),
 		Interval:       interval,
 		done:           make(chan struct{}),
@@ -210,7 +212,7 @@ func (c *Controller) Reconcile(ctx context.Context, appName string) error {
 					current.LastError = ""
 				} else {
 					current.Paused = true
-					current.PauseReason = "rollout_failed"
+					current.PauseReason = core.AppAutoDeployPauseReasonRolloutFailed
 					current.LastError = fmt.Sprintf("automatic deployment paused after rollout for %s failed; retry the version to resume", rollout.Version)
 				}
 				return nil
@@ -322,7 +324,7 @@ func (c *Controller) Reconcile(ctx context.Context, appName string) error {
 
 func (c *Controller) validate() error {
 	if c == nil || c.Settings == nil || c.Rollouts == nil || c.ChangeRequests == nil ||
-		c.Reader == nil || c.Installer == nil {
+		c.Reader == nil || c.Installer == nil || c.Fleet == nil {
 		return fmt.Errorf("auto-deploy controller is not configured")
 	}
 	return nil
@@ -335,7 +337,7 @@ func (c *Controller) failedRolloutIsHealthy(ctx context.Context, app string, rol
 	if c.Fleet == nil {
 		return false, fmt.Errorf("check failed rollout health: fleet health reader is not configured")
 	}
-	projection, err := c.Fleet.Project(ctx, app)
+	projection, err := c.Fleet.ProjectForRollout(ctx, rollout)
 	if err != nil {
 		return false, fmt.Errorf("check failed rollout health for %s: %w", app, err)
 	}

--- a/gestaltd/internal/appregistry/autodeploy/controller.go
+++ b/gestaltd/internal/appregistry/autodeploy/controller.go
@@ -202,7 +202,7 @@ func (c *Controller) Reconcile(ctx context.Context, appName string) error {
 			if healthErr != nil {
 				return healthErr
 			}
-			_, updateErr := c.Settings.Update(ctx, appName, func(current *core.AppAutoDeploySettings) error {
+			_, _, updateErr := c.Settings.UpdateForRollout(ctx, rollout, func(current *core.AppAutoDeploySettings) error {
 				current.PendingVersion = ""
 				current.LastSeenVersion = ""
 				current.LastFailedRolloutAt = failedAt
@@ -213,7 +213,7 @@ func (c *Controller) Reconcile(ctx context.Context, appName string) error {
 				} else {
 					current.Paused = true
 					current.PauseReason = core.AppAutoDeployPauseReasonRolloutFailed
-					current.LastError = fmt.Sprintf("automatic deployment paused after rollout for %s failed; retry the version to resume", rollout.Version)
+					current.LastError = fmt.Sprintf("Automatic deployment is paused because rollout of version %s failed. Select that version again to retry.", rollout.Version)
 				}
 				return nil
 			})

--- a/gestaltd/internal/appregistry/autodeploy/controller.go
+++ b/gestaltd/internal/appregistry/autodeploy/controller.go
@@ -29,12 +29,17 @@ type Installer interface {
 	Select(ctx context.Context, input appregistry.InstallInput) (*appregistry.InstallOutput, error)
 }
 
+type FleetHealthReader interface {
+	Project(ctx context.Context, app string) (*core.AppFleetProjection, error)
+}
+
 type Controller struct {
 	Settings       *coredata.AutoDeploySettingsService
 	Rollouts       *coredata.AppRolloutService
 	ChangeRequests *coredata.AppVersionChangeRequestService
 	Reader         RegistryReader
 	Installer      Installer
+	Fleet          FleetHealthReader
 	Apps           map[string]AppConfig
 	Interval       time.Duration
 
@@ -146,7 +151,7 @@ func (c *Controller) ReconcileAll(ctx context.Context) error {
 	if err := c.validate(); err != nil {
 		return err
 	}
-	settings, err := c.Settings.ListEnabled(ctx)
+	settings, err := c.Settings.ListAll(ctx)
 	if err != nil {
 		return err
 	}
@@ -178,23 +183,36 @@ func (c *Controller) Reconcile(ctx context.Context, appName string) error {
 	if err != nil {
 		return err
 	}
-	if !settings.Enabled {
-		return nil
-	}
-
 	rollout, err := c.Rollouts.Get(ctx, appName)
 	if err != nil && !errors.Is(err, core.ErrNotFound) {
 		return err
 	}
+	if !settings.Enabled {
+		return c.repairLegacyPause(ctx, settings, rollout)
+	}
+	if settings.Paused {
+		return nil
+	}
 	if rollout != nil && rollout.State == core.AppRolloutStateFailed {
 		failedAt := rollout.FailedAt.UTC().Truncate(time.Millisecond)
 		if settings.LastFailedRolloutAt.Before(failedAt) {
+			healthy, healthErr := c.failedRolloutIsHealthy(ctx, appName, rollout)
+			if healthErr != nil {
+				return healthErr
+			}
 			_, updateErr := c.Settings.Update(ctx, appName, func(current *core.AppAutoDeploySettings) error {
-				current.Enabled = false
 				current.PendingVersion = ""
 				current.LastSeenVersion = ""
-				current.LastError = fmt.Sprintf("rollout for %s failed", rollout.Version)
 				current.LastFailedRolloutAt = failedAt
+				if healthy {
+					current.Paused = false
+					current.PauseReason = ""
+					current.LastError = ""
+				} else {
+					current.Paused = true
+					current.PauseReason = "rollout_failed"
+					current.LastError = fmt.Sprintf("rollout for %s failed", rollout.Version)
+				}
 				return nil
 			})
 			return updateErr
@@ -237,6 +255,9 @@ func (c *Controller) Reconcile(ctx context.Context, appName string) error {
 	}
 
 	if !settings.Enabled {
+		return nil
+	}
+	if settings.Paused {
 		return nil
 	}
 	if rollout != nil && (rollout.State == core.AppRolloutStateEnrolling || rollout.State == core.AppRolloutStateRestarting) {
@@ -305,6 +326,37 @@ func (c *Controller) validate() error {
 		return fmt.Errorf("auto-deploy controller is not configured")
 	}
 	return nil
+}
+
+func (c *Controller) failedRolloutIsHealthy(ctx context.Context, app string, rollout *core.AppRollout) (bool, error) {
+	if c.Fleet == nil || rollout == nil {
+		return false, nil
+	}
+	projection, err := c.Fleet.Project(ctx, app)
+	if err != nil {
+		return false, fmt.Errorf("check failed rollout health for %s: %w", app, err)
+	}
+	return projection != nil && projection.State == core.AppFleetStateHealthy &&
+		strings.TrimSpace(projection.DesiredVersion) == strings.TrimSpace(rollout.Version), nil
+}
+
+func (c *Controller) repairLegacyPause(ctx context.Context, settings *core.AppAutoDeploySettings, rollout *core.AppRollout) error {
+	if settings == nil || rollout == nil || rollout.State != core.AppRolloutStateFailed || c.Fleet == nil ||
+		!strings.HasPrefix(settings.LastError, "rollout for ") {
+		return nil
+	}
+	healthy, err := c.failedRolloutIsHealthy(ctx, settings.App, rollout)
+	if err != nil || !healthy {
+		return err
+	}
+	_, err = c.Settings.Update(ctx, settings.App, func(current *core.AppAutoDeploySettings) error {
+		current.Enabled = true
+		current.Paused = false
+		current.PauseReason = ""
+		current.LastError = ""
+		return nil
+	})
+	return err
 }
 
 func isCandidateRejection(err error) bool {

--- a/gestaltd/internal/appregistry/autodeploy/controller_test.go
+++ b/gestaltd/internal/appregistry/autodeploy/controller_test.go
@@ -181,13 +181,16 @@ func TestControllerDisablesOnFailedRollout(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Get settings: %v", err)
 	}
-	if settings.Enabled || settings.PendingVersion != "" || settings.LastSeenVersion != "" ||
-		settings.LastError == "" || !settings.LastFailedRolloutAt.Equal(start.Add(15*time.Minute)) {
+	if !settings.Enabled || !settings.Paused || settings.PauseReason != "rollout_failed" ||
+		settings.PendingVersion != "" || settings.LastSeenVersion != "" || settings.LastError == "" ||
+		!settings.LastFailedRolloutAt.Equal(start.Add(15*time.Minute)) {
 		t.Fatalf("settings = %#v", settings)
 	}
 
 	if _, err := services.AutoDeploySettings.Update(t.Context(), "g-issues", func(current *core.AppAutoDeploySettings) error {
 		current.Enabled = true
+		current.Paused = false
+		current.PauseReason = ""
 		current.LastError = ""
 		return nil
 	}); err != nil {
@@ -200,8 +203,93 @@ func TestControllerDisablesOnFailedRollout(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Get re-enabled settings: %v", err)
 	}
-	if !settings.Enabled || len(installer.inputs) != 1 || installer.inputs[0].Version != "v2" {
+	if !settings.Enabled || settings.Paused || len(installer.inputs) != 1 || installer.inputs[0].Version != "v2" {
 		t.Fatalf("re-enabled settings = %#v, inputs = %#v", settings, installer.inputs)
+	}
+}
+
+func TestControllerDoesNotPauseHealthyFailedRollout(t *testing.T) {
+	t.Parallel()
+
+	services := testutil.NewStubServices(t)
+	enableAutoDeploy(t, services, "g-issues")
+	start := time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)
+	rollout, err := services.AppRollouts.Create(t.Context(), &core.AppRollout{
+		App:              "g-issues",
+		Version:          "v1",
+		State:            core.AppRolloutStateEnrolling,
+		CreatedAt:        start,
+		EnrollmentEndsAt: start.Add(time.Minute),
+		Deadline:         start.Add(15 * time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("Create rollout: %v", err)
+	}
+	if _, err := services.AppRollouts.MarkFailedForRollout(t.Context(), rollout, start.Add(15*time.Minute)); err != nil {
+		t.Fatalf("MarkFailed: %v", err)
+	}
+	reader := &fakeReader{results: []*appregistry.AppIndexFetchResult{{Index: testIndex("g-issues", "v1")}}}
+	controller := testController(services, reader, &fakeInstaller{})
+	controller.Fleet = fakeFleetHealthReader{projection: &core.AppFleetProjection{
+		State:          core.AppFleetStateHealthy,
+		DesiredVersion: "v1",
+	}}
+
+	if err := controller.Reconcile(t.Context(), "g-issues"); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	settings, err := services.AutoDeploySettings.Get(t.Context(), "g-issues")
+	if err != nil {
+		t.Fatalf("Get settings: %v", err)
+	}
+	if !settings.Enabled || settings.Paused || settings.LastError != "" ||
+		!settings.LastFailedRolloutAt.Equal(start.Add(15*time.Minute)) {
+		t.Fatalf("settings = %#v", settings)
+	}
+}
+
+func TestControllerRepairsLegacyDisabledHealthyRollout(t *testing.T) {
+	t.Parallel()
+
+	services := testutil.NewStubServices(t)
+	start := time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)
+	rollout, err := services.AppRollouts.Create(t.Context(), &core.AppRollout{
+		App:              "g-issues",
+		Version:          "v1",
+		State:            core.AppRolloutStateEnrolling,
+		CreatedAt:        start,
+		EnrollmentEndsAt: start.Add(time.Minute),
+		Deadline:         start.Add(15 * time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("Create rollout: %v", err)
+	}
+	failedAt := start.Add(15 * time.Minute)
+	if _, err := services.AppRollouts.MarkFailedForRollout(t.Context(), rollout, failedAt); err != nil {
+		t.Fatalf("MarkFailed: %v", err)
+	}
+	if _, err := services.AutoDeploySettings.Update(t.Context(), "g-issues", func(settings *core.AppAutoDeploySettings) error {
+		settings.LastError = "rollout for v1 failed"
+		settings.LastFailedRolloutAt = failedAt
+		return nil
+	}); err != nil {
+		t.Fatalf("seed legacy settings: %v", err)
+	}
+	controller := testController(services, &fakeReader{}, &fakeInstaller{})
+	controller.Fleet = fakeFleetHealthReader{projection: &core.AppFleetProjection{
+		State:          core.AppFleetStateHealthy,
+		DesiredVersion: "v1",
+	}}
+
+	if err := controller.ReconcileAll(t.Context()); err != nil {
+		t.Fatalf("ReconcileAll: %v", err)
+	}
+	settings, err := services.AutoDeploySettings.Get(t.Context(), "g-issues")
+	if err != nil {
+		t.Fatalf("Get settings: %v", err)
+	}
+	if !settings.Enabled || settings.Paused || settings.LastError != "" {
+		t.Fatalf("repaired settings = %#v", settings)
 	}
 }
 
@@ -272,6 +360,15 @@ func (r *fakeReader) FetchAppIndexConditional(
 type fakeInstaller struct {
 	inputs []appregistry.InstallInput
 	errs   []error
+}
+
+type fakeFleetHealthReader struct {
+	projection *core.AppFleetProjection
+	err        error
+}
+
+func (f fakeFleetHealthReader) Project(context.Context, string) (*core.AppFleetProjection, error) {
+	return f.projection, f.err
 }
 
 func (i *fakeInstaller) Select(_ context.Context, input appregistry.InstallInput) (*appregistry.InstallOutput, error) {

--- a/gestaltd/internal/appregistry/autodeploy/controller_test.go
+++ b/gestaltd/internal/appregistry/autodeploy/controller_test.go
@@ -147,7 +147,7 @@ func TestControllerCoalescesDuringActiveRollout(t *testing.T) {
 	}
 }
 
-func TestControllerDisablesOnFailedRollout(t *testing.T) {
+func TestControllerPausesOnFailedRollout(t *testing.T) {
 	t.Parallel()
 
 	services := testutil.NewStubServices(t)

--- a/gestaltd/internal/appregistry/autodeploy/controller_test.go
+++ b/gestaltd/internal/appregistry/autodeploy/controller_test.go
@@ -173,6 +173,10 @@ func TestControllerDisablesOnFailedRollout(t *testing.T) {
 	}}
 	installer := &fakeInstaller{}
 	controller := testController(services, reader, installer)
+	controller.Fleet = fakeFleetHealthReader{projection: &core.AppFleetProjection{
+		State:          core.AppFleetStateDegraded,
+		DesiredVersion: "v1",
+	}}
 
 	if err := controller.Reconcile(t.Context(), "g-issues"); err != nil {
 		t.Fatalf("Reconcile: %v", err)
@@ -248,7 +252,7 @@ func TestControllerDoesNotPauseHealthyFailedRollout(t *testing.T) {
 	}
 }
 
-func TestControllerRepairsLegacyDisabledHealthyRollout(t *testing.T) {
+func TestControllerPreservesExplicitlyDisabledAutoDeploy(t *testing.T) {
 	t.Parallel()
 
 	services := testutil.NewStubServices(t)
@@ -276,11 +280,6 @@ func TestControllerRepairsLegacyDisabledHealthyRollout(t *testing.T) {
 		t.Fatalf("seed legacy settings: %v", err)
 	}
 	controller := testController(services, &fakeReader{}, &fakeInstaller{})
-	controller.Fleet = fakeFleetHealthReader{projection: &core.AppFleetProjection{
-		State:          core.AppFleetStateHealthy,
-		DesiredVersion: "v1",
-	}}
-
 	if err := controller.ReconcileAll(t.Context()); err != nil {
 		t.Fatalf("ReconcileAll: %v", err)
 	}
@@ -288,8 +287,8 @@ func TestControllerRepairsLegacyDisabledHealthyRollout(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Get settings: %v", err)
 	}
-	if !settings.Enabled || settings.Paused || settings.LastError != "" {
-		t.Fatalf("repaired settings = %#v", settings)
+	if settings.Enabled || settings.Paused || settings.LastError != "rollout for v1 failed" {
+		t.Fatalf("preserved settings = %#v", settings)
 	}
 }
 

--- a/gestaltd/internal/appregistry/autodeploy/controller_test.go
+++ b/gestaltd/internal/appregistry/autodeploy/controller_test.go
@@ -366,7 +366,7 @@ type fakeFleetHealthReader struct {
 	err        error
 }
 
-func (f fakeFleetHealthReader) Project(context.Context, string) (*core.AppFleetProjection, error) {
+func (f fakeFleetHealthReader) ProjectForRollout(context.Context, *core.AppRollout) (*core.AppFleetProjection, error) {
 	return f.projection, f.err
 }
 
@@ -386,6 +386,7 @@ func testController(services *testutil.Services, reader RegistryReader, installe
 		services.AppVersionChangeRequests,
 		reader,
 		installer,
+		fakeFleetHealthReader{},
 		map[string]AppConfig{
 			"g-issues": {Registry: "toolshed", PublicRoot: "https://registry.test"},
 		},

--- a/gestaltd/internal/appregistry/errors.go
+++ b/gestaltd/internal/appregistry/errors.go
@@ -8,6 +8,10 @@ var ErrInstallVersionLocked = errors.New("app rollout admission already in progr
 // ErrAppRolloutActive means the app already has an enrolling or restarting rollout.
 var ErrAppRolloutActive = errors.New("app already has an active rollout")
 
+// ErrAppRolloutRetryNotAllowed means retry was requested without a matching
+// terminal failed rollout for the current desired version.
+var ErrAppRolloutRetryNotAllowed = errors.New("app rollout retry is not allowed")
+
 // ErrAppVersionAlreadyInstalled means the requested app version is already in the catalog.
 var ErrAppVersionAlreadyInstalled = errors.New("app version is already installed")
 

--- a/gestaltd/internal/appregistry/fleet_state.go
+++ b/gestaltd/internal/appregistry/fleet_state.go
@@ -103,6 +103,53 @@ func (p *FleetProjector) Project(ctx context.Context, app string) (*core.AppFlee
 	return &projection, nil
 }
 
+// ProjectForRollout evaluates the fleet using the rollout's admission
+// snapshot. A terminal rollout must not be judged using a later source or
+// capacity change, because that would answer a different rollout's question.
+func (p *FleetProjector) ProjectForRollout(ctx context.Context, rollout *core.AppRollout) (*core.AppFleetProjection, error) {
+	if p == nil || p.Heartbeats == nil {
+		return nil, fmt.Errorf("fleet projector is not configured")
+	}
+	if rollout == nil {
+		return nil, fmt.Errorf("fleet projector: rollout is required")
+	}
+	app := strings.TrimSpace(rollout.App)
+	if app == "" {
+		return nil, fmt.Errorf("fleet projector: rollout app is required")
+	}
+	// Enrollment rollouts predate the heartbeat snapshot fields. Preserve
+	// their existing current-fleet behavior; heartbeat rollouts have the
+	// explicit inputs needed for an exact historical evaluation.
+	if rollout.Mode != core.AppRolloutModeHeartbeat ||
+		strings.TrimSpace(rollout.TargetSourceVersion) == "" || rollout.MinimumHealthyInstances <= 0 {
+		return p.Project(ctx, app)
+	}
+	now := p.now()
+	ttl := p.HeartbeatTTL
+	if ttl <= 0 {
+		return nil, fmt.Errorf("fleet projector: heartbeat TTL must be positive")
+	}
+	heartbeats, err := p.Heartbeats.ListFreshBySourceVersion(
+		ctx,
+		rollout.TargetSourceVersion,
+		now.Add(-ttl),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("project rollout fleet: load fresh heartbeats: %w", err)
+	}
+	projection := EvaluateFleetState(FleetEvaluation{
+		App:                     app,
+		DesiredVersion:          rollout.Version,
+		SourceVersion:           rollout.TargetSourceVersion,
+		MinimumHealthyInstances: rollout.MinimumHealthyInstances,
+		Cutoff:                  now.Add(-ttl),
+		EvaluatedAt:             now,
+		Heartbeats:              heartbeats,
+	})
+	projection.HeartbeatTTL = ttl
+	return &projection, nil
+}
+
 type FleetEvaluation struct {
 	App                     string
 	DesiredVersion          string

--- a/gestaltd/internal/appregistry/fleet_state.go
+++ b/gestaltd/internal/appregistry/fleet_state.go
@@ -171,6 +171,12 @@ func EvaluateFleetState(input FleetEvaluation) core.AppFleetProjection {
 		case core.GestaltdInstanceAppStateError, core.GestaltdInstanceAppStateUnknown:
 			replica.Class = core.AppFleetReplicaClassError
 			projection.Errors++
+		case core.GestaltdInstanceAppStateStarting, core.GestaltdInstanceAppStateNotRunning:
+			// A live host can exist without a running provider, especially for
+			// low-traffic Cloud Run apps. This is neutral fleet evidence: it is
+			// neither proof of the desired version nor evidence of an old one.
+			replica.Class = core.AppFleetReplicaClassNotRunning
+			projection.NotRunning++
 		default:
 			replica.Class = core.AppFleetReplicaClassMismatched
 			projection.Mismatched++
@@ -183,7 +189,8 @@ func EvaluateFleetState(input FleetEvaluation) core.AppFleetProjection {
 	switch {
 	case !validBasis || projection.LiveInstances < input.MinimumHealthyInstances:
 		projection.State = core.AppFleetStateUnknown
-	case projection.RunningDesiredVersion == projection.LiveInstances:
+	case projection.RunningDesiredVersion >= input.MinimumHealthyInstances &&
+		projection.Mismatched == 0 && projection.Errors == 0:
 		projection.State = core.AppFleetStateHealthy
 	default:
 		projection.State = core.AppFleetStateDegraded

--- a/gestaltd/internal/appregistry/fleet_state_test.go
+++ b/gestaltd/internal/appregistry/fleet_state_test.go
@@ -1,11 +1,55 @@
 package appregistry
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/valon-technologies/gestalt/server/core"
 )
+
+type rolloutProjectionHeartbeats struct {
+	source     string
+	heartbeats []*core.GestaltdInstanceHeartbeat
+}
+
+func (r rolloutProjectionHeartbeats) ListFreshBySourceVersion(_ context.Context, source string, _ time.Time) ([]*core.GestaltdInstanceHeartbeat, error) {
+	if source != r.source {
+		return nil, nil
+	}
+	return r.heartbeats, nil
+}
+
+func TestFleetProjectorProjectForRolloutUsesRolloutSnapshot(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+	projector := &FleetProjector{
+		Heartbeats: rolloutProjectionHeartbeats{
+			source: "source-old",
+			heartbeats: []*core.GestaltdInstanceHeartbeat{
+				heartbeatForFleet("one", "source-old", now, map[string]core.GestaltdInstanceAppHeartbeat{
+					"app": {State: core.GestaltdInstanceAppStateRunning, RunningVersion: "v1"},
+				}),
+			},
+		},
+		HeartbeatTTL: time.Minute,
+		Now:          func() time.Time { return now },
+	}
+	projection, err := projector.ProjectForRollout(context.Background(), &core.AppRollout{
+		App:                     "app",
+		Version:                 "v1",
+		Mode:                    core.AppRolloutModeHeartbeat,
+		TargetSourceVersion:     "source-old",
+		MinimumHealthyInstances: 1,
+	})
+	if err != nil {
+		t.Fatalf("ProjectForRollout: %v", err)
+	}
+	if projection.State != core.AppFleetStateHealthy ||
+		projection.SourceVersion != "source-old" || projection.DesiredVersion != "v1" {
+		t.Fatalf("projection = %#v", projection)
+	}
+}
 
 func TestEvaluateFleetState(t *testing.T) {
 	t.Parallel()

--- a/gestaltd/internal/appregistry/fleet_state_test.go
+++ b/gestaltd/internal/appregistry/fleet_state_test.go
@@ -142,6 +142,34 @@ func TestEvaluateFleetState(t *testing.T) {
 			wantIdle:  1,
 		},
 		{
+			name:    "starting replica is neutral while desired capacity is met",
+			minimum: 1,
+			heartbeats: []*core.GestaltdInstanceHeartbeat{
+				healthy("one", now),
+				heartbeatForFleet("starting", "source", now, map[string]core.GestaltdInstanceAppHeartbeat{
+					"app": {State: core.GestaltdInstanceAppStateStarting},
+				}),
+			},
+			wantState: core.AppFleetStateHealthy,
+			wantLive:  2,
+			wantRun:   1,
+			wantIdle:  1,
+		},
+		{
+			name:    "live capacity below running desired minimum is degraded",
+			minimum: 2,
+			heartbeats: []*core.GestaltdInstanceHeartbeat{
+				healthy("one", now),
+				heartbeatForFleet("starting", "source", now, map[string]core.GestaltdInstanceAppHeartbeat{
+					"app": {State: core.GestaltdInstanceAppStateStarting},
+				}),
+			},
+			wantState: core.AppFleetStateDegraded,
+			wantLive:  2,
+			wantRun:   1,
+			wantIdle:  1,
+		},
+		{
 			name:    "matching active rollout overlays converging",
 			minimum: 1,
 			heartbeats: []*core.GestaltdInstanceHeartbeat{

--- a/gestaltd/internal/appregistry/fleet_state_test.go
+++ b/gestaltd/internal/appregistry/fleet_state_test.go
@@ -32,6 +32,7 @@ func TestEvaluateFleetState(t *testing.T) {
 		wantState  core.AppFleetState
 		wantLive   int
 		wantRun    int
+		wantIdle   int
 		wantMis    int
 		wantErrors int
 	}{
@@ -82,12 +83,19 @@ func TestEvaluateFleetState(t *testing.T) {
 			wantErrors: 1,
 		},
 		{
-			name:       "autoscaling requires every replica healthy",
-			minimum:    2,
-			heartbeats: []*core.GestaltdInstanceHeartbeat{healthy("one", now), healthy("two", now), healthy("three", now)},
-			wantState:  core.AppFleetStateHealthy,
-			wantLive:   3,
-			wantRun:    3,
+			name:    "idle replica is neutral when minimum is healthy",
+			minimum: 2,
+			heartbeats: []*core.GestaltdInstanceHeartbeat{
+				healthy("one", now),
+				healthy("two", now),
+				heartbeatForFleet("idle", "source", now, map[string]core.GestaltdInstanceAppHeartbeat{
+					"app": {State: core.GestaltdInstanceAppStateNotRunning},
+				}),
+			},
+			wantState: core.AppFleetStateHealthy,
+			wantLive:  3,
+			wantRun:   2,
+			wantIdle:  1,
 		},
 		{
 			name:    "matching active rollout overlays converging",
@@ -140,6 +148,7 @@ func TestEvaluateFleetState(t *testing.T) {
 			if got.State != tc.wantState ||
 				got.LiveInstances != tc.wantLive ||
 				got.RunningDesiredVersion != tc.wantRun ||
+				got.NotRunning != tc.wantIdle ||
 				got.Mismatched != tc.wantMis ||
 				got.Errors != tc.wantErrors {
 				t.Fatalf("projection = %#v", got)
@@ -147,22 +156,24 @@ func TestEvaluateFleetState(t *testing.T) {
 			if len(got.Replicas) != got.LiveInstances {
 				t.Fatalf("replicas len = %d, liveInstances = %d", len(got.Replicas), got.LiveInstances)
 			}
-			var onDesired, mismatched, errors int
+			var onDesired, idle, mismatched, errors int
 			for _, replica := range got.Replicas {
 				switch replica.Class {
 				case core.AppFleetReplicaClassOnDesired:
 					onDesired++
 				case core.AppFleetReplicaClassMismatched:
 					mismatched++
+				case core.AppFleetReplicaClassNotRunning:
+					idle++
 				case core.AppFleetReplicaClassError:
 					errors++
 				default:
 					t.Fatalf("unexpected replica class %q in %#v", replica.Class, replica)
 				}
 			}
-			if onDesired != got.RunningDesiredVersion || mismatched != got.Mismatched || errors != got.Errors {
-				t.Fatalf("replica class counts on=%d mis=%d err=%d; aggregates run=%d mis=%d err=%d",
-					onDesired, mismatched, errors, got.RunningDesiredVersion, got.Mismatched, got.Errors)
+			if onDesired != got.RunningDesiredVersion || idle != got.NotRunning || mismatched != got.Mismatched || errors != got.Errors {
+				t.Fatalf("replica class counts on=%d idle=%d mis=%d err=%d; aggregates run=%d idle=%d mis=%d err=%d",
+					onDesired, idle, mismatched, errors, got.RunningDesiredVersion, got.NotRunning, got.Mismatched, got.Errors)
 			}
 		})
 	}

--- a/gestaltd/internal/appregistry/installer.go
+++ b/gestaltd/internal/appregistry/installer.go
@@ -145,6 +145,7 @@ func (i *Installer) install(ctx context.Context, input InstallInput, mode instal
 		strings.TrimSpace(configEntry.Source.Registry) != registryName {
 		return nil, ErrRegistrySourceMismatch
 	}
+	currentDesired := coredata.LatestKnownVersion(knownVersions)
 	var fromVersion string
 	switch mode {
 	case installModeAdd:
@@ -156,9 +157,9 @@ func (i *Installer) install(ctx context.Context, input InstallInput, mode instal
 		if len(knownVersions) == 0 {
 			return nil, ErrAppNotAdded
 		}
-		fromVersion = coredata.LatestKnownVersion(knownVersions)
+		fromVersion = currentDesired
 	case installModeSelect:
-		fromVersion = coredata.LatestKnownVersion(knownVersions)
+		fromVersion = currentDesired
 		if fromVersion == "" {
 			fromVersion = "registry:first-install"
 		}
@@ -177,15 +178,30 @@ func (i *Installer) install(ctx context.Context, input InstallInput, mode instal
 			return nil, ErrAppVersionAlreadyInstalled
 		}
 	}
+	var currentRollout *core.AppRollout
 	if current, getErr := i.Rollouts.Get(installCtx, appName); getErr == nil {
+		currentRollout = current
 		if current.State == core.AppRolloutStateEnrolling || current.State == core.AppRolloutStateRestarting {
 			return nil, ErrAppRolloutActive
 		}
 	} else if !errors.Is(getErr, core.ErrNotFound) {
 		return nil, fmt.Errorf("check active app rollout: %w", getErr)
 	}
-	if mode == installModeSelect && coredata.LatestKnownVersion(knownVersions) == version {
-		return nil, ErrAppVersionAlreadyInstalled
+	if mode == installModeSelect && currentDesired == version {
+		if currentRollout == nil || currentRollout.State != core.AppRolloutStateFailed ||
+			strings.TrimSpace(currentRollout.Version) != version {
+			return nil, ErrAppVersionAlreadyInstalled
+		}
+		// Selecting the current desired version after its rollout failed is the
+		// user-facing retry command. Keep that decision inside admission so all
+		// callers share the same failed-rollout checks.
+		mode = installModeRetry
+	}
+	if mode == installModeRetry {
+		if currentRollout == nil || currentRollout.State != core.AppRolloutStateFailed ||
+			strings.TrimSpace(currentRollout.Version) != version || currentDesired != version {
+			return nil, fmt.Errorf("%w: version %q is not the failed current desired rollout", ErrAppRolloutRetryNotAllowed, version)
+		}
 	}
 	if strings.TrimSpace(i.SourceVersion) != "" {
 		if i.SourceVersions == nil {
@@ -216,7 +232,6 @@ func (i *Installer) install(ctx context.Context, input InstallInput, mode instal
 	if err != nil {
 		return nil, fmt.Errorf("fetch retention index: %w", err)
 	}
-	currentDesired := coredata.LatestKnownVersion(knownVersions)
 	if mode == installModeSelect || mode == installModeUpgrade || mode == installModeAdd {
 		if err := VersionSelectable(version, currentDesired, retentionIndex, policy, i.now()); err != nil {
 			return nil, err

--- a/gestaltd/internal/appregistry/installer.go
+++ b/gestaltd/internal/appregistry/installer.go
@@ -60,6 +60,7 @@ const (
 	installModeAdd
 	installModeUpgrade
 	installModeSelect
+	installModeRetry
 )
 
 func (i *Installer) Install(ctx context.Context, input InstallInput) (*InstallOutput, error) {
@@ -76,6 +77,13 @@ func (i *Installer) Upgrade(ctx context.Context, input InstallInput) (*InstallOu
 
 func (i *Installer) Select(ctx context.Context, input InstallInput) (*InstallOutput, error) {
 	return i.install(ctx, input, installModeSelect)
+}
+
+// Retry re-admits the currently desired version after a terminal rollout
+// failure. The version is already known to the fleet, so this bypasses the
+// normal already-installed guard while creating a fresh rollout event.
+func (i *Installer) Retry(ctx context.Context, input InstallInput) (*InstallOutput, error) {
+	return i.install(ctx, input, installModeRetry)
 }
 
 func (i *Installer) install(ctx context.Context, input InstallInput, mode installMode) (*InstallOutput, error) {
@@ -160,7 +168,7 @@ func (i *Installer) install(ctx context.Context, input InstallInput, mode instal
 			return nil, fmt.Errorf("resolve from_version: no known fleet version and app is not pinned in config")
 		}
 	}
-	if mode != installModeSelect {
+	if mode != installModeSelect && mode != installModeRetry {
 		alreadyKnown, err := i.ChangeRequests.HasKnownVersion(installCtx, appName, version)
 		if err != nil {
 			return nil, fmt.Errorf("check known app version: %w", err)
@@ -213,6 +221,9 @@ func (i *Installer) install(ctx context.Context, input InstallInput, mode instal
 		if err := VersionSelectable(version, currentDesired, retentionIndex, policy, i.now()); err != nil {
 			return nil, err
 		}
+	}
+	if mode == installModeRetry && currentDesired != version {
+		return nil, fmt.Errorf("retry version %q is not the current desired version", version)
 	}
 
 	source, err := fetchConfiguredRegistryEntry(installCtx, i.Registries, reader, registryName, appName, version)

--- a/gestaltd/internal/appregistry/installer.go
+++ b/gestaltd/internal/appregistry/installer.go
@@ -228,11 +228,12 @@ func (i *Installer) install(ctx context.Context, input InstallInput, mode instal
 	if err != nil {
 		return nil, fmt.Errorf("fetch retention index: %w", err)
 	}
-	if mode == installModeRetry {
+	switch mode {
+	case installModeRetry:
 		if err := RetryVersionSelectable(version, retentionIndex, policy, i.now()); err != nil {
 			return nil, err
 		}
-	} else if mode == installModeSelect || mode == installModeUpgrade || mode == installModeAdd {
+	case installModeSelect, installModeUpgrade, installModeAdd:
 		if err := VersionSelectable(version, currentDesired, retentionIndex, policy, i.now()); err != nil {
 			return nil, err
 		}

--- a/gestaltd/internal/appregistry/installer.go
+++ b/gestaltd/internal/appregistry/installer.go
@@ -51,6 +51,7 @@ type InstallOutput struct {
 	Installation *core.AppInstallation
 	FromVersion  string
 	Rollout      *core.AppRollout
+	Retried      bool
 }
 
 type installMode int
@@ -77,13 +78,6 @@ func (i *Installer) Upgrade(ctx context.Context, input InstallInput) (*InstallOu
 
 func (i *Installer) Select(ctx context.Context, input InstallInput) (*InstallOutput, error) {
 	return i.install(ctx, input, installModeSelect)
-}
-
-// Retry re-admits the currently desired version after a terminal rollout
-// failure. The version is already known to the fleet, so this bypasses the
-// normal already-installed guard while creating a fresh rollout event.
-func (i *Installer) Retry(ctx context.Context, input InstallInput) (*InstallOutput, error) {
-	return i.install(ctx, input, installModeRetry)
 }
 
 func (i *Installer) install(ctx context.Context, input InstallInput, mode installMode) (*InstallOutput, error) {
@@ -179,6 +173,7 @@ func (i *Installer) install(ctx context.Context, input InstallInput, mode instal
 		}
 	}
 	var currentRollout *core.AppRollout
+	retried := mode == installModeRetry
 	if current, getErr := i.Rollouts.Get(installCtx, appName); getErr == nil {
 		currentRollout = current
 		if current.State == core.AppRolloutStateEnrolling || current.State == core.AppRolloutStateRestarting {
@@ -196,6 +191,7 @@ func (i *Installer) install(ctx context.Context, input InstallInput, mode instal
 		// user-facing retry command. Keep that decision inside admission so all
 		// callers share the same failed-rollout checks.
 		mode = installModeRetry
+		retried = true
 	}
 	if mode == installModeRetry {
 		if currentRollout == nil || currentRollout.State != core.AppRolloutStateFailed ||
@@ -232,7 +228,11 @@ func (i *Installer) install(ctx context.Context, input InstallInput, mode instal
 	if err != nil {
 		return nil, fmt.Errorf("fetch retention index: %w", err)
 	}
-	if mode == installModeSelect || mode == installModeUpgrade || mode == installModeAdd {
+	if mode == installModeRetry {
+		if err := RetryVersionSelectable(version, retentionIndex, policy, i.now()); err != nil {
+			return nil, err
+		}
+	} else if mode == installModeSelect || mode == installModeUpgrade || mode == installModeAdd {
 		if err := VersionSelectable(version, currentDesired, retentionIndex, policy, i.now()); err != nil {
 			return nil, err
 		}
@@ -321,6 +321,7 @@ func (i *Installer) install(ctx context.Context, input InstallInput, mode instal
 		Installation: coredata.InstallationFromChangeRequest(addedRequest),
 		FromVersion:  fromVersion,
 		Rollout:      rollout,
+		Retried:      retried,
 	}, nil
 }
 

--- a/gestaltd/internal/appregistry/installer_test.go
+++ b/gestaltd/internal/appregistry/installer_test.go
@@ -201,7 +201,7 @@ func TestInstallerSelectReadmitsOnlyTheFailedDesiredVersion(t *testing.T) {
 		t.Fatalf("MarkFailed retry rollout: %v", err)
 	}
 
-	if _, err := installer.Retry(ctx, appregistry.InstallInput{
+	if _, err := installer.Select(ctx, appregistry.InstallInput{
 		Registry: "toolshed",
 		App:      "g-issues",
 		Version:  "not-current",
@@ -233,14 +233,14 @@ func TestInstallerRetryRejectsAnActiveRollout(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("first install: %v", err)
 	}
-	if _, err := installer.Retry(ctx, appregistry.InstallInput{
+	if _, err := installer.Select(ctx, appregistry.InstallInput{
 		Registry: "toolshed", App: "g-issues", Version: fixture.Version,
 	}); !errors.Is(err, appregistry.ErrAppRolloutActive) {
 		t.Fatalf("Retry error = %v, want %v", err, appregistry.ErrAppRolloutActive)
 	}
 }
 
-func TestInstallerRetryRejectsACompletedRollout(t *testing.T) {
+func TestInstallerSelectRejectsACompletedCurrentRollout(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -266,10 +266,10 @@ func TestInstallerRetryRejectsACompletedRollout(t *testing.T) {
 		t.Fatalf("MarkComplete: %v", err)
 	}
 
-	if _, err := installer.Retry(ctx, appregistry.InstallInput{
+	if _, err := installer.Select(ctx, appregistry.InstallInput{
 		Registry: "toolshed", App: "g-issues", Version: fixture.Version,
-	}); !errors.Is(err, appregistry.ErrAppRolloutRetryNotAllowed) {
-		t.Fatalf("Retry error = %v, want %v", err, appregistry.ErrAppRolloutRetryNotAllowed)
+	}); !errors.Is(err, appregistry.ErrAppVersionAlreadyInstalled) {
+		t.Fatalf("Select error = %v, want %v", err, appregistry.ErrAppVersionAlreadyInstalled)
 	}
 }
 

--- a/gestaltd/internal/appregistry/installer_test.go
+++ b/gestaltd/internal/appregistry/installer_test.go
@@ -146,7 +146,7 @@ func TestInstaller_rejects_already_installed_version(t *testing.T) {
 	}
 }
 
-func TestInstallerRetryReadmitsOnlyTheFailedDesiredVersion(t *testing.T) {
+func TestInstallerSelectReadmitsOnlyTheFailedDesiredVersion(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -179,12 +179,12 @@ func TestInstallerRetryReadmitsOnlyTheFailedDesiredVersion(t *testing.T) {
 		t.Fatalf("MarkFailed: %v", err)
 	}
 
-	if _, err := installer.Retry(ctx, appregistry.InstallInput{
+	if _, err := installer.Select(ctx, appregistry.InstallInput{
 		Registry: "toolshed",
 		App:      "g-issues",
 		Version:  fixture.Version,
 	}); err != nil {
-		t.Fatalf("Retry: %v", err)
+		t.Fatalf("Select failed desired version: %v", err)
 	}
 	requests, err := svc.AppVersionChangeRequests.ListRequestsByApp(ctx, "g-issues")
 	if err != nil {
@@ -237,6 +237,39 @@ func TestInstallerRetryRejectsAnActiveRollout(t *testing.T) {
 		Registry: "toolshed", App: "g-issues", Version: fixture.Version,
 	}); !errors.Is(err, appregistry.ErrAppRolloutActive) {
 		t.Fatalf("Retry error = %v, want %v", err, appregistry.ErrAppRolloutActive)
+	}
+}
+
+func TestInstallerRetryRejectsACompletedRollout(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	svc := testutil.NewStubServices(t)
+	fixture := registrytest.NewInstallFixture(t)
+	configEntry := configEntryWithResolvedVersion("0.0.0-config")
+	configEntry.Source.Registry = "toolshed"
+	installer := &appregistry.Installer{
+		Registries:     map[string]config.AppRegistryConfig{"toolshed": fixture.Registry},
+		ConfigApps:     map[string]*config.ProviderEntry{"g-issues": configEntry},
+		Reader:         fixture.Reader,
+		ChangeRequests: svc.AppVersionChangeRequests,
+		Locks:          svc.AppVersionInstallLocks,
+		Rollouts:       svc.AppRollouts,
+	}
+	first, err := installer.Install(ctx, appregistry.InstallInput{
+		Registry: "toolshed", App: "g-issues", Version: fixture.Version,
+	})
+	if err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+	if _, err := svc.AppRollouts.MarkCompleteForRollout(ctx, first.Rollout, time.Now().UTC()); err != nil {
+		t.Fatalf("MarkComplete: %v", err)
+	}
+
+	if _, err := installer.Retry(ctx, appregistry.InstallInput{
+		Registry: "toolshed", App: "g-issues", Version: fixture.Version,
+	}); !errors.Is(err, appregistry.ErrAppRolloutRetryNotAllowed) {
+		t.Fatalf("Retry error = %v, want %v", err, appregistry.ErrAppRolloutRetryNotAllowed)
 	}
 }
 

--- a/gestaltd/internal/appregistry/installer_test.go
+++ b/gestaltd/internal/appregistry/installer_test.go
@@ -146,6 +146,100 @@ func TestInstaller_rejects_already_installed_version(t *testing.T) {
 	}
 }
 
+func TestInstallerRetryReadmitsOnlyTheFailedDesiredVersion(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	svc := testutil.NewStubServices(t)
+	fixture := registrytest.NewInstallFixture(t)
+	configEntry := configEntryWithResolvedVersion("0.0.0-config")
+	configEntry.Source.Registry = "toolshed"
+	installer := &appregistry.Installer{
+		Registries: map[string]config.AppRegistryConfig{
+			"toolshed": fixture.Registry,
+		},
+		ConfigApps: map[string]*config.ProviderEntry{
+			"g-issues": configEntry,
+		},
+		Reader:         fixture.Reader,
+		ChangeRequests: svc.AppVersionChangeRequests,
+		Locks:          svc.AppVersionInstallLocks,
+		Rollouts:       svc.AppRollouts,
+	}
+
+	first, err := installer.Install(ctx, appregistry.InstallInput{
+		Registry: "toolshed",
+		App:      "g-issues",
+		Version:  fixture.Version,
+	})
+	if err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+	if _, err := svc.AppRollouts.MarkFailedForRollout(ctx, first.Rollout, time.Now().UTC()); err != nil {
+		t.Fatalf("MarkFailed: %v", err)
+	}
+
+	if _, err := installer.Retry(ctx, appregistry.InstallInput{
+		Registry: "toolshed",
+		App:      "g-issues",
+		Version:  fixture.Version,
+	}); err != nil {
+		t.Fatalf("Retry: %v", err)
+	}
+	requests, err := svc.AppVersionChangeRequests.ListRequestsByApp(ctx, "g-issues")
+	if err != nil {
+		t.Fatalf("ListRequestsByApp: %v", err)
+	}
+	if len(requests) != 2 {
+		t.Fatalf("requests = %d, want fresh retry request", len(requests))
+	}
+	second, err := svc.AppRollouts.Get(ctx, "g-issues")
+	if err != nil {
+		t.Fatalf("Get retry rollout: %v", err)
+	}
+	if _, err := svc.AppRollouts.MarkFailedForRollout(ctx, second, time.Now().UTC()); err != nil {
+		t.Fatalf("MarkFailed retry rollout: %v", err)
+	}
+
+	if _, err := installer.Retry(ctx, appregistry.InstallInput{
+		Registry: "toolshed",
+		App:      "g-issues",
+		Version:  "not-current",
+	}); err == nil {
+		t.Fatal("Retry accepted a version other than the current desired version")
+	}
+}
+
+func TestInstallerRetryRejectsAnActiveRollout(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	svc := testutil.NewStubServices(t)
+	fixture := registrytest.NewInstallFixture(t)
+	configEntry := configEntryWithResolvedVersion("0.0.0-config")
+	configEntry.Source.Registry = "toolshed"
+	installer := &appregistry.Installer{
+		Registries: map[string]config.AppRegistryConfig{"toolshed": fixture.Registry},
+		ConfigApps: map[string]*config.ProviderEntry{
+			"g-issues": configEntry,
+		},
+		Reader:         fixture.Reader,
+		ChangeRequests: svc.AppVersionChangeRequests,
+		Locks:          svc.AppVersionInstallLocks,
+		Rollouts:       svc.AppRollouts,
+	}
+	if _, err := installer.Install(ctx, appregistry.InstallInput{
+		Registry: "toolshed", App: "g-issues", Version: fixture.Version,
+	}); err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+	if _, err := installer.Retry(ctx, appregistry.InstallInput{
+		Registry: "toolshed", App: "g-issues", Version: fixture.Version,
+	}); !errors.Is(err, appregistry.ErrAppRolloutActive) {
+		t.Fatalf("Retry error = %v, want %v", err, appregistry.ErrAppRolloutActive)
+	}
+}
+
 func TestInstaller_creates_one_active_rollout_per_app(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/appregistry/poller.go
+++ b/gestaltd/internal/appregistry/poller.go
@@ -683,6 +683,7 @@ func (p *CatalogPoller) updateHeartbeatRolloutOutcome(ctx context.Context, rollo
 		FailureSummary: core.AppRolloutFailureSummary{
 			LiveInstances:         projection.LiveInstances,
 			RunningDesiredVersion: projection.RunningDesiredVersion,
+			NotRunning:            projection.NotRunning,
 			Mismatched:            projection.Mismatched,
 			Errors:                projection.Errors,
 		},

--- a/gestaltd/internal/appregistry/poller_heartbeat_test.go
+++ b/gestaltd/internal/appregistry/poller_heartbeat_test.go
@@ -87,6 +87,29 @@ func TestHeartbeatRolloutUsesFreshTargetSourceFleetAndReplacementReplicas(t *tes
 	}
 }
 
+func TestHeartbeatRolloutFailureSummaryIncludesNotRunningReplicas(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	services := testutil.NewStubServices(t)
+	start := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+	rollout := heartbeatPollerRollout(t, services, start, 2)
+	clock := start.Add(15 * time.Minute)
+	poller := heartbeatRolloutPoller(services, &clock)
+
+	upsertRolloutHeartbeat(t, services, "running", "source-a", clock, "v2", core.GestaltdInstanceAppStateRunning)
+	upsertRolloutHeartbeat(t, services, "starting", "source-a", clock, "v2", core.GestaltdInstanceAppStateStarting)
+	if terminal, err := poller.updateHeartbeatRolloutOutcome(ctx, rollout); err != nil || !terminal {
+		t.Fatalf("deadline evaluation terminal=%v err=%v", terminal, err)
+	}
+	failed, err := services.AppRollouts.Get(ctx, rollout.App)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if failed.FailureSummary == nil || failed.FailureSummary.NotRunning != 1 || failed.FailureSummary.RunningDesiredVersion != 1 {
+		t.Fatalf("failure summary = %#v", failed.FailureSummary)
+	}
+}
+
 func heartbeatPollerRollout(t *testing.T, services *coredata.Services, start time.Time, minimum int) *core.AppRollout {
 	t.Helper()
 	ctx := context.Background()

--- a/gestaltd/internal/appregistry/retention.go
+++ b/gestaltd/internal/appregistry/retention.go
@@ -246,6 +246,13 @@ func VersionSelectable(version, desiredVersion string, retention *RetentionIndex
 	}
 }
 
+// RetryVersionSelectable applies retention rules to a version that is already
+// desired. A failed rollout may retry that version, but only while its retained
+// artifact remains deployable.
+func RetryVersionSelectable(version string, retention *RetentionIndex, policy RetentionPolicy, now time.Time) error {
+	return VersionSelectable(version, "", retention, policy, now)
+}
+
 func retentionVersion(index *RetentionIndex, version string) (RetentionVersion, bool) {
 	if index == nil || index.Versions == nil {
 		return RetentionVersion{}, false

--- a/gestaltd/internal/appregistry/retention_test.go
+++ b/gestaltd/internal/appregistry/retention_test.go
@@ -86,6 +86,31 @@ func TestApplyDesiredVersionTransitionExpiresAt(t *testing.T) {
 	}
 }
 
+func TestRetryVersionSelectableUsesRetentionState(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC)
+	policy := appregistry.RetentionPolicy{UnusedRetention: 72 * time.Hour, DeployedRetention: 720 * time.Hour}
+	retention := appregistry.NewEmptyRetentionIndex()
+	retention.Versions["expired"] = appregistry.RetentionVersion{PublishedAt: now.Add(-96 * time.Hour)}
+	retention.Versions["locked"] = appregistry.RetentionVersion{
+		PublishedAt:  now.Add(-800 * time.Hour),
+		EverDeployed: true,
+		ExpiresAt:    ptrTime(now.Add(-time.Hour)),
+	}
+	retention.Versions["retryable"] = appregistry.RetentionVersion{EverDeployed: true}
+
+	if err := appregistry.RetryVersionSelectable("retryable", retention, policy, now); err != nil {
+		t.Fatalf("retryable version rejected: %v", err)
+	}
+	if err := appregistry.RetryVersionSelectable("expired", retention, policy, now); err != appregistry.ErrAppVersionExpired {
+		t.Fatalf("expired retry error = %v, want %v", err, appregistry.ErrAppVersionExpired)
+	}
+	if err := appregistry.RetryVersionSelectable("locked", retention, policy, now); err != appregistry.ErrAppVersionLocked {
+		t.Fatalf("locked retry error = %v, want %v", err, appregistry.ErrAppVersionLocked)
+	}
+}
+
 func ptrTime(value time.Time) *time.Time {
 	value = value.UTC()
 	return &value

--- a/gestaltd/internal/coredata/app_auto_deploy_settings.go
+++ b/gestaltd/internal/coredata/app_auto_deploy_settings.go
@@ -67,6 +67,21 @@ func (s *AutoDeploySettingsService) ListEnabled(ctx context.Context) ([]*core.Ap
 	return out, nil
 }
 
+func (s *AutoDeploySettingsService) ListAll(ctx context.Context) ([]*core.AppAutoDeploySettings, error) {
+	if s == nil {
+		return nil, fmt.Errorf("list app auto-deploy settings: service is not configured")
+	}
+	recs, err := s.store.GetAll(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("list app auto-deploy settings: %w", err)
+	}
+	out := make([]*core.AppAutoDeploySettings, 0, len(recs))
+	for _, rec := range recs {
+		out = append(out, recordToAppAutoDeploySettings(rec))
+	}
+	return out, nil
+}
+
 // Update atomically initializes or mutates one app's settings. A missing row
 // starts disabled with all progress fields empty.
 func (s *AutoDeploySettingsService) Update(
@@ -110,6 +125,7 @@ func normalizeAppAutoDeploySettings(settings *core.AppAutoDeploySettings) {
 	settings.App = strings.TrimSpace(settings.App)
 	settings.PendingVersion = strings.TrimSpace(settings.PendingVersion)
 	settings.LastSeenVersion = strings.TrimSpace(settings.LastSeenVersion)
+	settings.PauseReason = strings.TrimSpace(settings.PauseReason)
 	settings.LastError = strings.TrimSpace(settings.LastError)
 	if !settings.LastFailedRolloutAt.IsZero() {
 		settings.LastFailedRolloutAt = settings.LastFailedRolloutAt.UTC().Truncate(time.Millisecond)
@@ -121,6 +137,8 @@ func appAutoDeploySettingsRecord(settings *core.AppAutoDeploySettings) idb.Recor
 		"id":                     settings.App,
 		"app":                    settings.App,
 		"enabled":                settings.Enabled,
+		"paused":                 settings.Paused,
+		"pause_reason":           settings.PauseReason,
 		"pending_version":        settings.PendingVersion,
 		"last_seen_version":      settings.LastSeenVersion,
 		"last_error":             settings.LastError,
@@ -133,9 +151,16 @@ func recordToAppAutoDeploySettings(rec idb.Record) *core.AppAutoDeploySettings {
 	return &core.AppAutoDeploySettings{
 		App:                 recString(rec, "app"),
 		Enabled:             enabled,
+		Paused:              recBool(rec, "paused"),
+		PauseReason:         recString(rec, "pause_reason"),
 		PendingVersion:      recString(rec, "pending_version"),
 		LastSeenVersion:     recString(rec, "last_seen_version"),
 		LastError:           recString(rec, "last_error"),
 		LastFailedRolloutAt: recTime(rec, "last_failed_rollout_at"),
 	}
+}
+
+func recBool(rec idb.Record, key string) bool {
+	value, _ := rec[key].(bool)
+	return value
 }

--- a/gestaltd/internal/coredata/app_auto_deploy_settings.go
+++ b/gestaltd/internal/coredata/app_auto_deploy_settings.go
@@ -52,21 +52,6 @@ func (s *AutoDeploySettingsService) Get(ctx context.Context, app string) (*core.
 	return recordToAppAutoDeploySettings(rec), nil
 }
 
-func (s *AutoDeploySettingsService) ListEnabled(ctx context.Context) ([]*core.AppAutoDeploySettings, error) {
-	if s == nil {
-		return nil, fmt.Errorf("list enabled app auto-deploy settings: service is not configured")
-	}
-	recs, err := s.store.Index("by_enabled").GetAll(ctx, true)
-	if err != nil {
-		return nil, fmt.Errorf("list enabled app auto-deploy settings: %w", err)
-	}
-	out := make([]*core.AppAutoDeploySettings, 0, len(recs))
-	for _, rec := range recs {
-		out = append(out, recordToAppAutoDeploySettings(rec))
-	}
-	return out, nil
-}
-
 func (s *AutoDeploySettingsService) ListAll(ctx context.Context) ([]*core.AppAutoDeploySettings, error) {
 	if s == nil {
 		return nil, fmt.Errorf("list app auto-deploy settings: service is not configured")

--- a/gestaltd/internal/coredata/app_auto_deploy_settings.go
+++ b/gestaltd/internal/coredata/app_auto_deploy_settings.go
@@ -110,7 +110,7 @@ func normalizeAppAutoDeploySettings(settings *core.AppAutoDeploySettings) {
 	settings.App = strings.TrimSpace(settings.App)
 	settings.PendingVersion = strings.TrimSpace(settings.PendingVersion)
 	settings.LastSeenVersion = strings.TrimSpace(settings.LastSeenVersion)
-	settings.PauseReason = strings.TrimSpace(settings.PauseReason)
+	settings.PauseReason = core.AppAutoDeployPauseReason(strings.TrimSpace(string(settings.PauseReason)))
 	settings.LastError = strings.TrimSpace(settings.LastError)
 	if !settings.LastFailedRolloutAt.IsZero() {
 		settings.LastFailedRolloutAt = settings.LastFailedRolloutAt.UTC().Truncate(time.Millisecond)
@@ -123,7 +123,7 @@ func appAutoDeploySettingsRecord(settings *core.AppAutoDeploySettings) idb.Recor
 		"app":                    settings.App,
 		"enabled":                settings.Enabled,
 		"paused":                 settings.Paused,
-		"pause_reason":           settings.PauseReason,
+		"pause_reason":           string(settings.PauseReason),
 		"pending_version":        settings.PendingVersion,
 		"last_seen_version":      settings.LastSeenVersion,
 		"last_error":             settings.LastError,
@@ -137,7 +137,7 @@ func recordToAppAutoDeploySettings(rec idb.Record) *core.AppAutoDeploySettings {
 		App:                 recString(rec, "app"),
 		Enabled:             enabled,
 		Paused:              recBool(rec, "paused"),
-		PauseReason:         recString(rec, "pause_reason"),
+		PauseReason:         core.AppAutoDeployPauseReason(recString(rec, "pause_reason")),
 		PendingVersion:      recString(rec, "pending_version"),
 		LastSeenVersion:     recString(rec, "last_seen_version"),
 		LastError:           recString(rec, "last_error"),

--- a/gestaltd/internal/coredata/app_auto_deploy_settings.go
+++ b/gestaltd/internal/coredata/app_auto_deploy_settings.go
@@ -106,6 +106,95 @@ func (s *AutoDeploySettingsService) Update(
 	return settings, nil
 }
 
+// UpdateForRollout applies an update only while expected is still the current
+// failed rollout. Reading both records in one transaction prevents a stale
+// controller observation from pausing a newer manual retry.
+func (s *AutoDeploySettingsService) UpdateForRollout(
+	ctx context.Context,
+	expected *core.AppRollout,
+	update func(*core.AppAutoDeploySettings) error,
+) (*core.AppAutoDeploySettings, bool, error) {
+	if s == nil || s.db == nil {
+		return nil, false, fmt.Errorf("update app auto-deploy settings for rollout: service is not configured")
+	}
+	if expected == nil {
+		return nil, false, fmt.Errorf("update app auto-deploy settings for rollout: rollout is required")
+	}
+	if update == nil {
+		return nil, false, fmt.Errorf("update app auto-deploy settings for rollout: update function is required")
+	}
+	app := strings.TrimSpace(expected.App)
+	if app == "" {
+		return nil, false, fmt.Errorf("update app auto-deploy settings for rollout: rollout app is required")
+	}
+	if err := s.EnsureStore(ctx); err != nil {
+		return nil, false, err
+	}
+
+	tx, err := s.db.Transaction(ctx, []string{StoreAppAutoDeploySettings, StoreAppRollouts}, idb.TransactionReadwrite, idb.TransactionOptions{})
+	if err != nil {
+		return nil, false, fmt.Errorf("update app auto-deploy settings for rollout: begin transaction: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Abort(context.WithoutCancel(ctx))
+		}
+	}()
+
+	rolloutRec, err := tx.ObjectStore(StoreAppRollouts).Get(ctx, app)
+	if err != nil {
+		if errors.Is(err, idb.ErrNotFound) {
+			if err := tx.Commit(ctx); err != nil {
+				return nil, false, fmt.Errorf("update app auto-deploy settings for rollout: commit unchanged: %w", err)
+			}
+			committed = true
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("update app auto-deploy settings for rollout: load current rollout: %w", err)
+	}
+	currentRollout := recordToAppRollout(rolloutRec)
+	if !sameAppRolloutIdentity(currentRollout, expected) || currentRollout.State != core.AppRolloutStateFailed {
+		if err := tx.Commit(ctx); err != nil {
+			return nil, false, fmt.Errorf("update app auto-deploy settings for rollout: commit unchanged: %w", err)
+		}
+		committed = true
+		return nil, false, nil
+	}
+
+	settings := &core.AppAutoDeploySettings{App: app}
+	settingsRec, err := tx.ObjectStore(StoreAppAutoDeploySettings).Get(ctx, app)
+	if err == nil {
+		settings = recordToAppAutoDeploySettings(settingsRec)
+	} else if !errors.Is(err, idb.ErrNotFound) {
+		return nil, false, fmt.Errorf("update app auto-deploy settings for rollout: load current settings: %w", err)
+	}
+	if err := update(settings); err != nil {
+		return nil, false, err
+	}
+	settings.App = app
+	normalizeAppAutoDeploySettings(settings)
+	if err := tx.ObjectStore(StoreAppAutoDeploySettings).Put(ctx, appAutoDeploySettingsRecord(settings)); err != nil {
+		return nil, false, fmt.Errorf("update app auto-deploy settings for rollout: write: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, false, fmt.Errorf("update app auto-deploy settings for rollout: commit: %w", err)
+	}
+	committed = true
+	return settings, true, nil
+}
+
+func sameAppRolloutIdentity(left, right *core.AppRollout) bool {
+	if left == nil || right == nil {
+		return false
+	}
+	return strings.TrimSpace(left.App) == strings.TrimSpace(right.App) &&
+		strings.TrimSpace(left.Version) == strings.TrimSpace(right.Version) &&
+		left.Mode == right.Mode &&
+		strings.TrimSpace(left.TargetSourceVersion) == strings.TrimSpace(right.TargetSourceVersion) &&
+		left.CreatedAt.Equal(right.CreatedAt)
+}
+
 func normalizeAppAutoDeploySettings(settings *core.AppAutoDeploySettings) {
 	settings.App = strings.TrimSpace(settings.App)
 	settings.PendingVersion = strings.TrimSpace(settings.PendingVersion)

--- a/gestaltd/internal/coredata/app_auto_deploy_settings_test.go
+++ b/gestaltd/internal/coredata/app_auto_deploy_settings_test.go
@@ -112,4 +112,57 @@ func TestAutoDeploySettingsService(t *testing.T) {
 			t.Fatalf("Get after failed update error = %v, want %v", err, core.ErrNotFound)
 		}
 	})
+
+	t.Run("update for rollout ignores stale rollout", func(t *testing.T) {
+		t.Parallel()
+		svc := testutil.NewStubServices(t)
+		createdAt := time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)
+		failed, err := svc.AppRollouts.Create(ctx, &core.AppRollout{
+			App: "g-issues", Version: "v1", State: core.AppRolloutStateEnrolling,
+			CreatedAt: createdAt, EnrollmentEndsAt: createdAt.Add(time.Minute), Deadline: createdAt.Add(2 * time.Minute),
+		})
+		if err != nil {
+			t.Fatalf("create failed rollout: %v", err)
+		}
+		if _, err := svc.AppRollouts.MarkFailedForRollout(ctx, failed, createdAt.Add(time.Minute)); err != nil {
+			t.Fatalf("mark failed rollout: %v", err)
+		}
+		failed, err = svc.AppRollouts.Get(ctx, "g-issues")
+		if err != nil {
+			t.Fatalf("get failed rollout: %v", err)
+		}
+		if _, applied, err := svc.AutoDeploySettings.UpdateForRollout(ctx, failed, func(settings *core.AppAutoDeploySettings) error {
+			settings.Enabled = true
+			settings.Paused = true
+			return nil
+		}); err != nil || !applied {
+			t.Fatalf("initial update: applied=%v err=%v", applied, err)
+		}
+		replacement, err := svc.AppRollouts.Create(ctx, &core.AppRollout{
+			App: "g-issues", Version: "v1", State: core.AppRolloutStateEnrolling,
+			CreatedAt: createdAt.Add(2 * time.Minute), EnrollmentEndsAt: createdAt.Add(3 * time.Minute), Deadline: createdAt.Add(4 * time.Minute),
+		})
+		if err != nil {
+			t.Fatalf("create replacement rollout: %v", err)
+		}
+		if _, err := svc.AppRollouts.MarkFailedForRollout(ctx, replacement, createdAt.Add(3*time.Minute)); err != nil {
+			t.Fatalf("mark replacement failed rollout: %v", err)
+		}
+		if _, applied, err := svc.AutoDeploySettings.UpdateForRollout(ctx, failed, func(settings *core.AppAutoDeploySettings) error {
+			settings.Paused = false
+			return nil
+		}); err != nil || applied {
+			t.Fatalf("stale update: applied=%v err=%v", applied, err)
+		}
+		if replacement.CreatedAt.Equal(failed.CreatedAt) {
+			t.Fatal("replacement rollout did not get a new identity")
+		}
+		settings, err := svc.AutoDeploySettings.Get(ctx, "g-issues")
+		if err != nil {
+			t.Fatalf("get settings: %v", err)
+		}
+		if !settings.Paused {
+			t.Fatalf("stale update changed settings: %#v", settings)
+		}
+	})
 }

--- a/gestaltd/internal/coredata/app_auto_deploy_settings_test.go
+++ b/gestaltd/internal/coredata/app_auto_deploy_settings_test.go
@@ -38,6 +38,8 @@ func TestAutoDeploySettingsService(t *testing.T) {
 		failedAt := time.Date(2026, 7, 28, 12, 0, 0, 123456789, time.UTC)
 		got, err := svc.Update(ctx, " g-issues ", func(settings *core.AppAutoDeploySettings) error {
 			settings.Enabled = true
+			settings.Paused = true
+			settings.PauseReason = "rollout_failed"
 			settings.PendingVersion = " v2 "
 			settings.LastSeenVersion = " v2 "
 			settings.LastError = " validation failed "
@@ -47,7 +49,7 @@ func TestAutoDeploySettingsService(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Update: %v", err)
 		}
-		if got.App != "g-issues" || !got.Enabled || got.PendingVersion != "v2" ||
+		if got.App != "g-issues" || !got.Enabled || !got.Paused || got.PauseReason != "rollout_failed" || got.PendingVersion != "v2" ||
 			got.LastSeenVersion != "v2" || got.LastError != "validation failed" ||
 			!got.LastFailedRolloutAt.Equal(failedAt.Truncate(time.Millisecond)) {
 			t.Fatalf("updated settings = %#v", got)

--- a/gestaltd/internal/coredata/app_auto_deploy_settings_test.go
+++ b/gestaltd/internal/coredata/app_auto_deploy_settings_test.go
@@ -89,35 +89,6 @@ func TestAutoDeploySettingsService(t *testing.T) {
 		}
 	})
 
-	t.Run("list enabled", func(t *testing.T) {
-		t.Parallel()
-		svc := testutil.NewStubServices(t).AutoDeploySettings
-		for app, enabled := range map[string]bool{
-			"g-issues": true,
-			"g-slack":  false,
-			"g-tasks":  true,
-		} {
-			if _, err := svc.Update(ctx, app, func(settings *core.AppAutoDeploySettings) error {
-				settings.Enabled = enabled
-				return nil
-			}); err != nil {
-				t.Fatalf("Update %s: %v", app, err)
-			}
-		}
-		got, err := svc.ListEnabled(ctx)
-		if err != nil {
-			t.Fatalf("ListEnabled: %v", err)
-		}
-		if len(got) != 2 {
-			t.Fatalf("enabled settings = %#v, want two", got)
-		}
-		for _, settings := range got {
-			if !settings.Enabled || settings.App == "g-slack" {
-				t.Fatalf("enabled settings includes %#v", settings)
-			}
-		}
-	})
-
 	t.Run("validation and failed update", func(t *testing.T) {
 		t.Parallel()
 		svc := testutil.NewStubServices(t).AutoDeploySettings

--- a/gestaltd/internal/coredata/schema_compatibility_test.go
+++ b/gestaltd/internal/coredata/schema_compatibility_test.go
@@ -80,11 +80,26 @@ func TestRuntimeHeartbeatFieldsRoundTripWithLegacyStoreSchemas(t *testing.T) {
 			{Name: "failed_at", Type: idb.TypeTime},
 		},
 	}
+	legacyAutoDeploySettingsSchema := idb.ObjectStoreOptions{
+		Indexes: []idb.IndexSchema{
+			{Name: "by_enabled", KeyPath: []string{"enabled"}},
+		},
+		Columns: []idb.ColumnDef{
+			{Name: "id", Type: idb.TypeString, PrimaryKey: true},
+			{Name: "app", Type: idb.TypeString, NotNull: true, Unique: true},
+			{Name: "enabled", Type: idb.TypeBool, NotNull: true},
+			{Name: "pending_version", Type: idb.TypeString},
+			{Name: "last_seen_version", Type: idb.TypeString},
+			{Name: "last_error", Type: idb.TypeString},
+			{Name: "last_failed_rollout_at", Type: idb.TypeTime},
+		},
+	}
 	db := &schemaMatchingIndexedDB{
 		inner: &coretesting.StubIndexedDB{},
 		existing: map[string]idb.ObjectStoreOptions{
 			coredata.StoreGestaltdSourceVersionState: legacySourceVersionSchema,
 			coredata.StoreAppRollouts:                legacyAppRolloutsSchema,
+			coredata.StoreAppAutoDeploySettings:      legacyAutoDeploySettingsSchema,
 		},
 	}
 	services, err := coredata.New(db)
@@ -179,6 +194,14 @@ func TestRuntimeHeartbeatFieldsRoundTripWithLegacyStoreSchemas(t *testing.T) {
 	if !transitioned {
 		t.Fatal("deadline heartbeat did not transition")
 	}
+	if _, err := services.AutoDeploySettings.Update(ctx, "g-issues", func(settings *core.AppAutoDeploySettings) error {
+		settings.Enabled = true
+		settings.Paused = true
+		settings.PauseReason = core.AppAutoDeployPauseReasonRolloutFailed
+		return nil
+	}); err != nil {
+		t.Fatalf("persist auto-deploy pause state: %v", err)
+	}
 
 	// A second bootstrap represents either a replacement process or an older
 	// process joining during a rolling deployment. It must accept the unchanged
@@ -199,5 +222,12 @@ func TestRuntimeHeartbeatFieldsRoundTripWithLegacyStoreSchemas(t *testing.T) {
 		rollout.FailureSummary.MinimumHealthyInstances != 2 ||
 		rollout.FailureSummary.SourceVersion != "source-a" {
 		t.Fatalf("round-tripped failed heartbeat rollout = %#v", rollout)
+	}
+	settings, err := services.AutoDeploySettings.Get(ctx, "g-issues")
+	if err != nil {
+		t.Fatalf("read auto-deploy settings after repeat bootstrap: %v", err)
+	}
+	if !settings.Enabled || !settings.Paused || settings.PauseReason != core.AppAutoDeployPauseReasonRolloutFailed {
+		t.Fatalf("round-tripped auto-deploy settings = %#v", settings)
 	}
 }

--- a/gestaltd/internal/coredata/schemas.go
+++ b/gestaltd/internal/coredata/schemas.go
@@ -180,6 +180,8 @@ var AppAutoDeploySettingsSchema = idb.ObjectStoreOptions{
 		{Name: "id", Type: idb.TypeString, PrimaryKey: true},
 		{Name: "app", Type: idb.TypeString, NotNull: true, Unique: true},
 		{Name: "enabled", Type: idb.TypeBool, NotNull: true},
+		{Name: "paused", Type: idb.TypeBool},
+		{Name: "pause_reason", Type: idb.TypeString},
 		{Name: "pending_version", Type: idb.TypeString},
 		{Name: "last_seen_version", Type: idb.TypeString},
 		{Name: "last_error", Type: idb.TypeString},

--- a/gestaltd/internal/coredata/schemas.go
+++ b/gestaltd/internal/coredata/schemas.go
@@ -173,6 +173,9 @@ var AppInstanceMaterializationsSchema = idb.ObjectStoreOptions{
 }
 
 var AppAutoDeploySettingsSchema = idb.ObjectStoreOptions{
+	// Keep this schema compatible with the store deployed before pause state
+	// was added. relationaldb preserves undeclared record fields, so the new
+	// fields are persisted without changing existing store metadata.
 	Indexes: []idb.IndexSchema{
 		{Name: "by_enabled", KeyPath: []string{"enabled"}},
 	},
@@ -180,8 +183,6 @@ var AppAutoDeploySettingsSchema = idb.ObjectStoreOptions{
 		{Name: "id", Type: idb.TypeString, PrimaryKey: true},
 		{Name: "app", Type: idb.TypeString, NotNull: true, Unique: true},
 		{Name: "enabled", Type: idb.TypeBool, NotNull: true},
-		{Name: "paused", Type: idb.TypeBool},
-		{Name: "pause_reason", Type: idb.TypeString},
 		{Name: "pending_version", Type: idb.TypeString},
 		{Name: "last_seen_version", Type: idb.TypeString},
 		{Name: "last_error", Type: idb.TypeString},

--- a/gestaltd/internal/server/handlers_admin_app_rollout.go
+++ b/gestaltd/internal/server/handlers_admin_app_rollout.go
@@ -64,6 +64,7 @@ type adminAppFleetStateInfo struct {
 	MinimumHealthyInstances int    `json:"minimumHealthyInstances"`
 	LiveInstances           int    `json:"liveInstances"`
 	RunningDesiredVersion   int    `json:"runningDesiredVersion"`
+	NotRunning              int    `json:"notRunning"`
 	Mismatched              int    `json:"mismatched"`
 	Errors                  int    `json:"errors"`
 	HeartbeatTTLSeconds     int64  `json:"heartbeatTtlSeconds"`
@@ -404,6 +405,7 @@ func adminAppFleetStateFromCore(projection *core.AppFleetProjection) adminAppFle
 		MinimumHealthyInstances: projection.MinimumHealthyInstances,
 		LiveInstances:           projection.LiveInstances,
 		RunningDesiredVersion:   projection.RunningDesiredVersion,
+		NotRunning:              projection.NotRunning,
 		Mismatched:              projection.Mismatched,
 		Errors:                  projection.Errors,
 		HeartbeatTTLSeconds:     int64(projection.HeartbeatTTL / time.Second),

--- a/gestaltd/internal/server/handlers_app_admin_registry.go
+++ b/gestaltd/internal/server/handlers_app_admin_registry.go
@@ -438,7 +438,7 @@ func appAdminAutoDeployFromCore(settings *core.AppAutoDeploySettings) appAdminAu
 	return appAdminAutoDeploy{
 		Enabled:        settings.Enabled,
 		Paused:         settings.Paused,
-		PauseReason:    settings.PauseReason,
+		PauseReason:    string(settings.PauseReason),
 		PendingVersion: settings.PendingVersion,
 		LastError:      settings.LastError,
 	}
@@ -691,17 +691,7 @@ func (s *Server) selectAppAdminRegistryVersion(w http.ResponseWriter, r *http.Re
 		Version:  version,
 		Actor:    subjectID,
 	}
-	install := s.appRegistryInstaller.Select
-	if s.appRollouts != nil && s.appVersionChanges != nil {
-		if rollout, rolloutErr := s.appRollouts.Get(r.Context(), app.name); rolloutErr == nil &&
-			rollout.State == core.AppRolloutStateFailed && rollout.Version == version {
-			if known, knownErr := s.appVersionChanges.ListKnownVersionsByApp(r.Context(), app.name); knownErr == nil &&
-				coredata.LatestKnownVersion(known) == version {
-				install = s.appRegistryInstaller.Retry
-			}
-		}
-	}
-	result, err := install(r.Context(), installInput)
+	result, err := s.appRegistryInstaller.Select(r.Context(), installInput)
 	if err != nil {
 		writeAppAdminRegistryInstallError(w, err)
 		return
@@ -757,6 +747,7 @@ func writeAppAdminRegistryInstallError(w http.ResponseWriter, err error) {
 	status := http.StatusBadGateway
 	switch {
 	case errors.Is(err, appregistry.ErrAppVersionAlreadyInstalled),
+		errors.Is(err, appregistry.ErrAppRolloutRetryNotAllowed),
 		errors.Is(err, appregistry.ErrInstallValidationFailed),
 		errors.Is(err, appregistry.ErrAppVersionExpired),
 		errors.Is(err, appregistry.ErrAppVersionLocked):

--- a/gestaltd/internal/server/handlers_app_admin_registry.go
+++ b/gestaltd/internal/server/handlers_app_admin_registry.go
@@ -696,7 +696,7 @@ func (s *Server) selectAppAdminRegistryVersion(w http.ResponseWriter, r *http.Re
 		writeAppAdminRegistryInstallError(w, err)
 		return
 	}
-	if s.autoDeploySettings != nil {
+	if result.Retried && s.autoDeploySettings != nil {
 		if current, settingsErr := s.autoDeploySettings.Get(r.Context(), app.name); settingsErr == nil && current.Enabled && current.Paused {
 			if _, settingsErr = s.autoDeploySettings.Update(r.Context(), app.name, func(settings *core.AppAutoDeploySettings) error {
 				settings.Paused = false

--- a/gestaltd/internal/server/handlers_app_admin_registry.go
+++ b/gestaltd/internal/server/handlers_app_admin_registry.go
@@ -40,6 +40,8 @@ type appAdminRegistryResponse struct {
 
 type appAdminAutoDeploy struct {
 	Enabled        bool   `json:"enabled"`
+	Paused         bool   `json:"paused"`
+	PauseReason    string `json:"pauseReason,omitempty"`
 	PendingVersion string `json:"pendingVersion,omitempty"`
 	LastError      string `json:"lastError,omitempty"`
 }
@@ -93,6 +95,7 @@ type appAdminFleetState struct {
 	MinimumHealthyInstances int                    `json:"minimumHealthyInstances"`
 	LiveInstances           int                    `json:"liveInstances"`
 	RunningDesiredVersion   int                    `json:"runningDesiredVersion"`
+	NotRunning              int                    `json:"notRunning"`
 	Mismatched              int                    `json:"mismatched"`
 	Errors                  int                    `json:"errors"`
 	HeartbeatTTLSeconds     int64                  `json:"heartbeatTtlSeconds"`
@@ -405,6 +408,8 @@ func (s *Server) updateAppAdminRegistryAutoDeploy(w http.ResponseWriter, r *http
 	}
 	settings, err := s.autoDeploySettings.Update(r.Context(), app.name, func(settings *core.AppAutoDeploySettings) error {
 		settings.Enabled = *request.Enabled
+		settings.Paused = false
+		settings.PauseReason = ""
 		if settings.Enabled {
 			settings.LastError = ""
 			settings.LastSeenVersion = ""
@@ -431,6 +436,8 @@ func appAdminAutoDeployFromCore(settings *core.AppAutoDeploySettings) appAdminAu
 	}
 	return appAdminAutoDeploy{
 		Enabled:        settings.Enabled,
+		Paused:         settings.Paused,
+		PauseReason:    settings.PauseReason,
 		PendingVersion: settings.PendingVersion,
 		LastError:      settings.LastError,
 	}
@@ -476,6 +483,7 @@ func appAdminFleetStateFromProjection(projection *core.AppFleetProjection) *appA
 		MinimumHealthyInstances: projection.MinimumHealthyInstances,
 		LiveInstances:           projection.LiveInstances,
 		RunningDesiredVersion:   projection.RunningDesiredVersion,
+		NotRunning:              projection.NotRunning,
 		Mismatched:              projection.Mismatched,
 		Errors:                  projection.Errors,
 		HeartbeatTTLSeconds:     int64(projection.HeartbeatTTL / time.Second),
@@ -676,15 +684,40 @@ func (s *Server) selectAppAdminRegistryVersion(w http.ResponseWriter, r *http.Re
 		return
 	}
 	subjectID := strings.TrimSpace(principal.Canonicalized(PrincipalFromContext(r.Context())).SubjectID)
-	result, err := s.appRegistryInstaller.Select(r.Context(), appregistry.InstallInput{
+	installInput := appregistry.InstallInput{
 		Registry: app.registry,
 		App:      app.name,
 		Version:  version,
 		Actor:    subjectID,
-	})
+	}
+	install := s.appRegistryInstaller.Select
+	if s.appRollouts != nil && s.appVersionChanges != nil {
+		if rollout, rolloutErr := s.appRollouts.Get(r.Context(), app.name); rolloutErr == nil &&
+			rollout.State == core.AppRolloutStateFailed && rollout.Version == version {
+			if known, knownErr := s.appVersionChanges.ListKnownVersionsByApp(r.Context(), app.name); knownErr == nil &&
+				coredata.LatestKnownVersion(known) == version {
+				install = s.appRegistryInstaller.Retry
+			}
+		}
+	}
+	result, err := install(r.Context(), installInput)
 	if err != nil {
 		writeAppAdminRegistryInstallError(w, err)
 		return
+	}
+	if s.autoDeploySettings != nil {
+		if current, settingsErr := s.autoDeploySettings.Get(r.Context(), app.name); settingsErr == nil && current.Enabled && current.Paused {
+			if _, settingsErr = s.autoDeploySettings.Update(r.Context(), app.name, func(settings *core.AppAutoDeploySettings) error {
+				settings.Paused = false
+				settings.PauseReason = ""
+				settings.LastError = ""
+				return nil
+			}); settingsErr != nil {
+				slog.Error("clear app auto-deploy pause after manual retry failed", "app", app.name, "error", settingsErr)
+			}
+		} else if settingsErr != nil && !errors.Is(settingsErr, core.ErrNotFound) {
+			slog.Error("load app auto-deploy settings after manual retry failed", "app", app.name, "error", settingsErr)
+		}
 	}
 	s.notifyAppRegistryReconcile(app.name)
 	writeJSON(w, http.StatusOK, appAdminRegistryVersionResponse{

--- a/gestaltd/internal/server/handlers_app_admin_registry.go
+++ b/gestaltd/internal/server/handlers_app_admin_registry.go
@@ -415,6 +415,7 @@ func (s *Server) updateAppAdminRegistryAutoDeploy(w http.ResponseWriter, r *http
 			settings.LastSeenVersion = ""
 		} else {
 			settings.PendingVersion = ""
+			settings.LastError = ""
 		}
 		return nil
 	})

--- a/gestaltd/internal/server/handlers_app_admin_registry_test.go
+++ b/gestaltd/internal/server/handlers_app_admin_registry_test.go
@@ -276,7 +276,7 @@ func TestAppAdminRegistryAutoDeploy(t *testing.T) {
 	}
 
 	disabled := update(`{"enabled":false}`, http.StatusOK)
-	if disabled.AutoDeploy.Enabled || disabled.AutoDeploy.PendingVersion != "" {
+	if disabled.AutoDeploy.Enabled || disabled.AutoDeploy.PendingVersion != "" || disabled.AutoDeploy.LastError != "" {
 		t.Fatalf("disabled response = %#v", disabled)
 	}
 	update(`{}`, http.StatusBadRequest)

--- a/gestaltd/internal/server/handlers_app_admin_registry_test.go
+++ b/gestaltd/internal/server/handlers_app_admin_registry_test.go
@@ -96,7 +96,10 @@ func TestAppAdminRegistrySelectAndRead(t *testing.T) {
 		SelectionDisabled bool   `json:"selectionDisabled"`
 		DisabledReason    string `json:"disabledReason"`
 		AutoDeploy        struct {
-			Enabled bool `json:"enabled"`
+			Enabled     bool   `json:"enabled"`
+			Paused      bool   `json:"paused"`
+			PauseReason string `json:"pauseReason"`
+			LastError   string `json:"lastError"`
 		} `json:"autoDeploy"`
 		PublishedVersions []struct {
 			SourceRef   string `json:"sourceRef"`
@@ -112,7 +115,7 @@ func TestAppAdminRegistrySelectAndRead(t *testing.T) {
 	if state.DesiredVersion != fixture.Version || !state.SelectionDisabled || state.DisabledReason != "rollout in progress" {
 		t.Fatalf("registry state = %#v", state)
 	}
-	if state.AutoDeploy.Enabled {
+	if state.AutoDeploy.Enabled || state.AutoDeploy.Paused || state.AutoDeploy.PauseReason != "" || state.AutoDeploy.LastError != "" {
 		t.Fatalf("autoDeploy = %#v, want disabled default", state.AutoDeploy)
 	}
 	if len(state.PublishedVersions) != 1 || state.PublishedVersions[0].SourceRef == "" ||

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -100,6 +100,13 @@ func run(ctx context.Context, cfg *config.Config, result *bootstrap.Result, gest
 	if err != nil {
 		return fmt.Errorf("resolve app registry heartbeat TTL: %w", err)
 	}
+	fleetProjector := &appregistry.FleetProjector{
+		ChangeRequests: result.Services.AppVersionChangeRequests,
+		SourceVersions: result.Services.GestaltdSourceVersionState,
+		Heartbeats:     result.Services.GestaltdInstanceHeartbeats,
+		Rollouts:       result.Services.AppRollouts,
+		HeartbeatTTL:   heartbeatTTL,
+	}
 	baseConfig := Config{
 		Auth:                  result.Auth,
 		SelectedAuthProvider:  result.SelectedAuthProvider,
@@ -163,6 +170,7 @@ func run(ctx context.Context, cfg *config.Config, result *bootstrap.Result, gest
 		OperationAccessChecker:  operationAccessChecker(result.Invoker),
 		AppRegistries:           cfg.AppRegistries,
 		AppRegistryReader:       appRegistryReader,
+		AppFleetProjector:       fleetProjector,
 		AppRegistryHeartbeatTTL: heartbeatTTL,
 		AppRegistryRolloutMode:  cfg.Server.AppRegistry.RolloutMode,
 		ArtifactsDir:            cfg.Server.ArtifactsDir,
@@ -182,7 +190,7 @@ func run(ctx context.Context, cfg *config.Config, result *bootstrap.Result, gest
 	if err := result.Start(ctx); err != nil {
 		return err
 	}
-	autoDeployController, err := startAppRegistryAutoDeployController(ctx, cfg, result, gestaltdVersion, appRegistryReader)
+	autoDeployController, err := startAppRegistryAutoDeployController(ctx, cfg, result, gestaltdVersion, appRegistryReader, fleetProjector)
 	if err != nil {
 		return err
 	}
@@ -721,6 +729,7 @@ func startAppRegistryAutoDeployController(
 	result *bootstrap.Result,
 	gestaltdVersion string,
 	reader *appregistry.RegistryReader,
+	fleet *appregistry.FleetProjector,
 ) (*autodeploy.Controller, error) {
 	if cfg == nil || result == nil || result.Services == nil {
 		return nil, nil
@@ -769,16 +778,8 @@ func startAppRegistryAutoDeployController(
 		SourceVersion:    appregistry.ResolveSourceVersion(),
 		RolloutMode:      core.AppRolloutMode(cfg.Server.AppRegistry.RolloutMode),
 	}
-	heartbeatTTL, err := cfg.Server.AppRegistry.HeartbeatTTLDuration()
-	if err != nil {
-		return nil, fmt.Errorf("server.appRegistry.heartbeatTtl: %w", err)
-	}
-	fleet := &appregistry.FleetProjector{
-		ChangeRequests: services.AppVersionChangeRequests,
-		SourceVersions: services.GestaltdSourceVersionState,
-		Heartbeats:     services.GestaltdInstanceHeartbeats,
-		Rollouts:       services.AppRollouts,
-		HeartbeatTTL:   heartbeatTTL,
+	if fleet == nil {
+		return nil, fmt.Errorf("app registry fleet projector is not configured")
 	}
 	controller := autodeploy.New(
 		services.AutoDeploySettings,

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -778,6 +778,17 @@ func startAppRegistryAutoDeployController(
 		apps,
 		interval,
 	)
+	heartbeatTTL, err := cfg.Server.AppRegistry.HeartbeatTTLDuration()
+	if err != nil {
+		return nil, fmt.Errorf("server.appRegistry.heartbeatTtl: %w", err)
+	}
+	controller.Fleet = &appregistry.FleetProjector{
+		ChangeRequests: services.AppVersionChangeRequests,
+		SourceVersions: services.GestaltdSourceVersionState,
+		Heartbeats:     services.GestaltdInstanceHeartbeats,
+		Rollouts:       services.AppRollouts,
+		HeartbeatTTL:   heartbeatTTL,
+	}
 	controller.Start(ctx)
 	return controller, nil
 }

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -769,26 +769,27 @@ func startAppRegistryAutoDeployController(
 		SourceVersion:    appregistry.ResolveSourceVersion(),
 		RolloutMode:      core.AppRolloutMode(cfg.Server.AppRegistry.RolloutMode),
 	}
-	controller := autodeploy.New(
-		services.AutoDeploySettings,
-		services.AppRollouts,
-		services.AppVersionChangeRequests,
-		reader,
-		installer,
-		apps,
-		interval,
-	)
 	heartbeatTTL, err := cfg.Server.AppRegistry.HeartbeatTTLDuration()
 	if err != nil {
 		return nil, fmt.Errorf("server.appRegistry.heartbeatTtl: %w", err)
 	}
-	controller.Fleet = &appregistry.FleetProjector{
+	fleet := &appregistry.FleetProjector{
 		ChangeRequests: services.AppVersionChangeRequests,
 		SourceVersions: services.GestaltdSourceVersionState,
 		Heartbeats:     services.GestaltdInstanceHeartbeats,
 		Rollouts:       services.AppRollouts,
 		HeartbeatTTL:   heartbeatTTL,
 	}
+	controller := autodeploy.New(
+		services.AutoDeploySettings,
+		services.AppRollouts,
+		services.AppVersionChangeRequests,
+		reader,
+		installer,
+		fleet,
+		apps,
+		interval,
+	)
 	controller.Start(ctx)
 	return controller, nil
 }

--- a/gestaltd/internal/server/runtime_app_registry_test.go
+++ b/gestaltd/internal/server/runtime_app_registry_test.go
@@ -61,7 +61,14 @@ func TestServerInstallerWiringPreservesConfiguredRolloutMode(t *testing.T) {
 			cfg.Server.AppRegistry.RolloutMode = mode
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
-			controller, err := startAppRegistryAutoDeployController(ctx, cfg, &bootstrap.Result{Services: services}, "0.1.0", fixture.Reader)
+			fleet := &appregistry.FleetProjector{
+				ChangeRequests: services.AppVersionChangeRequests,
+				SourceVersions: services.GestaltdSourceVersionState,
+				Heartbeats:     services.GestaltdInstanceHeartbeats,
+				Rollouts:       services.AppRollouts,
+				HeartbeatTTL:   time.Minute,
+			}
+			controller, err := startAppRegistryAutoDeployController(ctx, cfg, &bootstrap.Result{Services: services}, "0.1.0", fixture.Reader, fleet)
 			if err != nil {
 				t.Fatalf("startAppRegistryAutoDeployController: %v", err)
 			}

--- a/plans/app_registry/architecture/indexeddb.md
+++ b/plans/app_registry/architecture/indexeddb.md
@@ -431,6 +431,8 @@ Primary key: `app` (app name).
 {
   "app": "g-issues",
   "enabled": true,
+  "paused": false,
+  "pause_reason": "",
   "pending_version": "0.0.0-snapshot.gdef456",
   "last_seen_version": "0.0.0-snapshot.gabc123",
   "last_error": "",
@@ -441,10 +443,12 @@ Primary key: `app` (app name).
 | Field | Purpose |
 | --- | --- |
 | `enabled` | Per-app toggle; writable only via app-admin API |
+| `paused` | Runtime safety stop set after a failed rollout; does not change user intent |
+| `pause_reason` | Stable runtime pause reason, currently `rollout_failed` |
 | `pending_version` | Newest published version waiting for admission |
 | `last_seen_version` | Deduplicate publish detection across polls |
 | `last_error` | Last failure message; set on validation failure or rollout `failed` |
-| `last_failed_rollout_at` | Deduplicate handling of a persisted failed rollout across disable and re-enable |
+| `last_failed_rollout_at` | Deduplicate handling of a persisted failed rollout |
 
 The store is created idempotently during bootstrap. When `SkipSchemaBootstrap` is true, `EnsureStore` runs before reads and writes so existing deployments that started before the store was added still converge. See [lifecycle.md](../operations/lifecycle.md#auto-deploy-published-snapshots).
 
@@ -455,11 +459,11 @@ The store is created idempotently during bootstrap. When `SkipSchemaBootstrap` i
 | Method | Description |
 | --- | --- |
 | `Get(ctx, app)` | Load settings for one app. Returns `ErrNotFound` when no row exists. |
-| `ListEnabled(ctx)` | List apps with `enabled: true`. |
+| `ListAll(ctx)` | List persisted settings; the controller filters disabled and unknown apps. |
 | `Update(ctx, app, fn)` | Read-modify-write one app's settings. Missing rows start disabled with empty progress fields. |
 | `EnsureStore(ctx)` | Idempotently create the object store when schema bootstrap is skipped. |
 
-`Get` and `Update` back `GET` and `PUT /api/v1/apps/{app}/admin/registry/auto-deploy`. The registry-state route projects `enabled`, `pendingVersion`, and `lastError`.
+`Get` and `Update` back `GET` and `PUT /api/v1/apps/{app}/admin/registry/auto-deploy`. The registry-state route projects `enabled`, `paused`, `pauseReason`, `pendingVersion`, and `lastError`.
 
 ---
 

--- a/plans/app_registry/one-pagers/auto-deploy.md
+++ b/plans/app_registry/one-pagers/auto-deploy.md
@@ -16,7 +16,7 @@ Scope is `/apps/{app}/admin` only — not the embedded fleet `/admin` UI.
 - Trigger on publish completion — when `index.json` includes the version (after `gestaltd app registry pending clear`). Pending and failed publishes do not trigger auto-deploy.
 - At most one rollout per app (unchanged). While rollout state is `enrolling` or `restarting`, new publishes update the **pending target** but do not start another admission.
 - When the rollout reaches `complete`, admit the pending target if it differs from the current desired version. Intermediate publishes are skipped.
-- On rollout `failed`, disable auto-deploy and require manual intervention before any further automatic admissions.
+- On rollout `failed`, pause automatic admissions without changing the user’s enabled choice; a manual selection of the failed desired version resumes it.
 - Record auto-deploy admissions in revision history with actor `system:auto-deploy`.
 - Detect new publishes via background `index.json` polling. See [Publish Detection](#publish-detection).
 
@@ -42,11 +42,12 @@ Per auto-deploy-enabled app, Gestalt tracks a **pending target**: the newest pub
 
 1. If auto-deploy is disabled, stop. Disabling clears `pendingTarget`.
 2. On publish detection or enable — set `pendingTarget` to the newest published version.
-3. On a new rollout `failed` transition — disable auto-deploy, clear `pendingTarget` and `last_seen_version`, record `lastError` and the handled failure timestamp; stop. The timestamp prevents the retained terminal rollout row from immediately disabling a later app-admin re-enable.
-4. If rollout state is `enrolling` or `restarting`, stop. `pendingTarget` is already updated.
-5. If `pendingTarget` is empty, stop.
-6. If `pendingTarget == desiredVersion`, clear `pendingTarget` and stop.
-7. Capture `pendingTarget` and attempt admission for that version (same as manual version selection). Run this step both after publish detection and on periodic or rollout-terminal reconciliation, including when the registry returns **304**.
+3. On a new rollout `failed` transition — retain the user’s auto-deploy choice, set a separate runtime pause with reason `rollout_failed`, clear `pendingTarget` and `last_seen_version`, record `lastError` and the handled failure timestamp; stop. A manual selection of the failed current desired version creates a fresh rollout and clears the runtime pause.
+4. If auto-deploy is runtime-paused, stop.
+5. If rollout state is `enrolling` or `restarting`, stop. `pendingTarget` is already updated.
+6. If `pendingTarget` is empty, stop.
+7. If `pendingTarget == desiredVersion`, clear `pendingTarget` and stop.
+8. Capture `pendingTarget` and attempt admission for that version (same as manual version selection). Run this step both after publish detection and on periodic or rollout-terminal reconciliation, including when the registry returns **304**.
    - **Success** — clear `pendingTarget` only if it still equals the captured version. Preserve a newer target written concurrently by another replica.
    - **Validation failure (400)** — clear `pendingTarget` and set `lastError` only if it still equals the captured version. Do not retry until the next publish or a manual deploy.
    - **Active rollout (409)** — keep `pendingTarget`; retry when the rollout reaches `complete`.
@@ -55,8 +56,8 @@ Per auto-deploy-enabled app, Gestalt tracks a **pending target**: the newest pub
 
 | Action | Behavior |
 | --- | --- |
-| Disable | Clear the pending target and stop future automatic admissions. An in-flight rollout continues; the current desired version is unchanged. |
-| Enable | Run coalescing once. When no rollout is active and the newest published version is not desired, admit it. |
+| Disable | Clear the pending target, clear any runtime pause, and stop future automatic admissions. An in-flight rollout continues; the current desired version is unchanged. |
+| Enable | Clear any runtime pause, then run coalescing once. When no rollout is active and the newest published version is not desired, admit it. |
 
 ## State
 
@@ -65,10 +66,12 @@ Stored in IndexedDB (fleet policy, not GCS publish metadata):
 | Field | Purpose |
 | --- | --- |
 | `enabled` | Per-app toggle; writable only via app-admin API |
+| `paused` | Runtime safety stop set by the controller after a rollout failure |
+| `pause_reason` | Stable reason for the runtime pause, currently `rollout_failed` |
 | `pending_version` | Newest published version waiting for admission |
 | `last_seen_version` | Deduplicate publish detection across polls |
 | `last_error` | Last failure message; set on validation failure or rollout `failed` |
-| `last_failed_rollout_at` | Deduplicate handling of a persisted failed rollout across disable and re-enable |
+| `last_failed_rollout_at` | Deduplicate handling of a persisted failed rollout |
 
 The app-scoped install lock serializes concurrent manual and automatic admissions.
 
@@ -80,6 +83,8 @@ Extend `GET /api/v1/apps/{app}/admin/registry`:
 {
   "autoDeploy": {
     "enabled": true,
+    "paused": false,
+    "pauseReason": null,
     "pendingVersion": "0.0.0-snapshot.gdef456",
     "lastError": null
   }
@@ -94,7 +99,7 @@ Authorization matches version selection: `admin` on `app/{app}`. Auto-deploy doe
 
 ## App Admin UI
 
-- Toggle: **Automatically deploy new snapshots**. Turn off automatically on rollout `failed`; show `lastError` until an app admin re-enables auto-deploy or deploys manually.
+- Toggle: **Automatically deploy new snapshots**. Keep the user’s choice when a rollout fails, show the runtime pause and `lastError`, and resume after an app admin retries the failed desired version or toggles the policy.
 - During an active rollout, show **Queued for deploy** on the snapshot row for `autoDeploy.pendingVersion` (distinct from **Deploying...** on the admitted version).
 - Revision history shows `system:auto-deploy` for automatic admissions.
 
@@ -106,7 +111,7 @@ Authorization matches version selection: `admin` on `app/{app}`. Auto-deploy doe
 | Version expired or locked | Admission rejected (400); clear pending. |
 | No fleet-known version yet | First publish triggers `add`. |
 | Concurrent manual deploy | Install lock serializes; auto-deploy retries when the rollout reaches `complete`. |
-| Rollout `failed` | Disable auto-deploy, clear pending, record `lastError`. App admin must deploy manually and re-enable auto-deploy to resume automatic admissions. |
+| Rollout `failed` | Pause automatic admissions, clear pending, record `lastError`, and retain the enabled choice. App admin can retry the failed desired version or toggle the policy to resume. |
 
 ## Out of Scope
 
@@ -139,7 +144,7 @@ IndexedDB persistence, registry conditional GET support, and poll-interval confi
 **PR 3 — App-admin API**
 
 - `PUT /api/v1/apps/{app}/admin/registry/auto-deploy`
-- Extend `GET …/registry` with `autoDeploy: { enabled, pendingVersion, lastError }`
+- Extend `GET …/registry` with `autoDeploy: { enabled, paused, pauseReason, pendingVersion, lastError }`
 - Tests: `handlers_app_admin_registry_test.go`
 
 **PR 4 — Watcher and coalescing**

--- a/plans/app_registry/one-pagers/runtime-heartbeats.md
+++ b/plans/app_registry/one-pagers/runtime-heartbeats.md
@@ -176,9 +176,9 @@ States:
 
 | State | Condition |
 | --- | --- |
-| `healthy` | Live count is at least the minimum, and every live replica reports `running` at the desired version. |
+| `healthy` | Live count and running desired count are both at least the minimum, with no running old-version or error replicas. `starting`/`not_running` replicas are neutral idle capacity. |
 | `converging` | A rollout is active and the fleet is not yet healthy, but its deadline has not passed. |
-| `degraded` | At least the minimum replicas are live, but one or more report an error, unknown state, no running version, or a version mismatch. |
+| `degraded` | At least the minimum replicas are live, but one or more running replicas report an error, unknown state, or a version mismatch, or fewer than the minimum are running desired. |
 | `unknown` | Source/minimum state is unavailable, or fewer than the minimum replicas have fresh heartbeats. |
 
 The projection includes:
@@ -191,6 +191,7 @@ The projection includes:
   "minimumHealthyInstances": 5,
   "liveInstances": 5,
   "runningDesiredVersion": 5,
+  "notRunning": 0,
   "mismatched": 0,
   "errors": 0,
   "heartbeatTtlSeconds": 45,
@@ -225,9 +226,9 @@ The minimum count is snapshotted from current source-version state at admission.
 The heartbeat evaluator may set `healthy_since` when:
 
 - the rollout's target source version is still current
-- at least `minimum_healthy_instances` fresh target-source heartbeats exist
-- every fresh target-source heartbeat reports the rollout version as running
-- no fresh heartbeat reports an app error, unknown state, missing app, or version mismatch
+  - at least `minimum_healthy_instances` fresh target-source heartbeats exist
+  - at least `minimum_healthy_instances` fresh target-source heartbeats report the rollout version as running
+  - no fresh heartbeat reports an app error, unknown state, missing app, or running version mismatch
 
 If the condition becomes false, clear `healthy_since`.
 
@@ -251,7 +252,7 @@ Replica identity is diagnostic, not a required rollout slot:
 5. B runs the desired app version.
 6. If the live fleet meets the minimum and every live replica agrees, the rollout may complete after the stability window.
 
-A fresh, unhealthy heartbeat cannot be hidden by scaling above the minimum. Every fresh target-source replica must agree.
+A fresh running replica on the wrong version or with an error cannot be hidden by scaling above the minimum. A live host with the app `starting` or `not_running` is reported as neutral idle capacity; it is not counted as desired-version evidence or as a version mismatch.
 
 ## Recovery After Failure
 
@@ -278,6 +279,10 @@ Record recovery once when:
 - current fleet state satisfies the same 60-second healthy stability window
 
 Recovery does not change rollout state, append a change request, reset retention, or trigger auto-deploy coalescing. It is observability, not a second admission.
+
+### Auto-deploy safety
+
+`enabled` is user intent and is never cleared by a rollout evaluator. A real failed rollout sets a separate runtime pause with reason `rollout_failed`, retaining the user's enabled setting and the failure history. If the current fleet is already healthy for the failed desired version, the evaluator clears the stale runtime error instead of pausing. Manual retry or an explicit user toggle clears the runtime pause; unrelated manual disables remain disabled.
 
 ## APIs and Admin UI
 

--- a/plans/app_registry/operations/lifecycle.md
+++ b/plans/app_registry/operations/lifecycle.md
@@ -859,7 +859,7 @@ App admins opt a registry-only app into automatic fleet admission on `/apps/{app
 
 Scope is `/apps/{app}/admin` only — not the embedded fleet `/admin` UI. Only an authenticated user with `admin` on `app/{app}` may enable or disable the policy. Auto-deploy does not bypass install-time validation, retention locks, or rollout admission checks.
 
-Admission triggers on publish completion — when `index.json` includes the version (after `gestaltd app registry pending clear`). Pending and failed publishes do not trigger auto-deploy. See [pending-publish.md](./pending-publish.md). At most one rollout per app remains unchanged: while rollout state is `enrolling` or `restarting`, new publishes update the pending version but do not start another admission. When the rollout reaches `complete`, Gestalt admits the pending version if it differs from the current desired version; intermediate publishes are skipped. On rollout `failed`, Gestalt disables auto-deploy, clears pending state, and records `lastError` until an app admin deploys manually and re-enables the policy. Automatic admissions appear in revision history with actor `system:auto-deploy`.
+Admission triggers on publish completion — when `index.json` includes the version (after `gestaltd app registry pending clear`). Pending and failed publishes do not trigger auto-deploy. See [pending-publish.md](./pending-publish.md). At most one rollout per app remains unchanged: while rollout state is `enrolling` or `restarting`, new publishes update the pending version but do not start another admission. When the rollout reaches `complete`, Gestalt admits the pending version if it differs from the current desired version; intermediate publishes are skipped. On rollout `failed`, Gestalt pauses automatic admissions without changing the enabled choice, clears pending state, and records `lastError` until an app admin retries the failed desired version or toggles the policy. Automatic admissions appear in revision history with actor `system:auto-deploy`.
 
 Fleet policy is stored in IndexedDB (`app_auto_deploy_settings`). See [indexeddb.md](../architecture/indexeddb.md#store-app_auto_deploy_settings-auto-deploy-policy).
 
@@ -885,11 +885,12 @@ Per enabled app, Gestalt tracks a pending version: the newest published snapshot
 
 1. If auto-deploy is disabled, stop. Disabling clears `pending_version`.
 2. On publish detection or enable — set `pending_version` to the newest published version.
-3. On a new rollout `failed` transition — disable auto-deploy, clear `pending_version` and `last_seen_version`, record `last_error` and `last_failed_rollout_at`; stop. The timestamp prevents the retained terminal rollout row from immediately disabling a later app-admin re-enable.
-4. If rollout state is `enrolling` or `restarting`, stop. `pending_version` is already updated.
-5. If `pending_version` is empty, stop.
-6. If `pending_version` equals the desired version, clear `pending_version` and stop.
-7. Capture `pending_version` and attempt admission for that version (same as manual version selection). Run this step after publish detection and on periodic or rollout-terminal reconciliation, including when the registry returns **304**.
+3. On a new rollout `failed` transition — retain the user’s `enabled` setting, set `paused: true` with `pause_reason: rollout_failed`, clear `pending_version` and `last_seen_version`, record `last_error` and `last_failed_rollout_at`; stop. A manual selection of the failed current desired version starts a fresh rollout and clears the runtime pause.
+4. If `paused` is true, stop.
+5. If rollout state is `enrolling` or `restarting`, stop. `pending_version` is already updated.
+6. If `pending_version` is empty, stop.
+7. If `pending_version` equals the desired version, clear `pending_version` and stop.
+8. Capture `pending_version` and attempt admission for that version (same as manual version selection). Run this step after publish detection and on periodic or rollout-terminal reconciliation, including when the registry returns **304**.
    - **Success** — clear `pending_version` only if it still equals the captured version. Preserve a newer target written concurrently by another replica.
    - **Validation failure (400)** — clear `pending_version` and set `last_error` only if it still equals the captured version. Do not retry until the next publish or a manual deploy.
    - **Active rollout (409)** — keep `pending_version`; retry when the rollout reaches `complete`.
@@ -916,13 +917,15 @@ Per enabled app, Gestalt tracks a pending version: the newest published snapshot
   "app": "g-issues",
   "autoDeploy": {
     "enabled": true,
+    "paused": false,
+    "pauseReason": null,
     "pendingVersion": "0.0.0-snapshot.gdef456",
     "lastError": null
   }
 }
 ```
 
-`GET /api/v1/apps/{app}/admin/registry` projects `autoDeploy.enabled`, `autoDeploy.pendingVersion`, and `autoDeploy.lastError` alongside rollout and published-version state.
+`GET /api/v1/apps/{app}/admin/registry` projects `autoDeploy.enabled`, `autoDeploy.paused`, `autoDeploy.pauseReason`, `autoDeploy.pendingVersion`, and `autoDeploy.lastError` alongside rollout and published-version state.
 
 ##### Edge Cases
 
@@ -932,7 +935,7 @@ Per enabled app, Gestalt tracks a pending version: the newest published snapshot
 | Version expired or locked | Admission rejected (**400**); clear pending. |
 | No fleet-known version yet | First publish triggers `add`. |
 | Concurrent manual deploy | Install lock serializes; auto-deploy retries when the rollout reaches `complete`. |
-| Rollout `failed` | Disable auto-deploy, clear pending, record `lastError`. App admin must deploy manually and re-enable auto-deploy to resume automatic admissions. |
+| Rollout `failed` | Pause automatic admissions, clear pending, record `lastError`, and retain the enabled choice. App admin can retry the failed desired version or toggle the policy to resume. |
 
 ### Errors
 

--- a/plans/app_registry/project/tests.md
+++ b/plans/app_registry/project/tests.md
@@ -589,7 +589,7 @@ go test ./internal/coredata/... -run TestAutoDeploySettingsService -count=1
 | --- | --- |
 | `TestAutoDeploySettingsService/missing_settings` | `Get` returns `ErrNotFound` for an app with no row |
 | `TestAutoDeploySettingsService/update_initializes_and_round_trips` | `Update` creates a row, normalizes fields, and round-trips through `Get` |
-| `TestAutoDeploySettingsService/list_enabled` | `ListEnabled` returns only apps with `enabled: true` |
+| `TestAutoDeploySettingsService/update_initializes_and_round_trips` | `Update` persists pause state alongside the legacy settings schema |
 
 ### Gestalt Controller Tests (`autodeploy/controller_test.go`)
 
@@ -606,7 +606,7 @@ go test ./internal/appregistry/autodeploy/... -count=1
 | --- | --- |
 | `TestControllerDetectsAndAdmitsNewestVersion` | Publish detection admits the newest snapshot when no rollout is active |
 | `TestControllerCoalescesDuringActiveRollout` | Active rollout updates `pending_version` without starting a second admission |
-| `TestControllerDisablesOnFailedRollout` | Rollout `failed` disables auto-deploy, clears pending, and records `last_error` |
+| `TestControllerPausesOnFailedRollout` | Rollout `failed` pauses auto-deploy while retaining `enabled`, clears pending, and records `last_error` |
 | `TestControllerCandidateRejectionWaitsForNextPublish` | Validation failure clears pending and records `last_error` without retrying until the next publish |
 
 ### Gestalt API Tests (`handlers_app_admin_registry_test.go`)


### PR DESCRIPTION
## Summary

This change makes app registry rollout history and current fleet health answer different questions. That prevents a failed rollout, an idle replica, or a concurrent retry from putting auto-deploy into the wrong state.

## Why this is necessary

When an app rollout fails, the system needs to distinguish between:

- the rollout attempt that failed, and
- the fleet state that exists now.

Previously, those signals could be mixed together. Idle replicas could look like version mismatches even when enough active replicas were healthy. A failed rollout could also disable auto-deploy permanently, forcing an operator to re-enable it manually. Finally, a retry or a newly published version could race with background reconciliation and leave stale pause or pending-version state behind.

This matters operationally because the control plane should stop making new automatic changes after a real rollout failure, while preserving the operator's intent to use auto-deploy. The operator should be able to select the failed desired version again to retry it, and a stale background pass must not undo that retry.

## What changed

- Live fleet health now treats starting and not-running replicas as neutral capacity, and reports whether the active fleet has enough healthy replicas on the desired version.
- Failed rollouts are evaluated against the rollout's recorded version, source, and minimum replica requirements, rather than only today's fleet configuration.
- Auto-deploy remains enabled when a rollout fails, but enters a separate paused state with a clear retry message.
- Selecting the failed current version is now the supported retry path. It creates a new rollout attempt, still applies retention and lock checks, and clears the pause only after a successful retry admission.
- Settings updates are conditional on the exact rollout being handled, so stale reconciliation cannot re-pause a newer retry or publish work while paused.
- The existing IndexedDB schema remains compatible with deployed stores; pause fields are persisted without changing the existing store metadata.

## Validation

- [x] Go tests
- [x] Go lint and vet
- [x] Semgrep
- [x] Helm chart validation
- [x] Cursor Bugbot
- [x] Regression coverage for idle capacity, failed rollouts, retry retention, stale updates, schema compatibility, and API pause fields
- [ ] UI demo not applicable: this PR changes backend behavior, tests, and operational documentation only

## Reviewer focus

Please focus on the state transitions around failed rollouts, manual retry, concurrent reconciliation, and reopening an existing app registry store.

## Rollout and compatibility

No migration or deployment ordering is required. Existing stores keep their current schema metadata, and new pause fields round-trip through the existing persistence layer.