### PR TITLE
Filter platform-admins API to gestalt#admin grants only

### DIFF
--- a/gestaltd/internal/server/handlers_admin_platform_admins.go
+++ b/gestaltd/internal/server/handlers_admin_platform_admins.go
@@ -47,17 +47,24 @@ func (s *Server) listAdminPlatformAdmins(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	resource := s.platformAdminResource()
+	role := s.configuredPlatformAdminRole()
 	rows, err := s.listAuthorizationMemberRows(r.Context(), resource)
 	if err != nil {
 		writeError(w, http.StatusServiceUnavailable, "authorization is unavailable")
 		return
+	}
+	filtered := make([]appAdminMemberRow, 0, len(rows))
+	for i := range rows {
+		if strings.TrimSpace(rows[i].Role) == role {
+			filtered = append(filtered, rows[i])
+		}
 	}
 	writeJSON(w, http.StatusOK, adminPlatformAdminsResponse{
 		Resource: adminPlatformAdminResource{
 			Type: resource.GetType(),
 			ID:   resource.GetId(),
 		},
-		Role:    s.configuredPlatformAdminRole(),
-		Members: s.projectAppAdminHumanMemberRows(r.Context(), rows),
+		Role:    role,
+		Members: s.projectAppAdminHumanMemberRows(r.Context(), filtered),
 	})
 }

--- a/gestaltd/internal/server/handlers_admin_platform_admins_test.go
+++ b/gestaltd/internal/server/handlers_admin_platform_admins_test.go
@@ -34,6 +34,21 @@ func TestAdminPlatformAdminsList(t *testing.T) {
 				},
 				SourceLayer: proto.SourceLayer_SOURCE_LAYER_STATIC_CONFIG,
 			},
+			{
+				Tuple: &proto.RelationshipTuple{
+					Target: &proto.RelationshipTarget{
+						Kind: &proto.RelationshipTarget_SubjectSet{
+							SubjectSet: &proto.SubjectSet{
+								Resource: &proto.Resource{Type: "group", Id: "carrington"},
+								Relation: "member",
+							},
+						},
+					},
+					Relation: "viewer",
+					Resource: &proto.Resource{Type: "gestalt", Id: "gestalt"},
+				},
+				SourceLayer: proto.SourceLayer_SOURCE_LAYER_STATIC_CONFIG,
+			},
 		},
 	}
 	authz.relationships[0].SourceLayer = proto.SourceLayer_SOURCE_LAYER_RUNTIME


### PR DESCRIPTION
## Summary
- Restrict `GET /admin/api/v1/platform-admins` to relationships whose relation matches the configured platform-admin role (`admin`).
- Exclude `gestalt:gestalt#viewer` grants (for example Carrington and Valon Employees) that were incorrectly appearing on the Platform admins page.
- Add a regression test proving viewer grants are not returned.

## Test plan
- [x] `go test ./internal/server -run TestAdminPlatformAdmins -count=1`
- [ ] After deploy, confirm `/admin/platform-admins` lists only Gestalt Team


Made with [Cursor](https://cursor.com)