### PR TITLE
Prune materializations with stale instances

### DIFF
--- a/gestaltd/internal/coredata/gestaltd_instance_heartbeats.go
+++ b/gestaltd/internal/coredata/gestaltd_instance_heartbeats.go
@@ -124,13 +124,15 @@ func (s *GestaltdInstanceHeartbeatService) Delete(ctx context.Context, instanceI
 	return nil
 }
 
+// PruneBefore removes stale instance heartbeats and their per-instance
+// materialization state atomically.
 func (s *GestaltdInstanceHeartbeatService) PruneBefore(ctx context.Context, cutoff time.Time) (int, error) {
 	if s == nil || s.db == nil {
 		return 0, fmt.Errorf("prune gestaltd instance heartbeats: service is not configured")
 	}
 	tx, err := s.db.Transaction(
 		ctx,
-		[]string{StoreGestaltdInstanceHeartbeats},
+		[]string{StoreGestaltdInstanceHeartbeats, StoreAppInstanceMaterializations},
 		idb.TransactionReadwrite,
 		idb.TransactionOptions{},
 	)
@@ -153,6 +155,20 @@ func (s *GestaltdInstanceHeartbeatService) PruneBefore(ctx context.Context, cuto
 		instanceID := recString(rec, "instance_id")
 		if instanceID == "" {
 			continue
+		}
+		materializations, err := tx.ObjectStore(StoreAppInstanceMaterializations).
+			Index("by_instance").GetAll(ctx, instanceID)
+		if err != nil {
+			return pruned, fmt.Errorf("prune gestaltd instance heartbeats: list materializations for %q: %w", instanceID, err)
+		}
+		for _, materialization := range materializations {
+			id := recString(materialization, "id")
+			if id == "" {
+				continue
+			}
+			if err := tx.ObjectStore(StoreAppInstanceMaterializations).Delete(ctx, id); err != nil && !errors.Is(err, idb.ErrNotFound) {
+				return pruned, fmt.Errorf("prune gestaltd instance heartbeats: delete materialization %q: %w", id, err)
+			}
 		}
 		if err := store.Delete(ctx, instanceID); err != nil && !errors.Is(err, idb.ErrNotFound) {
 			return pruned, fmt.Errorf("prune gestaltd instance heartbeats: delete %q: %w", instanceID, err)

--- a/gestaltd/internal/coredata/gestaltd_instance_heartbeats_test.go
+++ b/gestaltd/internal/coredata/gestaltd_instance_heartbeats_test.go
@@ -97,7 +97,8 @@ func TestGestaltdInstanceHeartbeatServiceListsBySourceVersion(t *testing.T) {
 func TestGestaltdInstanceHeartbeatServiceListsFreshAndPrunesByIndexedTime(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	svc := testutil.NewStubServices(t).GestaltdInstanceHeartbeats
+	services := testutil.NewStubServices(t)
+	svc := services.GestaltdInstanceHeartbeats
 	now := time.Date(2026, 7, 30, 14, 0, 0, 0, time.UTC)
 	for _, heartbeat := range []*core.GestaltdInstanceHeartbeat{
 		{InstanceID: "boundary", SourceVersion: "source-a", StartedAt: now.Add(-time.Hour), HeartbeatAt: now.Add(-45 * time.Second), Apps: map[string]core.GestaltdInstanceAppHeartbeat{}},
@@ -106,6 +107,17 @@ func TestGestaltdInstanceHeartbeatServiceListsFreshAndPrunesByIndexedTime(t *tes
 	} {
 		if _, err := svc.Upsert(ctx, heartbeat); err != nil {
 			t.Fatalf("Upsert(%s): %v", heartbeat.InstanceID, err)
+		}
+	}
+	for _, instanceID := range []string{"boundary", "stale", "other"} {
+		if _, err := services.AppInstanceMaterializations.Acknowledge(ctx, &core.AppInstanceMaterialization{
+			InstanceID:     instanceID,
+			SourceVersion:  "source-a",
+			App:            "g-issues",
+			Version:        "v2",
+			AcknowledgedAt: now.Add(-time.Minute),
+		}); err != nil {
+			t.Fatalf("Acknowledge(%s): %v", instanceID, err)
 		}
 	}
 	fresh, err := svc.ListFreshBySourceVersion(ctx, "source-a", now.Add(-45*time.Second))
@@ -128,6 +140,14 @@ func TestGestaltdInstanceHeartbeatServiceListsFreshAndPrunesByIndexedTime(t *tes
 	}
 	if len(all) != 2 {
 		t.Fatalf("remaining heartbeats = %#v", all)
+	}
+	if _, err := services.AppInstanceMaterializations.Get(ctx, "stale", "g-issues", "v2"); err == nil {
+		t.Fatal("stale instance materialization still exists after heartbeat pruning")
+	}
+	for _, instanceID := range []string{"boundary", "other"} {
+		if _, err := services.AppInstanceMaterializations.Get(ctx, instanceID, "g-issues", "v2"); err != nil {
+			t.Fatalf("Get materialization for retained instance %s: %v", instanceID, err)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- delete a stale instance’s materialization rows when its heartbeat expires
- keep heartbeat and materialization cleanup in one transaction
- prevent Cloud Run instance churn from growing materialization state without bound

## Test plan
- [x] `TMPDIR=/tmp go test ./gestaltd/internal/coredata`
- [x] `TMPDIR=/tmp go test ./gestaltd/internal/appregistry/...`
- [x] Verify the retention contract removes stale instance state while preserving boundary-fresh and unrelated instances