### PR TITLE
Reconcile workflow definitions after app rollouts

### DIFF
--- a/gestaltd/internal/appregistry/poller.go
+++ b/gestaltd/internal/appregistry/poller.go
@@ -45,6 +45,7 @@ type CatalogPoller struct {
 	BootstrapReady              <-chan struct{}
 	MaxReconcileAttempts        int
 	Now                         func() time.Time
+	BeforeRolloutComplete       func(context.Context, string, string) (bool, error)
 	OnRolloutTerminal           func(string)
 	HeartbeatTTL                time.Duration
 	HealthyStabilityWindow      time.Duration
@@ -78,6 +79,7 @@ type CatalogPollerConfig struct {
 	BootstrapReady              <-chan struct{}
 	MaxReconcileAttempts        int
 	Now                         func() time.Time
+	BeforeRolloutComplete       func(context.Context, string, string) (bool, error)
 	OnRolloutTerminal           func(string)
 	HeartbeatTTL                time.Duration
 	HealthyStabilityWindow      time.Duration
@@ -102,6 +104,7 @@ func NewCatalogPoller(cfg CatalogPollerConfig) *CatalogPoller {
 		BootstrapReady:              cfg.BootstrapReady,
 		MaxReconcileAttempts:        cfg.MaxReconcileAttempts,
 		Now:                         cfg.Now,
+		BeforeRolloutComplete:       cfg.BeforeRolloutComplete,
 		OnRolloutTerminal:           cfg.OnRolloutTerminal,
 		HeartbeatTTL:                cfg.HeartbeatTTL,
 		HealthyStabilityWindow:      cfg.HealthyStabilityWindow,
@@ -371,7 +374,7 @@ func (p *CatalogPoller) reconcileApp(ctx context.Context, instanceID, appName st
 					return fmt.Errorf("fail rollout without accepted version %s@%s: %w", appName, rolloutVersion, err)
 				}
 				p.recordRolloutOutcome(ctx, updated)
-				p.notifyRolloutTerminal(appName)
+				p.notifyRolloutTerminal(updated.App)
 			}
 			return nil
 		}
@@ -627,15 +630,21 @@ func (p *CatalogPoller) updateRolloutOutcome(ctx context.Context, rollout *core.
 		converged = false
 	}
 	if converged {
-		updated, err := p.Rollouts.MarkCompleteForRollout(ctx, rollout, p.now())
-		if errors.Is(err, coredata.ErrAppRolloutEpochMismatch) {
-			return false, nil
-		} else if err != nil {
-			return false, fmt.Errorf("complete rollout %s@%s: %w", rollout.App, rollout.Version, err)
+		ready, prepareErr := p.prepareRolloutCompletion(ctx, rollout)
+		if prepareErr != nil && p.now().Before(rollout.Deadline) {
+			return false, prepareErr
 		}
-		p.recordRolloutOutcome(ctx, updated)
-		p.notifyRolloutTerminal(rollout.App)
-		return true, nil
+		if prepareErr == nil && ready {
+			updated, err := p.Rollouts.MarkCompleteForRollout(ctx, rollout, p.now())
+			if errors.Is(err, coredata.ErrAppRolloutEpochMismatch) {
+				return false, nil
+			} else if err != nil {
+				return false, fmt.Errorf("complete rollout %s@%s: %w", rollout.App, rollout.Version, err)
+			}
+			p.recordRolloutOutcome(ctx, updated)
+			p.notifyRolloutTerminal(updated.App)
+			return true, nil
+		}
 	}
 	if !p.now().Before(rollout.Deadline) {
 		updated, err := p.Rollouts.MarkFailedForRollout(ctx, rollout, p.now())
@@ -645,7 +654,7 @@ func (p *CatalogPoller) updateRolloutOutcome(ctx context.Context, rollout *core.
 			return false, fmt.Errorf("fail rollout %s@%s: %w", rollout.App, rollout.Version, err)
 		}
 		p.recordRolloutOutcome(ctx, updated)
-		p.notifyRolloutTerminal(rollout.App)
+		p.notifyRolloutTerminal(updated.App)
 		return true, nil
 	}
 	return false, nil
@@ -676,8 +685,22 @@ func (p *CatalogPoller) updateHeartbeatRolloutOutcome(ctx context.Context, rollo
 		EvaluatedAt:             now,
 		Heartbeats:              heartbeats,
 	})
+	healthy := projection.State == core.AppFleetStateHealthy
+	stableAt := rollout.HealthySince.Add(p.HealthyStabilityWindow)
+	if healthy && !rollout.HealthySince.IsZero() && !now.Before(stableAt) && !stableAt.After(rollout.Deadline) {
+		ready, prepareErr := p.prepareRolloutCompletion(ctx, rollout)
+		if prepareErr != nil {
+			if now.Before(rollout.Deadline) {
+				return false, prepareErr
+			}
+			healthy = false
+		}
+		if prepareErr == nil && !ready {
+			return false, nil
+		}
+	}
 	updated, transitioned, err := p.Rollouts.EvaluateHeartbeatRollout(ctx, rollout, coredata.HeartbeatRolloutEvaluation{
-		Healthy:         projection.State == core.AppFleetStateHealthy,
+		Healthy:         healthy,
 		StabilityWindow: p.HealthyStabilityWindow,
 		EvaluatedAt:     now,
 		FailureSummary: core.AppRolloutFailureSummary{
@@ -700,6 +723,17 @@ func (p *CatalogPoller) updateHeartbeatRolloutOutcome(ctx context.Context, rollo
 	p.recordRolloutOutcome(ctx, updated)
 	p.notifyRolloutTerminal(updated.App)
 	return true, nil
+}
+
+func (p *CatalogPoller) prepareRolloutCompletion(ctx context.Context, rollout *core.AppRollout) (bool, error) {
+	if p == nil || p.BeforeRolloutComplete == nil {
+		return true, nil
+	}
+	ready, err := p.BeforeRolloutComplete(ctx, rollout.App, rollout.Version)
+	if err != nil {
+		return false, fmt.Errorf("prepare rollout completion for %s@%s: %w", rollout.App, rollout.Version, err)
+	}
+	return ready, nil
 }
 
 func (p *CatalogPoller) notifyRolloutTerminal(app string) {

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -285,7 +285,8 @@ type Result struct {
 	AppRuntimeSnapshotter interface {
 		SnapshotRegistryApps() map[string]core.RegistryAppRuntimeObservation
 	}
-	RegistryAppStartup func(context.Context)
+	RegistryAppStartup              func(context.Context)
+	ReconcileAppWorkflowDefinitions func(context.Context, string) error
 
 	runtimeRegistry                     *runtimeRegistry
 	workflowConfigReconcileTasks        []workflowConfigReconcileTask
@@ -1522,11 +1523,19 @@ func BootstrapWithOptions(ctx context.Context, cfg *config.Config, factories *Fa
 	}
 	var deferredWorkflowConfigReconcileTasks []workflowConfigReconcileTask
 	var startupWorkflowConfigReconcile func(context.Context) error
+	var appWorkflowConfigReconcile func(context.Context, string) error
 	if flags.Enabled(featureflags.Workflow) {
 		defaultWorkflowProvider, _, defaultProviderErr := cfg.EffectiveWorkflowProvider("")
 		switch {
 		case defaultProviderErr == nil && strings.TrimSpace(defaultWorkflowProvider) != "":
-			deferredWorkflowConfigReconcileTasks = append(deferredWorkflowConfigReconcileTasks, deferredAppWorkflowReconcileTask(deferred, prepared.Deps.WorkflowRuntime, defaultWorkflowProvider, reconcileWorkflowConfig))
+			appWorkflowReconcileTask := deferredAppWorkflowReconcileTask(deferred, prepared.Deps.WorkflowRuntime, defaultWorkflowProvider, reconcileWorkflowConfig)
+			appWorkflowConfigReconcile = func(ctx context.Context, app string) error {
+				if err := waitRuntimeWorkflowProviderReady(ctx, prepared.Deps.WorkflowRuntime, defaultWorkflowProvider); err != nil {
+					return err
+				}
+				return reconcileAppWorkflowDefinitions(ctx, cfg, prepared.Deps.WorkflowRuntime, prepared.Deps.AppWorkflowDeclarations, app)
+			}
+			deferredWorkflowConfigReconcileTasks = append(deferredWorkflowConfigReconcileTasks, appWorkflowReconcileTask)
 		case defaultProviderErr != nil:
 			slog.Warn("skipping deferred app workflow declaration reconcile: default workflow provider unavailable", "error", defaultProviderErr)
 		default:
@@ -1642,6 +1651,7 @@ func BootstrapWithOptions(ctx context.Context, cfg *config.Config, factories *Fa
 		startup:                        startup,
 		deferred:                       deferred,
 	}
+	result.ReconcileAppWorkflowDefinitions = appWorkflowConfigReconcile
 	for _, pending := range updateBuilds.pending {
 		if pending.proxy != nil {
 			pending.proxy.setActivationTrigger(result.ActivateAppProviders)

--- a/gestaltd/internal/bootstrap/workflow_app_definitions.go
+++ b/gestaltd/internal/bootstrap/workflow_app_definitions.go
@@ -146,6 +146,7 @@ func desiredAppWorkflowDefinitions(cfg *config.Config, decls map[string][]*proto
 		}
 	}
 
+	knownApps := slices.Sorted(maps.Keys(cfg.Apps))
 	for _, appName := range slices.Sorted(maps.Keys(decls)) {
 		specs := decls[appName]
 		for i, specProto := range specs {
@@ -173,6 +174,15 @@ func desiredAppWorkflowDefinitions(cfg *config.Config, decls map[string][]*proto
 			}
 			spec.ID = appWorkflowDefinitionID(appName, localID)
 			storedID := spec.ID
+			if owner := coreworkflow.DefinitionOwnerApp(storedID, knownApps); owner != appName {
+				return nil, fmt.Errorf(
+					"bootstrap: app %q workflow definition %q has ambiguous id %q owned by configured app %q",
+					appName,
+					localID,
+					storedID,
+					owner,
+				)
+			}
 			if _, exists := desired[storedID]; exists {
 				return nil, fmt.Errorf(
 					"bootstrap: workflow definition id %q is declared by both app %q and app %q",

--- a/gestaltd/internal/bootstrap/workflow_config_definitions.go
+++ b/gestaltd/internal/bootstrap/workflow_config_definitions.go
@@ -32,6 +32,37 @@ type desiredWorkflowConfigDefinition struct {
 type workflowConfigProviderFilter func(providerName string) bool
 
 func reconcileWorkflowConfigDefinitions(ctx context.Context, cfg *config.Config, runtime *workflowRuntime, appDecls *appWorkflowDeclarations, includeProvider workflowConfigProviderFilter) error {
+	var reported map[string][]*proto.WorkflowDefinitionSpec
+	if appDecls != nil {
+		reported = appDecls.Snapshot()
+	}
+	return reconcileWorkflowConfigDefinitionsFromDeclarations(ctx, cfg, runtime, reported, includeProvider, "")
+}
+
+func reconcileAppWorkflowDefinitions(ctx context.Context, cfg *config.Config, runtime *workflowRuntime, appDecls *appWorkflowDeclarations, app string) error {
+	app = strings.TrimSpace(app)
+	if cfg == nil || runtime == nil || appDecls == nil || app == "" {
+		return nil
+	}
+	reported := appDecls.Snapshot()
+	if _, ok := reported[app]; !ok {
+		return fmt.Errorf("bootstrap: app %q has not reported workflow definitions", app)
+	}
+	defaultProvider, _, err := cfg.EffectiveWorkflowProvider("")
+	if err != nil {
+		return err
+	}
+	return reconcileWorkflowConfigDefinitionsFromDeclarations(
+		ctx,
+		cfg,
+		runtime,
+		reported,
+		workflowConfigOnlyProvider(defaultProvider),
+		app,
+	)
+}
+
+func reconcileWorkflowConfigDefinitionsFromDeclarations(ctx context.Context, cfg *config.Config, runtime *workflowRuntime, reported map[string][]*proto.WorkflowDefinitionSpec, includeProvider workflowConfigProviderFilter, app string) error {
 	if cfg == nil || runtime == nil {
 		return nil
 	}
@@ -39,10 +70,6 @@ func reconcileWorkflowConfigDefinitions(ctx context.Context, cfg *config.Config,
 	cfgDesired, err := desiredWorkflowConfigDefinitions(cfg)
 	if err != nil {
 		return err
-	}
-	var reported map[string][]*proto.WorkflowDefinitionSpec
-	if appDecls != nil {
-		reported = appDecls.Snapshot()
 	}
 	appDesired, err := desiredAppWorkflowDefinitions(cfg, reported)
 	if err != nil {
@@ -56,6 +83,9 @@ func reconcileWorkflowConfigDefinitions(ctx context.Context, cfg *config.Config,
 	for _, definitionID := range slices.Sorted(maps.Keys(desired)) {
 		desiredEntry := desired[definitionID]
 		if !workflowConfigProviderIncluded(includeProvider, desiredEntry.ProviderName) {
+			continue
+		}
+		if app != "" && desiredEntry.FromApp != app {
 			continue
 		}
 		spec := desiredEntry.Spec
@@ -101,7 +131,7 @@ func reconcileWorkflowConfigDefinitions(ctx context.Context, cfg *config.Config,
 		}
 	}
 
-	if err := cleanupRemovedWorkflowConfigDefinitions(ctx, cfg, runtime, reported, desired, includeProvider); err != nil {
+	if err := cleanupRemovedWorkflowConfigDefinitions(ctx, cfg, runtime, reported, desired, includeProvider, app); err != nil {
 		return err
 	}
 	return nil
@@ -191,16 +221,20 @@ func isWorkflowObjectNotFound(err error) bool {
 	return errors.Is(err, core.ErrNotFound) || status.Code(err) == codes.NotFound
 }
 
-func cleanupRemovedWorkflowConfigDefinitions(ctx context.Context, cfg *config.Config, runtime *workflowRuntime, reported map[string][]*proto.WorkflowDefinitionSpec, desired map[string]desiredWorkflowConfigDefinition, includeProvider workflowConfigProviderFilter) error {
+func cleanupRemovedWorkflowConfigDefinitions(ctx context.Context, cfg *config.Config, runtime *workflowRuntime, reported map[string][]*proto.WorkflowDefinitionSpec, desired map[string]desiredWorkflowConfigDefinition, includeProvider workflowConfigProviderFilter, app string) error {
 	desiredByProviderDefinition := make(map[string]struct{}, len(desired))
 	for definitionID := range desired {
 		entry := desired[definitionID]
 		if !workflowConfigProviderIncluded(includeProvider, entry.ProviderName) {
 			continue
 		}
+		if app != "" && entry.FromApp != app {
+			continue
+		}
 		desiredByProviderDefinition[workflowConfigProviderObjectKey(entry.ProviderName, entry.DefinitionID)] = struct{}{}
 	}
 	protectedPrefixes := appWorkflowProtectedPrefixes(cfg, reported)
+	knownApps := slices.Sorted(maps.Keys(cfg.Apps))
 	for _, providerName := range runtime.ConfiguredProviderNames() {
 		if !workflowConfigProviderIncluded(includeProvider, providerName) {
 			continue
@@ -220,6 +254,9 @@ func cleanupRemovedWorkflowConfigDefinitions(ctx context.Context, cfg *config.Co
 				return fmt.Errorf("bootstrap: decode workflow definition from provider %q: %w", providerName, err)
 			}
 			if definition == nil || !isManagedWorkflowDefinitionOwned(definition, definition.ID) {
+				continue
+			}
+			if app != "" && coreworkflow.DefinitionOwnerApp(definition.ID, knownApps) != app {
 				continue
 			}
 			if _, ok := desiredByProviderDefinition[workflowConfigProviderObjectKey(providerName, definition.ID)]; ok {

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -592,6 +592,34 @@ func startAppRegistryCatalogPoller(
 	if changeRequests == nil || materializations == nil || rollouts == nil {
 		return nil
 	}
+	appRuntimeState, _ := result.AppRestarter.(AppRuntimeState)
+	beforeRolloutComplete := func(ctx context.Context, app, version string) (bool, error) {
+		if result.ReconcileAppWorkflowDefinitions == nil {
+			return true, nil
+		}
+		restartable, err := result.AppRestarter.Restartable(app)
+		if err != nil {
+			return false, err
+		}
+		if !restartable {
+			return true, nil
+		}
+		if appRuntimeState == nil {
+			return false, nil
+		}
+		ready := false
+		err = appRuntimeState.WithRunningVersion(app, func(runningVersion string) error {
+			if strings.TrimSpace(runningVersion) != strings.TrimSpace(version) {
+				return nil
+			}
+			ready = true
+			return result.ReconcileAppWorkflowDefinitions(ctx, app)
+		})
+		if !ready {
+			return false, nil
+		}
+		return true, err
+	}
 	var materializer *appregistry.Materializer
 	if cfg != nil && len(cfg.AppRegistries) > 0 {
 		artifactsDir := strings.TrimSpace(cfg.Server.ArtifactsDir)
@@ -638,6 +666,7 @@ func startAppRegistryCatalogPoller(
 		RestartReady:                result.AppProvidersInitialized,
 		BootstrapReady:              result.AppProvidersInitialized,
 		MaxReconcileAttempts:        cfg.Server.AppRegistry.MaxReconcileAttempts,
+		BeforeRolloutComplete:       beforeRolloutComplete,
 		OnRolloutTerminal:           onRolloutTerminal,
 	})
 	poller.Start(ctx)


### PR DESCRIPTION
## Why

Registry app auto-deploy replaces an app provider in-process, but workflow definitions were only reconciled during gestaltd startup. The app could emit events with its new declaration while the workflow provider still enforced the previous schema.

## What

- make exact-version workflow reconciliation part of rollout completion
- keep the rollout active until reconciliation succeeds, so the existing catalog poll is the durable retry loop across process replacement
- reconcile only definitions declared by that app; cleanup uses unambiguous longest-app ownership
- preserve existing terminal notification behavior for auto-deploy
- remove the post-completion goroutine, expanded restarter interface, and all test-fake changes from the earlier design

No app-specific behavior, fallback path, documentation, or test-file changes.

## Verification

- focused app registry, bootstrap, and server tests pass
- focused golangci-lint passes with zero issues
- GitHub Go tests, Go lint/vet, Helm validation, image build, and Semgrep pass