### PR TITLE
Keep Python IndexedDB transactions open after missing reads

### DIFF
--- a/sdk/python/gestalt/_indexeddb.py
+++ b/sdk/python/gestalt/_indexeddb.py
@@ -37,6 +37,21 @@ CURSOR_PREV = 2
 #: Iterate in descending key order while collapsing duplicate index keys.
 CURSOR_PREV_UNIQUE = 3
 
+_TRANSACTION_READ_OPERATIONS = frozenset(
+    {
+        "get",
+        "get_key",
+        "get_all",
+        "get_all_keys",
+        "count",
+        "index_get",
+        "index_get_key",
+        "index_get_all",
+        "index_get_all_keys",
+        "index_count",
+    }
+)
+
 
 class NotFoundError(Exception):
     """Raised when an IndexedDB record, store, or cursor target is missing."""
@@ -969,6 +984,7 @@ class Transaction:
         durability_hint: str = "default",
     ) -> None:
         self._stub = stub
+        self._stores = frozenset(stores)
         self._closed = False
         self._request_id = 0
         self._request_iter = _RequestIterator()
@@ -1073,9 +1089,16 @@ class Transaction:
             raise TransactionError("transaction response request_id mismatch")
         try:
             _raise_rpc_status(op_resp.error)
-        except Exception:
-            self._closed = True
-            self._request_iter.close()
+        except Exception as error:
+            operation_name = operation.WhichOneof("operation")
+            recoverable_missing_read = (
+                isinstance(error, NotFoundError)
+                and operation_name in _TRANSACTION_READ_OPERATIONS
+                and getattr(operation, operation_name).store in self._stores
+            )
+            if not recoverable_missing_read:
+                self._closed = True
+                self._request_iter.close()
             raise
         return op_resp
 

--- a/sdk/python/tests/test_indexeddb_transport.py
+++ b/sdk/python/tests/test_indexeddb_transport.py
@@ -247,6 +247,38 @@ class TestNestedJSON(unittest.TestCase):
 
 
 class TestTransaction(unittest.TestCase):
+    def test_not_found_read_keeps_transaction_open(self) -> None:
+        c = _client()
+        c.create_object_store("transaction_missing_read")
+
+        with c.transaction(["transaction_missing_read"], "readwrite") as tx:
+            store = tx.object_store("transaction_missing_read")
+            with self.assertRaises(NotFoundError):
+                store.get("missing")
+            store.put({"id": "created-after-miss"})
+
+        self.assertEqual(
+            c.object_store("transaction_missing_read").get("created-after-miss")["id"],
+            "created-after-miss",
+        )
+        c.close()
+
+    def test_not_found_write_closes_transaction(self) -> None:
+        c = _client()
+        c.create_object_store("transaction_allowed")
+        c.create_object_store("transaction_out_of_scope")
+
+        tx = c.transaction(["transaction_allowed"], "readwrite")
+        allowed = tx.object_store("transaction_allowed")
+        allowed.put({"id": "rolled-back"})
+        with self.assertRaises(NotFoundError):
+            tx.object_store("transaction_out_of_scope").put({"id": "denied"})
+        with self.assertRaises(TransactionError):
+            allowed.put({"id": "also-denied"})
+        with self.assertRaises(NotFoundError):
+            c.object_store("transaction_allowed").get("rolled-back")
+        c.close()
+
     def test_readwrite_commits_and_reads_own_writes(self) -> None:
         c = _client()
         c.create_object_store("transaction_commit")


### PR DESCRIPTION
A missing transactional read now preserves the stream, matching the server contract. This lets callers use indexed point reads instead of range-scan workarounds.