### PR TITLE
Batch app access profile reads

### DIFF
--- a/gestaltd/services/invocation/authorization_batch.go
+++ b/gestaltd/services/invocation/authorization_batch.go
@@ -119,15 +119,26 @@ func (b *Broker) CheckOperationAccessMany(
 ) ([]error, error) {
 	results := make([]error, len(queries))
 	pending := make([]int, 0, len(queries))
+	type appAccess struct {
+		profile *core.AppAccessProfile
+		err     error
+	}
+	appAccessByProvider := make(map[string]appAccess)
 	for i, query := range queries {
-		switch {
-		case !principal.AllowsOperationPermission(p, query.Provider, query.Operation):
+		if !principal.AllowsOperationPermission(p, query.Provider, query.Operation) {
 			results[i] = operationAccessDenied(query)
-		case b.checkAppAccess(ctx, p, query.Provider, query.Operation) != nil:
+			continue
+		}
+		access, ok := appAccessByProvider[query.Provider]
+		if !ok {
+			access.profile, access.err = b.appAccessProfile(ctx, p, query.Provider)
+			appAccessByProvider[query.Provider] = access
+		}
+		if access.err != nil || !appAccessProfileAllows(access.profile, query.Operation) {
 			results[i] = operationAccessDenied(query)
-		case b.providerDelegatesRemoteAuthorization(ctx, query.Provider):
-			// The remote app owns this decision, exactly as at invoke time.
-		default:
+			continue
+		}
+		if !b.providerDelegatesRemoteAuthorization(ctx, query.Provider) {
 			pending = append(pending, i)
 		}
 	}

--- a/gestaltd/services/invocation/broker.go
+++ b/gestaltd/services/invocation/broker.go
@@ -1271,17 +1271,28 @@ func (b *Broker) checkInvocationOperationAccess(ctx context.Context, p *principa
 }
 
 func (b *Broker) checkAppAccess(ctx context.Context, p *principal.Principal, providerName, operationID string) error {
-	if b == nil || b.appAccessProfiles == nil || p == nil || principal.IsNonUserPrincipal(p) {
+	profile, err := b.appAccessProfile(ctx, p, providerName)
+	if err != nil {
+		return fmt.Errorf("%w: %s.%s: %v", ErrAuthorizationDenied, providerName, operationID, err)
+	}
+	if appAccessProfileAllows(profile, operationID) {
 		return nil
+	}
+	return fmt.Errorf("%w: %s.%s", ErrAuthorizationDenied, providerName, operationID)
+}
+
+func (b *Broker) appAccessProfile(ctx context.Context, p *principal.Principal, providerName string) (*core.AppAccessProfile, error) {
+	if b == nil || b.appAccessProfiles == nil || p == nil || principal.IsNonUserPrincipal(p) {
+		return nil, nil
 	}
 	subjectID, err := principal.ResolveAuthorizationSubjectID(ctx, b.users, p)
 	if err != nil {
 		if !errors.Is(err, principal.ErrOpaqueCredentialSubject) {
-			return fmt.Errorf("%w: %s.%s: %v", ErrAuthorizationDenied, providerName, operationID, err)
+			return nil, err
 		}
 		subjectID = legacyAppAccessSubjectID(p)
 		if subjectID == "" {
-			return fmt.Errorf("%w: %s.%s: %v", ErrAuthorizationDenied, providerName, operationID, err)
+			return nil, err
 		}
 		// Older local callers can carry a non-UUID user ID. Preserve their
 		// existing no-profile allow behavior, but honor a legacy raw profile
@@ -1291,16 +1302,23 @@ func (b *Broker) checkAppAccess(ctx context.Context, p *principal.Principal, pro
 	profile, err := b.appAccessProfiles.GetAppAccessProfile(ctx, subjectID, providerName)
 	if err != nil {
 		if errors.Is(err, core.ErrNotFound) {
-			return nil
+			return nil, nil
 		}
-		return fmt.Errorf("%w: %s.%s: %v", ErrAuthorizationDenied, providerName, operationID, err)
+		return nil, err
+	}
+	return profile, nil
+}
+
+func appAccessProfileAllows(profile *core.AppAccessProfile, operationID string) bool {
+	if profile == nil {
+		return true
 	}
 	for _, enabled := range profile.EnabledOperations {
 		if strings.TrimSpace(enabled) == strings.TrimSpace(operationID) {
-			return nil
+			return true
 		}
 	}
-	return fmt.Errorf("%w: %s.%s", ErrAuthorizationDenied, providerName, operationID)
+	return false
 }
 
 func legacyAppAccessSubjectID(p *principal.Principal) string {


### PR DESCRIPTION
## Summary

Load each user app-access profile once per operation-access batch instead of once per catalog operation. For `g-issues`, this reduces profile reads from 82 to 1 without caching or changing authorization behavior.

## Validation

- `go test ./gestaltd/services/invocation ./gestaltd/internal/server ./gestaltd/services/apps/mcp`
- `TMPDIR=/tmp go test ./gestaltd/internal/bootstrap -run 'TestAgentRuntimeConfigUses(PublicHostServiceRelayBinding|HostedAgentProvider)' -count=1`\n- `TMPDIR=/tmp go test ./gestaltd/services/runtimehost -run TestDialUnixSocketReceivesLargeProviderResponse -count=1`