### PR TITLE
App-admin CLI ergonomics for members and groups

### DIFF
--- a/gestalt/cli/src/cli.rs
+++ b/gestalt/cli/src/cli.rs
@@ -300,7 +300,7 @@ pub struct AuthorizationAppsMembersSetArgs {
         required_unless_present_any = ["subject_id", "group_id"]
     )]
     pub email: Option<String>,
-    /// Member subject id, such as user:abc or service_account:bot
+    /// Member subject id, such as user:<uuid> or service_account:bot
     #[arg(
         long = "subject-id",
         conflicts_with_all = ["email", "group_id"],
@@ -323,7 +323,7 @@ pub struct AuthorizationAppsMembersSetArgs {
 pub struct AuthorizationAppsMembersRemoveArgs {
     /// App name
     pub app: String,
-    /// Member subject id, such as user:abc
+    /// Member subject id, such as user:<uuid>
     #[arg(
         conflicts_with_all = ["email", "subject_id", "group_id"],
         required_unless_present_any = ["email", "subject_id", "group_id"]
@@ -332,7 +332,7 @@ pub struct AuthorizationAppsMembersRemoveArgs {
     /// Existing roster member email address
     #[arg(long, conflicts_with_all = ["subject", "subject_id", "group_id"])]
     pub email: Option<String>,
-    /// Member subject id, such as user:abc or service_account:bot
+    /// Member subject id, such as user:<uuid> or service_account:bot
     #[arg(long = "subject-id", conflicts_with_all = ["subject", "email", "group_id"])]
     pub subject_id: Option<String>,
     /// Workspace group id to remove (maps to group:{id}#member)

--- a/gestalt/cli/src/cli.rs
+++ b/gestalt/cli/src/cli.rs
@@ -243,6 +243,17 @@ pub enum AuthorizationCommands {
         #[command(subcommand)]
         command: AuthorizationAppsCommands,
     },
+    /// Inspect workspace groups from Admin
+    Groups {
+        #[command(subcommand)]
+        command: AuthorizationGroupsCommands,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum AuthorizationGroupsCommands {
+    /// List workspace groups
+    List,
 }
 
 #[derive(Subcommand)]
@@ -283,11 +294,26 @@ pub struct AuthorizationAppsMembersSetArgs {
     /// App name
     pub app: String,
     /// Existing roster member email address
-    #[arg(long, conflicts_with = "subject_id")]
+    #[arg(
+        long,
+        conflicts_with_all = ["subject_id", "group_id"],
+        required_unless_present_any = ["subject_id", "group_id"]
+    )]
     pub email: Option<String>,
     /// Member subject id, such as user:abc or service_account:bot
-    #[arg(long = "subject-id", conflicts_with = "email")]
+    #[arg(
+        long = "subject-id",
+        conflicts_with_all = ["email", "group_id"],
+        required_unless_present_any = ["email", "group_id"]
+    )]
     pub subject_id: Option<String>,
+    /// Workspace group id to grant (maps to group:{id}#member)
+    #[arg(
+        long = "group-id",
+        conflicts_with_all = ["email", "subject_id"],
+        required_unless_present_any = ["email", "subject_id"]
+    )]
+    pub group_id: Option<String>,
     /// App role to grant, such as viewer, editor, or admin
     #[arg(long)]
     pub role: String,
@@ -298,14 +324,20 @@ pub struct AuthorizationAppsMembersRemoveArgs {
     /// App name
     pub app: String,
     /// Member subject id, such as user:abc
-    #[arg(conflicts_with_all = ["email", "subject_id"], required_unless_present_any = ["email", "subject_id"])]
+    #[arg(
+        conflicts_with_all = ["email", "subject_id", "group_id"],
+        required_unless_present_any = ["email", "subject_id", "group_id"]
+    )]
     pub subject: Option<String>,
     /// Existing roster member email address
-    #[arg(long, conflicts_with_all = ["subject", "subject_id"])]
+    #[arg(long, conflicts_with_all = ["subject", "subject_id", "group_id"])]
     pub email: Option<String>,
     /// Member subject id, such as user:abc or service_account:bot
-    #[arg(long = "subject-id", conflicts_with_all = ["subject", "email"])]
+    #[arg(long = "subject-id", conflicts_with_all = ["subject", "email", "group_id"])]
     pub subject_id: Option<String>,
+    /// Workspace group id to remove (maps to group:{id}#member)
+    #[arg(long = "group-id", conflicts_with_all = ["subject", "email", "subject_id"])]
+    pub group_id: Option<String>,
     /// Relationship role to remove; when omitted, removes all mutable grants for the subject
     #[arg(long)]
     pub role: Option<String>,

--- a/gestalt/cli/src/commands/authorization.rs
+++ b/gestalt/cli/src/commands/authorization.rs
@@ -12,6 +12,7 @@ use crate::output::{self, Format};
 
 use crate::api::ApiClient;
 use crate::commands::authorization_apps;
