### PR TITLE
auth: show duplicate OAuth connections clearly

### DIFF
--- a/gestaltd/internal/server/handlers_oauth.go
+++ b/gestaltd/internal/server/handlers_oauth.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
-	"net/url"
 	"strings"
 	"time"
 
@@ -346,8 +345,8 @@ func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request
 	// A browser popup can't be closed by its opener after OAuth (COOP severs the
 	// link), so serve a self-closing page; API clients keep the redirect.
 	if strings.Contains(strings.ToLower(r.Header.Get("Accept")), "text/html") {
-		writeConnectionCompletePage(w, providerName)
+		writeConnectionCompletePage(w, providerName, result.AlreadyConnected)
 		return
 	}
-	http.Redirect(w, r, "/apps?connected="+url.QueryEscape(providerName), http.StatusSeeOther)
+	http.Redirect(w, r, connectionSuccessURL(providerName, result.AlreadyConnected), http.StatusSeeOther)
 }

--- a/gestaltd/internal/server/pending_connection.go
+++ b/gestaltd/internal/server/pending_connection.go
@@ -115,7 +115,14 @@ var pendingConnectionSelectionPage = template.Must(template.New("pending-connect
   </main>
   {{if .AutoClose}}
   <script>
-    try { if (window.opener) { window.opener.postMessage({ type: "gestalt:connection-complete" }, "*"); } } catch (e) {}
+    try {
+      if (window.opener) {
+        window.opener.postMessage({
+          type: "gestalt:connection-complete",
+          alreadyConnected: {{if .AlreadyConnected}}true{{else}}false{{end}}
+        }, "*");
+      }
+    } catch (e) {}
     setTimeout(function () { window.close(); }, 600);
   </script>
   {{end}}
@@ -124,15 +131,16 @@ var pendingConnectionSelectionPage = template.Must(template.New("pending-connect
 `))
 
 type pendingConnectionPageView struct {
-	Title        string
-	Message      string
-	Action       string
-	PendingToken string
-	Candidates   []core.DiscoveryCandidate
-	LinkURL      string
-	LinkLabel    string
-	Footer       string
-	AutoClose    bool
+	Title            string
+	Message          string
+	Action           string
+	PendingToken     string
+	Candidates       []core.DiscoveryCandidate
+	LinkURL          string
+	LinkLabel        string
+	Footer           string
+	AutoClose        bool
+	AlreadyConnected bool
 }
 
 func writePendingConnectionPage(w http.ResponseWriter, status int, view pendingConnectionPageView, renderErr string) {
@@ -240,30 +248,36 @@ func (s *Server) writePendingConnectionSelectionPage(w http.ResponseWriter, stat
 // browser popup: it closes itself (window.close) since, post-OAuth, the opener
 // can't close it — Cross-Origin-Opener-Policy on the provider's pages severs the
 // opener↔popup link. A visible message + link is the fallback if close is blocked.
-func writeConnectionCompletePage(w http.ResponseWriter, integration string) {
+func connectionSuccessURL(integration string, alreadyConnected bool) string {
 	linkURL := "/apps"
 	if connectedURL, err := setURLQueryParam(linkURL, "connected", integration); err == nil {
 		linkURL = connectedURL
 	}
+	if alreadyConnected {
+		if duplicateURL, err := setURLQueryParam(linkURL, "alreadyConnected", "true"); err == nil {
+			linkURL = duplicateURL
+		}
+	}
+	return linkURL
+}
+
+func writeConnectionCompletePage(w http.ResponseWriter, integration string, alreadyConnected bool) {
 	writePendingConnectionPage(w, http.StatusOK, pendingConnectionPageView{
-		Title:     integration + " connected",
-		Message:   "Your connection has been saved. This window will close automatically.",
-		LinkURL:   linkURL,
-		LinkLabel: "Open integrations",
-		AutoClose: true,
+		Title:            integration + " connected",
+		Message:          "Your connection has been saved. This window will close automatically.",
+		LinkURL:          connectionSuccessURL(integration, alreadyConnected),
+		LinkLabel:        "Open integrations",
+		AutoClose:        true,
+		AlreadyConnected: alreadyConnected,
 	}, "failed to render connection success page")
 }
 
-func (s *Server) writePendingConnectionSuccessPage(w http.ResponseWriter, integration string) {
+func (s *Server) writePendingConnectionSuccessPage(w http.ResponseWriter, integration string, alreadyConnected bool) {
 	s.clearPendingConnectionCookie(w)
-	linkURL := "/apps"
-	if connectedURL, err := setURLQueryParam(linkURL, "connected", integration); err == nil {
-		linkURL = connectedURL
-	}
 	writePendingConnectionPage(w, http.StatusOK, pendingConnectionPageView{
 		Title:     integration + " connected",
 		Message:   "Your connection has been saved. You can close this tab now.",
-		LinkURL:   linkURL,
+		LinkURL:   connectionSuccessURL(integration, alreadyConnected),
 		LinkLabel: "Open integrations",
 	}, "failed to render success page")
 }
@@ -459,7 +473,8 @@ func (s *Server) selectPendingConnection(w http.ResponseWriter, r *http.Request)
 		auditErr = errors.New("integration not found")
 		return
 	}
-	if _, err := s.completeConnection(credentialMaterialContext(r.Context(), completionPrincipal, tm), prov, tm); err != nil {
+	result, err := s.completeConnection(credentialMaterialContext(r.Context(), completionPrincipal, tm), prov, tm)
+	if err != nil {
 		status, message := connectionSetupFailure(err)
 		auditErr = errors.New(message)
 		writeError(w, status, message)
@@ -468,10 +483,7 @@ func (s *Server) selectPendingConnection(w http.ResponseWriter, r *http.Request)
 
 	if _, err := r.Cookie(sessionCookieName); err == nil {
 		s.clearPendingConnectionCookie(w)
-		connectedURL := "/apps"
-		if nextURL, err := setURLQueryParam(connectedURL, "connected", state.Credential.Integration); err == nil {
-			connectedURL = nextURL
-		}
+		connectedURL := connectionSuccessURL(state.Credential.Integration, result.AlreadyConnected)
 		auditAllowed = true
 		auditErr = nil
 		http.Redirect(w, r, connectedURL, http.StatusSeeOther)
@@ -480,5 +492,5 @@ func (s *Server) selectPendingConnection(w http.ResponseWriter, r *http.Request)
 
 	auditAllowed = true
 	auditErr = nil
-	s.writePendingConnectionSuccessPage(w, state.Credential.Integration)
+	s.writePendingConnectionSuccessPage(w, state.Credential.Integration, result.AlreadyConnected)
 }

--- a/gestaltd/internal/server/pending_connection.go
+++ b/gestaltd/internal/server/pending_connection.go
@@ -261,10 +261,24 @@ func connectionSuccessURL(integration string, alreadyConnected bool) string {
 	return linkURL
 }
 
+func connectionSuccessCopy(integration string, alreadyConnected, autoClose bool) (string, string) {
+	if alreadyConnected {
+		if autoClose {
+			return integration + " already connected", "This account was already connected. This window will close automatically."
+		}
+		return integration + " already connected", "This account was already connected. You can close this tab now."
+	}
+	if autoClose {
+		return integration + " connected", "Your connection has been saved. This window will close automatically."
+	}
+	return integration + " connected", "Your connection has been saved. You can close this tab now."
+}
+
 func writeConnectionCompletePage(w http.ResponseWriter, integration string, alreadyConnected bool) {
+	title, message := connectionSuccessCopy(integration, alreadyConnected, true)
 	writePendingConnectionPage(w, http.StatusOK, pendingConnectionPageView{
-		Title:            integration + " connected",
-		Message:          "Your connection has been saved. This window will close automatically.",
+		Title:            title,
+		Message:          message,
 		LinkURL:          connectionSuccessURL(integration, alreadyConnected),
 		LinkLabel:        "Open integrations",
 		AutoClose:        true,
@@ -273,10 +287,11 @@ func writeConnectionCompletePage(w http.ResponseWriter, integration string, alre
 }
 
 func (s *Server) writePendingConnectionSuccessPage(w http.ResponseWriter, integration string, alreadyConnected bool) {
+	title, message := connectionSuccessCopy(integration, alreadyConnected, false)
 	s.clearPendingConnectionCookie(w)
 	writePendingConnectionPage(w, http.StatusOK, pendingConnectionPageView{
-		Title:     integration + " connected",
-		Message:   "Your connection has been saved. You can close this tab now.",
+		Title:     title,
+		Message:   message,
 		LinkURL:   connectionSuccessURL(integration, alreadyConnected),
 		LinkLabel: "Open integrations",
 	}, "failed to render success page")

--- a/gestaltd/internal/server/pending_connection_test.go
+++ b/gestaltd/internal/server/pending_connection_test.go
@@ -20,10 +20,35 @@ func TestConnectionCompletePagePostsDuplicateResult(t *testing.T) {
 	writeConnectionCompletePage(response, "slack", true)
 
 	body := response.Body.String()
+	if !strings.Contains(body, `<title>slack already connected</title>`) {
+		t.Fatalf("completion page did not identify duplicate connection: %s", body)
+	}
+	if !strings.Contains(body, "This account was already connected.") {
+		t.Fatalf("completion page did not explain duplicate connection: %s", body)
+	}
 	if !strings.Contains(body, `alreadyConnected: true`) {
 		t.Fatalf("completion page did not post duplicate result: %s", body)
 	}
 	if !strings.Contains(body, `/apps?alreadyConnected=true&amp;connected=slack`) {
 		t.Fatalf("completion page did not include duplicate fallback URL: %s", body)
+	}
+}
+
+func TestConnectionCompletePagePostsNewConnectionResult(t *testing.T) {
+	response := httptest.NewRecorder()
+	writeConnectionCompletePage(response, "slack", false)
+
+	body := response.Body.String()
+	if !strings.Contains(body, `<title>slack connected</title>`) {
+		t.Fatalf("completion page did not identify new connection: %s", body)
+	}
+	if strings.Contains(body, "already connected") {
+		t.Fatalf("completion page used duplicate copy for new connection: %s", body)
+	}
+	if !strings.Contains(body, `alreadyConnected: false`) {
+		t.Fatalf("completion page did not post new-connection result: %s", body)
+	}
+	if !strings.Contains(body, `/apps?connected=slack`) {
+		t.Fatalf("completion page did not include new-connection fallback URL: %s", body)
 	}
 }

--- a/gestaltd/internal/server/pending_connection_test.go
+++ b/gestaltd/internal/server/pending_connection_test.go
@@ -1,0 +1,29 @@
+package server
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestConnectionSuccessURLIncludesDuplicateResult(t *testing.T) {
+	if got, want := connectionSuccessURL("slack", true), "/apps?alreadyConnected=true&connected=slack"; got != want {
+		t.Fatalf("connectionSuccessURL() = %q, want %q", got, want)
+	}
+	if got, want := connectionSuccessURL("slack", false), "/apps?connected=slack"; got != want {
+		t.Fatalf("connectionSuccessURL() = %q, want %q", got, want)
+	}
+}
+
+func TestConnectionCompletePagePostsDuplicateResult(t *testing.T) {
+	response := httptest.NewRecorder()
+	writeConnectionCompletePage(response, "slack", true)
+
+	body := response.Body.String()
+	if !strings.Contains(body, `alreadyConnected: true`) {
+		t.Fatalf("completion page did not post duplicate result: %s", body)
+	}
+	if !strings.Contains(body, `/apps?alreadyConnected=true&amp;connected=slack`) {
+		t.Fatalf("completion page did not include duplicate fallback URL: %s", body)
+	}
+}

--- a/gestaltd/internal/server/pending_connection_test.go
+++ b/gestaltd/internal/server/pending_connection_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 func TestConnectionSuccessURLIncludesDuplicateResult(t *testing.T) {
+	t.Parallel()
+
 	if got, want := connectionSuccessURL("slack", true), "/apps?alreadyConnected=true&connected=slack"; got != want {
 		t.Fatalf("connectionSuccessURL() = %q, want %q", got, want)
 	}
@@ -16,6 +18,8 @@ func TestConnectionSuccessURLIncludesDuplicateResult(t *testing.T) {
 }
 
 func TestConnectionCompletePagePostsDuplicateResult(t *testing.T) {
+	t.Parallel()
+
 	response := httptest.NewRecorder()
 	writeConnectionCompletePage(response, "slack", true)
 
@@ -35,6 +39,8 @@ func TestConnectionCompletePagePostsDuplicateResult(t *testing.T) {
 }
 
 func TestConnectionCompletePagePostsNewConnectionResult(t *testing.T) {
+	t.Parallel()
+
 	response := httptest.NewRecorder()
 	writeConnectionCompletePage(response, "slack", false)
 

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -9890,6 +9890,72 @@ func TestIntegrationOAuthCallback(t *testing.T) {
 		if auditRecord["target_name"] != "default/default" {
 			t.Fatalf("expected audit target_name default/default, got %v", auditRecord["target_name"])
 		}
+
+		duplicateStartReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/start-oauth", bytes.NewBufferString(`{"integration":"oauth-svc"}`))
+		duplicateStartReq.Header.Set("Content-Type", "application/json")
+		duplicateStartReq.Header.Set("Authorization", "Bearer session-token")
+		duplicateStartResp, err := http.DefaultClient.Do(duplicateStartReq)
+		if err != nil {
+			t.Fatalf("duplicate start request: %v", err)
+		}
+		defer func() { _ = duplicateStartResp.Body.Close() }()
+		if duplicateStartResp.StatusCode != http.StatusOK {
+			t.Fatalf("duplicate start status = %d, want 200", duplicateStartResp.StatusCode)
+		}
+		var duplicateStartResult map[string]string
+		if err := json.NewDecoder(duplicateStartResp.Body).Decode(&duplicateStartResult); err != nil {
+			t.Fatalf("decoding duplicate start response: %v", err)
+		}
+
+		duplicateCallbackReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/auth/callback?code=good-code&state="+url.QueryEscape(duplicateStartResult["state"]), nil)
+		duplicateCallbackResp, err := noRedirect.Do(duplicateCallbackReq)
+		if err != nil {
+			t.Fatalf("duplicate callback request: %v", err)
+		}
+		defer func() { _ = duplicateCallbackResp.Body.Close() }()
+		if duplicateCallbackResp.StatusCode != http.StatusSeeOther {
+			t.Fatalf("duplicate callback status = %d, want 303", duplicateCallbackResp.StatusCode)
+		}
+		if got, want := duplicateCallbackResp.Header.Get("Location"), "/apps?alreadyConnected=true&connected=oauth-svc"; got != want {
+			t.Fatalf("duplicate callback Location = %q, want %q", got, want)
+		}
+
+		popupStartReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/start-oauth", bytes.NewBufferString(`{"integration":"oauth-svc"}`))
+		popupStartReq.Header.Set("Content-Type", "application/json")
+		popupStartReq.Header.Set("Authorization", "Bearer session-token")
+		popupStartResp, err := http.DefaultClient.Do(popupStartReq)
+		if err != nil {
+			t.Fatalf("popup start request: %v", err)
+		}
+		defer func() { _ = popupStartResp.Body.Close() }()
+		if popupStartResp.StatusCode != http.StatusOK {
+			t.Fatalf("popup start status = %d, want 200", popupStartResp.StatusCode)
+		}
+		var popupStartResult map[string]string
+		if err := json.NewDecoder(popupStartResp.Body).Decode(&popupStartResult); err != nil {
+			t.Fatalf("decoding popup start response: %v", err)
+		}
+
+		popupCallbackReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/auth/callback?code=good-code&state="+url.QueryEscape(popupStartResult["state"]), nil)
+		popupCallbackReq.Header.Set("Accept", "text/html")
+		popupCallbackResp, err := noRedirect.Do(popupCallbackReq)
+		if err != nil {
+			t.Fatalf("popup duplicate callback request: %v", err)
+		}
+		defer func() { _ = popupCallbackResp.Body.Close() }()
+		if popupCallbackResp.StatusCode != http.StatusOK {
+			t.Fatalf("popup duplicate callback status = %d, want 200", popupCallbackResp.StatusCode)
+		}
+		popupBody, err := io.ReadAll(popupCallbackResp.Body)
+		if err != nil {
+			t.Fatalf("read popup duplicate callback body: %v", err)
+		}
+		if !strings.Contains(string(popupBody), `alreadyConnected: true`) {
+			t.Fatalf("popup duplicate callback omitted alreadyConnected=true: %s", popupBody)
+		}
+		if !strings.Contains(string(popupBody), `/apps?alreadyConnected=true&amp;connected=oauth-svc`) {
+			t.Fatalf("popup duplicate callback omitted fallback URL: %s", popupBody)
+		}
 	})
 
 	t.Run("selection_required", func(t *testing.T) {
@@ -10077,6 +10143,107 @@ func TestIntegrationOAuthCallback(t *testing.T) {
 		}
 		if !strings.Contains(identityRaw, `"kind":"site"`) || !strings.Contains(identityRaw, "Site B") {
 			t.Fatalf("stored account_identity = %q, want site fact for Site B", identityRaw)
+		}
+
+		duplicateStartReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/start-oauth", bytes.NewBufferString(`{"integration":"oauth-svc"}`))
+		duplicateStartReq.Header.Set("Content-Type", "application/json")
+		duplicateStartReq.Header.Set("Authorization", "Bearer cli-api-token")
+		duplicateStartResp, err := http.DefaultClient.Do(duplicateStartReq)
+		if err != nil {
+			t.Fatalf("duplicate selection start request: %v", err)
+		}
+		defer func() { _ = duplicateStartResp.Body.Close() }()
+		if duplicateStartResp.StatusCode != http.StatusOK {
+			t.Fatalf("duplicate selection start status = %d, want 200", duplicateStartResp.StatusCode)
+		}
+		var duplicateStartResult map[string]string
+		if err := json.NewDecoder(duplicateStartResp.Body).Decode(&duplicateStartResult); err != nil {
+			t.Fatalf("decoding duplicate selection start response: %v", err)
+		}
+
+		duplicateCallbackReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/auth/callback?code=good-code&state="+url.QueryEscape(duplicateStartResult["state"]), nil)
+		duplicateCallbackResp, err := noRedirect.Do(duplicateCallbackReq)
+		if err != nil {
+			t.Fatalf("duplicate selection callback request: %v", err)
+		}
+		defer func() { _ = duplicateCallbackResp.Body.Close() }()
+		if duplicateCallbackResp.StatusCode != http.StatusOK {
+			t.Fatalf("duplicate selection callback status = %d, want 200", duplicateCallbackResp.StatusCode)
+		}
+		duplicateBody, err := io.ReadAll(duplicateCallbackResp.Body)
+		if err != nil {
+			t.Fatalf("read duplicate selection page: %v", err)
+		}
+		duplicateText := string(duplicateBody)
+		duplicateForm := url.Values{
+			"pending_token":   {extractHiddenInputValue(t, duplicateText, "pending_token")},
+			"candidate_index": {"1"},
+		}
+		duplicateSelectReq, _ := http.NewRequest(http.MethodPost, ts.URL+pendingSelectionPath, strings.NewReader(duplicateForm.Encode()))
+		duplicateSelectReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		duplicateSelectReq.AddCookie(&http.Cookie{Name: "session_token", Value: "cli-api-token"})
+		duplicateSelectResp, err := noRedirect.Do(duplicateSelectReq)
+		if err != nil {
+			t.Fatalf("duplicate selection request: %v", err)
+		}
+		defer func() { _ = duplicateSelectResp.Body.Close() }()
+		if duplicateSelectResp.StatusCode != http.StatusSeeOther {
+			t.Fatalf("duplicate selection status = %d, want 303", duplicateSelectResp.StatusCode)
+		}
+		if got, want := duplicateSelectResp.Header.Get("Location"), "/apps?alreadyConnected=true&connected=oauth-svc"; got != want {
+			t.Fatalf("duplicate selection Location = %q, want %q", got, want)
+		}
+
+		fallbackStartReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/start-oauth", bytes.NewBufferString(`{"integration":"oauth-svc"}`))
+		fallbackStartReq.Header.Set("Content-Type", "application/json")
+		fallbackStartReq.Header.Set("Authorization", "Bearer cli-api-token")
+		fallbackStartResp, err := http.DefaultClient.Do(fallbackStartReq)
+		if err != nil {
+			t.Fatalf("fallback start request: %v", err)
+		}
+		defer func() { _ = fallbackStartResp.Body.Close() }()
+		if fallbackStartResp.StatusCode != http.StatusOK {
+			t.Fatalf("fallback start status = %d, want 200", fallbackStartResp.StatusCode)
+		}
+		var fallbackStartResult map[string]string
+		if err := json.NewDecoder(fallbackStartResp.Body).Decode(&fallbackStartResult); err != nil {
+			t.Fatalf("decoding fallback start response: %v", err)
+		}
+
+		fallbackCallbackReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/auth/callback?code=good-code&state="+url.QueryEscape(fallbackStartResult["state"]), nil)
+		fallbackCallbackResp, err := noRedirect.Do(fallbackCallbackReq)
+		if err != nil {
+			t.Fatalf("fallback callback request: %v", err)
+		}
+		defer func() { _ = fallbackCallbackResp.Body.Close() }()
+		if fallbackCallbackResp.StatusCode != http.StatusOK {
+			t.Fatalf("fallback callback status = %d, want 200", fallbackCallbackResp.StatusCode)
+		}
+		fallbackBody, err := io.ReadAll(fallbackCallbackResp.Body)
+		if err != nil {
+			t.Fatalf("read fallback selection page: %v", err)
+		}
+		fallbackText := string(fallbackBody)
+		fallbackForm := url.Values{
+			"pending_token":   {extractHiddenInputValue(t, fallbackText, "pending_token")},
+			"candidate_index": {"1"},
+		}
+		fallbackSelectReq, _ := http.NewRequest(http.MethodPost, ts.URL+pendingSelectionPath, strings.NewReader(fallbackForm.Encode()))
+		fallbackSelectReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		fallbackSelectResp, err := noRedirect.Do(fallbackSelectReq)
+		if err != nil {
+			t.Fatalf("fallback selection request: %v", err)
+		}
+		defer func() { _ = fallbackSelectResp.Body.Close() }()
+		if fallbackSelectResp.StatusCode != http.StatusOK {
+			t.Fatalf("fallback selection status = %d, want 200", fallbackSelectResp.StatusCode)
+		}
+		fallbackSuccessBody, err := io.ReadAll(fallbackSelectResp.Body)
+		if err != nil {
+			t.Fatalf("read fallback success page: %v", err)
+		}
+		if !strings.Contains(string(fallbackSuccessBody), `/apps?alreadyConnected=true&amp;connected=oauth-svc`) {
+			t.Fatalf("fallback success page omitted duplicate URL: %s", fallbackSuccessBody)
 		}
 	})
 }

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -9742,12 +9742,16 @@ func TestIntegrationOAuthCallback(t *testing.T) {
 		handler := &testOAuthHandler{
 			authorizationBaseURLVal: "https://auth.example.com/oauth/authorize",
 			exchangeCodeFn: func(_ context.Context, code string) (*core.OAuthTokenResponse, error) {
-				if code == "good-code" {
+				if code == "good-code" || code == "new-popup-code" {
+					accountID := "account-456"
+					if code == "new-popup-code" {
+						accountID = "account-789"
+					}
 					return &core.OAuthTokenResponse{
 						AccessToken: "oauth-token",
 						Extra: map[string]any{
 							"tenant":  map[string]any{"id": "tenant-123"},
-							"account": map[string]any{"id": "account-456"},
+							"account": map[string]any{"id": accountID},
 						},
 					}, nil
 				}
@@ -9891,6 +9895,42 @@ func TestIntegrationOAuthCallback(t *testing.T) {
 			t.Fatalf("expected audit target_name default/default, got %v", auditRecord["target_name"])
 		}
 
+		newPopupStartReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/start-oauth", bytes.NewBufferString(`{"integration":"oauth-svc","instance":"new-popup"}`))
+		newPopupStartReq.Header.Set("Content-Type", "application/json")
+		newPopupStartReq.Header.Set("Authorization", "Bearer session-token")
+		newPopupStartResp, err := http.DefaultClient.Do(newPopupStartReq)
+		if err != nil {
+			t.Fatalf("new popup start request: %v", err)
+		}
+		defer func() { _ = newPopupStartResp.Body.Close() }()
+		if newPopupStartResp.StatusCode != http.StatusOK {
+			t.Fatalf("new popup start status = %d, want 200", newPopupStartResp.StatusCode)
+		}
+		var newPopupStartResult map[string]string
+		if err := json.NewDecoder(newPopupStartResp.Body).Decode(&newPopupStartResult); err != nil {
+			t.Fatalf("decoding new popup start response: %v", err)
+		}
+		newPopupCallbackReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/auth/callback?code=new-popup-code&state="+url.QueryEscape(newPopupStartResult["state"]), nil)
+		newPopupCallbackReq.Header.Set("Accept", "text/html")
+		newPopupCallbackResp, err := noRedirect.Do(newPopupCallbackReq)
+		if err != nil {
+			t.Fatalf("new popup callback request: %v", err)
+		}
+		defer func() { _ = newPopupCallbackResp.Body.Close() }()
+		if newPopupCallbackResp.StatusCode != http.StatusOK {
+			t.Fatalf("new popup callback status = %d, want 200", newPopupCallbackResp.StatusCode)
+		}
+		newPopupBody, err := io.ReadAll(newPopupCallbackResp.Body)
+		if err != nil {
+			t.Fatalf("read new popup callback body: %v", err)
+		}
+		if !strings.Contains(string(newPopupBody), `alreadyConnected: false`) {
+			t.Fatalf("new popup callback omitted alreadyConnected=false: %s", newPopupBody)
+		}
+		if !strings.Contains(string(newPopupBody), `/apps?connected=oauth-svc`) || strings.Contains(string(newPopupBody), "alreadyConnected=true") {
+			t.Fatalf("new popup callback had incorrect fallback URL: %s", newPopupBody)
+		}
+
 		duplicateStartReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/start-oauth", bytes.NewBufferString(`{"integration":"oauth-svc"}`))
 		duplicateStartReq.Header.Set("Content-Type", "application/json")
 		duplicateStartReq.Header.Set("Authorization", "Bearer session-token")
@@ -9952,6 +9992,9 @@ func TestIntegrationOAuthCallback(t *testing.T) {
 		}
 		if !strings.Contains(string(popupBody), `alreadyConnected: true`) {
 			t.Fatalf("popup duplicate callback omitted alreadyConnected=true: %s", popupBody)
+		}
+		if !strings.Contains(string(popupBody), "oauth-svc already connected") || !strings.Contains(string(popupBody), "This account was already connected.") {
+			t.Fatalf("popup duplicate callback omitted duplicate copy: %s", popupBody)
 		}
 		if !strings.Contains(string(popupBody), `/apps?alreadyConnected=true&amp;connected=oauth-svc`) {
 			t.Fatalf("popup duplicate callback omitted fallback URL: %s", popupBody)
@@ -10244,6 +10287,9 @@ func TestIntegrationOAuthCallback(t *testing.T) {
 		}
 		if !strings.Contains(string(fallbackSuccessBody), `/apps?alreadyConnected=true&amp;connected=oauth-svc`) {
 			t.Fatalf("fallback success page omitted duplicate URL: %s", fallbackSuccessBody)
+		}
+		if !strings.Contains(string(fallbackSuccessBody), "oauth-svc already connected") || !strings.Contains(string(fallbackSuccessBody), "This account was already connected.") {
+			t.Fatalf("fallback success page omitted duplicate copy: %s", fallbackSuccessBody)
 		}
 	})
 }

--- a/plans/oauth-duplicate-toast.md
+++ b/plans/oauth-duplicate-toast.md
@@ -25,6 +25,11 @@ the flag only selects the duplicate-specific copy.
 ## Validation
 
 - `go test ./gestaltd/internal/server`
+- Handler-level regression coverage must verify that a duplicate OAuth callback
+  preserves `AlreadyConnected` in both the popup completion payload and the
+  non-HTML redirect.
+- Pending-connection selection must preserve the same result in both the
+  authenticated redirect path and the unauthenticated fallback page.
 - Client validation runs in the companion toolshed worktree.
 - `git diff --check`
 

--- a/plans/oauth-duplicate-toast.md
+++ b/plans/oauth-duplicate-toast.md
@@ -1,0 +1,35 @@
+# OAuth duplicate connection feedback
+
+## Problem
+
+When an OAuth connection is completed for an account that is already linked,
+the UI only receives a generic connected signal and shows `${app} is connected.`
+The connection setup code already knows whether the account was already linked,
+but the callback success paths discarded that result.
+
+## Decision
+
+Preserve the existing server-side `AlreadyConnected` result through every OAuth
+completion path. The popup success page sends it with the existing completion
+message, and same-tab/fallback links include it as a query parameter. The client
+still confirms the connection by refreshing the catalog before showing success;
+the flag only selects the duplicate-specific copy.
+
+## Acceptance criteria
+
+- Duplicate OAuth completion communicates `${app} is already connected.`.
+- New OAuth completion continues to communicate `${app} is connected.`.
+- Popup and same-tab/fallback completion paths preserve the result.
+- Existing manual connection and popup-close recovery behavior is unchanged.
+
+## Validation
+
+- `go test ./gestaltd/internal/server`
+- Client validation runs in the companion toolshed worktree.
+- `git diff --check`
+
+## Rollout and rollback
+
+Deploy the backend commit before relying on the duplicate-specific popup copy.
+The query and message fields are additive, so older clients continue to use the
+generic success copy. Roll back by reverting this commit if needed.

--- a/plans/oauth-duplicate-toast.md
+++ b/plans/oauth-duplicate-toast.md
@@ -11,9 +11,10 @@ but the callback success paths discarded that result.
 
 Preserve the existing server-side `AlreadyConnected` result through every OAuth
 completion path. The popup success page sends it with the existing completion
-message, and same-tab/fallback links include it as a query parameter. The client
-still confirms the connection by refreshing the catalog before showing success;
-the flag only selects the duplicate-specific copy.
+message, visible fallback pages use the duplicate-specific copy, and same-tab/
+fallback links include it as a query parameter. The client still confirms the
+connection by refreshing the catalog before showing success; the flag only
+selects the duplicate-specific copy.
 
 ## Acceptance criteria
 


### PR DESCRIPTION
## Summary

- Preserve whether an OAuth connection was already linked when the backend completes sign-in.
- Send that result through popup completion messages and same-tab fallback redirects so the client can show `Slack is already connected.` instead of the generic connected message.
- Keep the existing generic success behavior for newly linked accounts.

## Why / context

The connection setup path already determines whether the account is already connected, but the OAuth callback discarded that result. The UI could confirm that Slack was connected, but it could not tell whether this was a duplicate.

## What changed

- Added the duplicate result to the existing popup completion message.
- Added `alreadyConnected=true` to fallback success URLs only for duplicate completions.
- Applied the same result to pending-connection candidate selection.
- Added regression tests for the success URL and rendered popup payload.

## Validation

- [x] Automated: `go test ./gestaltd/internal/server`
- [x] Automated: `git diff --check`
- [ ] Manual: live OAuth duplicate-connection flow not run from this backend worktree.

## Test plan

- [x] Run the server package tests.
- [ ] Deploy the backend, then retry the same Slack OAuth connection and verify the duplicate copy in the popup flow.
- [ ] Verify a new Slack OAuth connection still shows the normal connected copy.

## Reviewer focus

Please verify that `AlreadyConnected` remains authoritative from connection setup through both OAuth callback completion paths, and that older clients continue to work when the new metadata is ignored.

## Rollout / compatibility

Deploy this backend change before relying on the duplicate-specific popup copy. The new message field and query parameter are additive. Roll back by reverting this commit if needed.
