### PR TITLE
Release gestalt CLI 0.0.2-alpha.19

### DIFF
--- a/gestalt/Cargo.toml
+++ b/gestalt/Cargo.toml
@@ -3,5 +3,5 @@ resolver = "2"
 members = ["cli"]
 
 [workspace.package]
-version = "0.0.2-alpha.18"
+version = "0.0.2-alpha.19"
 edition = "2024"


### PR DESCRIPTION
## Summary
- Bump the gestalt CLI crate version to `0.0.2-alpha.19` so plan 12 step 3 can tag and publish the app-admin ergonomics shipped in #3217.

## Test plan
- [ ] CI passes (version verify + Rust lint/build)
- [ ] Tag `gestalt/v0.0.2-alpha.19` after merge to trigger release workflow

Made with [Cursor](https://cursor.com)