### PR TITLE
Log skipped workflow providers during explicit temporal promotion

### DIFF
--- a/gestaltd/internal/bootstrap/shared_startup_promotion.go
+++ b/gestaltd/internal/bootstrap/shared_startup_promotion.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"strconv"
 	"strings"
@@ -87,6 +88,7 @@ type promotableWorkflowProvider interface {
 
 func promoteWorkflowProviders(ctx context.Context, providers []coreworkflow.Provider) error {
 	var errs []error
+	promoted := 0
 	for _, provider := range providers {
 		if provider == nil {
 			continue
@@ -94,8 +96,25 @@ func promoteWorkflowProviders(ctx context.Context, providers []coreworkflow.Prov
 		if promotable, ok := provider.(promotableWorkflowProvider); ok {
 			if err := promotable.PromoteWorkers(ctx); err != nil {
 				errs = append(errs, err)
+				continue
 			}
+			promoted++
+			continue
 		}
+		slog.WarnContext(
+			ctx,
+			"workflow provider does not support explicit worker promotion",
+			"provider_type",
+			fmt.Sprintf("%T", provider),
+		)
+	}
+	if len(providers) > 0 && promoted == 0 {
+		slog.WarnContext(
+			ctx,
+			"no workflow providers handled explicit worker promotion",
+			"provider_count",
+			len(providers),
+		)
 	}
 	return errors.Join(errs...)
 }

--- a/gestaltd/internal/bootstrap/shared_startup_promotion_test.go
+++ b/gestaltd/internal/bootstrap/shared_startup_promotion_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/coredata"
@@ -21,6 +22,28 @@ func TestResolvePromoteSharedStateOnActivateHonorsConfig(t *testing.T) {
 	cfg := &config.Config{Server: config.ServerConfig{PromoteSharedStateOnActivate: boolPtr(false)}}
 	if resolvePromoteSharedStateOnActivate(cfg) {
 		t.Fatal("expected config false to disable promote-on-activate")
+	}
+}
+
+type promotableTestWorkflowProvider struct {
+	startupTestWorkflowProvider
+	promoteCalls int
+}
+
+func (p *promotableTestWorkflowProvider) PromoteWorkers(context.Context) error {
+	p.promoteCalls++
+	return nil
+}
+
+func TestPromoteWorkflowProvidersInvokesPromotableProviders(t *testing.T) {
+	t.Parallel()
+
+	provider := &promotableTestWorkflowProvider{}
+	if err := promoteWorkflowProviders(context.Background(), []coreworkflow.Provider{provider}); err != nil {
+		t.Fatalf("promoteWorkflowProviders: %v", err)
+	}
+	if provider.promoteCalls != 1 {
+		t.Fatalf("promoteCalls = %d, want 1", provider.promoteCalls)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Warn when a workflow provider does not implement `PromoteWorkers` during explicit `/promote/temporal`.
- Warn when no configured workflow provider handled explicit promotion.

## Test plan
- [x] `go test ./internal/bootstrap -run TestPromoteWorkflowProviders`

Made with [Cursor](https://cursor.com)