### PR TITLE
Show current group names in app-admin member listings

### DIFF
--- a/gestalt/cli/src/commands/authorization_apps.rs
+++ b/gestalt/cli/src/commands/authorization_apps.rs
@@ -432,18 +432,33 @@ fn member_row(value: &Value) -> Vec<String> {
             .and_then(Value::as_bool)
             .map(|mutable| mutable.to_string())
             .unwrap_or_default(),
-        value
-            .get("subjectId")
-            .or_else(|| value.get("selectorValue"))
-            .and_then(Value::as_str)
-            .unwrap_or("")
-            .to_string(),
+        member_subject_label(value),
         value
             .get("email")
             .and_then(Value::as_str)
             .unwrap_or("")
             .to_string(),
     ]
+}
+
+fn member_subject_label(value: &Value) -> String {
+    let selector = value
+        .get("subjectId")
+        .or_else(|| value.get("selectorValue"))
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    let display_name = value
+        .get("subjectSet")
+        .and_then(|subject_set| subject_set.get("resource"))
+        .and_then(|resource| resource.get("displayName"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|name| !name.is_empty());
+    match display_name {
+        Some(name) if !selector.is_empty() => format!("{name} ({selector})"),
+        Some(name) => name.to_string(),
+        None => selector.to_string(),
+    }
 }
 
 fn is_service_account_subject(subject_id: &str) -> bool {
@@ -531,8 +546,9 @@ struct OperationOverrideBody {
 mod tests {
     use super::{
         AppAdminMember, AuthorizationAppsAllowedOperationsSetArgs,
-        canonical_subject_id_from_members, is_service_account_subject, normalize_subject_id,
-        parse_operation_roles_assignment, subject_id_for_email_in_members, subject_matches_member,
+        canonical_subject_id_from_members, is_service_account_subject, member_subject_label,
+        normalize_subject_id, parse_operation_roles_assignment, subject_id_for_email_in_members,
+        subject_matches_member,
     };
 
     #[test]
@@ -604,6 +620,15 @@ mod tests {
             subject_id_for_email_in_members(&members, "bob@example.com"),
             None
         );
+    }
+
+    #[test]
+    fn member_subject_label_prefers_subject_set_display_name_and_keeps_selector() {
+        let row = serde_json::json!({
+            "selectorValue": "group:eng#member",
+            "subjectSet": {"resource": {"displayName": "Engineering"}}
+        });
+        assert_eq!(member_subject_label(&row), "Engineering (group:eng#member)");
     }
 
     #[test]

--- a/gestaltd/core/authorization.go
+++ b/gestaltd/core/authorization.go
@@ -6,6 +6,10 @@ import (
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 )
 
+// AuthorizationResourceDisplayNameProperty is the canonical resource property
+// used when authorization-backed resources need a human-readable name.
+const AuthorizationResourceDisplayNameProperty = "displayName"
+
 type AuthorizationProvider interface {
 	CheckAccess(ctx context.Context, req *proto.CheckAccessRequest) (*proto.CheckAccessResponse, error)
 	CheckAccessMany(ctx context.Context, req *proto.CheckAccessManyRequest) (*proto.CheckAccessManyResponse, error)

--- a/gestaltd/core/authorization.go
+++ b/gestaltd/core/authorization.go
@@ -10,6 +10,12 @@ import (
 // used when authorization-backed resources need a human-readable name.
 const AuthorizationResourceDisplayNameProperty = "displayName"
 
+// AuthorizationResourceDisplayNameResolver resolves current presentation
+// metadata for authorization resources without changing their stable IDs.
+// It is optional because a provider may carry displayName in resource
+// properties while a resource-owning service can supply fresher metadata.
+type AuthorizationResourceDisplayNameResolver func(context.Context, *proto.Resource) (string, error)
+
 type AuthorizationProvider interface {
 	CheckAccess(ctx context.Context, req *proto.CheckAccessRequest) (*proto.CheckAccessResponse, error)
 	CheckAccessMany(ctx context.Context, req *proto.CheckAccessManyRequest) (*proto.CheckAccessManyResponse, error)

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -245,6 +245,7 @@ type Result struct {
 	SelectedAuthProvider    string
 	AuthProviders           map[string]core.IdentityProvider
 	Authorization           map[string]core.AuthorizationProvider
+	DisplayNameResolver     core.AuthorizationResourceDisplayNameResolver
 	Services                *coredata.Services
 	ExtraIndexedDBs         []indexeddb.IndexedDB
 	ExtraCaches             []corecache.Cache
@@ -1586,10 +1587,16 @@ func BootstrapWithOptions(ctx context.Context, cfg *config.Config, factories *Fa
 		scimHandler = scim.NewHandler(prepared.SCIM)
 	}
 	result := &Result{
-		Auth:                           prepared.Auth,
-		SelectedAuthProvider:           prepared.SelectedAuthProvider,
-		AuthProviders:                  prepared.AuthProviders,
-		Authorization:                  prepared.Authorization,
+		Auth:                 prepared.Auth,
+		SelectedAuthProvider: prepared.SelectedAuthProvider,
+		AuthProviders:        prepared.AuthProviders,
+		Authorization:        prepared.Authorization,
+		DisplayNameResolver: func(ctx context.Context, resource *proto.Resource) (string, error) {
+			if prepared.SCIM == nil {
+				return "", nil
+			}
+			return prepared.SCIM.ResolveAuthorizationResourceDisplayName(ctx, resource)
+		},
 		Services:                       prepared.Services,
 		ExtraIndexedDBs:                prepared.ExtraIndexedDBs,
 		ExtraCaches:                    prepared.ExtraCaches,

--- a/gestaltd/internal/scim/compact_http_test.go
+++ b/gestaltd/internal/scim/compact_http_test.go
@@ -150,6 +150,41 @@ func TestCompactSCIMUserAndGroupContract(t *testing.T) {
 		t.Fatal("missing ETag")
 	}
 }
+
+func TestSCIMAuthorizationResourceDisplayNameFollowsGroup(t *testing.T) {
+	t.Parallel()
+
+	service, _, handler := newSCIMService(t, nil, newRecordingAuthorization(), testSCIMConfig(map[string]config.SCIMClientConfig{
+		"rippling": ripplingClient(nil),
+	}))
+	created := scimRequest(t, handler, http.MethodPost, "/scim/v2/Groups", testCurrentToken, map[string]any{
+		"schemas":     []string{scim.GroupSchemaURN},
+		"displayName": "Engineering",
+	})
+	if created.Code != http.StatusCreated {
+		t.Fatalf("create group: %d %s", created.Code, created.Body.String())
+	}
+	var group scim.Group
+	if err := json.Unmarshal(created.Body.Bytes(), &group); err != nil {
+		t.Fatal(err)
+	}
+
+	name, err := service.ResolveAuthorizationResourceDisplayName(context.Background(), &proto.Resource{Type: "group", Id: group.ID})
+	if err != nil || name != "Engineering" {
+		t.Fatalf("resolved initial group name = %q, err = %v", name, err)
+	}
+	updated := scimRequest(t, handler, http.MethodPut, "/scim/v2/Groups/"+group.ID, testCurrentToken, map[string]any{
+		"schemas":     []string{scim.GroupSchemaURN},
+		"displayName": "Platform Engineering",
+	})
+	if updated.Code != http.StatusOK {
+		t.Fatalf("rename group: %d %s", updated.Code, updated.Body.String())
+	}
+	name, err = service.ResolveAuthorizationResourceDisplayName(context.Background(), &proto.Resource{Type: "group", Id: group.ID})
+	if err != nil || name != "Platform Engineering" {
+		t.Fatalf("resolved renamed group name = %q, err = %v", name, err)
+	}
+}
 func TestCompactSCIMNamespaceAndETag(t *testing.T) {
 	t.Parallel()
 	h, _, _ := setup(t)

--- a/gestaltd/internal/scim/compact_service.go
+++ b/gestaltd/internal/scim/compact_service.go
@@ -61,6 +61,23 @@ type CompactService struct {
 	now           func() time.Time
 }
 
+func (s *CompactService) authorizationResourceDisplayName(ctx context.Context, resource *proto.Resource) (string, error) {
+	if resource == nil || !strings.EqualFold(strings.TrimSpace(resource.GetType()), "group") || strings.TrimSpace(resource.GetId()) == "" {
+		return "", nil
+	}
+	record, err := s.db.ObjectStore(coredata.StoreSCIMResources).Get(ctx, strings.TrimSpace(resource.GetId()))
+	if err != nil {
+		if errors.Is(err, idb.ErrNotFound) {
+			return "", nil
+		}
+		return "", err
+	}
+	if recordString(record, "resource_type") != "Group" {
+		return "", nil
+	}
+	return strings.TrimSpace(recordString(record, "display_name")), nil
+}
+
 func NewService(db coredb.IndexedDB, authorization core.AuthorizationProvider, baseURL string, cfg config.ServerSCIMConfig) (*Service, error) {
 	s := &CompactService{db: db, authorization: authorization, baseURL: strings.TrimRight(baseURL, "/"), clients: map[string]*compactClient{}, domainOwners: map[string]string{}, now: time.Now}
 	if _, err := db.CreateObjectStore(context.Background(), coredata.StoreSCIMResources, coredata.SCIMResourcesSchema); err != nil && !errors.Is(err, idb.ErrAlreadyExists) {

--- a/gestaltd/internal/scim/service_runtime.go
+++ b/gestaltd/internal/scim/service_runtime.go
@@ -1,6 +1,10 @@
 package scim
 
-import "context"
+import (
+	"context"
+
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+)
 
 // Service is the SCIM handle shared by HTTP bootstrap and authorization
 // gating. SCIM state is held by CompactService; the AuthorizationProvider is
@@ -23,4 +27,15 @@ func (s *Service) IsEligible(ctx context.Context, coreID, email string) (bool, e
 		return true, nil
 	}
 	return s.compact.IsEligible(ctx, coreID, email)
+}
+
+// ResolveAuthorizationResourceDisplayName returns current metadata from the
+// resource-owning SCIM store. Authorization relationships intentionally keep
+// only stable resource IDs, so renamed groups do not require relationship
+// rewrites to remain readable in admin projections.
+func (s *Service) ResolveAuthorizationResourceDisplayName(ctx context.Context, resource *proto.Resource) (string, error) {
+	if s == nil || s.compact == nil {
+		return "", nil
+	}
+	return s.compact.authorizationResourceDisplayName(ctx, resource)
 }

--- a/gestaltd/internal/server/handlers_app_admin_identities.go
+++ b/gestaltd/internal/server/handlers_app_admin_identities.go
@@ -54,7 +54,8 @@ func (s *Server) projectAppAdminIdentityRows(ctx context.Context, rows []appAdmi
 	allowLookup := s.userLookupAllowed(ctx)
 	labels := make(map[string]string)
 	out := make([]appAdminIdentityRow, 0)
-	for _, row := range rows {
+	for i := range rows {
+		row := rows[i]
 		if !isAppAdminServiceAccountRow(row) {
 			continue
 		}

--- a/gestaltd/internal/server/handlers_app_admin_members.go
+++ b/gestaltd/internal/server/handlers_app_admin_members.go
@@ -21,26 +21,30 @@ import (
 // appAdminMemberRow is the shared authorization grant roster row used before
 // Members / Identities projections. Field names match the Members UI contract.
 type appAdminMemberRow struct {
-	Email         string                   `json:"email,omitempty"`
-	Role          string                   `json:"role"`
-	Source        string                   `json:"source"`
-	Mutable       bool                     `json:"mutable"`
-	Effective     bool                     `json:"effective"`
-	ShadowedBy    string                   `json:"shadowedBy,omitempty"`
-	SelectorKind  string                   `json:"selectorKind,omitempty"`
-	SelectorValue string                   `json:"selectorValue,omitempty"`
-	SubjectID     string                   `json:"subjectId,omitempty"`
-	Principal     *appAdminMemberPrincipal `json:"principal,omitempty"`
+	Email         string                    `json:"email,omitempty"`
+	Role          string                    `json:"role"`
+	Source        string                    `json:"source"`
+	Mutable       bool                      `json:"mutable"`
+	Effective     bool                      `json:"effective"`
+	ShadowedBy    string                    `json:"shadowedBy,omitempty"`
+	SelectorKind  string                    `json:"selectorKind,omitempty"`
+	SelectorValue string                    `json:"selectorValue,omitempty"`
+	SubjectID     string                    `json:"subjectId,omitempty"`
+	SubjectSet    *appAdminMemberSubjectSet `json:"subjectSet,omitempty"`
 }
 
-// appAdminMemberPrincipal carries display metadata without changing the
-// canonical selector used by authorization mutations. Group names are
-// optional because older relationships may not have resource properties.
-type appAdminMemberPrincipal struct {
-	Kind        string `json:"kind"`
+// appAdminMemberSubjectSet mirrors the authorization target shape while
+// carrying presentation metadata separately from the canonical selector used
+// by authorization mutations.
+type appAdminMemberSubjectSet struct {
+	Resource appAdminMemberSubjectSetResource `json:"resource"`
+	Relation string                           `json:"relation,omitempty"`
+}
+
+type appAdminMemberSubjectSetResource struct {
+	Type        string `json:"type"`
 	ID          string `json:"id"`
 	DisplayName string `json:"displayName,omitempty"`
-	Relation    string `json:"relation,omitempty"`
 }
 
 func (s *Server) mountAppAdminMembersRoutes(r chi.Router) {
@@ -462,13 +466,13 @@ func (s *Server) appAdminMemberRowFromRelationship(_ context.Context, relationsh
 		}
 		row.SelectorKind = "subject_set"
 		row.SelectorValue = selector
-		if resourceType == "group" {
-			row.Principal = &appAdminMemberPrincipal{
-				Kind:        "group",
+		row.SubjectSet = &appAdminMemberSubjectSet{
+			Resource: appAdminMemberSubjectSetResource{
+				Type:        resourceType,
 				ID:          resourceID,
 				DisplayName: authorizationResourceDisplayName(target.SubjectSet.GetResource()),
-				Relation:    relation,
-			}
+			},
+			Relation: relation,
 		}
 		return row, true
 	default:
@@ -476,18 +480,18 @@ func (s *Server) appAdminMemberRowFromRelationship(_ context.Context, relationsh
 	}
 }
 
-// authorizationResourceDisplayName reads the optional display metadata carried
-// by the group resource. Authorization keeps the resource ID stable; the
-// resource's display name is presentation data and may change independently.
+// authorizationResourceDisplayName reads the one canonical display metadata
+// field carried by an authorization resource. Authorization keeps the
+// resource ID stable; the resource's display name is presentation data and may
+// change independently.
 func authorizationResourceDisplayName(resource *proto.Resource) string {
 	if resource == nil || resource.GetProperties() == nil {
 		return ""
 	}
-	for _, key := range []string{"displayName", "display_name", "name"} {
-		if value := resource.GetProperties().GetFields()[key]; value != nil {
-			if displayName := strings.TrimSpace(value.GetStringValue()); displayName != "" {
-				return displayName
-			}
+	value := resource.GetProperties().GetFields()[core.AuthorizationResourceDisplayNameProperty]
+	if value != nil {
+		if displayName := strings.TrimSpace(value.GetStringValue()); displayName != "" {
+			return displayName
 		}
 	}
 	return ""

--- a/gestaltd/internal/server/handlers_app_admin_members.go
+++ b/gestaltd/internal/server/handlers_app_admin_members.go
@@ -21,15 +21,26 @@ import (
 // appAdminMemberRow is the shared authorization grant roster row used before
 // Members / Identities projections. Field names match the Members UI contract.
 type appAdminMemberRow struct {
-	Email         string `json:"email,omitempty"`
-	Role          string `json:"role"`
-	Source        string `json:"source"`
-	Mutable       bool   `json:"mutable"`
-	Effective     bool   `json:"effective"`
-	ShadowedBy    string `json:"shadowedBy,omitempty"`
-	SelectorKind  string `json:"selectorKind,omitempty"`
-	SelectorValue string `json:"selectorValue,omitempty"`
-	SubjectID     string `json:"subjectId,omitempty"`
+	Email         string                   `json:"email,omitempty"`
+	Role          string                   `json:"role"`
+	Source        string                   `json:"source"`
+	Mutable       bool                     `json:"mutable"`
+	Effective     bool                     `json:"effective"`
+	ShadowedBy    string                   `json:"shadowedBy,omitempty"`
+	SelectorKind  string                   `json:"selectorKind,omitempty"`
+	SelectorValue string                   `json:"selectorValue,omitempty"`
+	SubjectID     string                   `json:"subjectId,omitempty"`
+	Principal     *appAdminMemberPrincipal `json:"principal,omitempty"`
+}
+
+// appAdminMemberPrincipal carries display metadata without changing the
+// canonical selector used by authorization mutations. Group names are
+// optional because older relationships may not have resource properties.
+type appAdminMemberPrincipal struct {
+	Kind        string `json:"kind"`
+	ID          string `json:"id"`
+	DisplayName string `json:"displayName,omitempty"`
+	Relation    string `json:"relation,omitempty"`
 }
 
 func (s *Server) mountAppAdminMembersRoutes(r chi.Router) {
@@ -451,10 +462,35 @@ func (s *Server) appAdminMemberRowFromRelationship(_ context.Context, relationsh
 		}
 		row.SelectorKind = "subject_set"
 		row.SelectorValue = selector
+		if resourceType == "group" {
+			row.Principal = &appAdminMemberPrincipal{
+				Kind:        "group",
+				ID:          resourceID,
+				DisplayName: authorizationResourceDisplayName(target.SubjectSet.GetResource()),
+				Relation:    relation,
+			}
+		}
 		return row, true
 	default:
 		return appAdminMemberRow{}, false
 	}
+}
+
+// authorizationResourceDisplayName reads the optional display metadata carried
+// by the group resource. Authorization keeps the resource ID stable; the
+// resource's display name is presentation data and may change independently.
+func authorizationResourceDisplayName(resource *proto.Resource) string {
+	if resource == nil || resource.GetProperties() == nil {
+		return ""
+	}
+	for _, key := range []string{"displayName", "display_name", "name"} {
+		if value := resource.GetProperties().GetFields()[key]; value != nil {
+			if displayName := strings.TrimSpace(value.GetStringValue()); displayName != "" {
+				return displayName
+			}
+		}
+	}
+	return ""
 }
 
 func appAdminMemberSource(layer proto.SourceLayer) (source string, mutable bool) {

--- a/gestaltd/internal/server/handlers_app_admin_members.go
+++ b/gestaltd/internal/server/handlers_app_admin_members.go
@@ -425,13 +425,15 @@ func memberGrantKey(row appAdminMemberRow) string {
 // exists as both static and runtime, the runtime row is marked shadowed.
 func projectAppAdminMemberRoster(rows []appAdminMemberRow) []appAdminMemberRow {
 	staticKeys := make(map[string]struct{})
-	for _, row := range rows {
+	for i := range rows {
+		row := rows[i]
 		if row.Source == "static" {
 			staticKeys[memberGrantKey(row)] = struct{}{}
 		}
 	}
 	out := make([]appAdminMemberRow, 0, len(rows))
-	for _, row := range rows {
+	for i := range rows {
+		row := rows[i]
 		if row.Source == "dynamic" {
 			if _, ok := staticKeys[memberGrantKey(row)]; ok {
 				row.Effective = false
@@ -502,11 +504,7 @@ func projectAppAdminMemberResponses(rows []appAdminMemberRow) []appAdminMemberRe
 	out := make([]appAdminMemberResponse, 0, len(rows))
 	for i := range rows {
 		row := rows[i]
-		out = append(out, appAdminMemberResponse{
-			Email: row.Email, Role: row.Role, Source: row.Source, Mutable: row.Mutable,
-			Effective: row.Effective, ShadowedBy: row.ShadowedBy, SelectorKind: row.SelectorKind,
-			SelectorValue: row.SelectorValue, SubjectID: row.SubjectID, SubjectSet: row.SubjectSet,
-		})
+		out = append(out, appAdminMemberResponse(row))
 	}
 	return out
 }

--- a/gestaltd/internal/server/handlers_app_admin_members.go
+++ b/gestaltd/internal/server/handlers_app_admin_members.go
@@ -30,6 +30,22 @@ type appAdminMemberRow struct {
 	SelectorKind  string                    `json:"selectorKind,omitempty"`
 	SelectorValue string                    `json:"selectorValue,omitempty"`
 	SubjectID     string                    `json:"subjectId,omitempty"`
+	SubjectSet    *appAdminMemberSubjectSet `json:"-"`
+}
+
+// appAdminMemberResponse is the app-admin members wire contract. Keeping it
+// separate from the shared roster row prevents subject-set presentation data
+// from leaking into platform-admin responses that reuse the internal mapper.
+type appAdminMemberResponse struct {
+	Email         string                    `json:"email,omitempty"`
+	Role          string                    `json:"role"`
+	Source        string                    `json:"source"`
+	Mutable       bool                      `json:"mutable"`
+	Effective     bool                      `json:"effective"`
+	ShadowedBy    string                    `json:"shadowedBy,omitempty"`
+	SelectorKind  string                    `json:"selectorKind,omitempty"`
+	SelectorValue string                    `json:"selectorValue,omitempty"`
+	SubjectID     string                    `json:"subjectId,omitempty"`
 	SubjectSet    *appAdminMemberSubjectSet `json:"subjectSet,omitempty"`
 }
 
@@ -97,7 +113,7 @@ func (s *Server) listAppAdminMembers(w http.ResponseWriter, r *http.Request) {
 	}
 	// Members is the human/group access roster. Service-account grants are
 	// owned by GET /apps/{app}/admin/identities.
-	writeJSON(w, http.StatusOK, s.projectAppAdminHumanMemberRows(r.Context(), rows))
+	writeJSON(w, http.StatusOK, projectAppAdminMemberResponses(s.projectAppAdminHumanMemberRows(r.Context(), rows)))
 }
 
 func (s *Server) setAppAdminMember(w http.ResponseWriter, r *http.Request) {
@@ -248,7 +264,8 @@ func isAppAdminServiceAccountRow(row appAdminMemberRow) bool {
 func (s *Server) projectAppAdminHumanMemberRows(ctx context.Context, rows []appAdminMemberRow) []appAdminMemberRow {
 	allowLookup := s.userLookupAllowed(ctx)
 	out := make([]appAdminMemberRow, 0, len(rows))
-	for _, row := range rows {
+	for i := range rows {
+		row := rows[i]
 		if isAppAdminServiceAccountRow(row) {
 			continue
 		}
@@ -329,7 +346,8 @@ func (s *Server) mutableAppAdminMemberRoles(ctx context.Context, appName, subjec
 		return nil, err
 	}
 	roles := make([]string, 0)
-	for _, row := range rows {
+	for i := range rows {
+		row := rows[i]
 		if !row.Mutable || !appAdminMemberRowMatchesSubject(row, subjectID) {
 			continue
 		}
@@ -425,7 +443,7 @@ func projectAppAdminMemberRoster(rows []appAdminMemberRow) []appAdminMemberRow {
 	return out
 }
 
-func (s *Server) appAdminMemberRowFromRelationship(_ context.Context, relationship *proto.Relationship) (appAdminMemberRow, bool) {
+func (s *Server) appAdminMemberRowFromRelationship(ctx context.Context, relationship *proto.Relationship) (appAdminMemberRow, bool) {
 	if relationship == nil || relationship.GetTuple() == nil {
 		return appAdminMemberRow{}, false
 	}
@@ -470,7 +488,7 @@ func (s *Server) appAdminMemberRowFromRelationship(_ context.Context, relationsh
 			Resource: appAdminMemberSubjectSetResource{
 				Type:        resourceType,
 				ID:          resourceID,
-				DisplayName: authorizationResourceDisplayName(target.SubjectSet.GetResource()),
+				DisplayName: s.authorizationResourceDisplayName(ctx, target.SubjectSet.GetResource()),
 			},
 			Relation: relation,
 		}
@@ -480,18 +498,43 @@ func (s *Server) appAdminMemberRowFromRelationship(_ context.Context, relationsh
 	}
 }
 
+func projectAppAdminMemberResponses(rows []appAdminMemberRow) []appAdminMemberResponse {
+	out := make([]appAdminMemberResponse, 0, len(rows))
+	for i := range rows {
+		row := rows[i]
+		out = append(out, appAdminMemberResponse{
+			Email: row.Email, Role: row.Role, Source: row.Source, Mutable: row.Mutable,
+			Effective: row.Effective, ShadowedBy: row.ShadowedBy, SelectorKind: row.SelectorKind,
+			SelectorValue: row.SelectorValue, SubjectID: row.SubjectID, SubjectSet: row.SubjectSet,
+		})
+	}
+	return out
+}
+
 // authorizationResourceDisplayName reads the one canonical display metadata
 // field carried by an authorization resource. Authorization keeps the
 // resource ID stable; the resource's display name is presentation data and may
 // change independently.
-func authorizationResourceDisplayName(resource *proto.Resource) string {
+func (s *Server) authorizationResourceDisplayName(ctx context.Context, resource *proto.Resource) string {
 	if resource == nil || resource.GetProperties() == nil {
+		if s.displayNameResolver != nil {
+			name, err := s.displayNameResolver(ctx, resource)
+			if err == nil {
+				return strings.TrimSpace(name)
+			}
+		}
 		return ""
 	}
 	value := resource.GetProperties().GetFields()[core.AuthorizationResourceDisplayNameProperty]
 	if value != nil {
 		if displayName := strings.TrimSpace(value.GetStringValue()); displayName != "" {
 			return displayName
+		}
+	}
+	if s.displayNameResolver != nil {
+		name, err := s.displayNameResolver(ctx, resource)
+		if err == nil {
+			return strings.TrimSpace(name)
 		}
 	}
 	return ""

--- a/gestaltd/internal/server/handlers_app_admin_members_test.go
+++ b/gestaltd/internal/server/handlers_app_admin_members_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/server"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
@@ -224,7 +225,26 @@ func TestAppAdminMembersListSubjectSet(t *testing.T) {
 								Resource: &proto.Resource{
 									Type:       "group",
 									Id:         "eng",
-									Properties: mustStruct(t, map[string]any{"displayName": "Engineering"}),
+									Properties: mustStruct(t, map[string]any{core.AuthorizationResourceDisplayNameProperty: "Engineering"}),
+								},
+								Relation: "member",
+							},
+						},
+					},
+					Relation: "viewer",
+					Resource: &proto.Resource{Type: "app", Id: "g-issues"},
+				},
+				SourceLayer: proto.SourceLayer_SOURCE_LAYER_STATIC_CONFIG,
+			},
+			{
+				Tuple: &proto.RelationshipTuple{
+					Target: &proto.RelationshipTarget{
+						Kind: &proto.RelationshipTarget_SubjectSet{
+							SubjectSet: &proto.SubjectSet{
+								Resource: &proto.Resource{
+									Type:       "group",
+									Id:         "legacy",
+									Properties: mustStruct(t, map[string]any{"name": "Legacy Name"}),
 								},
 								Relation: "member",
 							},
@@ -263,28 +283,39 @@ func TestAppAdminMembersListSubjectSet(t *testing.T) {
 		SelectorKind  string `json:"selectorKind"`
 		SelectorValue string `json:"selectorValue"`
 		SubjectID     string `json:"subjectId"`
-		Principal     *struct {
-			Kind        string `json:"kind"`
-			ID          string `json:"id"`
-			DisplayName string `json:"displayName"`
-			Relation    string `json:"relation"`
-		} `json:"principal"`
+		SubjectSet    *struct {
+			Resource struct {
+				Type        string `json:"type"`
+				ID          string `json:"id"`
+				DisplayName string `json:"displayName"`
+			} `json:"resource"`
+			Relation string `json:"relation"`
+		} `json:"subjectSet"`
 	}
 	if err := json.NewDecoder(response.Body).Decode(&rows); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
 	found := false
+	legacyFound := false
 	for _, row := range rows {
 		if row.SelectorKind == "subject_set" && row.SelectorValue == "group:eng#member" && row.Role == "viewer" && row.SubjectID == "" {
-			if row.Principal == nil || row.Principal.Kind != "group" || row.Principal.ID != "eng" || row.Principal.DisplayName != "Engineering" || row.Principal.Relation != "member" {
-				t.Fatalf("subject_set principal = %#v, want named group", row.Principal)
+			if row.SubjectSet == nil || row.SubjectSet.Resource.Type != "group" || row.SubjectSet.Resource.ID != "eng" || row.SubjectSet.Resource.DisplayName != "Engineering" || row.SubjectSet.Relation != "member" {
+				t.Fatalf("subject_set = %#v, want named group subject set", row.SubjectSet)
 			}
 			found = true
-			break
+		}
+		if row.SelectorKind == "subject_set" && row.SelectorValue == "group:legacy#member" {
+			if row.SubjectSet == nil || row.SubjectSet.Resource.DisplayName != "" {
+				t.Fatalf("legacy subject_set = %#v, want no non-canonical display name", row.SubjectSet)
+			}
+			legacyFound = true
 		}
 	}
 	if !found {
 		t.Fatalf("subject_set row missing: %#v", rows)
+	}
+	if !legacyFound {
+		t.Fatalf("legacy subject_set row missing: %#v", rows)
 	}
 }
 

--- a/gestaltd/internal/server/handlers_app_admin_members_test.go
+++ b/gestaltd/internal/server/handlers_app_admin_members_test.go
@@ -2,12 +2,12 @@ package server_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
 	"testing"
 
-	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/server"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
@@ -225,7 +225,7 @@ func TestAppAdminMembersListSubjectSet(t *testing.T) {
 								Resource: &proto.Resource{
 									Type:       "group",
 									Id:         "eng",
-									Properties: mustStruct(t, map[string]any{core.AuthorizationResourceDisplayNameProperty: "Engineering"}),
+									Properties: mustStruct(t, map[string]any{"displayName": "Engineering"}),
 								},
 								Relation: "member",
 							},
@@ -255,6 +255,21 @@ func TestAppAdminMembersListSubjectSet(t *testing.T) {
 				},
 				SourceLayer: proto.SourceLayer_SOURCE_LAYER_STATIC_CONFIG,
 			},
+			{
+				Tuple: &proto.RelationshipTuple{
+					Target: &proto.RelationshipTarget{
+						Kind: &proto.RelationshipTarget_SubjectSet{
+							SubjectSet: &proto.SubjectSet{
+								Resource: &proto.Resource{Type: "group", Id: "resolved"},
+								Relation: "member",
+							},
+						},
+					},
+					Relation: "viewer",
+					Resource: &proto.Resource{Type: "app", Id: "g-issues"},
+				},
+				SourceLayer: proto.SourceLayer_SOURCE_LAYER_STATIC_CONFIG,
+			},
 		},
 	}
 	authz.relationships[0].SourceLayer = proto.SourceLayer_SOURCE_LAYER_STATIC_CONFIG
@@ -263,6 +278,12 @@ func TestAppAdminMembersListSubjectSet(t *testing.T) {
 		cfg.Auth = authStubWithSessionTokenIntrospect("alice-token", adminID, "")
 		cfg.Authorization = authz
 		cfg.AppDefs = appAdminTestAppDefs()
+		cfg.DisplayNameResolver = func(_ context.Context, resource *proto.Resource) (string, error) {
+			if resource.GetType() == "group" && resource.GetId() == "resolved" {
+				return "Resolved from owner", nil
+			}
+			return "", nil
+		}
 	})
 	testutil.CloseOnCleanup(t, ts)
 
@@ -297,6 +318,7 @@ func TestAppAdminMembersListSubjectSet(t *testing.T) {
 	}
 	found := false
 	legacyFound := false
+	resolvedFound := false
 	for _, row := range rows {
 		if row.SelectorKind == "subject_set" && row.SelectorValue == "group:eng#member" && row.Role == "viewer" && row.SubjectID == "" {
 			if row.SubjectSet == nil || row.SubjectSet.Resource.Type != "group" || row.SubjectSet.Resource.ID != "eng" || row.SubjectSet.Resource.DisplayName != "Engineering" || row.SubjectSet.Relation != "member" {
@@ -310,12 +332,21 @@ func TestAppAdminMembersListSubjectSet(t *testing.T) {
 			}
 			legacyFound = true
 		}
+		if row.SelectorKind == "subject_set" && row.SelectorValue == "group:resolved#member" {
+			if row.SubjectSet == nil || row.SubjectSet.Resource.DisplayName != "Resolved from owner" {
+				t.Fatalf("resolved subject_set = %#v, want owner metadata", row.SubjectSet)
+			}
+			resolvedFound = true
+		}
 	}
 	if !found {
 		t.Fatalf("subject_set row missing: %#v", rows)
 	}
 	if !legacyFound {
 		t.Fatalf("legacy subject_set row missing: %#v", rows)
+	}
+	if !resolvedFound {
+		t.Fatalf("resolved subject_set row missing: %#v", rows)
 	}
 }
 

--- a/gestaltd/internal/server/handlers_app_admin_members_test.go
+++ b/gestaltd/internal/server/handlers_app_admin_members_test.go
@@ -221,7 +221,11 @@ func TestAppAdminMembersListSubjectSet(t *testing.T) {
 					Target: &proto.RelationshipTarget{
 						Kind: &proto.RelationshipTarget_SubjectSet{
 							SubjectSet: &proto.SubjectSet{
-								Resource: &proto.Resource{Type: "group", Id: "eng"},
+								Resource: &proto.Resource{
+									Type:       "group",
+									Id:         "eng",
+									Properties: mustStruct(t, map[string]any{"displayName": "Engineering"}),
+								},
 								Relation: "member",
 							},
 						},
@@ -259,6 +263,12 @@ func TestAppAdminMembersListSubjectSet(t *testing.T) {
 		SelectorKind  string `json:"selectorKind"`
 		SelectorValue string `json:"selectorValue"`
 		SubjectID     string `json:"subjectId"`
+		Principal     *struct {
+			Kind        string `json:"kind"`
+			ID          string `json:"id"`
+			DisplayName string `json:"displayName"`
+			Relation    string `json:"relation"`
+		} `json:"principal"`
 	}
 	if err := json.NewDecoder(response.Body).Decode(&rows); err != nil {
 		t.Fatalf("decode response: %v", err)
@@ -266,6 +276,9 @@ func TestAppAdminMembersListSubjectSet(t *testing.T) {
 	found := false
 	for _, row := range rows {
 		if row.SelectorKind == "subject_set" && row.SelectorValue == "group:eng#member" && row.Role == "viewer" && row.SubjectID == "" {
+			if row.Principal == nil || row.Principal.Kind != "group" || row.Principal.ID != "eng" || row.Principal.DisplayName != "Engineering" || row.Principal.Relation != "member" {
+				t.Fatalf("subject_set principal = %#v, want named group", row.Principal)
+			}
 			found = true
 			break
 		}

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -105,6 +105,7 @@ func run(ctx context.Context, cfg *config.Config, result *bootstrap.Result, gest
 		SelectedAuthProvider:  result.SelectedAuthProvider,
 		AuthProviders:         result.AuthProviders,
 		Authorization:         authorizationProvider,
+		DisplayNameResolver:   result.DisplayNameResolver,
 		ProviderKinds:         bootstrap.ProviderAuthorizationKinds(cfg),
 		AuthorizationPolicies: bootstrap.ProviderAuthorizationPolicies(cfg),
 		AuditSink:             result.AuditSink,

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -119,6 +119,7 @@ type Server struct {
 	authProviders                 map[string]core.IdentityProvider
 	serverAuthProvider            string
 	authorization                 core.AuthorizationProvider
+	displayNameResolver           core.AuthorizationResourceDisplayNameResolver
 	providerKinds                 map[string]invocation.ProviderKind
 	authorizationPolicies         map[string]string
 	operationAccess               invocation.OperationAccessChecker
@@ -225,6 +226,7 @@ type Config struct {
 	SelectedAuthProvider  string
 	AuthProviders         map[string]core.IdentityProvider
 	Authorization         core.AuthorizationProvider
+	DisplayNameResolver   core.AuthorizationResourceDisplayNameResolver
 	ProviderKinds         map[string]invocation.ProviderKind
 	AuthorizationPolicies map[string]string
 	// OperationAccessChecker answers batched operation-access questions for
@@ -470,6 +472,7 @@ func New(cfg Config) (*Server, error) {
 		authProviders:                 authProviders,
 		serverAuthProvider:            serverAuthProvider,
 		authorization:                 cfg.Authorization,
+		displayNameResolver:           cfg.DisplayNameResolver,
 		providerKinds:                 cfg.ProviderKinds,
 		authorizationPolicies:         cfg.AuthorizationPolicies,
 		operationAccess:               operationAccess,


### PR DESCRIPTION
## Summary

The app-admin members list can contain direct people as well as groups. Before this change, a group grant was returned mainly as an internal selector such as `group:eng#member`. That is enough to authorize a change, but it is not enough for an administrator to understand who the grant applies to.

This change lets the members API and CLI show a group's current human-readable name while keeping the stable selector used for authorization changes.

## Why this is necessary

A group has two different identities:

- Its stable ID and relation, such as `group:eng#member`, which must be used for authorization decisions and mutations.
- Its display name, such as `Engineering`, which is for people and can change over time.

Treating the display name as the identity would make renaming a group break or silently redirect authorization changes. Showing only the stable selector makes the admin experience confusing and forces users to recognize opaque IDs.

The distinction also matters for SCIM-managed groups. SCIM owns the current group name, while authorization owns the grant. The members endpoint now asks the resource owner for the current name, so a SCIM rename is reflected without rewriting every authorization relationship.

## What changed

- App-admin members responses include structured `subjectSet` metadata for group-style grants: resource type, stable ID, relation, and optional display name.
- Existing `selectorKind` and `selectorValue` fields remain unchanged and continue to drive authorization mutations.
- Display names use the canonical `displayName` property when authorization already provides it, with a resolver for current SCIM group names.
- The CLI shows the readable name alongside the stable selector, for example `Engineering (group:eng#member)`.
- The shared internal roster type does not add this field to unrelated platform-admin responses.

## Validation

- [x] `go test ./core ./internal/server ./internal/scim ./internal/bootstrap -run 'TestAppAdminMembers|TestSCIMAuthorizationResourceDisplayName' -count=1`
- [x] `go vet ./core ./internal/server ./internal/scim ./internal/bootstrap`
- [x] `cargo fmt --check`
- [x] `cargo test -p gestalt member_subject_label -- --nocapture`
- [x] Required CI checks: Go lint and vet, Go tests, Helm validation, and Cursor Bugbot

## Reviewer focus

Please focus on whether the stable selector remains the only authorization identity, whether SCIM renames return current names, and whether legacy resources without canonical display metadata remain safe.

## Rollout / compatibility

This is additive for the app-admin members response. Existing selectors and mutation behavior are unchanged. Resources without a current display name continue to work and simply omit the optional `displayName`.

## Evidence

No browser demo is included because this is a backend/API and CLI contract change rather than a browser UI change.