+use crate::commands::authorization_groups;
 use crate::commands::authorization_subjects;
 
 use gestalt_sdk::authorization::source_layer::{
@@ -134,6 +135,11 @@ pub fn dispatch(
         AuthorizationCommands::Apps { command } => {
             authorization_apps::dispatch(api, authz, command, format)
         }
+        AuthorizationCommands::Groups { command } => match command {
+            crate::cli::AuthorizationGroupsCommands::List => {
+                authorization_groups::list_groups(api, format)
+            }
+        },
         AuthorizationCommands::State { command } => match command {
             AuthorizationStateCommands::Apply(args) => apply_state(api, &args, format),
         },
@@ -350,7 +356,25 @@ fn model_id(value: &Value) -> Option<&str> {
 mod tests {
     use serde_json::json;
 
-    use super::{model_id, next_page_token};
+    use super::{build_relationship_from_args, model_id, next_page_token};
+    use crate::cli::AuthorizationRelationshipMutationArgs;
+    use gestalt_sdk::authorization::source_layer::SOURCE_LAYER_RUNTIME;
+
+    #[test]
+    fn build_relationship_from_args_supports_subject_set_target() {
+        let relationship = build_relationship_from_args(&AuthorizationRelationshipMutationArgs {
+            resource_type: "app".to_string(),
+            resource_id: "g-issues".to_string(),
+            relation: "viewer".to_string(),
+            subject_id: None,
+            subject_set: Some("group:valon-employees#member".to_string()),
+        })
+        .unwrap();
+        let tuple = relationship.tuple.expect("tuple");
+        assert_eq!(tuple.resource.as_ref().map(|r| r.id.as_str()), Some("g-issues"));
+        assert_eq!(tuple.relation, "viewer");
+        assert_eq!(relationship.source_layer, SOURCE_LAYER_RUNTIME);
+    }
 
     #[test]
     fn next_page_token_returns_trimmed_non_empty_token() {

--- a/gestalt/cli/src/commands/authorization.rs
+++ b/gestalt/cli/src/commands/authorization.rs
@@ -11,10 +11,10 @@ use crate::cli::{
 use crate::output::{self, Format};
 
 use crate::api::ApiClient;
+use crate::cli::AuthorizationGroupsCommands;
 use crate::commands::authorization_apps;
 use crate::commands::authorization_groups;
 use crate::commands::authorization_subjects;
-use crate::cli::AuthorizationGroupsCommands;
 
 use gestalt_sdk::authorization::source_layer::{
     SOURCE_LAYER_RUNTIME, SOURCE_LAYER_STATIC_CONFIG, SOURCE_LAYER_UNSPECIFIED,
@@ -370,7 +370,10 @@ mod tests {
         })
         .unwrap();
         let tuple = relationship.tuple.expect("tuple");
-        assert_eq!(tuple.resource.as_ref().map(|r| r.id.as_str()), Some("g-issues"));
+        assert_eq!(
+            tuple.resource.as_ref().map(|r| r.id.as_str()),
+            Some("g-issues")
+        );
         assert_eq!(tuple.relation, "viewer");
         assert_eq!(relationship.source_layer, SOURCE_LAYER_RUNTIME);
     }

--- a/gestalt/cli/src/commands/authorization.rs
+++ b/gestalt/cli/src/commands/authorization.rs
@@ -14,6 +14,7 @@ use crate::api::ApiClient;
 use crate::commands::authorization_apps;
 use crate::commands::authorization_groups;
 use crate::commands::authorization_subjects;
+use crate::cli::AuthorizationGroupsCommands;
 
 use gestalt_sdk::authorization::source_layer::{
     SOURCE_LAYER_RUNTIME, SOURCE_LAYER_STATIC_CONFIG, SOURCE_LAYER_UNSPECIFIED,
@@ -136,9 +137,7 @@ pub fn dispatch(
             authorization_apps::dispatch(api, authz, command, format)
         }
         AuthorizationCommands::Groups { command } => match command {
-            crate::cli::AuthorizationGroupsCommands::List => {
-                authorization_groups::list_groups(api, format)
-            }
+            AuthorizationGroupsCommands::List => authorization_groups::list_groups(api, format),
         },
         AuthorizationCommands::State { command } => match command {
             AuthorizationStateCommands::Apply(args) => apply_state(api, &args, format),

--- a/gestalt/cli/src/commands/authorization_app_member_groups.rs
+++ b/gestalt/cli/src/commands/authorization_app_member_groups.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result, bail};
 use serde_json::Value;
 
-use crate::api::ApiClient;
+use crate::api::{ApiClient, encode_path_segment};
 use crate::cli::AuthorizationRelationshipMutationArgs;
 use crate::commands::authorization::{
     build_relationship_from_args, relationship_tuple_from_parts,
@@ -51,16 +51,19 @@ pub(crate) fn set_group_member(
 pub(crate) fn remove_group_member(
     api: &ApiClient,
     authz: &AuthorizationClient<SyncRestTransport>,
-    members_path: &str,
     app: &str,
     group_id: &str,
     role: Option<&str>,
     format: Format,
 ) -> Result<()> {
+    let members_path = format!(
+        "/api/v1/apps/{}/admin/members",
+        encode_path_segment(app)
+    );
     let subject_set = group_member_subject_set(group_id);
     let roles = match role {
         Some(role) => vec![role.to_string()],
-        None => mutable_group_roles(api, members_path, &subject_set)?,
+        None => mutable_group_roles(api, &members_path, &subject_set)?,
     };
     if roles.is_empty() {
         bail!("no mutable group grants found for {group_id} on {app}");

--- a/gestalt/cli/src/commands/authorization_app_member_groups.rs
+++ b/gestalt/cli/src/commands/authorization_app_member_groups.rs
@@ -1,0 +1,135 @@
+use anyhow::{Context, Result, bail};
+use serde_json::Value;
+
+use crate::api::ApiClient;
+use crate::cli::AuthorizationRelationshipMutationArgs;
+use crate::commands::authorization::{
+    build_relationship_from_args, relationship_tuple_from_parts,
+};
+use crate::output::{self, Format};
+
+use gestalt_sdk::authorization::{AddRelationshipRequest, DeleteRelationshipRequest};
+use gestalt_sdk::public::generated::app_client::AuthorizationClient;
+use gestalt_sdk::public::rest_transport::SyncRestTransport;
+
+pub(crate) fn set_group_member(
+    authz: &AuthorizationClient<SyncRestTransport>,
+    app: &str,
+    group_id: &str,
+    role: &str,
+    format: Format,
+) -> Result<()> {
+    let subject_set = group_member_subject_set(group_id);
+    let relationship = build_relationship_from_args(&AuthorizationRelationshipMutationArgs {
+        resource_type: "app".to_string(),
+        resource_id: app.to_string(),
+        relation: role.to_string(),
+        subject_id: None,
+        subject_set: Some(subject_set.clone()),
+    })?;
+    authz
+        .add_relationship_sync(AddRelationshipRequest {
+            relationship: Some(relationship),
+        })
+        .with_context(|| {
+            format!("failed to grant {role} on {app} to group {group_id} ({subject_set})")
+        })?;
+    match format {
+        Format::Json => output::print_json(&serde_json::json!({
+            "changed": true,
+            "groupId": group_id,
+            "role": role,
+            "subjectSet": subject_set,
+        })),
+        Format::Table => output::print_success(&format!(
+            "Granted {role} on {app} to group {group_id}."
+        )),
+    }
+    Ok(())
+}
+
+pub(crate) fn remove_group_member(
+    api: &ApiClient,
+    authz: &AuthorizationClient<SyncRestTransport>,
+    members_path: &str,
+    app: &str,
+    group_id: &str,
+    role: Option<&str>,
+    format: Format,
+) -> Result<()> {
+    let subject_set = group_member_subject_set(group_id);
+    let roles = match role {
+        Some(role) => vec![role.to_string()],
+        None => mutable_group_roles(api, members_path, &subject_set)?,
+    };
+    if roles.is_empty() {
+        bail!("no mutable group grants found for {group_id} on {app}");
+    }
+    for role in &roles {
+        let tuple =
+            relationship_tuple_from_parts("app", app, role, None, Some(&subject_set))?;
+        authz
+            .delete_relationship_sync(DeleteRelationshipRequest {
+                relationship_tuple: Some(tuple),
+            })
+            .with_context(|| {
+                format!("failed to remove {role} on {app} for group {group_id} ({subject_set})")
+            })?;
+    }
+    match format {
+        Format::Json => output::print_json(&serde_json::json!({
+            "removedRoles": roles,
+            "groupId": group_id,
+            "subjectSet": subject_set,
+        })),
+        Format::Table => output::print_success(&format!(
+            "Removed {} grant(s) for group {group_id} on {app}.",
+            roles.len()
+        )),
+    }
+    Ok(())
+}
+
+pub(crate) fn group_member_subject_set(group_id: &str) -> String {
+    format!("group:{}#member", group_id.trim())
+}
+
+fn mutable_group_roles(
+    api: &ApiClient,
+    members_path: &str,
+    subject_set: &str,
+) -> Result<Vec<String>> {
+    let resp = api
+        .get(members_path)
+        .context("failed to list app members for group removal")?;
+    let empty = Vec::new();
+    let rows = resp.as_array().unwrap_or(&empty);
+    let mut roles = Vec::new();
+    for row in rows {
+        if row.get("selectorValue").and_then(Value::as_str) != Some(subject_set) {
+            continue;
+        }
+        if row.get("mutable").and_then(Value::as_bool) != Some(true) {
+            continue;
+        }
+        if let Some(role) = row.get("role").and_then(Value::as_str).map(str::trim) {
+            if !role.is_empty() {
+                roles.push(role.to_string());
+            }
+        }
+    }
+    Ok(roles)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::group_member_subject_set;
+
+    #[test]
+    fn group_member_subject_set_formats_selector() {
+        assert_eq!(
+            group_member_subject_set("valon-employees"),
+            "group:valon-employees#member"
+        );
+    }
+}

--- a/gestalt/cli/src/commands/authorization_app_member_groups.rs
+++ b/gestalt/cli/src/commands/authorization_app_member_groups.rs
@@ -3,9 +3,7 @@ use serde_json::Value;
 
 use crate::api::{ApiClient, encode_path_segment};
 use crate::cli::AuthorizationRelationshipMutationArgs;
-use crate::commands::authorization::{
-    build_relationship_from_args, relationship_tuple_from_parts,
-};
+use crate::commands::authorization::{build_relationship_from_args, relationship_tuple_from_parts};
 use crate::output::{self, Format};
 
 use gestalt_sdk::authorization::{AddRelationshipRequest, DeleteRelationshipRequest};
@@ -41,9 +39,9 @@ pub(crate) fn set_group_member(
             "role": role,
             "subjectSet": subject_set,
         })),
-        Format::Table => output::print_success(&format!(
-            "Granted {role} on {app} to group {group_id}."
-        )),
+        Format::Table => {
+            output::print_success(&format!("Granted {role} on {app} to group {group_id}."))
+        }
     }
     Ok(())
 }
@@ -56,10 +54,7 @@ pub(crate) fn remove_group_member(
     role: Option<&str>,
     format: Format,
 ) -> Result<()> {
-    let members_path = format!(
-        "/api/v1/apps/{}/admin/members",
-        encode_path_segment(app)
-    );
+    let members_path = format!("/api/v1/apps/{}/admin/members", encode_path_segment(app));
     let subject_set = group_member_subject_set(group_id);
     let roles = match role {
         Some(role) => vec![role.to_string()],
@@ -69,8 +64,7 @@ pub(crate) fn remove_group_member(
         bail!("no mutable group grants found for {group_id} on {app}");
     }
     for role in &roles {
-        let tuple =
-            relationship_tuple_from_parts("app", app, role, None, Some(&subject_set))?;
+        let tuple = relationship_tuple_from_parts("app", app, role, None, Some(&subject_set))?;
         authz
             .delete_relationship_sync(DeleteRelationshipRequest {
                 relationship_tuple: Some(tuple),
@@ -115,10 +109,10 @@ fn mutable_group_roles(
         if row.get("mutable").and_then(Value::as_bool) != Some(true) {
             continue;
         }
-        if let Some(role) = row.get("role").and_then(Value::as_str).map(str::trim) {
-            if !role.is_empty() {
-                roles.push(role.to_string());
-            }
+        if let Some(role) = row.get("role").and_then(Value::as_str).map(str::trim)
+            && !role.is_empty()
+        {
+            roles.push(role.to_string());
         }
     }
     Ok(roles)

--- a/gestalt/cli/src/commands/authorization_app_member_people.rs
+++ b/gestalt/cli/src/commands/authorization_app_member_people.rs
@@ -20,9 +20,7 @@ pub(crate) fn trimmed_option(value: Option<&str>) -> Option<&str> {
 }
 
 pub(crate) fn load_app_admin_members(api: &ApiClient, path: &str) -> Result<Vec<AppAdminMember>> {
-    let resp = api
-        .get(path)
-        .context("failed to list app admin members")?;
+    let resp = api.get(path).context("failed to list app admin members")?;
     serde_json::from_value(resp).context("failed to parse app admin members response")
 }
 
@@ -41,8 +39,8 @@ pub(crate) fn resolve_canonical_member_subject_id(
         return canonical_subject_id_from_members(&members, &normalized);
     }
 
-    let email = trimmed_option(email)
-        .context("either --email, --subject-id, or --group-id is required")?;
+    let email =
+        trimmed_option(email).context("either --email, --subject-id, or --group-id is required")?;
     resolve_email_subject_id(api, members_path, email)
 }
 
@@ -199,9 +197,7 @@ fn is_canonical_user_uuid(value: &str) -> bool {
     if bytes[8] != b'-' || bytes[13] != b'-' || bytes[18] != b'-' || bytes[23] != b'-' {
         return false;
     }
-    value
-        .chars()
-        .all(|ch| ch.is_ascii_hexdigit() || ch == '-')
+    value.chars().all(|ch| ch.is_ascii_hexdigit() || ch == '-')
 }
 
 #[cfg(test)]
@@ -261,7 +257,9 @@ mod tests {
     #[test]
     fn service_account_subject_detection() {
         assert!(is_service_account_subject("service_account:bot"));
-        assert!(!is_service_account_subject("user:11111111-1111-1111-1111-111111111111"));
+        assert!(!is_service_account_subject(
+            "user:11111111-1111-1111-1111-111111111111"
+        ));
     }
 
     #[test]

--- a/gestalt/cli/src/commands/authorization_app_member_people.rs
+++ b/gestalt/cli/src/commands/authorization_app_member_people.rs
@@ -1,0 +1,330 @@
+use anyhow::{Context, Result, bail};
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::api::ApiClient;
+
+const WORKSPACE_USERS_LIST_PATH: &str = "/api/v1/home/users.list";
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct AppAdminMember {
+    #[serde(default)]
+    subject_id: Option<String>,
+    #[serde(default)]
+    email: Option<String>,
+}
+
+pub(crate) fn trimmed_option(value: Option<&str>) -> Option<&str> {
+    value.map(str::trim).filter(|value| !value.is_empty())
+}
+
+pub(crate) fn load_app_admin_members(api: &ApiClient, path: &str) -> Result<Vec<AppAdminMember>> {
+    let resp = api
+        .get(path)
+        .context("failed to list app admin members")?;
+    serde_json::from_value(resp).context("failed to parse app admin members response")
+}
+
+pub(crate) fn resolve_canonical_member_subject_id(
+    api: &ApiClient,
+    members_path: &str,
+    email: Option<&str>,
+    subject_id: Option<&str>,
+) -> Result<String> {
+    if let Some(subject_id) = trimmed_option(subject_id) {
+        let normalized = normalize_subject_id(subject_id)?;
+        if is_service_account_subject(&normalized) {
+            return Ok(normalized);
+        }
+        let members = load_app_admin_members(api, members_path)?;
+        return canonical_subject_id_from_members(&members, &normalized);
+    }
+
+    let email = trimmed_option(email)
+        .context("either --email, --subject-id, or --group-id is required")?;
+    resolve_email_subject_id(api, members_path, email)
+}
+
+fn resolve_email_subject_id(api: &ApiClient, members_path: &str, email: &str) -> Result<String> {
+    let members = load_app_admin_members(api, members_path)?;
+    if let Some(subject_id) = subject_id_for_email_in_members(&members, email) {
+        return Ok(subject_id);
+    }
+    resolve_workspace_user_subject_id(api, email)
+}
+
+fn resolve_workspace_user_subject_id(api: &ApiClient, email: &str) -> Result<String> {
+    let resp = api
+        .get(WORKSPACE_USERS_LIST_PATH)
+        .context("failed to load workspace user directory")?;
+    let empty = Vec::new();
+    let users = resp
+        .get("users")
+        .and_then(Value::as_array)
+        .unwrap_or(&empty);
+    workspace_user_subject_id_for_email(email, users)
+}
+
+fn workspace_user_subject_id_for_email(email: &str, users: &[Value]) -> Result<String> {
+    let normalized = email.trim().to_lowercase();
+    for user in users {
+        let Some(user_email) = user.get("email").and_then(Value::as_str).map(str::trim) else {
+            continue;
+        };
+        let Some(user_id) = user.get("id").and_then(Value::as_str).map(str::trim) else {
+            continue;
+        };
+        if user_email.is_empty() || user_id.is_empty() {
+            continue;
+        }
+        if user_email.eq_ignore_ascii_case(&normalized) {
+            return Ok(format!("user:{user_id}"));
+        }
+    }
+    bail!(
+        "could not resolve {email} from the workspace user directory; use --email with a workspace address or pass --subject-id user:<uuid>"
+    )
+}
+
+fn canonical_subject_id_from_members(
+    members: &[AppAdminMember],
+    subject_id: &str,
+) -> Result<String> {
+    let normalized = normalize_subject_id(subject_id)?;
+    if is_service_account_subject(&normalized) {
+        return Ok(normalized);
+    }
+    for member in members {
+        if !subject_matches_member(&normalized, member) {
+            continue;
+        }
+        if let Some(canonical) = member
+            .subject_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            return Ok(canonical.to_string());
+        }
+    }
+    Ok(normalized)
+}
+
+fn subject_id_for_email_in_members(members: &[AppAdminMember], email: &str) -> Option<String> {
+    let normalized_email = email.trim().to_lowercase();
+    for member in members {
+        let Some(member_email) = member.email.as_deref() else {
+            continue;
+        };
+        if member_email.trim().eq_ignore_ascii_case(&normalized_email)
+            && let Some(subject_id) = member
+                .subject_id
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+        {
+            return Some(subject_id.to_string());
+        }
+    }
+    None
+}
+
+fn subject_matches_member(subject_id: &str, member: &AppAdminMember) -> bool {
+    let Ok(normalized) = normalize_subject_id(subject_id) else {
+        return false;
+    };
+    member.subject_id.as_deref().is_some_and(|subject| {
+        normalize_subject_id(subject)
+            .ok()
+            .is_some_and(|candidate| candidate == normalized)
+    })
+}
+
+fn is_service_account_subject(subject_id: &str) -> bool {
+    subject_id
+        .trim()
+        .to_ascii_lowercase()
+        .starts_with("service_account:")
+}
+
+fn normalize_subject_id(raw: &str) -> Result<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        bail!("subject id is required");
+    }
+    if trimmed.contains('#') {
+        bail!(
+            "subject id must be a direct subject, not a subject-set selector; use --group-id or `authorization relationships` for group grants"
+        );
+    }
+    let subject_id = if trimmed.contains(':') {
+        trimmed.to_string()
+    } else if is_canonical_user_uuid(trimmed) {
+        format!("user:{trimmed}")
+    } else {
+        bail!(
+            "subject id must be user:<uuid>, service_account:<id>, or a bare user uuid; resolve people with --email"
+        );
+    };
+    validate_person_subject_id(&subject_id)?;
+    Ok(subject_id)
+}
+
+fn validate_person_subject_id(subject_id: &str) -> Result<()> {
+    if is_service_account_subject(subject_id) {
+        return Ok(());
+    }
+    let Some(local) = subject_id
+        .strip_prefix("user:")
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return Ok(());
+    };
+    if local.contains('@') || !is_canonical_user_uuid(local) {
+        bail!(
+            "subject id must be user:<uuid>; resolve people with --email from the workspace directory"
+        );
+    }
+    Ok(())
+}
+
+fn is_canonical_user_uuid(value: &str) -> bool {
+    let value = value.trim();
+    if value.len() != 36 {
+        return false;
+    }
+    let bytes = value.as_bytes();
+    if bytes[8] != b'-' || bytes[13] != b'-' || bytes[18] != b'-' || bytes[23] != b'-' {
+        return false;
+    }
+    value
+        .chars()
+        .all(|ch| ch.is_ascii_hexdigit() || ch == '-')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        AppAdminMember, canonical_subject_id_from_members, is_service_account_subject,
+        normalize_subject_id, subject_id_for_email_in_members, subject_matches_member,
+        trimmed_option, workspace_user_subject_id_for_email,
+    };
+
+    #[test]
+    fn normalize_subject_id_accepts_bare_user_uuid() {
+        assert_eq!(
+            normalize_subject_id("11111111-1111-1111-1111-111111111111").unwrap(),
+            "user:11111111-1111-1111-1111-111111111111"
+        );
+    }
+
+    #[test]
+    fn normalize_subject_id_rejects_opaque_user_ids() {
+        assert!(normalize_subject_id("user_123").is_err());
+    }
+
+    #[test]
+    fn subject_matches_member_compares_subject_id_only() {
+        let member = AppAdminMember {
+            subject_id: Some("user:11111111-1111-1111-1111-111111111111".to_string()),
+            email: Some("alice@example.com".to_string()),
+        };
+        assert!(subject_matches_member(
+            "user:11111111-1111-1111-1111-111111111111",
+            &member
+        ));
+        assert!(!subject_matches_member(
+            "user:22222222-2222-2222-2222-222222222222",
+            &member
+        ));
+    }
+
+    #[test]
+    fn normalize_subject_id_rejects_user_email_subject() {
+        let err = normalize_subject_id("user:alice@example.com").unwrap_err();
+        assert!(err.to_string().contains("user:<uuid>"));
+        let err = normalize_subject_id("alice@example.com").unwrap_err();
+        assert!(err.to_string().contains("user:<uuid>"));
+    }
+
+    #[test]
+    fn normalize_subject_id_rejects_subject_set_selectors() {
+        let err = normalize_subject_id("group:valon-employees#member").unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("subject id must be a direct subject")
+        );
+    }
+
+    #[test]
+    fn service_account_subject_detection() {
+        assert!(is_service_account_subject("service_account:bot"));
+        assert!(!is_service_account_subject("user:11111111-1111-1111-1111-111111111111"));
+    }
+
+    #[test]
+    fn canonical_subject_id_prefers_roster_subject_id() {
+        let members = [AppAdminMember {
+            subject_id: Some("user:11111111-1111-1111-1111-111111111111".to_string()),
+            email: Some("alice@example.com".to_string()),
+        }];
+        assert_eq!(
+            canonical_subject_id_from_members(
+                &members,
+                "user:11111111-1111-1111-1111-111111111111"
+            )
+            .unwrap(),
+            "user:11111111-1111-1111-1111-111111111111"
+        );
+    }
+
+    #[test]
+    fn subject_id_for_email_uses_roster_only() {
+        let members = [AppAdminMember {
+            subject_id: Some("user:11111111-1111-1111-1111-111111111111".to_string()),
+            email: Some("Alice@Example.com".to_string()),
+        }];
+        assert_eq!(
+            subject_id_for_email_in_members(&members, "alice@example.com"),
+            Some("user:11111111-1111-1111-1111-111111111111".to_string())
+        );
+        assert_eq!(
+            subject_id_for_email_in_members(&members, "bob@example.com"),
+            None
+        );
+    }
+
+    #[test]
+    fn workspace_user_subject_id_for_email_resolves_directory_match() {
+        let users = [serde_json::json!({
+            "id": "11111111-1111-1111-1111-111111111111",
+            "email": "Alice@Example.com",
+        })];
+        assert_eq!(
+            workspace_user_subject_id_for_email("alice@example.com", &users).unwrap(),
+            "user:11111111-1111-1111-1111-111111111111"
+        );
+    }
+
+    #[test]
+    fn workspace_user_subject_id_for_email_rejects_unknown_directory_user() {
+        let users = [serde_json::json!({
+            "id": "11111111-1111-1111-1111-111111111111",
+            "email": "alice@example.com",
+        })];
+        let err = workspace_user_subject_id_for_email("bob@example.com", &users).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("could not resolve bob@example.com from the workspace user directory")
+        );
+    }
+
+    #[test]
+    fn trimmed_option_rejects_blank_values() {
+        assert_eq!(trimmed_option(Some("  alice  ")), Some("alice"));
+        assert_eq!(trimmed_option(Some("   ")), None);
+        assert_eq!(trimmed_option(None), None);
+    }
+}

--- a/gestalt/cli/src/commands/authorization_apps.rs
+++ b/gestalt/cli/src/commands/authorization_apps.rs
@@ -155,14 +155,7 @@ fn remove_member(
         let role = trimmed_option(args.role.as_deref())
             .map(require_role)
             .transpose()?;
-        return remove_group_member(
-            api,
-            authz,
-            &app,
-            group_id,
-            role.as_deref(),
-            format,
-        );
+        return remove_group_member(api, authz, &app, group_id, role.as_deref(), format);
     }
     let subject = resolve_canonical_member_subject_id(
         api,

--- a/gestalt/cli/src/commands/authorization_apps.rs
+++ b/gestalt/cli/src/commands/authorization_apps.rs
@@ -464,18 +464,10 @@ fn subject_id_for_email_in_members(members: &[AppAdminMember], email: &str) -> O
 
 fn subject_matches_member(subject_id: &str, member: &AppAdminMember) -> bool {
     let normalized = normalize_subject_id(subject_id).unwrap_or_default();
-    if let Some(subject) = member.subject_id.as_deref()
-        && normalize_subject_id(subject).ok().as_deref() == Some(normalized.as_str())
-    {
-        return true;
-    }
-    if let Some(email) = member.email.as_deref() {
-        let email_subject = format!("user:{}", email.trim().to_lowercase());
-        if normalize_subject_id(&email_subject).ok().as_deref() == Some(normalized.as_str()) {
-            return true;
-        }
-    }
-    false
+    member
+        .subject_id
+        .as_deref()
+        .is_some_and(|subject| normalize_subject_id(subject).ok().as_deref() == Some(normalized.as_str()))
 }
 
 fn member_row(value: &Value) -> Vec<String> {
@@ -541,11 +533,33 @@ fn normalize_subject_id(raw: &str) -> Result<String> {
             "subject id must be a direct subject, not a subject-set selector; use --group-id or `authorization relationships` for group grants"
         );
     }
-    if trimmed.contains(':') {
-        Ok(trimmed.to_string())
+    let subject_id = if trimmed.contains(':') {
+        trimmed.to_string()
     } else {
-        Ok(format!("user:{trimmed}"))
+        format!("user:{trimmed}")
+    };
+    reject_user_email_subject_id(&subject_id)?;
+    Ok(subject_id)
+}
+
+fn reject_user_email_subject_id(subject_id: &str) -> Result<()> {
+    if is_service_account_subject(subject_id) {
+        return Ok(());
     }
+    let Some(local) = subject_id
+        .trim()
+        .strip_prefix("user:")
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return Ok(());
+    };
+    if local.contains('@') {
+        bail!(
+            "subject id must be a canonical user uuid (user:<uuid>); resolve people with --email from the workspace directory"
+        );
+    }
+    Ok(())
 }
 
 fn require_app_name(app: &str) -> Result<String> {
@@ -626,8 +640,8 @@ mod tests {
             email: Some("alice@example.com".to_string()),
         };
         assert!(subject_matches_member("user:abc", &member));
-        assert!(subject_matches_member("user:alice@example.com", &member));
         assert!(!subject_matches_member("user:def", &member));
+        assert!(!subject_matches_member("user:alice@example.com", &member));
     }
 
     #[test]
@@ -640,6 +654,14 @@ mod tests {
             "group:valon-employees#member",
             &member
         ));
+    }
+
+    #[test]
+    fn normalize_subject_id_rejects_user_email_subject() {
+        let err = normalize_subject_id("user:alice@example.com").unwrap_err();
+        assert!(err.to_string().contains("canonical user uuid"));
+        let err = normalize_subject_id("alice@example.com").unwrap_err();
+        assert!(err.to_string().contains("canonical user uuid"));
     }
 
     #[test]
@@ -664,7 +686,7 @@ mod tests {
             email: Some("alice@example.com".to_string()),
         }];
         assert_eq!(
-            canonical_subject_id_from_members(&members, "user:alice@example.com").unwrap(),
+            canonical_subject_id_from_members(&members, "user:canonical-id").unwrap(),
             "user:canonical-id"
         );
     }

--- a/gestalt/cli/src/commands/authorization_apps.rs
+++ b/gestalt/cli/src/commands/authorization_apps.rs
@@ -383,7 +383,6 @@ fn resolve_email_subject_id(api: &ApiClient, app: &str, email: &str) -> Result<S
 }
 
 fn resolve_workspace_user_subject_id(api: &ApiClient, email: &str) -> Result<String> {
-    let normalized = email.trim().to_lowercase();
     let resp = api
         .get("/api/v1/home/users.list")
         .context("failed to load workspace user directory")?;
@@ -392,6 +391,11 @@ fn resolve_workspace_user_subject_id(api: &ApiClient, email: &str) -> Result<Str
         .get("users")
         .and_then(Value::as_array)
         .unwrap_or(&empty);
+    workspace_user_subject_id_for_email(email, users)
+}
+
+fn workspace_user_subject_id_for_email(email: &str, users: &[Value]) -> Result<String> {
+    let normalized = email.trim().to_lowercase();
     for user in users {
         let Some(user_email) = user.get("email").and_then(Value::as_str).map(str::trim) else {
             continue;
@@ -406,7 +410,9 @@ fn resolve_workspace_user_subject_id(api: &ApiClient, email: &str) -> Result<Str
             return Ok(format!("user:{user_id}"));
         }
     }
-    Ok(format!("user:{normalized}"))
+    bail!(
+        "could not resolve {email} from the workspace user directory; use an address from `home.users.list` or pass --subject-id user:<uuid>"
+    )
 }
 
 fn trimmed_option(value: Option<&str>) -> Option<&str> {
@@ -676,6 +682,31 @@ mod tests {
         assert_eq!(
             subject_id_for_email_in_members(&members, "bob@example.com"),
             None
+        );
+    }
+
+    #[test]
+    fn workspace_user_subject_id_for_email_resolves_directory_match() {
+        let users = [serde_json::json!({
+            "id": "11111111-1111-1111-1111-111111111111",
+            "email": "Alice@Example.com",
+        })];
+        assert_eq!(
+            super::workspace_user_subject_id_for_email("alice@example.com", &users).unwrap(),
+            "user:11111111-1111-1111-1111-111111111111"
+        );
+    }
+
+    #[test]
+    fn workspace_user_subject_id_for_email_rejects_unknown_directory_user() {
+        let users = [serde_json::json!({
+            "id": "11111111-1111-1111-1111-111111111111",
+            "email": "alice@example.com",
+        })];
+        let err = super::workspace_user_subject_id_for_email("bob@example.com", &users).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("could not resolve bob@example.com from the workspace user directory")
         );
     }
 

