### PR TITLE
Raise invocation capability TTL to 30 minutes

### DIFF
--- a/gestaltd/services/runtimehost/capability_ingress_test.go
+++ b/gestaltd/services/runtimehost/capability_ingress_test.go
@@ -80,6 +80,32 @@ func TestAuthenticateGRPCRejectsWrongMethodPrefix(t *testing.T) {
 	}
 }
 
+func TestCallerCapabilityDefaultsToThirtyMinutes(t *testing.T) {
+	t.Parallel()
+
+	manager := testRelayTokenManager(t)
+	start := time.Unix(1_700_000_000, 0)
+	manager.now = func() time.Time { return start }
+	token, err := manager.MintToken(HostServiceRelayTokenRequest{
+		Service:      "identity",
+		MethodPrefix: "/" + proto.Identity_ServiceDesc.ServiceName + "/",
+		Caller:       &PrincipalClaims{SubjectID: "user:alice"},
+	})
+	if err != nil {
+		t.Fatalf("MintToken: %v", err)
+	}
+
+	manager.now = func() time.Time { return start.Add(30*time.Minute - time.Second) }
+	if _, err := manager.ResolveToken(token); err != nil {
+		t.Fatalf("ResolveToken before 30m: %v", err)
+	}
+
+	manager.now = func() time.Time { return start.Add(30*time.Minute + time.Second) }
+	if _, err := manager.ResolveToken(token); err == nil {
+		t.Fatal("ResolveToken after 30m: want expired")
+	}
+}
+
 func TestAuthenticateGRPCRejectsExpiredCapability(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/services/runtimehost/host_service_relay_token.go
+++ b/gestaltd/services/runtimehost/host_service_relay_token.go
@@ -16,9 +16,7 @@ const (
 	hostServiceRelayTokenAudience   = "gestalt-host-service-relay"
 	defaultHostServiceRelayTokenTTL = 24 * time.Hour
 	maxHostServiceRelayTokenTTL     = 30 * 24 * time.Hour
-	// DefaultInvocationCapabilityTTL is the lifetime of caller-scoped tokens
-	// minted for a provider Execute. request.gestalt() reuses that JWT for
-	// agent, identity, app, and workflow RPCs until the activity returns.
+	// DefaultInvocationCapabilityTTL scopes caller-scoped invocation capabilities.
 	DefaultInvocationCapabilityTTL = 30 * time.Minute
 )
 

--- a/gestaltd/services/runtimehost/host_service_relay_token.go
+++ b/gestaltd/services/runtimehost/host_service_relay_token.go
@@ -16,8 +16,10 @@ const (
 	hostServiceRelayTokenAudience   = "gestalt-host-service-relay"
 	defaultHostServiceRelayTokenTTL = 24 * time.Hour
 	maxHostServiceRelayTokenTTL     = 30 * 24 * time.Hour
-	// DefaultInvocationCapabilityTTL scopes short-lived invocation capabilities.
-	DefaultInvocationCapabilityTTL = 5 * time.Minute
+	// DefaultInvocationCapabilityTTL is the lifetime of caller-scoped tokens
+	// minted for a provider Execute. request.gestalt() reuses that JWT for
+	// agent, identity, app, and workflow RPCs until the activity returns.
+	DefaultInvocationCapabilityTTL = 30 * time.Minute
 )
 
 // PrincipalClaims carries verified caller identity inside a host-service capability.


### PR DESCRIPTION
## Summary
- Caller-scoped host-service relay tokens were minted for 5 minutes. `request.gestalt()` (agent, identity, app, workflow) reuses that JWT for the whole provider activity.
- Long workflow steps such as Knowledge Hub redaction outlive that window and fail with `invalid-host-service-relay-token` even though the Temporal activity is still running.
- Default TTL is now 30 minutes, aligned with the existing activity timeout. Tokens still expire; this only covers one Execute.

## Test plan
- [x] `go test ./services/runtimehost/` (new default-TTL expiry test)
- [ ] After gestaltd deploy, retry Property Tax redaction as a single kick; it should survive past 5 minutes
- [ ] Confirm a token minted with an explicit short `TTL` still expires on that deadline


Made with [Cursor](https://cursor.com)