### PR TITLE
Plan 11 M2: UI qualification and startup admission

### DIFF
--- a/gestaltd/internal/appregistry/process_id.go
+++ b/gestaltd/internal/appregistry/process_id.go
@@ -1,0 +1,31 @@
+package appregistry
+
+import (
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/google/uuid"
+)
+
+const processIDEnvVar = "GESTALTD_PROCESS_ID"
+
+var (
+	resolvedProcessID     string
+	resolvedProcessIDOnce sync.Once
+)
+
+// ResolveProcessID returns a stable process identity for fleet readiness reports.
+func ResolveProcessID() string {
+	resolvedProcessIDOnce.Do(func() {
+		resolvedProcessID = resolveProcessID(os.Getenv(processIDEnvVar))
+	})
+	return resolvedProcessID
+}
+
+func resolveProcessID(processIDEnv string) string {
+	if v := strings.TrimSpace(processIDEnv); v != "" {
+		return v
+	}
+	return uuid.NewString()
+}

--- a/gestaltd/internal/appregistry/process_id_test.go
+++ b/gestaltd/internal/appregistry/process_id_test.go
@@ -12,6 +12,7 @@ func TestResolveProcessIDFromEnv(t *testing.T) {
 }
 
 func TestResolveProcessIDGeneratesUUIDWhenUnset(t *testing.T) {
+	t.Parallel()
 	got := resolveProcessID("")
 	if got == "" {
 		t.Fatal("resolveProcessID returned empty string")

--- a/gestaltd/internal/appregistry/process_id_test.go
+++ b/gestaltd/internal/appregistry/process_id_test.go
@@ -1,0 +1,31 @@
+package appregistry
+
+import (
+	"testing"
+)
+
+func TestResolveProcessIDFromEnv(t *testing.T) {
+	t.Setenv(processIDEnvVar, "process-a")
+	if got := resolveProcessID("process-a"); got != "process-a" {
+		t.Fatalf("resolveProcessID() = %q, want process-a", got)
+	}
+}
+
+func TestResolveProcessIDGeneratesUUIDWhenUnset(t *testing.T) {
+	got := resolveProcessID("")
+	if got == "" {
+		t.Fatal("resolveProcessID returned empty string")
+	}
+}
+
+func TestResolveProcessIDIsStableWithinProcess(t *testing.T) {
+	t.Setenv(processIDEnvVar, "")
+	first := ResolveProcessID()
+	second := ResolveProcessID()
+	if first == "" || second == "" {
+		t.Fatal("ResolveProcessID returned empty string")
+	}
+	if first != second {
+		t.Fatalf("ResolveProcessID() = %q then %q, want stable value within process", first, second)
+	}
+}

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -2027,11 +2027,32 @@ type ServerConfig struct {
 	// authorization state it would have applied. This keeps no-traffic
 	// candidates from mutating shared authorization state by default.
 	AuthorizationStateApply *bool `yaml:"authorizationStateApply,omitempty"`
+	// UIReadiness gates startup admission on local mounted-UI qualification and
+	// exposes instance-scoped fleet readiness reports for Plan 11 milestone 2.
+	UIReadiness *UIReadinessConfig `yaml:"uiReadiness,omitempty"`
 	// Dev is set programmatically when gestaltd is launched via the dev
 	// subcommand. It gates CLI config resolution and reverse-tunnel startup.
 	Dev bool `yaml:"-"`
 	// RemotePreviewServe is set when gestaltd serve runs with --remote-preview.
 	RemotePreviewServe bool `yaml:"-"`
+}
+
+// UIReadinessConfig controls local UI qualification for startup admission and
+// fleet readiness reporting.
+type UIReadinessConfig struct {
+	Enabled          *bool    `yaml:"enabled,omitempty"`
+	ReleaseID        string   `yaml:"releaseId,omitempty"`
+	ProbeBearerToken string   `yaml:"probeBearerToken,omitempty"`
+	ExtraProbePaths  []string `yaml:"extraProbePaths,omitempty"`
+	RecheckInterval  string   `yaml:"recheckInterval,omitempty"`
+}
+
+func (c UIReadinessConfig) RecheckIntervalDuration() (time.Duration, error) {
+	raw := strings.TrimSpace(c.RecheckInterval)
+	if raw == "" {
+		return 0, nil
+	}
+	return time.ParseDuration(raw)
 }
 
 // TODO(app-registry-step-9): Remove this temporary rollout configuration after step 9 is complete.

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -228,6 +228,12 @@ func (s *Server) readinessCheck(w http.ResponseWriter, _ *http.Request) {
 			return
 		}
 	}
+	if s.uiReadiness != nil {
+		if reason := s.uiReadiness.ReadinessReason(); reason != "" {
+			writeJSON(w, http.StatusServiceUnavailable, map[string]string{"status": reason})
+			return
+		}
+	}
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 }
 

