### PR TITLE
Consolidate app authorization on app:{appKey}

### DIFF
--- a/gestaltd/internal/bootstrap/authorization_bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/authorization_bootstrap_test.go
@@ -540,7 +540,7 @@ func (p *statefulAuthorizationProvider) Ping(context.Context) error { return nil
 
 func (p *statefulAuthorizationProvider) Close() error { return nil }
 
-func TestProviderAuthorizationKindsSkipsDedicatedAppResourceTypes(t *testing.T) {
+func TestProviderAuthorizationKindsRegistersApps(t *testing.T) {
 	t.Parallel()
 
 	cfg := &config.Config{
@@ -552,23 +552,14 @@ func TestProviderAuthorizationKindsSkipsDedicatedAppResourceTypes(t *testing.T) 
 			Workflow: map[string]*config.ProviderEntry{"nightly": {}},
 			Agent:    map[string]*config.ProviderEntry{"assistant": {}},
 		},
-		Authorization: config.AuthorizationConfig{
-			Models: map[string]config.AuthorizationModelDef{
-				"default": {
-					ResourceTypes: map[string]config.AuthorizationResourceTypeDef{
-						"legacy_app": {},
-					},
-				},
-			},
-		},
 	}
 
 	got := ProviderAuthorizationKinds(cfg)
 	if _, ok := got["workspace_review"]; !ok || got["workspace_review"] != invocation.ProviderKindApp {
 		t.Fatalf("workspace_review kind = %v, want app", got["workspace_review"])
 	}
-	if _, ok := got["legacy_app"]; ok {
-		t.Fatalf("legacy_app should be excluded from provider kinds, got %v", got["legacy_app"])
+	if got["legacy_app"] != invocation.ProviderKindApp {
+		t.Fatalf("legacy_app kind = %v, want app", got["legacy_app"])
 	}
 	if got["nightly"] != invocation.ProviderKindWorkflow {
 		t.Fatalf("nightly kind = %v, want workflow", got["nightly"])
@@ -603,10 +594,10 @@ func TestProviderAuthorizationPolicies(t *testing.T) {
 		t.Fatalf("shared policy = %q, want workspace", got["shared"])
 	}
 	if _, ok := got["own"]; ok {
-		t.Fatal("own app should use its app name instead of an explicit policy")
+		t.Fatal("own app should not get an implicit policy alias")
 	}
-	if got["legacy"] != "legacy" {
-		t.Fatalf("legacy policy = %q, want self-alias", got["legacy"])
+	if _, ok := got["legacy"]; ok {
+		t.Fatalf("legacy app should not auto-map to a dedicated policy alias, got %v", got["legacy"])
 	}
 }
 

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -2562,11 +2562,7 @@ func ProviderAuthorizationKinds(cfg *config.Config) map[string]invocation.Provid
 	if cfg == nil {
 		return kinds
 	}
-	dedicatedResourceTypes := AuthorizationResourceTypeNames(cfg)
 	for name := range cfg.Apps {
-		if _, hasDedicatedResourceType := dedicatedResourceTypes[name]; hasDedicatedResourceType {
-			continue
-		}
 		kinds[name] = invocation.ProviderKindApp
 	}
 	for name := range cfg.Providers.Workflow {
@@ -2583,14 +2579,9 @@ func ProviderAuthorizationPolicies(cfg *config.Config) map[string]string {
 	if cfg == nil {
 		return policies
 	}
-	dedicatedResourceTypes := AuthorizationResourceTypeNames(cfg)
 	for name, app := range cfg.Apps {
 		if policy := strings.TrimSpace(app.AuthorizationPolicy); policy != "" {
 			policies[name] = policy
-			continue
-		}
-		if _, hasDedicatedResourceType := dedicatedResourceTypes[name]; hasDedicatedResourceType {
-			policies[name] = name
 		}
 	}
 	return policies

--- a/gestaltd/internal/server/authorization_decision.go
+++ b/gestaltd/internal/server/authorization_decision.go
@@ -17,10 +17,16 @@ func (s *Server) authorizationMapper() invocation.AuthorizationResourceMapper {
 	return invocation.NewAuthorizationResourceMapper(s.providerKinds, s.authorizationPolicies)
 }
 
-// authorizationResource resolves the authorization resource for an app key or
-// policy alias.
+// authorizationResource resolves the authorization resource for an app key.
 func (s *Server) authorizationResource(appKey string) *proto.Resource {
 	return s.authorizationMapper().Resource(appKey)
+}
+
+// configuredAuthorizationResource resolves a configured authorization policy
+// name to its dedicated resource type. Use this for server admin, mounted UI,
+// and other platform gates that are not app keys.
+func configuredAuthorizationResource(policy string) *proto.Resource {
+	return invocation.DedicatedAuthorizationResource(policy)
 }
 
 // checkResourceAccess routes an HTTP-surface authorization question through the

--- a/gestaltd/internal/server/handlers_admin_platform_admins.go
+++ b/gestaltd/internal/server/handlers_admin_platform_admins.go
@@ -28,7 +28,7 @@ func (s *Server) platformAdminResource() *proto.Resource {
 	if name == "" {
 		name = defaultAdminAuthorizationResource
 	}
-	return s.authorizationResource(name)
+	return configuredAuthorizationResource(name)
 }
 
 func (s *Server) configuredPlatformAdminRole() string {

--- a/gestaltd/internal/server/integration_visibility.go
+++ b/gestaltd/internal/server/integration_visibility.go
@@ -104,7 +104,7 @@ func (s *Server) mountedUIListingAccessRequest(appName, subjectID string) (invoc
 	return invocation.ResourceAccessRequest{
 		SubjectID:    access.subjectID,
 		Action:       access.action(),
-		Resource:     s.authorizationResource(access.resourceName),
+		Resource:     s.mountedUIAuthorizationResource(mounted),
 		AllowedRoles: access.allowedRoles,
 	}, true
 }

--- a/gestaltd/internal/server/mounted_ui.go
+++ b/gestaltd/internal/server/mounted_ui.go
@@ -273,6 +273,7 @@ func (s *Server) authorizeMountedAppAccess(ctx context.Context, p *principal.Pri
 	return s.authorizeMountedResourceRoles(ctx, mountedResourceAccess{
 		actionName:   mountedUIAuthorizationActionName(mounted),
 		resourceName: resourceName,
+		resource:     s.mountedUIAuthorizationResource(mounted),
 		subjectID:    subjectID,
 		allowedRoles: mounted.AllowedRoles,
 	})
@@ -284,6 +285,7 @@ func (s *Server) authorizeMountedAppAccess(ctx context.Context, p *principal.Pri
 type mountedResourceAccess struct {
 	actionName   string
 	resourceName string
+	resource     *proto.Resource
 	subjectID    string
 	allowedRoles []string
 }
@@ -341,7 +343,7 @@ func (s *Server) authorizeMountedResourceRoles(ctx context.Context, access mount
 	decision, err := s.checkResourceAccess(ctx, invocation.ResourceAccessRequest{
 		SubjectID:    access.subjectID,
 		Action:       access.action(),
-		Resource:     s.authorizationResource(access.resourceName),
+		Resource:     access.resource,
 		AllowedRoles: access.allowedRoles,
 	})
 	if err != nil {
@@ -353,7 +355,7 @@ func (s *Server) authorizeMountedResourceRoles(ctx context.Context, access mount
 
 	// The evaluator did not name an authorizing relation. Read the active model
 	// once for the resource type's defaultRole.
-	model, err := s.mountedUIResourceModel(ctx, access.resourceName)
+	model, err := s.mountedUIResourceModel(ctx, access.resource)
 	if err != nil {
 		return invocation.AccessContext{}, false, err
 	}
@@ -374,6 +376,13 @@ func mountedUIAuthorizationResourceName(mounted MountedUI) string {
 		return name
 	}
 	return strings.TrimSpace(mounted.AppName)
+}
+
+func (s *Server) mountedUIAuthorizationResource(mounted MountedUI) *proto.Resource {
+	if name := strings.TrimSpace(mounted.AuthorizationPolicy); name != "" {
+		return configuredAuthorizationResource(name)
+	}
+	return s.authorizationResource(strings.TrimSpace(mounted.AppName))
 }
 
 func mountedUIRequiresAuthorization(mounted MountedUI) bool {
@@ -402,11 +411,11 @@ type mountedUIModelSnapshot struct {
 // mountedUIResourceModel reads the mount's resource type from the active model.
 // Within a listing request the read is memoized per resource type, so filtering
 // many apps does not re-read the same model entry once per app.
-func (s *Server) mountedUIResourceModel(ctx context.Context, resourceName string) (mountedUIModelSnapshot, error) {
-	if s == nil || s.authorization == nil {
+func (s *Server) mountedUIResourceModel(ctx context.Context, resource *proto.Resource) (mountedUIModelSnapshot, error) {
+	if s == nil || s.authorization == nil || resource == nil {
 		return mountedUIModelSnapshot{}, invocation.ErrAuthorizationUnavailable
 	}
-	typeName := strings.TrimSpace(s.authorizationResource(resourceName).GetType())
+	typeName := strings.TrimSpace(resource.GetType())
 	cache := listingDecisionCacheFromContext(ctx)
 	if cached, ok := cache.model(typeName); ok {
 		return cached, nil

--- a/gestaltd/internal/server/user_lookup.go
+++ b/gestaltd/internal/server/user_lookup.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	"github.com/valon-technologies/gestalt/server/services/apps/packageio"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
@@ -89,7 +90,7 @@ func (s *Server) userLookupAllowed(ctx context.Context) bool {
 	decision, err := s.checkResourceAccess(ctx, invocation.ResourceAccessRequest{
 		SubjectID:    subjectID,
 		Action:       policy,
-		Resource:     s.authorizationResource(policy),
+		Resource:     &proto.Resource{Type: policy, Id: policy},
 		AllowedRoles: s.userLookupRoute.AllowedRoles,
 	})
 	if err != nil {

--- a/gestaltd/internal/server/user_lookup.go
+++ b/gestaltd/internal/server/user_lookup.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	"github.com/valon-technologies/gestalt/server/services/apps/packageio"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
@@ -90,7 +89,7 @@ func (s *Server) userLookupAllowed(ctx context.Context) bool {
 	decision, err := s.checkResourceAccess(ctx, invocation.ResourceAccessRequest{
 		SubjectID:    subjectID,
 		Action:       policy,
-		Resource:     &proto.Resource{Type: policy, Id: policy},
+		Resource:     invocation.DedicatedAuthorizationResource(policy),
 		AllowedRoles: s.userLookupRoute.AllowedRoles,
 	})
 	if err != nil {

--- a/gestaltd/services/invocation/authorization_resource.go
+++ b/gestaltd/services/invocation/authorization_resource.go
@@ -11,7 +11,7 @@ func AuthorizationResource(name string, kinds map[string]ProviderKind) *proto.Re
 	if kind, ok := kinds[name]; ok {
 		return &proto.Resource{Type: string(kind), Id: name}
 	}
-	return &proto.Resource{Type: name, Id: name}
+	return &proto.Resource{Type: string(ProviderKindApp), Id: name}
 }
 
 // AuthorizationResourceMapper is the single place that maps an app key to the
@@ -39,13 +39,18 @@ func (m AuthorizationResourceMapper) Policy(appKey string) string {
 	return appKey
 }
 
-// Resource returns the authorization resource for an app key. A configured
-// policy alias becomes its own dedicated resource type; otherwise the provider
-// kind supplies the resource type.
+// Resource returns the authorization resource for an app key. An explicit
+// authorizationPolicy alias uses that dedicated resource type; otherwise apps
+// resolve to app:{appKey} (or the configured provider kind for workflows).
 func (m AuthorizationResourceMapper) Resource(appKey string) *proto.Resource {
 	appKey = strings.TrimSpace(appKey)
 	if policy := strings.TrimSpace(m.policies[appKey]); policy != "" {
 		return &proto.Resource{Type: policy, Id: policy}
+	}
+	for _, policy := range m.policies {
+		if strings.TrimSpace(policy) == appKey {
+			return &proto.Resource{Type: appKey, Id: appKey}
+		}
 	}
 	return AuthorizationResource(appKey, m.kinds)
 }

--- a/gestaltd/services/invocation/authorization_resource.go
+++ b/gestaltd/services/invocation/authorization_resource.go
@@ -6,6 +6,11 @@ import (
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 )
 
+func DedicatedAuthorizationResource(name string) *proto.Resource {
+	name = strings.TrimSpace(name)
+	return &proto.Resource{Type: name, Id: name}
+}
+
 func AuthorizationResource(name string, kinds map[string]ProviderKind) *proto.Resource {
 	name = strings.TrimSpace(name)
 	if kind, ok := kinds[name]; ok {
@@ -45,11 +50,11 @@ func (m AuthorizationResourceMapper) Policy(appKey string) string {
 func (m AuthorizationResourceMapper) Resource(appKey string) *proto.Resource {
 	appKey = strings.TrimSpace(appKey)
 	if policy := strings.TrimSpace(m.policies[appKey]); policy != "" {
-		return &proto.Resource{Type: policy, Id: policy}
+		return DedicatedAuthorizationResource(policy)
 	}
 	for _, policy := range m.policies {
 		if strings.TrimSpace(policy) == appKey {
-			return &proto.Resource{Type: appKey, Id: appKey}
+			return DedicatedAuthorizationResource(appKey)
 		}
 	}
 	return AuthorizationResource(appKey, m.kinds)

--- a/gestaltd/services/invocation/authorization_resource_test.go
+++ b/gestaltd/services/invocation/authorization_resource_test.go
@@ -23,9 +23,9 @@ func TestAuthorizationResource(t *testing.T) {
 			want:  struct{ typ, id string }{"app", "slack"},
 		},
 		{
-			name:  "dedicated resource type fallback",
+			name:  "unknown app key falls back to app resource",
 			kinds: map[string]ProviderKind{"slack": ProviderKindApp},
-			want:  struct{ typ, id string }{"legacyApp", "legacyApp"},
+			want:  struct{ typ, id string }{"app", "legacyApp"},
 		},
 		{
 			name:  "workflow provider",
@@ -39,7 +39,7 @@ func TestAuthorizationResource(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			resourceName := "slack"
-			if tc.name == "dedicated resource type fallback" {
+			if tc.name == "unknown app key falls back to app resource" {
 				resourceName = "legacyApp"
 			}
 			if tc.name == "workflow provider" {
@@ -50,6 +50,19 @@ func TestAuthorizationResource(t *testing.T) {
 				t.Fatalf("AuthorizationResource(%q) = {%q, %q}, want {%q, %q}", resourceName, got.GetType(), got.GetId(), tc.want.typ, tc.want.id)
 			}
 		})
+	}
+}
+
+func TestAuthorizationResourceMapperResolvesExplicitPolicyName(t *testing.T) {
+	t.Parallel()
+
+	mapper := NewAuthorizationResourceMapper(
+		map[string]ProviderKind{"traffic-cop": ProviderKindApp},
+		map[string]string{"traffic-cop": "trafficCop"},
+	)
+	resource := mapper.Resource("trafficCop")
+	if resource.GetType() != "trafficCop" || resource.GetId() != "trafficCop" {
+		t.Fatalf("Resource = %v, want trafficCop/trafficCop", resource)
 	}
 }
 
@@ -89,8 +102,8 @@ func TestAuthorizationResourceMapperZeroValueIsUsable(t *testing.T) {
 
 	var mapper AuthorizationResourceMapper
 	resource := mapper.Resource("unknown")
-	if resource.GetType() != "unknown" || resource.GetId() != "unknown" {
-		t.Fatalf("Resource = %v, want unknown/unknown", resource)
+	if resource.GetType() != "app" || resource.GetId() != "unknown" {
+		t.Fatalf("Resource = %v, want app/unknown", resource)
 	}
 }
 

--- a/gestaltd/services/invocation/broker.go
+++ b/gestaltd/services/invocation/broker.go
@@ -1230,17 +1230,12 @@ func (b *Broker) authorizationPolicy(providerName string) string {
 func (b *Broker) authorizationResource(ctx context.Context, providerName string) *proto.Resource {
 	providerName = strings.TrimSpace(providerName)
 	mapper := b.authorizationMapper()
-	if b != nil {
-		if strings.TrimSpace(b.authorizationPolicies[providerName]) != "" {
-			return mapper.Resource(providerName)
-		}
-		if b.providers != nil {
-			if _, err := b.providers.GetWithContext(ctx, providerName); err == nil {
-				return &proto.Resource{Type: string(ProviderKindApp), Id: providerName}
-			}
-		}
-		if b.providerKinds[providerName] != "" {
-			return mapper.Resource(providerName)
+	if b != nil && strings.TrimSpace(b.authorizationPolicies[providerName]) != "" {
+		return mapper.Resource(providerName)
+	}
+	if b != nil && b.providers != nil {
+		if _, err := b.providers.GetWithContext(ctx, providerName); err == nil {
+			return &proto.Resource{Type: string(ProviderKindApp), Id: providerName}
 		}
 	}
 	return mapper.Resource(providerName)


### PR DESCRIPTION
## Summary

- Route unknown and registered app keys through `app:{appKey}` instead of self-typed `{key}:{key}` resources unless `authorizationPolicy` is set explicitly in deploy config.
- Remove implicit dedicated-type policy aliases derived from authorization seed resource type names (for example `rippling` → `rippling:rippling`).
- Keep explicit `authorizationPolicy` aliases (for example `gestalt` → `gestalt:gestalt`) and platform gates (user lookup) on their configured dedicated resource types.

This fixes app-admin Members returning 403 when `check-access` on `app:{app}` succeeded — for example `valonLearn` and `workplaceHub` — because grants live on `app:{key}` while the middleware was checking `{key}:{key}`.

## Test plan

- [x] `go test ./services/invocation/... ./internal/bootstrap/...`
- [x] `go test ./internal/server/... -run 'TestConformancePolicyAlias|TestConformanceUserLookup'`
- [ ] Deploy gestaltd and verify `GET /api/v1/apps/valonLearn/admin/members` succeeds for an `app:valonLearn admin` holder


Made with [Cursor](https://cursor.com)