### PR TITLE
Reduce internal gRPC response limit to 16 MiB

### DIFF
--- a/gestaltd/internal/grpcutil/grpcutil.go
+++ b/gestaltd/internal/grpcutil/grpcutil.go
@@ -8,10 +8,10 @@ import (
 	"google.golang.org/grpc"
 )
 
-// InternalMaxReceiveMessageBytes is the maximum response size for internal
-// gRPC clients. It accommodates Gmail's 25 MiB attachment limit after
-// base64 expansion, while leaving the public gRPC defaults unchanged.
-const InternalMaxReceiveMessageBytes = 40 * 1024 * 1024
+// InternalMaxReceiveMessageBytes is the short-term maximum response size for
+// internal gRPC clients. It gives headroom above the observed Bradley Gmail
+// attachment response without allowing full Gmail-sized unary payloads.
+const InternalMaxReceiveMessageBytes = 16 * 1024 * 1024
 
 // InternalClientDialOption allows internal provider clients to receive large
 // operation results without changing public gRPC server or client limits.


### PR DESCRIPTION
## Summary
- reduce the short-term internal app-provider gRPC receive allowance from 40 MiB to 16 MiB
- update the comment to frame this as Bradley-production-response headroom rather than full Gmail 25 MiB coverage

## Validation
- not run; comment/constant-only change on top of #3199

Made with [Cursor](https://cursor.com)