### PR TITLE
Batch recovery observer change request reads

### DIFF
--- a/gestaltd/internal/appregistry/recovery_observer.go
+++ b/gestaltd/internal/appregistry/recovery_observer.go
@@ -15,8 +15,7 @@ import (
 )
 
 type RecoveryChangeRequests interface {
-	ListAllKnownVersions(context.Context) ([]*core.AppInstallation, error)
-	LatestDesiredRevisionID(context.Context, string, string) (string, error)
+	ListDesiredRevisions(context.Context) ([]coredata.AppDesiredRevision, error)
 }
 
 type RecoveryOutcomes interface {
@@ -170,7 +169,7 @@ func (o *RecoveryObserver) ObserveOnce(ctx context.Context) error {
 		return fmt.Errorf("app version recovery observer: stability window must be positive")
 	}
 
-	known, err := o.ChangeRequests.ListAllKnownVersions(ctx)
+	desiredRevisions, err := o.ChangeRequests.ListDesiredRevisions(ctx)
 	if err != nil {
 		o.resetAll()
 		return fmt.Errorf("observe app recovery: load desired versions: %w", err)
@@ -195,18 +194,13 @@ func (o *RecoveryObserver) ObserveOnce(ctx context.Context) error {
 		return fmt.Errorf("observe app recovery: load fresh heartbeats: %w", err)
 	}
 
-	byApp := groupInstallationsByApp(known)
-	seen := make(map[string]struct{}, len(byApp))
+	seen := make(map[string]struct{}, len(desiredRevisions))
 	var errs []error
-	for app, installations := range byApp {
+	for _, desired := range desiredRevisions {
+		app := strings.TrimSpace(desired.App)
 		seen[app] = struct{}{}
-		desiredVersion := coredata.LatestKnownVersion(installations)
-		changeRequestID, err := o.ChangeRequests.LatestDesiredRevisionID(ctx, app, desiredVersion)
-		if err != nil {
-			o.reset(app)
-			errs = append(errs, fmt.Errorf("observe app recovery for %s: load desired revision: %w", app, err))
-			continue
-		}
+		desiredVersion := strings.TrimSpace(desired.Version)
+		changeRequestID := strings.TrimSpace(desired.ChangeRequestID)
 		if changeRequestID == "" || o.isCompleted(changeRequestID) {
 			o.reset(app)
 			continue

--- a/gestaltd/internal/coredata/app_version_change_requests_projection.go
+++ b/gestaltd/internal/coredata/app_version_change_requests_projection.go
@@ -19,6 +19,12 @@ const (
 	appVersionChangeRequestMetaInstalledAt        = "installed_at"
 )
 
+type AppDesiredRevision struct {
+	App             string
+	Version         string
+	ChangeRequestID string
+}
+
 func ChangeRequestMetadata(installation *core.AppInstallation) map[string]any {
 	if installation == nil {
 		return nil
@@ -53,15 +59,66 @@ func (s *AppVersionChangeRequestService) ListAllKnownVersions(ctx context.Contex
 	if s == nil {
 		return nil, fmt.Errorf("list all known app versions: change request service is not configured")
 	}
-	recs, err := s.store.GetAll(ctx, nil)
+	requests, err := s.listAllRequests(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("list all known app versions: %w", err)
+	}
+	return knownVersionsFromRequests(requests), nil
+}
+
+func (s *AppVersionChangeRequestService) ListDesiredRevisions(ctx context.Context) ([]AppDesiredRevision, error) {
+	if s == nil {
+		return nil, fmt.Errorf("list desired app revisions: change request service is not configured")
+	}
+	requests, err := s.listAllRequests(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list desired app revisions: %w", err)
+	}
+	installationsByApp := make(map[string][]*core.AppInstallation)
+	for _, installation := range knownVersionsFromRequests(requests) {
+		if installation == nil {
+			continue
+		}
+		app := strings.TrimSpace(installation.AppName)
+		if app != "" {
+			installationsByApp[app] = append(installationsByApp[app], installation)
+		}
+	}
+	requestsByApp := make(map[string][]*core.AppVersionChangeRequest)
+	for _, request := range requests {
+		if request == nil {
+			continue
+		}
+		app := strings.TrimSpace(request.App)
+		if app != "" {
+			requestsByApp[app] = append(requestsByApp[app], request)
+		}
+	}
+	out := make([]AppDesiredRevision, 0, len(installationsByApp))
+	for app, installations := range installationsByApp {
+		version := LatestKnownVersion(installations)
+		out = append(out, AppDesiredRevision{
+			App:             app,
+			Version:         version,
+			ChangeRequestID: latestDesiredRevisionID(requestsByApp[app], version),
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].App < out[j].App
+	})
+	return out, nil
+}
+
+func (s *AppVersionChangeRequestService) listAllRequests(ctx context.Context) ([]*core.AppVersionChangeRequest, error) {
+	recs, err := s.store.GetAll(ctx, nil)
+	if err != nil {
+		return nil, err
 	}
 	requests := make([]*core.AppVersionChangeRequest, 0, len(recs))
 	for _, rec := range recs {
 		requests = append(requests, recordToAppVersionChangeRequest(rec))
 	}
-	return knownVersionsFromRequests(requests), nil
+	return requests, nil
 }
 
 func knownVersionsFromRequests(requests []*core.AppVersionChangeRequest) []*core.AppInstallation {

--- a/gestaltd/internal/coredata/app_version_change_requests_projection_test.go
+++ b/gestaltd/internal/coredata/app_version_change_requests_projection_test.go
@@ -1,11 +1,13 @@
 package coredata_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/coredata"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
 )
 
 func TestLatestKnownVersionBreaksTimestampTiesLexicographically(t *testing.T) {
@@ -43,5 +45,38 @@ func TestInstallationFromChangeRequestPreservesSourceIdentity(t *testing.T) {
 	}
 	if installation.SourceRef != "abc123" {
 		t.Fatalf("SourceRef = %q", installation.SourceRef)
+	}
+}
+
+func TestAppVersionChangeRequestServiceListDesiredRevisions(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	service := testutil.NewStubServices(t).AppVersionChangeRequests
+	start := time.Date(2026, 9, 11, 12, 0, 0, 0, time.UTC)
+	requests := []*core.AppVersionChangeRequest{
+		{ID: "issues-v1", App: "g-issues", FromVersion: "v0", ToVersion: "v1", Timestamp: start},
+		{ID: "issues-v2-first", App: "g-issues", FromVersion: "v1", ToVersion: "v2", Timestamp: start.Add(time.Minute)},
+		{ID: "issues-v2-latest", App: "g-issues", FromVersion: "v1", ToVersion: "v2", Timestamp: start.Add(2 * time.Minute)},
+		{ID: "slack-v1", App: "g-slack", FromVersion: "v0", ToVersion: "v1", Timestamp: start},
+	}
+	for _, request := range requests {
+		if _, err := service.AppendRequest(ctx, request); err != nil {
+			t.Fatalf("AppendRequest(%s): %v", request.ID, err)
+		}
+	}
+
+	got, err := service.ListDesiredRevisions(ctx)
+	if err != nil {
+		t.Fatalf("ListDesiredRevisions: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("desired revisions = %#v, want 2", got)
+	}
+	if got[0].App != "g-issues" || got[0].Version != "v2" || got[0].ChangeRequestID != "issues-v2-latest" {
+		t.Fatalf("g-issues desired revision = %#v", got[0])
+	}
+	if got[1].App != "g-slack" || got[1].Version != "v1" || got[1].ChangeRequestID != "slack-v1" {
+		t.Fatalf("g-slack desired revision = %#v", got[1])
 	}
 }


### PR DESCRIPTION
## Summary
- project each app desired version and its latest change-request ID from one object-store snapshot
- remove the recovery observer per-app rereads of app version change history
- keep rollout-outcome reads and recovery fencing unchanged

## Validation
- TMPDIR=/tmp go test ./...

## Production evidence
The current VT revision emits about 240 app_version_change_requests index reads in each synchronized recovery burst across four replicas, even though every observer has already loaded the same store. This change removes those redundant per-app reads.