--- a/gestalt/cli/src/commands/authorization_apps.rs
+++ b/gestalt/cli/src/commands/authorization_apps.rs
@@ -16,6 +16,9 @@ use gestalt_sdk::public::generated::app_client::AuthorizationClient;
 use gestalt_sdk::public::rest_transport::SyncRestTransport;
 
 use crate::commands::authorization_app_member_groups::{remove_group_member, set_group_member};
+use crate::commands::authorization_app_member_people::{
+    resolve_canonical_member_subject_id, trimmed_option,
+};
 
 pub fn dispatch(
     api: &ApiClient,
@@ -113,7 +116,7 @@ fn set_member(
     }
     let subject_id = resolve_canonical_member_subject_id(
         api,
-        &app,
+        &app_admin_members_path(&app),
         args.email.as_deref(),
         args.subject_id.as_deref(),
     )?;
@@ -152,11 +155,9 @@ fn remove_member(
         let role = trimmed_option(args.role.as_deref())
             .map(require_role)
             .transpose()?;
-        let members_path = app_admin_members_path(&app);
         return remove_group_member(
             api,
             authz,
-            &members_path,
             &app,
             group_id,
             role.as_deref(),
@@ -165,15 +166,11 @@ fn remove_member(
     }
     let subject = resolve_canonical_member_subject_id(
         api,
-        &app,
+        &app_admin_members_path(&app),
         args.email.as_deref(),
         args.subject_id.as_deref().or(args.subject.as_deref()),
     )?;
-    let role = args
-        .role
-        .as_deref()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
+    let role = trimmed_option(args.role.as_deref())
         .map(require_role)
         .transpose()?;
     let resp = api
@@ -346,130 +343,6 @@ fn allowed_operation_row(value: &Value) -> Vec<String> {
     ]
 }
 
-fn load_app_admin_members(api: &ApiClient, app: &str) -> Result<Vec<AppAdminMember>> {
-    let resp = api
-        .get(&app_admin_members_path(app))
-        .with_context(|| format!("failed to list members for app {app}"))?;
-    serde_json::from_value(resp).context("failed to parse app admin members response")
-}
-
-fn resolve_canonical_member_subject_id(
-    api: &ApiClient,
-    app: &str,
-    email: Option<&str>,
-    subject_id: Option<&str>,
-) -> Result<String> {
-    if let Some(subject_id) = subject_id.map(str::trim).filter(|value| !value.is_empty()) {
-        let normalized = normalize_subject_id(subject_id)?;
-        if is_service_account_subject(&normalized) {
-            return Ok(normalized);
-        }
-        return canonical_subject_id_from_members(&load_app_admin_members(api, app)?, &normalized);
-    }
-
-    let email = email
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .context("either --email, --subject-id, or --group-id is required")?;
-    resolve_email_subject_id(api, app, email)
-}
-
-fn resolve_email_subject_id(api: &ApiClient, app: &str, email: &str) -> Result<String> {
-    let members = load_app_admin_members(api, app)?;
-    if let Some(subject_id) = subject_id_for_email_in_members(&members, email) {
-        return Ok(subject_id);
-    }
-    resolve_workspace_user_subject_id(api, email)
-}
-
-fn resolve_workspace_user_subject_id(api: &ApiClient, email: &str) -> Result<String> {
-    let resp = api
-        .get("/api/v1/home/users.list")
-        .context("failed to load workspace user directory")?;
-    let empty = Vec::new();
-    let users = resp
-        .get("users")
-        .and_then(Value::as_array)
-        .unwrap_or(&empty);
-    workspace_user_subject_id_for_email(email, users)
-}
-
-fn workspace_user_subject_id_for_email(email: &str, users: &[Value]) -> Result<String> {
-    let normalized = email.trim().to_lowercase();
-    for user in users {
-        let Some(user_email) = user.get("email").and_then(Value::as_str).map(str::trim) else {
-            continue;
-        };
-        let Some(user_id) = user.get("id").and_then(Value::as_str).map(str::trim) else {
-            continue;
-        };
-        if user_email.is_empty() || user_id.is_empty() {
-            continue;
-        }
-        if user_email.eq_ignore_ascii_case(&normalized) {
-            return Ok(format!("user:{user_id}"));
-        }
-    }
-    bail!(
-        "could not resolve {email} from the workspace user directory; use an address from `home.users.list` or pass --subject-id user:<uuid>"
-    )
-}
-
-fn trimmed_option(value: Option<&str>) -> Option<&str> {
-    value.map(str::trim).filter(|value| !value.is_empty())
-}
-
-fn canonical_subject_id_from_members(
-    members: &[AppAdminMember],
-    subject_id: &str,
-) -> Result<String> {
-    let normalized = normalize_subject_id(subject_id)?;
-    if is_service_account_subject(&normalized) {
-        return Ok(normalized);
-    }
-    for member in members {
-        if !subject_matches_member(&normalized, member) {
-            continue;
-        }
-        if let Some(canonical) = member
-            .subject_id
-            .as_deref()
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-        {
-            return Ok(canonical.to_string());
-        }
-    }
-    Ok(normalized)
-}
-
-fn subject_id_for_email_in_members(members: &[AppAdminMember], email: &str) -> Option<String> {
-    let normalized_email = email.trim().to_lowercase();
-    for member in members {
-        let Some(member_email) = member.email.as_deref() else {
-            continue;
-        };
-        if member_email.trim().eq_ignore_ascii_case(&normalized_email)
-            && let Some(subject_id) = member
-                .subject_id
-                .as_deref()
-                .map(str::trim)
-                .filter(|value| !value.is_empty())
-        {
-            return Some(subject_id.to_string());
-        }
-    }
-    None
-}
-
-fn subject_matches_member(subject_id: &str, member: &AppAdminMember) -> bool {
-    let normalized = normalize_subject_id(subject_id).unwrap_or_default();
-    member
-        .subject_id
-        .as_deref()
-        .is_some_and(|subject| normalize_subject_id(subject).ok().as_deref() == Some(normalized.as_str()))
-}
-
 fn member_row(value: &Value) -> Vec<String> {
     vec![
         value
@@ -516,52 +389,6 @@ fn member_subject_label(value: &Value) -> String {
     }
 }
 
-fn is_service_account_subject(subject_id: &str) -> bool {
-    subject_id
-        .trim()
-        .to_ascii_lowercase()
-        .starts_with("service_account:")
-}
-
-fn normalize_subject_id(raw: &str) -> Result<String> {
-    let trimmed = raw.trim();
-    if trimmed.is_empty() {
-        bail!("subject id is required");
-    }
-    if trimmed.contains('#') {
-        bail!(
-            "subject id must be a direct subject, not a subject-set selector; use --group-id or `authorization relationships` for group grants"
-        );
-    }
-    let subject_id = if trimmed.contains(':') {
-        trimmed.to_string()
-    } else {
-        format!("user:{trimmed}")
-    };
-    reject_user_email_subject_id(&subject_id)?;
-    Ok(subject_id)
-}
-
-fn reject_user_email_subject_id(subject_id: &str) -> Result<()> {
-    if is_service_account_subject(subject_id) {
-        return Ok(());
-    }
-    let Some(local) = subject_id
-        .trim()
-        .strip_prefix("user:")
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-    else {
-        return Ok(());
-    };
-    if local.contains('@') {
-        bail!(
-            "subject id must be a canonical user uuid (user:<uuid>); resolve people with --email from the workspace directory"
-        );
-    }
-    Ok(())
-}
-
 fn require_app_name(app: &str) -> Result<String> {
     let trimmed = app.trim();
     if trimmed.is_empty() {
@@ -579,15 +406,6 @@ fn require_role(role: &str) -> Result<String> {
         bail!("role must be admin, viewer, or editor");
     }
     Ok(trimmed.to_string())
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct AppAdminMember {
-    #[serde(default)]
-    subject_id: Option<String>,
-    #[serde(default)]
-    email: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -622,122 +440,9 @@ struct OperationOverrideBody {
 #[cfg(test)]
 mod tests {
     use super::{
-        AppAdminMember, AuthorizationAppsAllowedOperationsSetArgs,
-        canonical_subject_id_from_members, is_service_account_subject, member_subject_label,
-        normalize_subject_id, parse_operation_roles_assignment, subject_id_for_email_in_members,
-        subject_matches_member, trimmed_option,
+        AuthorizationAppsAllowedOperationsSetArgs, member_subject_label,
+        parse_operation_roles_assignment,
     };
-
-    #[test]
-    fn normalize_subject_id_prefixes_bare_ids() {
-        assert_eq!(normalize_subject_id("user_123").unwrap(), "user:user_123");
-    }
-
-    #[test]
-    fn subject_matches_member_compares_subject_id_and_email() {
-        let member = AppAdminMember {
-            subject_id: Some("user:abc".to_string()),
-            email: Some("alice@example.com".to_string()),
-        };
-        assert!(subject_matches_member("user:abc", &member));
-        assert!(!subject_matches_member("user:def", &member));
-        assert!(!subject_matches_member("user:alice@example.com", &member));
-    }
-
-    #[test]
-    fn subject_matches_member_ignores_subject_set_selectors() {
-        let member = AppAdminMember {
-            subject_id: None,
-            email: None,
-        };
-        assert!(!subject_matches_member(
-            "group:valon-employees#member",
-            &member
-        ));
-    }
-
-    #[test]
-    fn normalize_subject_id_rejects_user_email_subject() {
-        let err = normalize_subject_id("user:alice@example.com").unwrap_err();
-        assert!(err.to_string().contains("canonical user uuid"));
-        let err = normalize_subject_id("alice@example.com").unwrap_err();
-        assert!(err.to_string().contains("canonical user uuid"));
-    }
-
-    #[test]
-    fn normalize_subject_id_rejects_subject_set_selectors() {
-        let err = normalize_subject_id("group:valon-employees#member").unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("subject id must be a direct subject")
-        );
-    }
-
-    #[test]
-    fn service_account_subject_detection() {
-        assert!(is_service_account_subject("service_account:bot"));
-        assert!(!is_service_account_subject("user:abc"));
-    }
-
-    #[test]
-    fn canonical_subject_id_prefers_roster_subject_id() {
-        let members = [AppAdminMember {
-            subject_id: Some("user:canonical-id".to_string()),
-            email: Some("alice@example.com".to_string()),
-        }];
-        assert_eq!(
-            canonical_subject_id_from_members(&members, "user:canonical-id").unwrap(),
-            "user:canonical-id"
-        );
-    }
-
-    #[test]
-    fn subject_id_for_email_uses_roster_only() {
-        let members = [AppAdminMember {
-            subject_id: Some("user:canonical-id".to_string()),
-            email: Some("Alice@Example.com".to_string()),
-        }];
-        assert_eq!(
-            subject_id_for_email_in_members(&members, "alice@example.com"),
-            Some("user:canonical-id".to_string())
-        );
-        assert_eq!(
-            subject_id_for_email_in_members(&members, "bob@example.com"),
-            None
-        );
-    }
-
-    #[test]
-    fn workspace_user_subject_id_for_email_resolves_directory_match() {
-        let users = [serde_json::json!({
-            "id": "11111111-1111-1111-1111-111111111111",
-            "email": "Alice@Example.com",
-        })];
-        assert_eq!(
-            super::workspace_user_subject_id_for_email("alice@example.com", &users).unwrap(),
-            "user:11111111-1111-1111-1111-111111111111"
-        );
-    }
-
-    #[test]
-    fn workspace_user_subject_id_for_email_rejects_unknown_directory_user() {
-        let users = [serde_json::json!({
-            "id": "11111111-1111-1111-1111-111111111111",
-            "email": "alice@example.com",
-        })];
-        let err = super::workspace_user_subject_id_for_email("bob@example.com", &users).unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("could not resolve bob@example.com from the workspace user directory")
-        );
-    }
-
-    #[test]
-    fn trimmed_option_rejects_blank_values() {
-        assert_eq!(trimmed_option(Some("  alice  ")), Some("alice"));
-        assert_eq!(trimmed_option(Some("   ")), None);
-        assert_eq!(trimmed_option(None), None);
-    }
 
     #[test]
     fn member_subject_label_prefers_subject_set_display_name_and_keeps_selector() {

--- a/gestalt/cli/src/commands/authorization_apps.rs
+++ b/gestalt/cli/src/commands/authorization_apps.rs
@@ -12,14 +12,10 @@ use crate::cli::{
 };
 use crate::output::{self, Format};
 
-use gestalt_sdk::authorization::source_layer::SOURCE_LAYER_RUNTIME;
-use gestalt_sdk::authorization::{
-    AddRelationshipRequest, DeleteRelationshipRequest, Relationship,
-};
 use gestalt_sdk::public::generated::app_client::AuthorizationClient;
 use gestalt_sdk::public::rest_transport::SyncRestTransport;
 
-use crate::commands::authorization::relationship_tuple_from_parts;
+use crate::commands::authorization_app_member_groups::{remove_group_member, set_group_member};
 
 pub fn dispatch(
     api: &ApiClient,
@@ -112,12 +108,7 @@ fn set_member(
 ) -> Result<()> {
     let app = require_app_name(&args.app)?;
     let role = require_role(&args.role)?;
-    if let Some(group_id) = args
-        .group_id
-        .as_deref()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-    {
+    if let Some(group_id) = trimmed_option(args.group_id.as_deref()) {
         return set_group_member(authz, &app, group_id, &role, format);
     }
     let subject_id = resolve_canonical_member_subject_id(
@@ -157,20 +148,20 @@ fn remove_member(
     format: Format,
 ) -> Result<()> {
     let app = require_app_name(&args.app)?;
-    if let Some(group_id) = args
-        .group_id
-        .as_deref()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-    {
-        let role = args
-            .role
-            .as_deref()
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
+    if let Some(group_id) = trimmed_option(args.group_id.as_deref()) {
+        let role = trimmed_option(args.role.as_deref())
             .map(require_role)
             .transpose()?;
-        return remove_group_member(api, authz, &app, group_id, role.as_deref(), format);
+        let members_path = app_admin_members_path(&app);
+        return remove_group_member(
+            api,
+            authz,
+            &members_path,
+            &app,
+            group_id,
+            role.as_deref(),
+            format,
+        );
     }
     let subject = resolve_canonical_member_subject_id(
         api,
@@ -396,131 +387,30 @@ fn resolve_workspace_user_subject_id(api: &ApiClient, email: &str) -> Result<Str
     let resp = api
         .get("/api/v1/home/users.list")
         .context("failed to load workspace user directory")?;
-    let users = resp.get("users").and_then(Value::as_array);
     let empty = Vec::new();
-    let users = users.unwrap_or(&empty);
+    let users = resp
+        .get("users")
+        .and_then(Value::as_array)
+        .unwrap_or(&empty);
     for user in users {
-        let user_email = user
-            .get("email")
-            .and_then(Value::as_str)
-            .map(str::trim)
-            .filter(|value| !value.is_empty());
-        let user_id = user
-            .get("id")
-            .and_then(Value::as_str)
-            .map(str::trim)
-            .filter(|value| !value.is_empty());
-        if let (Some(user_email), Some(user_id)) = (user_email, user_id)
-            && user_email.eq_ignore_ascii_case(&normalized)
-        {
+        let Some(user_email) = user.get("email").and_then(Value::as_str).map(str::trim) else {
+            continue;
+        };
+        let Some(user_id) = user.get("id").and_then(Value::as_str).map(str::trim) else {
+            continue;
+        };
+        if user_email.is_empty() || user_id.is_empty() {
+            continue;
+        }
+        if user_email.eq_ignore_ascii_case(&normalized) {
             return Ok(format!("user:{user_id}"));
         }
     }
     Ok(format!("user:{normalized}"))
 }
 
-fn set_group_member(
-    authz: &AuthorizationClient<SyncRestTransport>,
-    app: &str,
-    group_id: &str,
-    role: &str,
-    format: Format,
-) -> Result<()> {
-    let subject_set = group_member_subject_set(group_id);
-    let tuple = relationship_tuple_from_parts("app", app, role, None, Some(&subject_set))?;
-    authz
-        .add_relationship_sync(AddRelationshipRequest {
-            relationship: Some(Relationship {
-                tuple: Some(tuple),
-                properties: None,
-                source_layer: SOURCE_LAYER_RUNTIME,
-            }),
-        })
-        .with_context(|| {
-            format!("failed to grant {role} on {app} to group {group_id} ({subject_set})")
-        })?;
-    match format {
-        Format::Json => output::print_json(&serde_json::json!({
-            "changed": true,
-            "groupId": group_id,
-            "role": role,
-            "subjectSet": subject_set,
-        })),
-        Format::Table => output::print_success(&format!(
-            "Granted {role} on {app} to group {group_id}."
-        )),
-    }
-    Ok(())
-}
-
-fn remove_group_member(
-    api: &ApiClient,
-    authz: &AuthorizationClient<SyncRestTransport>,
-    app: &str,
-    group_id: &str,
-    role: Option<&str>,
-    format: Format,
-) -> Result<()> {
-    let subject_set = group_member_subject_set(group_id);
-    let roles = match role {
-        Some(role) => vec![role.to_string()],
-        None => mutable_group_roles(api, app, &subject_set)?,
-    };
-    if roles.is_empty() {
-        bail!("no mutable group grants found for {group_id} on {app}");
-    }
-    for role in &roles {
-        let tuple =
-            relationship_tuple_from_parts("app", app, role, None, Some(&subject_set))?;
-        authz
-            .delete_relationship_sync(DeleteRelationshipRequest {
-                relationship_tuple: Some(tuple),
-            })
-            .with_context(|| {
-                format!("failed to remove {role} on {app} for group {group_id} ({subject_set})")
-            })?;
-    }
-    match format {
-        Format::Json => output::print_json(&serde_json::json!({
-            "removedRoles": roles,
-            "groupId": group_id,
-            "subjectSet": subject_set,
-        })),
-        Format::Table => output::print_success(&format!(
-            "Removed {} grant(s) for group {group_id} on {app}.",
-            roles.len()
-        )),
-    }
-    Ok(())
-}
-
-fn group_member_subject_set(group_id: &str) -> String {
-    format!("group:{}#member", group_id.trim())
-}
-
-fn mutable_group_roles(api: &ApiClient, app: &str, subject_set: &str) -> Result<Vec<String>> {
-    let resp = api
-        .get(&app_admin_members_path(app))
-        .with_context(|| format!("failed to list members for app {app}"))?;
-    let mut roles = Vec::new();
-    for row in resp.as_array().unwrap_or(&Vec::new()) {
-        let selector = row
-            .get("selectorValue")
-            .and_then(Value::as_str)
-            .unwrap_or("");
-        if selector != subject_set {
-            continue;
-        }
-        if row.get("mutable").and_then(Value::as_bool) != Some(true) {
-            continue;
-        }
-        if let Some(role) = row.get("role").and_then(Value::as_str).map(str::trim) {
-            if !role.is_empty() {
-                roles.push(role.to_string());
-            }
-        }
-    }
-    Ok(roles)
+fn trimmed_option(value: Option<&str>) -> Option<&str> {
+    value.map(str::trim).filter(|value| !value.is_empty())
 }
 
 fn canonical_subject_id_from_members(
@@ -715,7 +605,7 @@ mod tests {
         AppAdminMember, AuthorizationAppsAllowedOperationsSetArgs,
         canonical_subject_id_from_members, is_service_account_subject, member_subject_label,
         normalize_subject_id, parse_operation_roles_assignment, subject_id_for_email_in_members,
-        subject_matches_member,
+        subject_matches_member, trimmed_option,
     };
 
     #[test]
@@ -790,11 +680,10 @@ mod tests {
     }
 
     #[test]
-    fn group_member_subject_set_formats_selector() {
-        assert_eq!(
-            super::group_member_subject_set("valon-employees"),
-            "group:valon-employees#member"
-        );
+    fn trimmed_option_rejects_blank_values() {
+        assert_eq!(trimmed_option(Some("  alice  ")), Some("alice"));
+        assert_eq!(trimmed_option(Some("   ")), None);
+        assert_eq!(trimmed_option(None), None);
     }
 
     #[test]

--- a/gestalt/cli/src/commands/authorization_apps.rs
+++ b/gestalt/cli/src/commands/authorization_apps.rs
@@ -12,12 +12,18 @@ use crate::cli::{
 };
 use crate::output::{self, Format};
 
+use gestalt_sdk::authorization::source_layer::SOURCE_LAYER_RUNTIME;
+use gestalt_sdk::authorization::{
+    AddRelationshipRequest, DeleteRelationshipRequest, Relationship,
+};
 use gestalt_sdk::public::generated::app_client::AuthorizationClient;
 use gestalt_sdk::public::rest_transport::SyncRestTransport;
 
+use crate::commands::authorization::relationship_tuple_from_parts;
+
 pub fn dispatch(
     api: &ApiClient,
-    _authz: &AuthorizationClient<SyncRestTransport>,
+    authz: &AuthorizationClient<SyncRestTransport>,
     command: AuthorizationAppsCommands,
     format: Format,
 ) -> Result<()> {
@@ -25,8 +31,10 @@ pub fn dispatch(
         AuthorizationAppsCommands::List => list_apps(api, format),
         AuthorizationAppsCommands::Members { command } => match command {
             AuthorizationAppsMembersCommands::List(args) => list_members(api, &args, format),
-            AuthorizationAppsMembersCommands::Set(args) => set_member(api, &args, format),
-            AuthorizationAppsMembersCommands::Remove(args) => remove_member(api, &args, format),
+            AuthorizationAppsMembersCommands::Set(args) => set_member(api, authz, &args, format),
+            AuthorizationAppsMembersCommands::Remove(args) => {
+                remove_member(api, authz, &args, format)
+            }
         },
         AuthorizationAppsCommands::AllowedOperations { command } => match command {
             AuthorizationAppsAllowedOperationsCommands::List(args) => {
@@ -98,11 +106,20 @@ fn list_members(
 
 fn set_member(
     api: &ApiClient,
+    authz: &AuthorizationClient<SyncRestTransport>,
     args: &AuthorizationAppsMembersSetArgs,
     format: Format,
 ) -> Result<()> {
     let app = require_app_name(&args.app)?;
     let role = require_role(&args.role)?;
+    if let Some(group_id) = args
+        .group_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        return set_group_member(authz, &app, group_id, &role, format);
+    }
     let subject_id = resolve_canonical_member_subject_id(
         api,
         &app,
@@ -135,10 +152,26 @@ fn set_member(
 
 fn remove_member(
     api: &ApiClient,
+    authz: &AuthorizationClient<SyncRestTransport>,
     args: &AuthorizationAppsMembersRemoveArgs,
     format: Format,
 ) -> Result<()> {
     let app = require_app_name(&args.app)?;
+    if let Some(group_id) = args
+        .group_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        let role = args
+            .role
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(require_role)
+            .transpose()?;
+        return remove_group_member(api, authz, &app, group_id, role.as_deref(), format);
+    }
     let subject = resolve_canonical_member_subject_id(
         api,
         &app,
@@ -346,14 +379,148 @@ fn resolve_canonical_member_subject_id(
     let email = email
         .map(str::trim)
         .filter(|value| !value.is_empty())
-        .context("either --email or --subject-id is required")?;
+        .context("either --email, --subject-id, or --group-id is required")?;
+    resolve_email_subject_id(api, app, email)
+}
+
+fn resolve_email_subject_id(api: &ApiClient, app: &str, email: &str) -> Result<String> {
     let members = load_app_admin_members(api, app)?;
     if let Some(subject_id) = subject_id_for_email_in_members(&members, email) {
         return Ok(subject_id);
     }
-    bail!(
-        "could not resolve {email} from the app member roster; pass --subject-id user:<uuid> from `members list`"
-    )
+    resolve_workspace_user_subject_id(api, email)
+}
+
+fn resolve_workspace_user_subject_id(api: &ApiClient, email: &str) -> Result<String> {
+    let normalized = email.trim().to_lowercase();
+    let resp = api
+        .get("/api/v1/home/users.list")
+        .context("failed to load workspace user directory")?;
+    let users = resp.get("users").and_then(Value::as_array);
+    let empty = Vec::new();
+    let users = users.unwrap_or(&empty);
+    for user in users {
+        let user_email = user
+            .get("email")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty());
+        let user_id = user
+            .get("id")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty());
+        if let (Some(user_email), Some(user_id)) = (user_email, user_id)
+            && user_email.eq_ignore_ascii_case(&normalized)
+        {
+            return Ok(format!("user:{user_id}"));
+        }
+    }
+    Ok(format!("user:{normalized}"))
+}
+
+fn set_group_member(
+    authz: &AuthorizationClient<SyncRestTransport>,
+    app: &str,
+    group_id: &str,
+    role: &str,
+    format: Format,
+) -> Result<()> {
+    let subject_set = group_member_subject_set(group_id);
+    let tuple = relationship_tuple_from_parts("app", app, role, None, Some(&subject_set))?;
+    authz
+        .add_relationship_sync(AddRelationshipRequest {
+            relationship: Some(Relationship {
+                tuple: Some(tuple),
+                properties: None,
+                source_layer: SOURCE_LAYER_RUNTIME,
+            }),
+        })
+        .with_context(|| {
+            format!("failed to grant {role} on {app} to group {group_id} ({subject_set})")
+        })?;
+    match format {
+        Format::Json => output::print_json(&serde_json::json!({
+            "changed": true,
+            "groupId": group_id,
+            "role": role,
+            "subjectSet": subject_set,
+        })),
+        Format::Table => output::print_success(&format!(
+            "Granted {role} on {app} to group {group_id}."
+        )),
+    }
+    Ok(())
+}
+
+fn remove_group_member(
+    api: &ApiClient,
+    authz: &AuthorizationClient<SyncRestTransport>,
+    app: &str,
+    group_id: &str,
+    role: Option<&str>,
+    format: Format,
+) -> Result<()> {
+    let subject_set = group_member_subject_set(group_id);
+    let roles = match role {
+        Some(role) => vec![role.to_string()],
+        None => mutable_group_roles(api, app, &subject_set)?,
+    };
+    if roles.is_empty() {
+        bail!("no mutable group grants found for {group_id} on {app}");
+    }
+    for role in &roles {
+        let tuple =
+            relationship_tuple_from_parts("app", app, role, None, Some(&subject_set))?;
+        authz
+            .delete_relationship_sync(DeleteRelationshipRequest {
+                relationship_tuple: Some(tuple),
+            })
+            .with_context(|| {
+                format!("failed to remove {role} on {app} for group {group_id} ({subject_set})")
+            })?;
+    }
+    match format {
+        Format::Json => output::print_json(&serde_json::json!({
+            "removedRoles": roles,
+            "groupId": group_id,
+            "subjectSet": subject_set,
+        })),
+        Format::Table => output::print_success(&format!(
+            "Removed {} grant(s) for group {group_id} on {app}.",
+            roles.len()
+        )),
+    }
+    Ok(())
+}
+
+fn group_member_subject_set(group_id: &str) -> String {
+    format!("group:{}#member", group_id.trim())
+}
+
+fn mutable_group_roles(api: &ApiClient, app: &str, subject_set: &str) -> Result<Vec<String>> {
+    let resp = api
+        .get(&app_admin_members_path(app))
+        .with_context(|| format!("failed to list members for app {app}"))?;
+    let mut roles = Vec::new();
+    for row in resp.as_array().unwrap_or(&Vec::new()) {
+        let selector = row
+            .get("selectorValue")
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        if selector != subject_set {
+            continue;
+        }
+        if row.get("mutable").and_then(Value::as_bool) != Some(true) {
+            continue;
+        }
+        if let Some(role) = row.get("role").and_then(Value::as_str).map(str::trim) {
+            if !role.is_empty() {
+                roles.push(role.to_string());
+            }
+        }
+    }
+    Ok(roles)
 }
 
 fn canonical_subject_id_from_members(
@@ -475,7 +642,7 @@ fn normalize_subject_id(raw: &str) -> Result<String> {
     }
     if trimmed.contains('#') {
         bail!(
-            "subject id must be a direct subject, not a subject-set selector; use `authorization relationships` for group grants"
+            "subject id must be a direct subject, not a subject-set selector; use --group-id or `authorization relationships` for group grants"
         );
     }
     if trimmed.contains(':') {
@@ -619,6 +786,14 @@ mod tests {
         assert_eq!(
             subject_id_for_email_in_members(&members, "bob@example.com"),
             None
+        );
+    }
+
+    #[test]
+    fn group_member_subject_set_formats_selector() {
+        assert_eq!(
+            super::group_member_subject_set("valon-employees"),
+            "group:valon-employees#member"
         );
     }
 

--- a/gestalt/cli/src/commands/authorization_groups.rs
+++ b/gestalt/cli/src/commands/authorization_groups.rs
@@ -49,11 +49,8 @@ fn group_row(value: &Value) -> Vec<String> {
             .to_string(),
         value
             .get("memberCount")
-            .map(|count| match count {
-                Value::Number(number) => number.to_string(),
-                Value::String(text) => text.clone(),
-                _ => String::new(),
-            })
+            .and_then(Value::as_u64)
+            .map(|count| count.to_string())
             .unwrap_or_default(),
         value
             .get("scimManaged")

--- a/gestalt/cli/src/commands/authorization_groups.rs
+++ b/gestalt/cli/src/commands/authorization_groups.rs
@@ -20,13 +20,7 @@ pub fn list_groups(api: &ApiClient, format: Format) -> Result<()> {
             println!(
                 "{}",
                 output::render_table(
-                    &[
-                        "ID",
-                        "Display Name",
-                        "Members",
-                        "SCIM Managed",
-                        "Editable",
-                    ],
+                    &["ID", "Display Name", "Members", "SCIM Managed", "Editable",],
                     &rows,
                 )
             );

--- a/gestalt/cli/src/commands/authorization_groups.rs
+++ b/gestalt/cli/src/commands/authorization_groups.rs
@@ -1,0 +1,69 @@
+use anyhow::{Context, Result};
+use serde_json::Value;
+
+use crate::api::ApiClient;
+use crate::output::{self, Format};
+
+pub fn list_groups(api: &ApiClient, format: Format) -> Result<()> {
+    let resp = api
+        .get("/api/v1/groups")
+        .context("failed to list workspace groups")?;
+    match format {
+        Format::Json => output::print_json(&resp),
+        Format::Table => {
+            let rows: Vec<Vec<String>> = resp
+                .as_array()
+                .unwrap_or(&Vec::new())
+                .iter()
+                .map(group_row)
+                .collect();
+            println!(
+                "{}",
+                output::render_table(
+                    &[
+                        "ID",
+                        "Display Name",
+                        "Members",
+                        "SCIM Managed",
+                        "Editable",
+                    ],
+                    &rows,
+                )
+            );
+        }
+    }
+    Ok(())
+}
+
+fn group_row(value: &Value) -> Vec<String> {
+    vec![
+        value
+            .get("id")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string(),
+        value
+            .get("displayName")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string(),
+        value
+            .get("memberCount")
+            .map(|count| match count {
+                Value::Number(number) => number.to_string(),
+                Value::String(text) => text.clone(),
+                _ => String::new(),
+            })
+            .unwrap_or_default(),
+        value
+            .get("scimManaged")
+            .and_then(Value::as_bool)
+            .map(|managed| managed.to_string())
+            .unwrap_or_default(),
+        value
+            .get("editable")
+            .and_then(Value::as_bool)
+            .map(|editable| editable.to_string())
+            .unwrap_or_default(),
+    ]
+}

--- a/gestalt/cli/src/commands/mod.rs
+++ b/gestalt/cli/src/commands/mod.rs
@@ -4,6 +4,7 @@ pub mod apps;
 pub mod auth;
 pub mod authorization;
 pub mod authorization_app_member_groups;
+pub mod authorization_app_member_people;
 pub mod authorization_apps;
 pub mod authorization_groups;
 pub mod authorization_subjects;

--- a/gestalt/cli/src/commands/mod.rs
+++ b/gestalt/cli/src/commands/mod.rs
@@ -3,6 +3,7 @@ mod app_errors;
 pub mod apps;
 pub mod auth;
 pub mod authorization;
+pub mod authorization_app_member_groups;
 pub mod authorization_apps;
 pub mod authorization_groups;
 pub mod authorization_subjects;

--- a/gestalt/cli/src/commands/mod.rs
+++ b/gestalt/cli/src/commands/mod.rs
@@ -4,6 +4,7 @@ pub mod apps;
 pub mod auth;
 pub mod authorization;
 pub mod authorization_apps;
+pub mod authorization_groups;
 pub mod authorization_subjects;
 pub mod config;
 pub mod describe;

--- a/sdk/rust/src/public/proto_json.rs
+++ b/sdk/rust/src/public/proto_json.rs
@@ -336,6 +336,9 @@ pub(crate) fn encode_struct(value: &prost_types::Struct) -> serde_json::Value {
 pub(crate) fn decode_struct(
     value: &serde_json::Value,
 ) -> Result<prost_types::Struct, GestaltError> {
+    if value.is_null() {
+        return Ok(prost_types::Struct::default());
+    }
     let Some(object) = value.as_object() else {
         return Err(invalid_argument("expected struct object"));
     };
@@ -554,5 +557,13 @@ mod tests {
         let encoded = encode_f64(f64::NAN);
         assert_eq!(encoded, serde_json::json!("NaN"));
         assert!(decode_f64(&encoded).expect("decode nan").is_nan());
+    }
+
+    #[test]
+    fn decode_struct_accepts_null() {
+        assert!(decode_struct(&serde_json::json!(null))
+            .unwrap()
+            .fields
+            .is_empty());
     }
 }

--- a/sdk/rust/src/public/proto_json.rs
+++ b/sdk/rust/src/public/proto_json.rs
@@ -561,9 +561,11 @@ mod tests {
 
     #[test]
     fn decode_struct_accepts_null() {
-        assert!(decode_struct(&serde_json::json!(null))
-            .unwrap()
-            .fields
-            .is_empty());
+        assert!(
+            decode_struct(&serde_json::json!(null))
+                .unwrap()
+                .fields
+                .is_empty()
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Add `--group-id` to `gestalt authorization apps members set/remove`, routing group grants through the v2 relationships API (same path as the Members UI).
- Add `gestalt authorization groups list` wrapping `GET /api/v1/groups`.
- Resolve `members set --email` against the workspace user directory (`home.users.list`) when the address is not already on the app roster.
- Fix `relationships add --subject-set` response decoding by treating null protobuf Struct JSON as empty in the Rust SDK.

## Test plan
- [x] `cargo test` in `gestalt/cli`
- [x] `cargo test decode_struct` in `sdk/rust`
- [ ] Smoke-test against `https://valon.tools`: `authorization groups list`, `apps members set/remove --group-id`, `members set --email` for a user not yet on the roster, and `relationships add --subject-set`

Made with [Cursor](https://cursor.com)