### PR TITLE
Fix group member set/remove role semantics

### DIFF
--- a/gestalt/Cargo.toml
+++ b/gestalt/Cargo.toml
@@ -3,5 +3,5 @@ resolver = "2"
 members = ["cli"]
 
 [workspace.package]
-version = "0.0.2-alpha.19"
+version = "0.0.2-alpha.20"
 edition = "2024"

--- a/gestalt/cli/src/commands/authorization_app_member_groups.rs
+++ b/gestalt/cli/src/commands/authorization_app_member_groups.rs
@@ -11,36 +11,60 @@ use gestalt_sdk::public::generated::app_client::AuthorizationClient;
 use gestalt_sdk::public::rest_transport::SyncRestTransport;
 
 pub(crate) fn set_group_member(
+    api: &ApiClient,
     authz: &AuthorizationClient<SyncRestTransport>,
     app: &str,
     group_id: &str,
     role: &str,
     format: Format,
 ) -> Result<()> {
+    let members_path = format!("/api/v1/apps/{}/admin/members", encode_path_segment(app));
     let subject_set = group_member_subject_set(group_id);
-    let relationship = build_relationship_from_args(&AuthorizationRelationshipMutationArgs {
-        resource_type: "app".to_string(),
-        resource_id: app.to_string(),
-        relation: role.to_string(),
-        subject_id: None,
-        subject_set: Some(subject_set.clone()),
-    })?;
-    authz
-        .add_relationship_sync(AddRelationshipRequest {
-            relationship: Some(relationship),
-        })
-        .with_context(|| {
-            format!("failed to grant {role} on {app} to group {group_id} ({subject_set})")
+    let existing = mutable_group_roles(api, &members_path, &subject_set)?;
+    let (add_role, roles_to_remove) = group_roles_to_replace(&existing, role);
+    for existing_role in &roles_to_remove {
+        let tuple =
+            relationship_tuple_from_parts("app", app, existing_role, None, Some(&subject_set))?;
+        authz
+            .delete_relationship_sync(DeleteRelationshipRequest {
+                relationship_tuple: Some(tuple),
+            })
+            .with_context(|| {
+                format!(
+                    "failed to remove {existing_role} on {app} for group {group_id} ({subject_set})"
+                )
+            })?;
+    }
+    if add_role {
+        let relationship = build_relationship_from_args(&AuthorizationRelationshipMutationArgs {
+            resource_type: "app".to_string(),
+            resource_id: app.to_string(),
+            relation: role.to_string(),
+            subject_id: None,
+            subject_set: Some(subject_set.clone()),
         })?;
+        authz
+            .add_relationship_sync(AddRelationshipRequest {
+                relationship: Some(relationship),
+            })
+            .with_context(|| {
+                format!("failed to grant {role} on {app} to group {group_id} ({subject_set})")
+            })?;
+    }
+    let changed = add_role || !roles_to_remove.is_empty();
     match format {
         Format::Json => output::print_json(&serde_json::json!({
-            "changed": true,
+            "changed": changed,
             "groupId": group_id,
             "role": role,
             "subjectSet": subject_set,
         })),
         Format::Table => {
-            output::print_success(&format!("Granted {role} on {app} to group {group_id}."))
+            if changed {
+                output::print_success(&format!("Granted {role} on {app} to group {group_id}."))
+            } else {
+                output::print_success(&format!("Group {group_id} already has {role} on {app}."))
+            }
         }
     }
     Ok(())
@@ -56,9 +80,13 @@ pub(crate) fn remove_group_member(
 ) -> Result<()> {
     let members_path = format!("/api/v1/apps/{}/admin/members", encode_path_segment(app));
     let subject_set = group_member_subject_set(group_id);
+    let mutable = mutable_group_roles(api, &members_path, &subject_set)?;
     let roles = match role {
-        Some(role) => vec![role.to_string()],
-        None => mutable_group_roles(api, &members_path, &subject_set)?,
+        Some(role) => {
+            require_mutable_group_role(&mutable, role, group_id, app)?;
+            vec![role.to_string()]
+        }
+        None => mutable,
     };
     if roles.is_empty() {
         bail!("no mutable group grants found for {group_id} on {app}");
@@ -118,9 +146,34 @@ fn mutable_group_roles(
     Ok(roles)
 }
 
+fn group_roles_to_replace(existing: &[String], target: &str) -> (bool, Vec<String>) {
+    let mut add_target = true;
+    let mut roles_to_remove = Vec::new();
+    for role in existing {
+        if role == target {
+            add_target = false;
+        } else {
+            roles_to_remove.push(role.clone());
+        }
+    }
+    (add_target, roles_to_remove)
+}
+
+fn require_mutable_group_role(
+    mutable: &[String],
+    role: &str,
+    group_id: &str,
+    app: &str,
+) -> Result<()> {
+    if mutable.iter().any(|existing| existing == role) {
+        return Ok(());
+    }
+    bail!("no mutable {role} grant found for group {group_id} on {app}");
+}
+
 #[cfg(test)]
 mod tests {
-    use super::group_member_subject_set;
+    use super::{group_member_subject_set, group_roles_to_replace, require_mutable_group_role};
 
     #[test]
     fn group_member_subject_set_formats_selector() {
@@ -128,5 +181,27 @@ mod tests {
             group_member_subject_set("valon-employees"),
             "group:valon-employees#member"
         );
+    }
+
+    #[test]
+    fn group_roles_to_replace_removes_other_mutable_roles() {
+        let (add, remove) =
+            group_roles_to_replace(&["admin".to_string(), "viewer".to_string()], "viewer");
+        assert!(!add);
+        assert_eq!(remove, vec!["admin".to_string()]);
+    }
+
+    #[test]
+    fn group_roles_to_replace_adds_when_role_missing() {
+        let (add, remove) = group_roles_to_replace(&["admin".to_string()], "viewer");
+        assert!(add);
+        assert_eq!(remove, vec!["admin".to_string()]);
+    }
+
+    #[test]
+    fn require_mutable_group_role_rejects_unknown_role() {
+        let err = require_mutable_group_role(&["viewer".to_string()], "admin", "eng", "demo")
+            .unwrap_err();
+        assert!(err.to_string().contains("no mutable admin grant found"));
     }
 }

--- a/gestalt/cli/src/commands/authorization_apps.rs
+++ b/gestalt/cli/src/commands/authorization_apps.rs
@@ -112,7 +112,7 @@ fn set_member(
     let app = require_app_name(&args.app)?;
     let role = require_role(&args.role)?;
     if let Some(group_id) = trimmed_option(args.group_id.as_deref()) {
-        return set_group_member(authz, &app, group_id, &role, format);
+        return set_group_member(api, authz, &app, group_id, &role, format);
     }
     let subject_id = resolve_canonical_member_subject_id(
         api,


### PR DESCRIPTION
## Summary
- `members set --group-id` now replaces other mutable group roles before granting the requested role, matching person `members set` behavior on the app-admin API.
- `members remove --group-id --role` now rejects roles that are not mutable on the members roster instead of attempting a blind relationship delete.

Bumps gestalt CLI to `0.0.2-alpha.20` for release after merge.

## Test plan
- [x] `cargo test` in `gestalt/cli`
- [x] `cargo clippy --all-targets -- -D warnings`
- [ ] Tag `gestalt/v0.0.2-alpha.20` after merge and smoke-test group role demotion on prod

Made with [Cursor](https://cursor.com)