--- a/gestaltd/internal/server/handlers_fleet_readiness.go
+++ b/gestaltd/internal/server/handlers_fleet_readiness.go
@@ -1,0 +1,13 @@
+package server
+
+import (
+	"net/http"
+)
+
+func (s *Server) fleetReadinessReport(w http.ResponseWriter, _ *http.Request) {
+	if s.uiReadiness == nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"status": "ui readiness disabled"})
+		return
+	}
+	writeJSON(w, http.StatusOK, s.uiReadiness.Report())
+}

--- a/gestaltd/internal/server/routes.go
+++ b/gestaltd/internal/server/routes.go
@@ -116,6 +116,7 @@ const (
 func (s *Server) mountCoreRoutes(r chi.Router, exposure metricsExposure) {
 	r.Get("/health", s.healthCheck)
 	r.Get("/ready", s.readinessCheck)
+	r.Get("/fleet-readiness", s.fleetReadinessReport)
 	if s.frpsHandler != nil {
 		r.Handle("/~!frp", s.frpsHandler)
 	}

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -249,6 +249,10 @@ func run(ctx context.Context, cfg *config.Config, result *bootstrap.Result, gest
 		return fmt.Errorf("creating public server: %w", err)
 	}
 
+	uiSettings := resolveUIReadinessSettings(cfg, gestaltdVersion, baseConfig.SourceVersion)
+	var uiMonitor *UIReadinessMonitor
+	var managementHandler *Server
+
 	servers := []namedHTTPServer{{
 		name:   "public",
 		server: newHTTPServer(cfg.Server.PublicAddr(), publicHandler),
@@ -270,7 +274,7 @@ func run(ctx context.Context, cfg *config.Config, result *bootstrap.Result, gest
 		managementConfig.RouteProfile = RouteProfileManagement
 		managementConfig.DevHandlerResolver = publicConfig.DevHandlerResolver
 
-		managementHandler, err := New(managementConfig)
+		managementHandler, err = New(managementConfig)
 		if err != nil {
 			if devSupervisor != nil {
 				devSupervisor.Stop()
@@ -283,7 +287,26 @@ func run(ctx context.Context, cfg *config.Config, result *bootstrap.Result, gest
 		})
 	}
 
-	return serveRuntime(ctx, cfg, connMaps, result, mcpInvoker, servers, mcpSlot, workflowProvidersReady, devSupervisor, onReady, reverseRemote)
+	if uiSettings.enabled {
+		uiMonitor = NewUIReadinessMonitor(UIReadinessMonitorConfig{
+			Handler:         publicHandler,
+			MountedUIs:      publicHandler.mountedUIs,
+			ExtraProbePaths: uiSettings.extraProbePaths,
+			ProbeBearer:     uiSettings.probeBearer,
+			ReleaseID:       uiSettings.releaseID,
+			SourceVersion:   baseConfig.SourceVersion,
+			InstanceID:      appregistry.ResolveInstanceID(),
+			ProcessID:       appregistry.ResolveProcessID(),
+			ServingReady:    result.AppProvidersInitialized,
+			RecheckInterval: uiSettings.recheckInterval,
+		})
+		publicHandler.uiReadiness = uiMonitor
+		if managementHandler != nil {
+			managementHandler.uiReadiness = uiMonitor
+		}
+	}
+
+	return serveRuntime(ctx, cfg, connMaps, result, mcpInvoker, servers, mcpSlot, workflowProvidersReady, devSupervisor, onReady, reverseRemote, uiMonitor)
 }
 
 func registryAppStartup(cfg *config.Config, result *bootstrap.Result, reader *appregistry.RegistryReader) func(context.Context) {
@@ -372,9 +395,12 @@ func runtimeReadinessStatus(workflowProvidersReady <-chan struct{}, services ind
 	}
 }
 
-func serveRuntime(ctx context.Context, cfg *config.Config, connMaps bootstrap.ConnectionMaps, result *bootstrap.Result, mcpInvoker invocation.Invoker, servers []namedHTTPServer, mcpSlot *switchableHandler, workflowProvidersReady chan<- struct{}, devSupervisor *providerdev.Supervisor, readyCallback func(), reverseRemote *reverseRemoteSetup) error {
+func serveRuntime(ctx context.Context, cfg *config.Config, connMaps bootstrap.ConnectionMaps, result *bootstrap.Result, mcpInvoker invocation.Invoker, servers []namedHTTPServer, mcpSlot *switchableHandler, workflowProvidersReady chan<- struct{}, devSupervisor *providerdev.Supervisor, readyCallback func(), reverseRemote *reverseRemoteSetup, uiMonitor *UIReadinessMonitor) error {
 	if devSupervisor != nil {
 		defer devSupervisor.Stop()
+	}
+	if uiMonitor != nil {
+		uiMonitor.Start(ctx)
 	}
 
 	type boundServer struct {

--- a/gestaltd/internal/server/runtime_test.go
+++ b/gestaltd/internal/server/runtime_test.go
@@ -148,7 +148,7 @@ func TestServeRuntimeReadyAfterWorkflowProvidersStart(t *testing.T) {
 	serveDone := make(chan struct{})
 	go func() {
 		defer close(serveDone)
-		_ = serveRuntime(ctx, &config.Config{}, bootstrap.ConnectionMaps{}, result, nil, servers, &switchableHandler{}, workflowProvidersReady, nil, nil, nil)
+		_ = serveRuntime(ctx, &config.Config{}, bootstrap.ConnectionMaps{}, result, nil, servers, &switchableHandler{}, workflowProvidersReady, nil, nil, nil, nil)
 	}()
 
 	select {
@@ -198,7 +198,7 @@ func TestServeRuntimeReadyBeforeRegistryAppsStart(t *testing.T) {
 	serveDone := make(chan struct{})
 	go func() {
 		defer close(serveDone)
-		_ = serveRuntime(ctx, &config.Config{}, bootstrap.ConnectionMaps{}, result, nil, servers, &switchableHandler{}, workflowProvidersReady, nil, nil, nil)
+		_ = serveRuntime(ctx, &config.Config{}, bootstrap.ConnectionMaps{}, result, nil, servers, &switchableHandler{}, workflowProvidersReady, nil, nil, nil, nil)
 	}()
 
 	select {

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -217,6 +217,7 @@ type Server struct {
 	appProviderRestarter          interface {
 		RestartApp(context.Context, string) error
 	}
+	uiReadiness *UIReadinessMonitor
 }
 
 func (s *Server) catalogSelectorConfig() invocation.CatalogSelectorConfig {
@@ -297,6 +298,7 @@ type Config struct {
 	PromoteSharedStateOnActivate  *bool
 	FinishSharedStartupPromotion  func(context.Context) error
 	ServingReady                  <-chan struct{}
+	UIReadiness                   *UIReadinessMonitor
 	AppProviderRestarter          interface {
 		RestartApp(context.Context, string) error
 	}
@@ -577,6 +579,7 @@ func New(cfg Config) (*Server, error) {
 		finishSharedStartupPromotion:  cfg.FinishSharedStartupPromotion,
 		servingReady:                  cfg.ServingReady,
 		appProviderRestarter:          cfg.AppProviderRestarter,
+		uiReadiness:                   cfg.UIReadiness,
 	}
 	s.workflowSchedules = workflowmanager.New(workflowmanager.Config{
 		Providers:         cfg.Providers,

--- a/gestaltd/internal/server/ui_readiness.go
+++ b/gestaltd/internal/server/ui_readiness.go
@@ -11,20 +11,20 @@ import (
 
 const uiReadinessIncompleteReason = "ui readiness incomplete"
 
-type uiProbeResult struct {
+type UIProbeResult struct {
 	Mount      string  `json:"mount"`
 	Ready      bool    `json:"ready"`
 	StatusCode *int    `json:"status_code"`
 	Error      *string `json:"error,omitempty"`
 }
 
-type fleetReadinessReport struct {
+type FleetReadinessReport struct {
 	ReleaseID     string          `json:"release_id"`
 	SourceVersion string          `json:"source_version"`
 	InstanceID    string          `json:"instance_id"`
 	ProcessID     string          `json:"process_id"`
 	ReportedAt    float64         `json:"reported_at"`
-	UIs           []uiProbeResult `json:"uis"`
+	UIs           []UIProbeResult `json:"uis"`
 }
 
 type UIReadinessMonitor struct {
@@ -41,7 +41,7 @@ type UIReadinessMonitor struct {
 	now             func() time.Time
 
 	mu     sync.RWMutex
-	report fleetReadinessReport
+	report FleetReadinessReport
 	ready  bool
 }
 
@@ -130,9 +130,9 @@ func (m *UIReadinessMonitor) ReadinessReason() string {
 	return ""
 }
 
-func (m *UIReadinessMonitor) Report() fleetReadinessReport {
+func (m *UIReadinessMonitor) Report() FleetReadinessReport {
 	if m == nil {
-		return fleetReadinessReport{}
+		return FleetReadinessReport{}
 	}
 	m.mu.RLock()
 	defer m.mu.RUnlock()
@@ -140,10 +140,11 @@ func (m *UIReadinessMonitor) Report() fleetReadinessReport {
 }
 
 func (m *UIReadinessMonitor) evaluate() {
-	results := make([]uiProbeResult, 0, len(m.mounted)+len(m.extraProbePaths))
+	results := make([]UIProbeResult, 0, len(m.mounted)+len(m.extraProbePaths))
 	ready := true
 
-	for _, mounted := range m.mounted {
+	for i := range m.mounted {
+		mounted := m.mounted[i]
 		if mounted.Handler == nil || strings.TrimSpace(mounted.Path) == "" {
 			continue
 		}
@@ -167,7 +168,7 @@ func (m *UIReadinessMonitor) evaluate() {
 		}
 	}
 
-	report := fleetReadinessReport{
+	report := FleetReadinessReport{
 		ReleaseID:     m.releaseID,
 		SourceVersion: m.sourceVersion,
 		InstanceID:    m.instanceID,
@@ -195,7 +196,7 @@ func mountedUIProbePaths(mounted MountedUI) []string {
 	return paths
 }
 
-func probeMountedUI(handler http.Handler, path string, bearer string) uiProbeResult {
+func probeMountedUI(handler http.Handler, path string, bearer string) UIProbeResult {
 	req := httptest.NewRequest(http.MethodGet, path, nil)
 	if bearer != "" {
 		req.Header.Set("Authorization", "Bearer "+bearer)
@@ -204,7 +205,7 @@ func probeMountedUI(handler http.Handler, path string, bearer string) uiProbeRes
 	handler.ServeHTTP(rec, req)
 
 	code := rec.Code
-	result := uiProbeResult{
+	result := UIProbeResult{
 		Mount:      path,
 		Ready:      uiProbeStatusReady(code),
 		StatusCode: &code,

--- a/gestaltd/internal/server/ui_readiness.go
+++ b/gestaltd/internal/server/ui_readiness.go
@@ -1,0 +1,224 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"time"
+)
+
+const uiReadinessIncompleteReason = "ui readiness incomplete"
+
+type uiProbeResult struct {
+	Mount      string  `json:"mount"`
+	Ready      bool    `json:"ready"`
+	StatusCode *int    `json:"status_code"`
+	Error      *string `json:"error,omitempty"`
+}
+
+type fleetReadinessReport struct {
+	ReleaseID     string          `json:"release_id"`
+	SourceVersion string          `json:"source_version"`
+	InstanceID    string          `json:"instance_id"`
+	ProcessID     string          `json:"process_id"`
+	ReportedAt    float64         `json:"reported_at"`
+	UIs           []uiProbeResult `json:"uis"`
+}
+
+type UIReadinessMonitor struct {
+	handler         http.Handler
+	mounted         []MountedUI
+	extraProbePaths []string
+	probeBearer     string
+	releaseID       string
+	sourceVersion   string
+	instanceID      string
+	processID       string
+	servingReady    <-chan struct{}
+	recheckInterval time.Duration
+	now             func() time.Time
+
+	mu     sync.RWMutex
+	report fleetReadinessReport
+	ready  bool
+}
+
+func NewUIReadinessMonitor(cfg UIReadinessMonitorConfig) *UIReadinessMonitor {
+	now := cfg.Now
+	if now == nil {
+		now = time.Now
+	}
+	interval := cfg.RecheckInterval
+	if interval <= 0 {
+		interval = defaultUIReadinessRecheckEvery
+	}
+	return &UIReadinessMonitor{
+		handler:         cfg.Handler,
+		mounted:         append([]MountedUI(nil), cfg.MountedUIs...),
+		extraProbePaths: append([]string(nil), cfg.ExtraProbePaths...),
+		probeBearer:     strings.TrimSpace(cfg.ProbeBearer),
+		releaseID:       strings.TrimSpace(cfg.ReleaseID),
+		sourceVersion:   strings.TrimSpace(cfg.SourceVersion),
+		instanceID:      strings.TrimSpace(cfg.InstanceID),
+		processID:       strings.TrimSpace(cfg.ProcessID),
+		servingReady:    cfg.ServingReady,
+		recheckInterval: interval,
+		now:             now,
+	}
+}
+
+type UIReadinessMonitorConfig struct {
+	Handler         http.Handler
+	MountedUIs      []MountedUI
+	ExtraProbePaths []string
+	ProbeBearer     string
+	ReleaseID       string
+	SourceVersion   string
+	InstanceID      string
+	ProcessID       string
+	ServingReady    <-chan struct{}
+	RecheckInterval time.Duration
+	Now             func() time.Time
+}
+
+func (m *UIReadinessMonitor) Start(ctx context.Context) {
+	if m == nil {
+		return
+	}
+	go func() {
+		if !m.waitForServingReady(ctx) {
+			return
+		}
+		m.evaluate()
+		ticker := time.NewTicker(m.recheckInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				m.evaluate()
+			}
+		}
+	}()
+}
+
+func (m *UIReadinessMonitor) waitForServingReady(ctx context.Context) bool {
+	if m.servingReady == nil {
+		return true
+	}
+	select {
+	case <-m.servingReady:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+func (m *UIReadinessMonitor) ReadinessReason() string {
+	if m == nil {
+		return ""
+	}
+	m.mu.RLock()
+	ready := m.ready
+	m.mu.RUnlock()
+	if !ready {
+		return uiReadinessIncompleteReason
+	}
+	return ""
+}
+
+func (m *UIReadinessMonitor) Report() fleetReadinessReport {
+	if m == nil {
+		return fleetReadinessReport{}
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.report
+}
+
+func (m *UIReadinessMonitor) evaluate() {
+	results := make([]uiProbeResult, 0, len(m.mounted)+len(m.extraProbePaths))
+	ready := true
+
+	for _, mounted := range m.mounted {
+		if mounted.Handler == nil || strings.TrimSpace(mounted.Path) == "" {
+			continue
+		}
+		for _, path := range mountedUIProbePaths(mounted) {
+			result := probeMountedUI(m.handler, path, m.probeBearer)
+			results = append(results, result)
+			if !result.Ready {
+				ready = false
+			}
+		}
+	}
+	for _, path := range m.extraProbePaths {
+		path = strings.TrimSpace(path)
+		if path == "" {
+			continue
+		}
+		result := probeMountedUI(m.handler, path, m.probeBearer)
+		results = append(results, result)
+		if !result.Ready {
+			ready = false
+		}
+	}
+
+	report := fleetReadinessReport{
+		ReleaseID:     m.releaseID,
+		SourceVersion: m.sourceVersion,
+		InstanceID:    m.instanceID,
+		ProcessID:     m.processID,
+		ReportedAt:    float64(m.now().Unix()),
+		UIs:           results,
+	}
+
+	m.mu.Lock()
+	m.report = report
+	m.ready = ready && len(results) > 0
+	m.mu.Unlock()
+}
+
+func mountedUIProbePaths(mounted MountedUI) []string {
+	mount := strings.TrimRight(strings.TrimSpace(mounted.Path), "/")
+	if mount == "" {
+		mount = "/"
+	}
+	paths := []string{mount + "/"}
+	if mounted.ThemeStylesheet != "" {
+		stylesheetPath, _ := mountedUIThemePaths(mount)
+		paths = append(paths, stylesheetPath)
+	}
+	return paths
+}
+
+func probeMountedUI(handler http.Handler, path string, bearer string) uiProbeResult {
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	code := rec.Code
+	result := uiProbeResult{
+		Mount:      path,
+		Ready:      uiProbeStatusReady(code),
+		StatusCode: &code,
+	}
+	if !result.Ready {
+		msg := strings.TrimSpace(rec.Body.String())
+		if msg == "" {
+			msg = http.StatusText(rec.Code)
+		}
+		result.Error = &msg
+	}
+	return result
+}
+
+func uiProbeStatusReady(statusCode int) bool {
+	return statusCode >= http.StatusOK && statusCode < http.StatusMultipleChoices
+}

--- a/gestaltd/internal/server/ui_readiness_config.go
+++ b/gestaltd/internal/server/ui_readiness_config.go
@@ -1,0 +1,58 @@
+package server
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/internal/config"
+)
+
+const (
+	uiReadinessEnabledEnv          = "GESTALTD_UI_READINESS_ENABLED"
+	releaseIDEnv                   = "GESTALTD_RELEASE_ID"
+	uiQualificationBearerTokenEnv  = "GESTALTD_UI_QUALIFICATION_BEARER_TOKEN"
+	defaultUIReadinessRecheckEvery = 5 * time.Second
+)
+
+type uiReadinessSettings struct {
+	enabled         bool
+	releaseID       string
+	probeBearer     string
+	extraProbePaths []string
+	recheckInterval time.Duration
+}
+
+func resolveUIReadinessSettings(cfg *config.Config, gestaltdVersion, sourceVersion string) uiReadinessSettings {
+	settings := uiReadinessSettings{
+		recheckInterval: defaultUIReadinessRecheckEvery,
+	}
+	if cfg != nil && cfg.Server.UIReadiness != nil {
+		uiCfg := cfg.Server.UIReadiness
+		if uiCfg.Enabled != nil {
+			settings.enabled = *uiCfg.Enabled
+		}
+		settings.releaseID = strings.TrimSpace(uiCfg.ReleaseID)
+		settings.probeBearer = strings.TrimSpace(uiCfg.ProbeBearerToken)
+		settings.extraProbePaths = append([]string(nil), uiCfg.ExtraProbePaths...)
+		if interval, err := uiCfg.RecheckIntervalDuration(); err == nil && interval > 0 {
+			settings.recheckInterval = interval
+		}
+	}
+	if raw := strings.TrimSpace(os.Getenv(uiReadinessEnabledEnv)); raw != "" {
+		if parsed, err := strconv.ParseBool(raw); err == nil {
+			settings.enabled = parsed
+		}
+	}
+	if settings.releaseID == "" {
+		settings.releaseID = strings.TrimSpace(os.Getenv(releaseIDEnv))
+	}
+	if settings.releaseID == "" {
+		settings.releaseID = strings.TrimSpace(gestaltdVersion) + "@" + strings.TrimSpace(sourceVersion)
+	}
+	if settings.probeBearer == "" {
+		settings.probeBearer = strings.TrimSpace(os.Getenv(uiQualificationBearerTokenEnv))
+	}
+	return settings
+}

--- a/gestaltd/internal/server/ui_readiness_config_test.go
+++ b/gestaltd/internal/server/ui_readiness_config_test.go
@@ -1,0 +1,40 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/internal/config"
+)
+
+func TestResolveUIReadinessSettingsDefaultsDisabled(t *testing.T) {
+	settings := resolveUIReadinessSettings(&config.Config{}, "1.2.3", "sha-a")
+	if settings.enabled {
+		t.Fatal("ui readiness should default to disabled")
+	}
+	if settings.releaseID != "1.2.3@sha-a" {
+		t.Fatalf("releaseID = %q, want 1.2.3@sha-a", settings.releaseID)
+	}
+}
+
+func TestResolveUIReadinessSettingsHonorsConfig(t *testing.T) {
+	enabled := true
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			UIReadiness: &config.UIReadinessConfig{
+				Enabled:         &enabled,
+				ReleaseID:       "digest-a",
+				ExtraProbePaths: []string{"/api/v1/apps/sample/operations"},
+			},
+		},
+	}
+	settings := resolveUIReadinessSettings(cfg, "1.2.3", "sha-a")
+	if !settings.enabled {
+		t.Fatal("ui readiness should be enabled from config")
+	}
+	if settings.releaseID != "digest-a" {
+		t.Fatalf("releaseID = %q, want digest-a", settings.releaseID)
+	}
+	if len(settings.extraProbePaths) != 1 || settings.extraProbePaths[0] != "/api/v1/apps/sample/operations" {
+		t.Fatalf("extraProbePaths = %#v", settings.extraProbePaths)
+	}
+}

--- a/gestaltd/internal/server/ui_readiness_config_test.go
+++ b/gestaltd/internal/server/ui_readiness_config_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestResolveUIReadinessSettingsDefaultsDisabled(t *testing.T) {
+	t.Parallel()
 	settings := resolveUIReadinessSettings(&config.Config{}, "1.2.3", "sha-a")
 	if settings.enabled {
 		t.Fatal("ui readiness should default to disabled")
@@ -17,6 +18,7 @@ func TestResolveUIReadinessSettingsDefaultsDisabled(t *testing.T) {
 }
 
 func TestResolveUIReadinessSettingsHonorsConfig(t *testing.T) {
+	t.Parallel()
 	enabled := true
 	cfg := &config.Config{
 		Server: config.ServerConfig{

--- a/gestaltd/internal/server/ui_readiness_test.go
+++ b/gestaltd/internal/server/ui_readiness_test.go
@@ -1,0 +1,139 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestUIReadinessMonitorMarksReadyAfterServingAndProbe(t *testing.T) {
+	servingReady := make(chan struct{})
+	mux := http.NewServeMux()
+	mux.HandleFunc("/sample/", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	monitor := NewUIReadinessMonitor(UIReadinessMonitorConfig{
+		Handler: mux,
+		MountedUIs: []MountedUI{{
+			Path:    "/sample",
+			Handler: mux,
+		}},
+		ReleaseID:     "release-a",
+		SourceVersion: "sha-a",
+		InstanceID:    "instance-a",
+		ProcessID:     "process-a",
+		ServingReady:  servingReady,
+		Now:           func() time.Time { return time.Unix(1_700_000_000, 0) },
+	})
+
+	if reason := monitor.ReadinessReason(); reason != uiReadinessIncompleteReason {
+		t.Fatalf("readiness before evaluation = %q, want %q", reason, uiReadinessIncompleteReason)
+	}
+
+	close(servingReady)
+	monitor.evaluate()
+
+	if reason := monitor.ReadinessReason(); reason != "" {
+		t.Fatalf("readiness after successful probe = %q, want ready", reason)
+	}
+
+	report := monitor.Report()
+	if report.ReleaseID != "release-a" || report.InstanceID != "instance-a" || len(report.UIs) != 1 || !report.UIs[0].Ready {
+		t.Fatalf("unexpected fleet report: %+v", report)
+	}
+}
+
+func TestUIReadinessMonitorRejectsRedirect(t *testing.T) {
+	servingReady := make(chan struct{})
+	close(servingReady)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/sample/", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusFound)
+	})
+
+	monitor := NewUIReadinessMonitor(UIReadinessMonitorConfig{
+		Handler: mux,
+		MountedUIs: []MountedUI{{
+			Path:    "/sample",
+			Handler: mux,
+		}},
+		ReleaseID:    "release-a",
+		InstanceID:   "instance-a",
+		ProcessID:    "process-a",
+		ServingReady: servingReady,
+	})
+	monitor.evaluate()
+
+	if reason := monitor.ReadinessReason(); reason != uiReadinessIncompleteReason {
+		t.Fatalf("readiness with redirect = %q, want %q", reason, uiReadinessIncompleteReason)
+	}
+}
+
+func TestReadinessCheckIncludesUIReadiness(t *testing.T) {
+	servingReady := make(chan struct{})
+	mux := http.NewServeMux()
+	mux.HandleFunc("/sample/", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	monitor := NewUIReadinessMonitor(UIReadinessMonitorConfig{
+		Handler: mux,
+		MountedUIs: []MountedUI{{
+			Path:    "/sample",
+			Handler: mux,
+		}},
+		ReleaseID:    "release-a",
+		InstanceID:   "instance-a",
+		ProcessID:    "process-a",
+		ServingReady: servingReady,
+	})
+	srv := &Server{uiReadiness: monitor}
+
+	rec := httptest.NewRecorder()
+	srv.readinessCheck(rec, httptest.NewRequest(http.MethodGet, "/ready", nil))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("ready before ui qualification = %d, want 503", rec.Code)
+	}
+
+	close(servingReady)
+	monitor.evaluate()
+
+	rec = httptest.NewRecorder()
+	srv.readinessCheck(rec, httptest.NewRequest(http.MethodGet, "/ready", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("ready after ui qualification = %d, want 200", rec.Code)
+	}
+}
+
+func TestFleetReadinessEndpoint(t *testing.T) {
+	servingReady := make(chan struct{})
+	close(servingReady)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/sample/", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	monitor := NewUIReadinessMonitor(UIReadinessMonitorConfig{
+		Handler: mux,
+		MountedUIs: []MountedUI{{
+			Path:    "/sample",
+			Handler: mux,
+		}},
+		ReleaseID:    "release-a",
+		InstanceID:   "instance-a",
+		ProcessID:    "process-a",
+		ServingReady: servingReady,
+	})
+	monitor.evaluate()
+
+	srv := &Server{uiReadiness: monitor}
+	rec := httptest.NewRecorder()
+	srv.fleetReadinessReport(rec, httptest.NewRequest(http.MethodGet, "/fleet-readiness", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /fleet-readiness = %d, want 200", rec.Code)
+	}
+}

--- a/gestaltd/internal/server/ui_readiness_test.go
+++ b/gestaltd/internal/server/ui_readiness_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestUIReadinessMonitorMarksReadyAfterServingAndProbe(t *testing.T) {
+	t.Parallel()
 	servingReady := make(chan struct{})
 	mux := http.NewServeMux()
 	mux.HandleFunc("/sample/", func(w http.ResponseWriter, _ *http.Request) {
@@ -46,6 +47,7 @@ func TestUIReadinessMonitorMarksReadyAfterServingAndProbe(t *testing.T) {
 }
 
 func TestUIReadinessMonitorRejectsRedirect(t *testing.T) {
+	t.Parallel()
 	servingReady := make(chan struct{})
 	close(servingReady)
 
@@ -73,6 +75,7 @@ func TestUIReadinessMonitorRejectsRedirect(t *testing.T) {
 }
 
 func TestReadinessCheckIncludesUIReadiness(t *testing.T) {
+	t.Parallel()
 	servingReady := make(chan struct{})
 	mux := http.NewServeMux()
 	mux.HandleFunc("/sample/", func(w http.ResponseWriter, _ *http.Request) {

--- a/gestaltd/internal/server/ui_readiness_test.go
+++ b/gestaltd/internal/server/ui_readiness_test.go
@@ -112,6 +112,7 @@ func TestReadinessCheckIncludesUIReadiness(t *testing.T) {
 }
 
 func TestFleetReadinessEndpoint(t *testing.T) {
+	t.Parallel()
 	servingReady := make(chan struct{})
 	close(servingReady)
 


### PR DESCRIPTION
## Summary
- Add optional `server.uiReadiness` config to probe every mounted UI locally and keep `/ready` unhealthy until all probes pass.
- Publish instance-scoped `/fleet-readiness` reports matching the toolshed `fleet_report_schema.json` contract (release_id, instance_id, process_id, per-UI results).
- Recheck on an interval so replacement instances re-admit independently of fleet promotion.

## Test plan
- [x] `go test ./gestaltd/internal/server/... ./gestaltd/internal/appregistry/... -run 'UIReadiness|FleetReadiness|ResolveUIReadiness|ResolveProcess'`
- [ ] Enable in staging with `GESTALTD_UI_READINESS_ENABLED=true` and qualification bearer token before controller integration.


Made with [Cursor](https://cursor.com)