### PR TITLE
Plan 11: wire subprocess workflow PromoteWorkers for explicit temporal promotion

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -755,6 +755,16 @@ func (p *workflowProviderWithCleanup) WaitRuntimeWorkersReady(ctx context.Contex
 	return nil
 }
 
+func (p *workflowProviderWithCleanup) PromoteWorkers(ctx context.Context) error {
+	if p == nil || p.Provider == nil {
+		return fmt.Errorf("workflow provider is not configured")
+	}
+	if promotable, ok := p.Provider.(promotableWorkflowProvider); ok {
+		return promotable.PromoteWorkers(ctx)
+	}
+	return fmt.Errorf("workflow provider does not support explicit worker promotion")
+}
+
 type agentProviderWithTracking struct {
 	delegate     coreagent.Provider
 	providerName string

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -756,13 +756,10 @@ func (p *workflowProviderWithCleanup) WaitRuntimeWorkersReady(ctx context.Contex
 }
 
 func (p *workflowProviderWithCleanup) PromoteWorkers(ctx context.Context) error {
-	if p == nil || p.Provider == nil {
+	if p == nil {
 		return fmt.Errorf("workflow provider is not configured")
 	}
-	if promotable, ok := p.Provider.(promotableWorkflowProvider); ok {
-		return promotable.PromoteWorkers(ctx)
-	}
-	return fmt.Errorf("workflow provider does not support explicit worker promotion")
+	return promoteDelegatedWorkflowWorkers(ctx, p.Provider)
 }
 
 type agentProviderWithTracking struct {

--- a/gestaltd/internal/bootstrap/hosted_workflow_provider.go
+++ b/gestaltd/internal/bootstrap/hosted_workflow_provider.go
@@ -313,13 +313,10 @@ func (p *workflowProviderWithRuntimeWorkers) WaitRuntimeWorkersReady(ctx context
 }
 
 func (p *workflowProviderWithRuntimeWorkers) PromoteWorkers(ctx context.Context) error {
-	if p == nil || p.Provider == nil {
+	if p == nil {
 		return fmt.Errorf("workflow provider is not configured")
 	}
-	if promotable, ok := p.Provider.(promotableWorkflowProvider); ok {
-		return promotable.PromoteWorkers(ctx)
-	}
-	return fmt.Errorf("workflow provider does not support explicit worker promotion")
+	return promoteDelegatedWorkflowWorkers(ctx, p.Provider)
 }
 
 func (p *workflowProviderWithRuntimeWorkers) Close() error {

--- a/gestaltd/internal/bootstrap/hosted_workflow_provider.go
+++ b/gestaltd/internal/bootstrap/hosted_workflow_provider.go
@@ -312,6 +312,16 @@ func (p *workflowProviderWithRuntimeWorkers) WaitRuntimeWorkersReady(ctx context
 	return p.workers.WaitReady(ctx)
 }
 
+func (p *workflowProviderWithRuntimeWorkers) PromoteWorkers(ctx context.Context) error {
+	if p == nil || p.Provider == nil {
+		return fmt.Errorf("workflow provider is not configured")
+	}
+	if promotable, ok := p.Provider.(promotableWorkflowProvider); ok {
+		return promotable.PromoteWorkers(ctx)
+	}
+	return fmt.Errorf("workflow provider does not support explicit worker promotion")
+}
+
 func (p *workflowProviderWithRuntimeWorkers) Close() error {
 	var errs []error
 	if p != nil && p.workers != nil {

--- a/gestaltd/internal/bootstrap/shared_startup_promotion.go
+++ b/gestaltd/internal/bootstrap/shared_startup_promotion.go
@@ -101,6 +101,7 @@ func promoteWorkflowProviders(ctx context.Context, providers []coreworkflow.Prov
 	var errs []error
 	promoted := 0
 	configured := 0
+	var unsupported []coreworkflow.Provider
 	for _, provider := range providers {
 		if provider == nil {
 			continue
@@ -114,6 +115,7 @@ func promoteWorkflowProviders(ctx context.Context, providers []coreworkflow.Prov
 			promoted++
 			continue
 		}
+		unsupported = append(unsupported, provider)
 		slog.WarnContext(
 			ctx,
 			"workflow provider does not support explicit worker promotion",
@@ -122,10 +124,22 @@ func promoteWorkflowProviders(ctx context.Context, providers []coreworkflow.Prov
 		)
 	}
 	if configured > 0 && promoted == 0 {
-		errs = append(
-			errs,
-			fmt.Errorf("no workflow providers handled explicit worker promotion (provider_count=%d)", configured),
-		)
+		if len(unsupported) == configured {
+			for _, provider := range unsupported {
+				errs = append(
+					errs,
+					fmt.Errorf(
+						"workflow provider does not support explicit worker promotion: %T",
+						provider,
+					),
+				)
+			}
+		} else {
+			errs = append(
+				errs,
+				fmt.Errorf("no workflow providers handled explicit worker promotion (provider_count=%d)", configured),
+			)
+		}
 	}
 	return errors.Join(errs...)
 }

--- a/gestaltd/internal/bootstrap/shared_startup_promotion.go
+++ b/gestaltd/internal/bootstrap/shared_startup_promotion.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"strconv"
 	"strings"
@@ -87,6 +88,7 @@ type promotableWorkflowProvider interface {
 
 func promoteWorkflowProviders(ctx context.Context, providers []coreworkflow.Provider) error {
 	var errs []error
+	promoted := 0
 	for _, provider := range providers {
 		if provider == nil {
 			continue
@@ -94,8 +96,25 @@ func promoteWorkflowProviders(ctx context.Context, providers []coreworkflow.Prov
 		if promotable, ok := provider.(promotableWorkflowProvider); ok {
 			if err := promotable.PromoteWorkers(ctx); err != nil {
 				errs = append(errs, err)
+				continue
 			}
+			promoted++
+			continue
 		}
+		slog.WarnContext(
+			ctx,
+			"workflow provider does not support explicit worker promotion",
+			"provider_type",
+			fmt.Sprintf("%T", provider),
+		)
+	}
+	if len(providers) > 0 && promoted == 0 {
+		slog.WarnContext(
+			ctx,
+			"no workflow providers handled explicit worker promotion",
+			"provider_count",
+			len(providers),
+		)
 	}
 	return errors.Join(errs...)
 }

--- a/gestaltd/internal/bootstrap/shared_startup_promotion.go
+++ b/gestaltd/internal/bootstrap/shared_startup_promotion.go
@@ -123,23 +123,20 @@ func promoteWorkflowProviders(ctx context.Context, providers []coreworkflow.Prov
 			fmt.Sprintf("%T", provider),
 		)
 	}
-	if configured > 0 && promoted == 0 {
-		if len(unsupported) == configured {
-			for _, provider := range unsupported {
-				errs = append(
-					errs,
-					fmt.Errorf(
-						"workflow provider does not support explicit worker promotion: %T",
-						provider,
-					),
-				)
-			}
-		} else {
-			errs = append(
-				errs,
-				fmt.Errorf("no workflow providers handled explicit worker promotion (provider_count=%d)", configured),
-			)
-		}
+	for _, provider := range unsupported {
+		errs = append(
+			errs,
+			fmt.Errorf(
+				"workflow provider does not support explicit worker promotion: %T",
+				provider,
+			),
+		)
+	}
+	if configured > 0 && promoted == 0 && len(unsupported) < configured {
+		errs = append(
+			errs,
+			fmt.Errorf("no workflow providers handled explicit worker promotion (provider_count=%d)", configured),
+		)
 	}
 	return errors.Join(errs...)
 }

--- a/gestaltd/internal/bootstrap/shared_startup_promotion.go
+++ b/gestaltd/internal/bootstrap/shared_startup_promotion.go
@@ -86,6 +86,17 @@ type promotableWorkflowProvider interface {
 	PromoteWorkers(context.Context) error
 }
 
+func promoteDelegatedWorkflowWorkers(ctx context.Context, provider coreworkflow.Provider) error {
+	if provider == nil {
+		return fmt.Errorf("workflow provider is not configured")
+	}
+	promotable, ok := provider.(promotableWorkflowProvider)
+	if !ok {
+		return fmt.Errorf("workflow provider does not support explicit worker promotion")
+	}
+	return promotable.PromoteWorkers(ctx)
+}
+
 func promoteWorkflowProviders(ctx context.Context, providers []coreworkflow.Provider) error {
 	var errs []error
 	promoted := 0

--- a/gestaltd/internal/bootstrap/shared_startup_promotion.go
+++ b/gestaltd/internal/bootstrap/shared_startup_promotion.go
@@ -89,10 +89,12 @@ type promotableWorkflowProvider interface {
 func promoteWorkflowProviders(ctx context.Context, providers []coreworkflow.Provider) error {
 	var errs []error
 	promoted := 0
+	configured := 0
 	for _, provider := range providers {
 		if provider == nil {
 			continue
 		}
+		configured++
 		if promotable, ok := provider.(promotableWorkflowProvider); ok {
 			if err := promotable.PromoteWorkers(ctx); err != nil {
 				errs = append(errs, err)
@@ -108,12 +110,10 @@ func promoteWorkflowProviders(ctx context.Context, providers []coreworkflow.Prov
 			fmt.Sprintf("%T", provider),
 		)
 	}
-	if len(providers) > 0 && promoted == 0 {
-		slog.WarnContext(
-			ctx,
-			"no workflow providers handled explicit worker promotion",
-			"provider_count",
-			len(providers),
+	if configured > 0 && promoted == 0 {
+		errs = append(
+			errs,
+			fmt.Errorf("no workflow providers handled explicit worker promotion (provider_count=%d)", configured),
 		)
 	}
 	return errors.Join(errs...)

--- a/gestaltd/internal/bootstrap/shared_startup_promotion_test.go
+++ b/gestaltd/internal/bootstrap/shared_startup_promotion_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/coredata"
@@ -21,6 +22,28 @@ func TestResolvePromoteSharedStateOnActivateHonorsConfig(t *testing.T) {
 	cfg := &config.Config{Server: config.ServerConfig{PromoteSharedStateOnActivate: boolPtr(false)}}
 	if resolvePromoteSharedStateOnActivate(cfg) {
 		t.Fatal("expected config false to disable promote-on-activate")
+	}
+}
+
+type promotableTestWorkflowProvider struct {
+	startupTestWorkflowProvider
+	promoteCalls int
+}
+
+func (p *promotableTestWorkflowProvider) PromoteWorkers(context.Context) error {
+	p.promoteCalls++
+	return nil
+}
+
+func TestPromoteWorkflowProvidersInvokesPromotableProviders(t *testing.T) {
+	t.Parallel()
+
+	provider := &promotableTestWorkflowProvider{}
+	if err := promoteWorkflowProviders(context.Background(), []coreworkflow.Provider{provider}); err != nil {
+		t.Fatalf("promoteWorkflowProviders: %v", err)
+	}
+	if provider.promoteCalls != 1 {
+		t.Fatalf("promoteCalls = %d, want 1", provider.promoteCalls)
 	}
 }
 

--- a/gestaltd/internal/bootstrap/shared_startup_promotion_test.go
+++ b/gestaltd/internal/bootstrap/shared_startup_promotion_test.go
@@ -64,6 +64,26 @@ func TestPromoteWorkflowProvidersFailsWhenNoProviderHandlesPromotion(t *testing.
 	}
 }
 
+func TestPromoteWorkflowProvidersFailsWhenMixedSuccessAndUnsupported(t *testing.T) {
+	t.Parallel()
+
+	promotable := &promotableTestWorkflowProvider{}
+	unsupported := &startupTestWorkflowProvider{}
+	err := promoteWorkflowProviders(
+		context.Background(),
+		[]coreworkflow.Provider{promotable, unsupported},
+	)
+	if err == nil {
+		t.Fatal("expected explicit promotion to fail when an unsupported provider is configured")
+	}
+	if promotable.promoteCalls != 1 {
+		t.Fatalf("promoteCalls = %d, want 1", promotable.promoteCalls)
+	}
+	if !strings.Contains(err.Error(), fmt.Sprintf("%T", unsupported)) {
+		t.Fatalf("promoteWorkflowProviders error = %v, want unsupported provider type", err)
+	}
+}
+
 func TestPromoteWorkflowProvidersReportsEachUnsupportedProvider(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/bootstrap/shared_startup_promotion_test.go
+++ b/gestaltd/internal/bootstrap/shared_startup_promotion_test.go
@@ -2,6 +2,7 @@ package bootstrap
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
@@ -28,11 +29,12 @@ func TestResolvePromoteSharedStateOnActivateHonorsConfig(t *testing.T) {
 type promotableTestWorkflowProvider struct {
 	startupTestWorkflowProvider
 	promoteCalls int
+	promoteErr   error
 }
 
 func (p *promotableTestWorkflowProvider) PromoteWorkers(context.Context) error {
 	p.promoteCalls++
-	return nil
+	return p.promoteErr
 }
 
 func TestPromoteWorkflowProvidersInvokesPromotableProviders(t *testing.T) {
@@ -44,6 +46,41 @@ func TestPromoteWorkflowProvidersInvokesPromotableProviders(t *testing.T) {
 	}
 	if provider.promoteCalls != 1 {
 		t.Fatalf("promoteCalls = %d, want 1", provider.promoteCalls)
+	}
+}
+
+func TestPromoteWorkflowProvidersFailsWhenNoProviderHandlesPromotion(t *testing.T) {
+	t.Parallel()
+
+	err := promoteWorkflowProviders(context.Background(), []coreworkflow.Provider{&startupTestWorkflowProvider{}})
+	if err == nil {
+		t.Fatal("expected explicit promotion to fail when provider is not promotable")
+	}
+}
+
+func TestPromoteWorkflowProvidersPropagatesProviderError(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("set worker deployment current version: boom")
+	provider := &promotableTestWorkflowProvider{
+		promoteErr: wantErr,
+	}
+	err := promoteWorkflowProviders(context.Background(), []coreworkflow.Provider{provider})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("promoteWorkflowProviders error = %v, want %v", err, wantErr)
+	}
+}
+
+func TestWorkflowCleanupWrapperForwardsPromoteWorkers(t *testing.T) {
+	t.Parallel()
+
+	inner := &promotableTestWorkflowProvider{}
+	wrapped := &workflowProviderWithCleanup{Provider: inner}
+	if err := promoteWorkflowProviders(context.Background(), []coreworkflow.Provider{wrapped}); err != nil {
+		t.Fatalf("promoteWorkflowProviders: %v", err)
+	}
+	if inner.promoteCalls != 1 {
+		t.Fatalf("inner promoteCalls = %d, want 1", inner.promoteCalls)
 	}
 }
 

--- a/gestaltd/internal/bootstrap/shared_startup_promotion_test.go
+++ b/gestaltd/internal/bootstrap/shared_startup_promotion_test.go
@@ -3,6 +3,8 @@ package bootstrap
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strings"
 	"testing"
 
 	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
@@ -52,9 +54,30 @@ func TestPromoteWorkflowProvidersInvokesPromotableProviders(t *testing.T) {
 func TestPromoteWorkflowProvidersFailsWhenNoProviderHandlesPromotion(t *testing.T) {
 	t.Parallel()
 
-	err := promoteWorkflowProviders(context.Background(), []coreworkflow.Provider{&startupTestWorkflowProvider{}})
+	provider := &startupTestWorkflowProvider{}
+	err := promoteWorkflowProviders(context.Background(), []coreworkflow.Provider{provider})
 	if err == nil {
 		t.Fatal("expected explicit promotion to fail when provider is not promotable")
+	}
+	if !strings.Contains(err.Error(), fmt.Sprintf("%T", provider)) {
+		t.Fatalf("promoteWorkflowProviders error = %v, want provider type %T", err, provider)
+	}
+}
+
+func TestPromoteWorkflowProvidersReportsEachUnsupportedProvider(t *testing.T) {
+	t.Parallel()
+
+	first := &startupTestWorkflowProvider{}
+	second := &startupTestWorkflowProvider{}
+	err := promoteWorkflowProviders(context.Background(), []coreworkflow.Provider{first, second})
+	if err == nil {
+		t.Fatal("expected explicit promotion to fail when every provider is unsupported")
+	}
+	if !strings.Contains(err.Error(), fmt.Sprintf("%T", first)) {
+		t.Fatalf("promoteWorkflowProviders error = %v, want first provider type", err)
+	}
+	if !strings.Contains(err.Error(), fmt.Sprintf("%T", second)) {
+		t.Fatalf("promoteWorkflowProviders error = %v, want second provider type", err)
 	}
 }
 

--- a/gestaltd/rpc/protov1/v1/runtime.pb.go
+++ b/gestaltd/rpc/protov1/v1/runtime.pb.go
@@ -414,6 +414,52 @@ func (x *StartRuntimeProviderResponse) GetProtocolVersion() int32 {
 	return 0
 }
 
+// PromoteWorkersResponse confirms the protocol version the provider is serving
+// after explicit worker promotion completes.
+type PromoteWorkersResponse struct {
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	ProtocolVersion int32                  `protobuf:"varint,1,opt,name=protocol_version,json=protocolVersion,proto3" json:"protocol_version,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *PromoteWorkersResponse) Reset() {
+	*x = PromoteWorkersResponse{}
+	mi := &file_v1_runtime_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PromoteWorkersResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PromoteWorkersResponse) ProtoMessage() {}
+
+func (x *PromoteWorkersResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_v1_runtime_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PromoteWorkersResponse.ProtoReflect.Descriptor instead.
+func (*PromoteWorkersResponse) Descriptor() ([]byte, []int) {
+	return file_v1_runtime_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *PromoteWorkersResponse) GetProtocolVersion() int32 {
+	if x != nil {
+		return x.ProtocolVersion
+	}
+	return 0
+}
+
 var File_v1_runtime_proto protoreflect.FileDescriptor
 
 const file_v1_runtime_proto_rawDesc = "" +
@@ -439,6 +485,8 @@ const file_v1_runtime_proto_rawDesc = "" +
 	"\x05ready\x18\x01 \x01(\bR\x05ready\x12\x18\n" +
 	"\amessage\x18\x02 \x01(\tR\amessage\"_\n" +
 	"\x1cStartRuntimeProviderResponse\x12)\n" +
+	"\x10protocol_version\x18\x01 \x01(\x05R\x0fprotocolVersion:\x14\x9a\xb5\x18\x10protocol_version\"Y\n" +
+	"\x16PromoteWorkersResponse\x12)\n" +
 	"\x10protocol_version\x18\x01 \x01(\x05R\x0fprotocolVersion:\x14\x9a\xb5\x18\x10protocol_version*\x94\x03\n" +
 	"\fProviderKind\x12\x1d\n" +
 	"\x19PROVIDER_KIND_UNSPECIFIED\x10\x00\x12\x15\n" +
@@ -455,12 +503,13 @@ const file_v1_runtime_proto_rawDesc = "" +
 	"\x12\x17\n" +
 	"\x13PROVIDER_KIND_AGENT\x10\v\x12%\n" +
 	"!PROVIDER_KIND_EXTERNAL_CREDENTIAL\x10\f\x12\x16\n" +
-	"\x12PROVIDER_KIND_TEST\x10\r2\xb3\x03\n" +
+	"\x12PROVIDER_KIND_TEST\x10\r2\x8a\x04\n" +
 	"\x11ProviderLifecycle\x12T\n" +
 	"\x13GetProviderIdentity\x12\x16.google.protobuf.Empty\x1a%.gestalt.provider.v1.ProviderIdentity\x12\x9a\x01\n" +
 	"\x11ConfigureProvider\x12-.gestalt.provider.v1.ConfigureProviderRequest\x1a..gestalt.provider.v1.ConfigureProviderResponse\"&\x8a\xb5\x18\x04name\x8a\xb5\x18\x10protocol_version\x8a\xb5\x18\x06config\x12O\n" +
 	"\vHealthCheck\x12\x16.google.protobuf.Empty\x1a(.gestalt.provider.v1.HealthCheckResponse\x12Z\n" +
-	"\rStartProvider\x12\x16.google.protobuf.Empty\x1a1.gestalt.provider.v1.StartRuntimeProviderResponseB\xd8\x01\n" +
+	"\rStartProvider\x12\x16.google.protobuf.Empty\x1a1.gestalt.provider.v1.StartRuntimeProviderResponse\x12U\n" +
+	"\x0ePromoteWorkers\x12\x16.google.protobuf.Empty\x1a+.gestalt.provider.v1.PromoteWorkersResponseB\xd8\x01\n" +
 	"\x17com.gestalt.provider.v1B\fRuntimeProtoP\x01ZAgithub.com/valon-technologies/gestalt/server/rpc/protov1/v1;proto\xa2\x02\x03GPX\xaa\x02\x13Gestalt.Provider.V1\xca\x02\x13Gestalt\\Provider\\V1\xe2\x02\x1fGestalt\\Provider\\V1\\GPBMetadata\xea\x02\x15Gestalt::Provider::V1b\x06proto3"
 
 var (
@@ -476,7 +525,7 @@ func file_v1_runtime_proto_rawDescGZIP() []byte {
 }
 
 var file_v1_runtime_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_v1_runtime_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
+var file_v1_runtime_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
 var file_v1_runtime_proto_goTypes = []any{
 	(ProviderKind)(0),                    // 0: gestalt.provider.v1.ProviderKind
 	(*ProviderIdentity)(nil),             // 1: gestalt.provider.v1.ProviderIdentity
@@ -484,22 +533,25 @@ var file_v1_runtime_proto_goTypes = []any{
 	(*ConfigureProviderResponse)(nil),    // 3: gestalt.provider.v1.ConfigureProviderResponse
 	(*HealthCheckResponse)(nil),          // 4: gestalt.provider.v1.HealthCheckResponse
 	(*StartRuntimeProviderResponse)(nil), // 5: gestalt.provider.v1.StartRuntimeProviderResponse
-	(*structpb.Struct)(nil),              // 6: google.protobuf.Struct
-	(*emptypb.Empty)(nil),                // 7: google.protobuf.Empty
+	(*PromoteWorkersResponse)(nil),       // 6: gestalt.provider.v1.PromoteWorkersResponse
+	(*structpb.Struct)(nil),              // 7: google.protobuf.Struct
+	(*emptypb.Empty)(nil),                // 8: google.protobuf.Empty
 }
 var file_v1_runtime_proto_depIdxs = []int32{
 	0, // 0: gestalt.provider.v1.ProviderIdentity.kind:type_name -> gestalt.provider.v1.ProviderKind
-	6, // 1: gestalt.provider.v1.ConfigureProviderRequest.config:type_name -> google.protobuf.Struct
-	7, // 2: gestalt.provider.v1.ProviderLifecycle.GetProviderIdentity:input_type -> google.protobuf.Empty
+	7, // 1: gestalt.provider.v1.ConfigureProviderRequest.config:type_name -> google.protobuf.Struct
+	8, // 2: gestalt.provider.v1.ProviderLifecycle.GetProviderIdentity:input_type -> google.protobuf.Empty
 	2, // 3: gestalt.provider.v1.ProviderLifecycle.ConfigureProvider:input_type -> gestalt.provider.v1.ConfigureProviderRequest
-	7, // 4: gestalt.provider.v1.ProviderLifecycle.HealthCheck:input_type -> google.protobuf.Empty
-	7, // 5: gestalt.provider.v1.ProviderLifecycle.StartProvider:input_type -> google.protobuf.Empty
-	1, // 6: gestalt.provider.v1.ProviderLifecycle.GetProviderIdentity:output_type -> gestalt.provider.v1.ProviderIdentity
-	3, // 7: gestalt.provider.v1.ProviderLifecycle.ConfigureProvider:output_type -> gestalt.provider.v1.ConfigureProviderResponse
-	4, // 8: gestalt.provider.v1.ProviderLifecycle.HealthCheck:output_type -> gestalt.provider.v1.HealthCheckResponse
-	5, // 9: gestalt.provider.v1.ProviderLifecycle.StartProvider:output_type -> gestalt.provider.v1.StartRuntimeProviderResponse
-	6, // [6:10] is the sub-list for method output_type
-	2, // [2:6] is the sub-list for method input_type
+	8, // 4: gestalt.provider.v1.ProviderLifecycle.HealthCheck:input_type -> google.protobuf.Empty
+	8, // 5: gestalt.provider.v1.ProviderLifecycle.StartProvider:input_type -> google.protobuf.Empty
+	8, // 6: gestalt.provider.v1.ProviderLifecycle.PromoteWorkers:input_type -> google.protobuf.Empty
+	1, // 7: gestalt.provider.v1.ProviderLifecycle.GetProviderIdentity:output_type -> gestalt.provider.v1.ProviderIdentity
+	3, // 8: gestalt.provider.v1.ProviderLifecycle.ConfigureProvider:output_type -> gestalt.provider.v1.ConfigureProviderResponse
+	4, // 9: gestalt.provider.v1.ProviderLifecycle.HealthCheck:output_type -> gestalt.provider.v1.HealthCheckResponse
+	5, // 10: gestalt.provider.v1.ProviderLifecycle.StartProvider:output_type -> gestalt.provider.v1.StartRuntimeProviderResponse
+	6, // 11: gestalt.provider.v1.ProviderLifecycle.PromoteWorkers:output_type -> gestalt.provider.v1.PromoteWorkersResponse
+	7, // [7:12] is the sub-list for method output_type
+	2, // [2:7] is the sub-list for method input_type
 	2, // [2:2] is the sub-list for extension type_name
 	2, // [2:2] is the sub-list for extension extendee
 	0, // [0:2] is the sub-list for field type_name
@@ -517,7 +569,7 @@ func file_v1_runtime_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_v1_runtime_proto_rawDesc), len(file_v1_runtime_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   5,
+			NumMessages:   6,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gestaltd/rpc/protov1/v1/runtime_grpc.pb.go
+++ b/gestaltd/rpc/protov1/v1/runtime_grpc.pb.go
@@ -24,6 +24,7 @@ const (
 	ProviderLifecycle_ConfigureProvider_FullMethodName   = "/gestalt.provider.v1.ProviderLifecycle/ConfigureProvider"
 	ProviderLifecycle_HealthCheck_FullMethodName         = "/gestalt.provider.v1.ProviderLifecycle/HealthCheck"
 	ProviderLifecycle_StartProvider_FullMethodName       = "/gestalt.provider.v1.ProviderLifecycle/StartProvider"
+	ProviderLifecycle_PromoteWorkers_FullMethodName      = "/gestalt.provider.v1.ProviderLifecycle/PromoteWorkers"
 )
 
 // ProviderLifecycleClient is the client API for ProviderLifecycle service.
@@ -37,6 +38,7 @@ type ProviderLifecycleClient interface {
 	ConfigureProvider(ctx context.Context, in *ConfigureProviderRequest, opts ...grpc.CallOption) (*ConfigureProviderResponse, error)
 	HealthCheck(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*HealthCheckResponse, error)
 	StartProvider(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*StartRuntimeProviderResponse, error)
+	PromoteWorkers(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*PromoteWorkersResponse, error)
 }
 
 type providerLifecycleClient struct {
@@ -87,6 +89,16 @@ func (c *providerLifecycleClient) StartProvider(ctx context.Context, in *emptypb
 	return out, nil
 }
 
+func (c *providerLifecycleClient) PromoteWorkers(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*PromoteWorkersResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(PromoteWorkersResponse)
+	err := c.cc.Invoke(ctx, ProviderLifecycle_PromoteWorkers_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // ProviderLifecycleServer is the server API for ProviderLifecycle service.
 // All implementations must embed UnimplementedProviderLifecycleServer
 // for forward compatibility.
@@ -98,6 +110,7 @@ type ProviderLifecycleServer interface {
 	ConfigureProvider(context.Context, *ConfigureProviderRequest) (*ConfigureProviderResponse, error)
 	HealthCheck(context.Context, *emptypb.Empty) (*HealthCheckResponse, error)
 	StartProvider(context.Context, *emptypb.Empty) (*StartRuntimeProviderResponse, error)
+	PromoteWorkers(context.Context, *emptypb.Empty) (*PromoteWorkersResponse, error)
 	mustEmbedUnimplementedProviderLifecycleServer()
 }
 
@@ -119,6 +132,9 @@ func (UnimplementedProviderLifecycleServer) HealthCheck(context.Context, *emptyp
 }
 func (UnimplementedProviderLifecycleServer) StartProvider(context.Context, *emptypb.Empty) (*StartRuntimeProviderResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method StartProvider not implemented")
+}
+func (UnimplementedProviderLifecycleServer) PromoteWorkers(context.Context, *emptypb.Empty) (*PromoteWorkersResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method PromoteWorkers not implemented")
 }
 func (UnimplementedProviderLifecycleServer) mustEmbedUnimplementedProviderLifecycleServer() {}
 func (UnimplementedProviderLifecycleServer) testEmbeddedByValue()                           {}
@@ -213,6 +229,24 @@ func _ProviderLifecycle_StartProvider_Handler(srv interface{}, ctx context.Conte
 	return interceptor(ctx, in, info, handler)
 }
 
+func _ProviderLifecycle_PromoteWorkers_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(emptypb.Empty)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ProviderLifecycleServer).PromoteWorkers(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ProviderLifecycle_PromoteWorkers_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ProviderLifecycleServer).PromoteWorkers(ctx, req.(*emptypb.Empty))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // ProviderLifecycle_ServiceDesc is the grpc.ServiceDesc for ProviderLifecycle service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -235,6 +269,10 @@ var ProviderLifecycle_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "StartProvider",
 			Handler:    _ProviderLifecycle_StartProvider_Handler,
+		},
+		{
+			MethodName: "PromoteWorkers",
+			Handler:    _ProviderLifecycle_PromoteWorkers_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/gestaltd/services/agents/provider_lifecycle_fake_test.go
+++ b/gestaltd/services/agents/provider_lifecycle_fake_test.go
@@ -26,3 +26,7 @@ func (*fakeProviderLifecycleClient) HealthCheck(context.Context, *emptypb.Empty,
 func (*fakeProviderLifecycleClient) StartProvider(context.Context, *emptypb.Empty, ...grpc.CallOption) (*proto.StartRuntimeProviderResponse, error) {
 	return nil, errors.New("unexpected StartProvider call")
 }
+
+func (*fakeProviderLifecycleClient) PromoteWorkers(context.Context, *emptypb.Empty, ...grpc.CallOption) (*proto.PromoteWorkersResponse, error) {
+	return nil, errors.New("unexpected PromoteWorkers call")
+}

--- a/gestaltd/services/runtimehost/runtime_client.go
+++ b/gestaltd/services/runtimehost/runtime_client.go
@@ -143,9 +143,6 @@ func PromoteRuntimeWorkers(ctx context.Context, client proto.ProviderLifecycleCl
 	defer cancel()
 	resp, err := client.PromoteWorkers(promoteCtx, &emptypb.Empty{})
 	if err != nil {
-		if status.Code(err) == codes.Canceled || status.Code(err) == codes.DeadlineExceeded {
-			return fmt.Errorf("promote workers: %w", err)
-		}
 		return fmt.Errorf("promote workers: %w", err)
 	}
 	if resp == nil {

--- a/gestaltd/services/runtimehost/runtime_client.go
+++ b/gestaltd/services/runtimehost/runtime_client.go
@@ -135,6 +135,28 @@ func StartRuntimeProvider(ctx context.Context, client proto.ProviderLifecycleCli
 	return nil
 }
 
+func PromoteRuntimeWorkers(ctx context.Context, client proto.ProviderLifecycleClient) error {
+	if client == nil {
+		return fmt.Errorf("runtime client is required")
+	}
+	promoteCtx, cancel := providerPromotionContext(ctx)
+	defer cancel()
+	resp, err := client.PromoteWorkers(promoteCtx, &emptypb.Empty{})
+	if err != nil {
+		if status.Code(err) == codes.Canceled || status.Code(err) == codes.DeadlineExceeded {
+			return fmt.Errorf("promote workers: %w", err)
+		}
+		return fmt.Errorf("promote workers: %w", err)
+	}
+	if resp == nil {
+		return fmt.Errorf("provider promote workers returned nil response")
+	}
+	if resp.GetProtocolVersion() != proto.CurrentProtocolVersion {
+		return fmt.Errorf("provider responded with protocol version %d, host requires %d", resp.GetProtocolVersion(), proto.CurrentProtocolVersion)
+	}
+	return nil
+}
+
 func validateRuntimeProtocol(meta *proto.ProviderIdentity) error {
 	if meta == nil {
 		return fmt.Errorf("provider identity is required")
@@ -173,6 +195,16 @@ func ProviderSessionCreateContext(parent context.Context) (context.Context, cont
 func providerStartContext(parent context.Context) (context.Context, context.CancelFunc) {
 	if parent == nil {
 		parent = context.Background()
+	}
+	return context.WithTimeout(parent, providerStartTimeout)
+}
+
+func providerPromotionContext(parent context.Context) (context.Context, context.CancelFunc) {
+	if parent == nil {
+		parent = context.Background()
+	}
+	if _, ok := parent.Deadline(); ok {
+		return context.WithCancel(parent)
 	}
 	return context.WithTimeout(parent, providerStartTimeout)
 }

--- a/gestaltd/services/runtimehost/runtime_client_test.go
+++ b/gestaltd/services/runtimehost/runtime_client_test.go
@@ -17,6 +17,7 @@ type fakeProviderLifecycleClient struct {
 	configureProvider   func(context.Context, *proto.ConfigureProviderRequest, ...grpc.CallOption) (*proto.ConfigureProviderResponse, error)
 	healthCheck         func(context.Context, *emptypb.Empty, ...grpc.CallOption) (*proto.HealthCheckResponse, error)
 	startProvider       func(context.Context, *emptypb.Empty, ...grpc.CallOption) (*proto.StartRuntimeProviderResponse, error)
+	promoteWorkers      func(context.Context, *emptypb.Empty, ...grpc.CallOption) (*proto.PromoteWorkersResponse, error)
 }
 
 func (c *fakeProviderLifecycleClient) GetProviderIdentity(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*proto.ProviderIdentity, error) {
@@ -39,6 +40,13 @@ func (c *fakeProviderLifecycleClient) StartProvider(ctx context.Context, in *emp
 		return c.startProvider(ctx, in, opts...)
 	}
 	return &proto.StartRuntimeProviderResponse{ProtocolVersion: proto.CurrentProtocolVersion}, nil
+}
+
+func (c *fakeProviderLifecycleClient) PromoteWorkers(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*proto.PromoteWorkersResponse, error) {
+	if c.promoteWorkers != nil {
+		return c.promoteWorkers(ctx, in, opts...)
+	}
+	return nil, status.Error(codes.Unimplemented, "promote workers not implemented")
 }
 
 func TestConfigureRuntimeProviderRefreshesMetadataAfterConfigure(t *testing.T) {
@@ -257,5 +265,67 @@ func TestStartRuntimeProviderValidatesProtocolVersion(t *testing.T) {
 	}
 	if err := StartRuntimeProvider(context.Background(), client); err == nil {
 		t.Fatal("StartRuntimeProvider should reject protocol mismatch")
+	}
+}
+
+func TestPromoteRuntimeWorkersPropagatesProviderError(t *testing.T) {
+	t.Parallel()
+
+	client := &fakeProviderLifecycleClient{
+		promoteWorkers: func(context.Context, *emptypb.Empty, ...grpc.CallOption) (*proto.PromoteWorkersResponse, error) {
+			return nil, status.Error(codes.Unknown, "set worker deployment current version: boom")
+		},
+	}
+	if err := PromoteRuntimeWorkers(context.Background(), client); err == nil {
+		t.Fatal("PromoteRuntimeWorkers should fail on provider error")
+	}
+}
+
+func TestPromoteRuntimeWorkersFailsWhenUnimplemented(t *testing.T) {
+	t.Parallel()
+
+	if err := PromoteRuntimeWorkers(context.Background(), &fakeProviderLifecycleClient{}); err == nil {
+		t.Fatal("PromoteRuntimeWorkers should fail when RPC is unimplemented")
+	}
+}
+
+func TestPromoteRuntimeWorkersHonorsCancellation(t *testing.T) {
+	t.Parallel()
+
+	client := &fakeProviderLifecycleClient{
+		promoteWorkers: func(ctx context.Context, _ *emptypb.Empty, _ ...grpc.CallOption) (*proto.PromoteWorkersResponse, error) {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := PromoteRuntimeWorkers(ctx, client); err == nil {
+		t.Fatal("PromoteRuntimeWorkers should fail when context is canceled")
+	}
+}
+
+func TestPromoteRuntimeWorkersUsesPromotionTimeout(t *testing.T) {
+	t.Parallel()
+
+	var remaining time.Duration
+	client := &fakeProviderLifecycleClient{
+		promoteWorkers: func(ctx context.Context, _ *emptypb.Empty, _ ...grpc.CallOption) (*proto.PromoteWorkersResponse, error) {
+			deadline, ok := ctx.Deadline()
+			if !ok {
+				t.Fatal("PromoteWorkers context has no deadline")
+			}
+			remaining = time.Until(deadline)
+			return &proto.PromoteWorkersResponse{ProtocolVersion: proto.CurrentProtocolVersion}, nil
+		},
+	}
+	if err := PromoteRuntimeWorkers(context.Background(), client); err != nil {
+		t.Fatalf("PromoteRuntimeWorkers: %v", err)
+	}
+	if remaining <= ProviderRPCTimeout {
+		t.Fatalf("PromoteWorkers remaining deadline = %s, want above request timeout %s", remaining, ProviderRPCTimeout)
+	}
+	if remaining > providerStartTimeout {
+		t.Fatalf("PromoteWorkers remaining deadline = %s, want at most promotion timeout %s", remaining, providerStartTimeout)
 	}
 }

--- a/gestaltd/services/workflows/client.go
+++ b/gestaltd/services/workflows/client.go
@@ -335,6 +335,13 @@ func (r *remoteWorkflow) Start(ctx context.Context) error {
 	return runtimehost.StartRuntimeProvider(ctx, r.runtime)
 }
 
+func (r *remoteWorkflow) PromoteWorkers(ctx context.Context) error {
+	if r.runtime == nil {
+		return fmt.Errorf("workflow provider runtime lifecycle is not configured")
+	}
+	return runtimehost.PromoteRuntimeWorkers(ctx, r.runtime)
+}
+
 func (r *remoteWorkflow) Close() error {
 	if r == nil || r.closer == nil {
 		return nil

--- a/gestaltd/services/workflows/promote_test.go
+++ b/gestaltd/services/workflows/promote_test.go
@@ -2,11 +2,9 @@ package workflows
 
 import (
 	"context"
-	"errors"
 	"strings"
 	"testing"
 
-	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
 	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -80,41 +78,6 @@ func TestRemoteWorkflowPromoteWorkersPropagatesProviderError(t *testing.T) {
 	if !strings.Contains(err.Error(), "set worker deployment current version: boom") {
 		t.Fatalf("PromoteWorkers error = %v", err)
 	}
-}
-
-func TestRemoteWorkflowPromoteWorkersThroughCleanupWrapper(t *testing.T) {
-	t.Parallel()
-
-	calls := 0
-	provider := &remoteWorkflow{
-		name: "local",
-		runtime: &recordingLifecycleClient{
-			promoteWorkers: func(context.Context, *emptypb.Empty, ...grpc.CallOption) (*proto.PromoteWorkersResponse, error) {
-				calls++
-				return &proto.PromoteWorkersResponse{ProtocolVersion: proto.CurrentProtocolVersion}, nil
-			},
-		},
-	}
-	wrapped := &promotionCleanupWrapper{Provider: provider}
-	if err := wrapped.PromoteWorkers(context.Background()); err != nil {
-		t.Fatalf("PromoteWorkers: %v", err)
-	}
-	if calls != 1 {
-		t.Fatalf("subprocess PromoteWorkers RPC calls = %d, want 1", calls)
-	}
-}
-
-type promotionCleanupWrapper struct {
-	coreworkflow.Provider
-}
-
-func (p *promotionCleanupWrapper) PromoteWorkers(ctx context.Context) error {
-	if promotable, ok := p.Provider.(interface {
-		PromoteWorkers(context.Context) error
-	}); ok {
-		return promotable.PromoteWorkers(ctx)
-	}
-	return errors.New("workflow provider does not support explicit worker promotion")
 }
 
 func TestRemoteWorkflowPromoteWorkersHonorsCancellation(t *testing.T) {

--- a/gestaltd/services/workflows/promote_test.go
+++ b/gestaltd/services/workflows/promote_test.go
@@ -1,0 +1,137 @@
+package workflows
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
+	proto "github.com/valon-technologies/gestalt/server/rpc/protov1/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+type recordingLifecycleClient struct {
+	promoteWorkers func(context.Context, *emptypb.Empty, ...grpc.CallOption) (*proto.PromoteWorkersResponse, error)
+}
+
+func (c *recordingLifecycleClient) GetProviderIdentity(context.Context, *emptypb.Empty, ...grpc.CallOption) (*proto.ProviderIdentity, error) {
+	return nil, status.Error(codes.Unimplemented, "not used")
+}
+
+func (c *recordingLifecycleClient) ConfigureProvider(context.Context, *proto.ConfigureProviderRequest, ...grpc.CallOption) (*proto.ConfigureProviderResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not used")
+}
+
+func (c *recordingLifecycleClient) HealthCheck(context.Context, *emptypb.Empty, ...grpc.CallOption) (*proto.HealthCheckResponse, error) {
+	return &proto.HealthCheckResponse{Ready: true}, nil
+}
+
+func (c *recordingLifecycleClient) StartProvider(context.Context, *emptypb.Empty, ...grpc.CallOption) (*proto.StartRuntimeProviderResponse, error) {
+	return &proto.StartRuntimeProviderResponse{ProtocolVersion: proto.CurrentProtocolVersion}, nil
+}
+
+func (c *recordingLifecycleClient) PromoteWorkers(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*proto.PromoteWorkersResponse, error) {
+	if c.promoteWorkers != nil {
+		return c.promoteWorkers(ctx, in, opts...)
+	}
+	return &proto.PromoteWorkersResponse{ProtocolVersion: proto.CurrentProtocolVersion}, nil
+}
+
+func TestRemoteWorkflowPromoteWorkersInvokesLifecycleRPC(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	provider := &remoteWorkflow{
+		name:    "local",
+		runtime: &recordingLifecycleClient{
+			promoteWorkers: func(context.Context, *emptypb.Empty, ...grpc.CallOption) (*proto.PromoteWorkersResponse, error) {
+				calls++
+				return &proto.PromoteWorkersResponse{ProtocolVersion: proto.CurrentProtocolVersion}, nil
+			},
+		},
+	}
+	if err := provider.PromoteWorkers(context.Background()); err != nil {
+		t.Fatalf("PromoteWorkers: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("PromoteWorkers RPC calls = %d, want 1", calls)
+	}
+}
+
+func TestRemoteWorkflowPromoteWorkersPropagatesProviderError(t *testing.T) {
+	t.Parallel()
+
+	provider := &remoteWorkflow{
+		name: "local",
+		runtime: &recordingLifecycleClient{
+			promoteWorkers: func(context.Context, *emptypb.Empty, ...grpc.CallOption) (*proto.PromoteWorkersResponse, error) {
+				return nil, status.Error(codes.Unknown, "set worker deployment current version: boom")
+			},
+		},
+	}
+	err := provider.PromoteWorkers(context.Background())
+	if err == nil {
+		t.Fatal("expected provider error")
+	}
+	if !strings.Contains(err.Error(), "set worker deployment current version: boom") {
+		t.Fatalf("PromoteWorkers error = %v", err)
+	}
+}
+
+func TestRemoteWorkflowPromoteWorkersThroughCleanupWrapper(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	provider := &remoteWorkflow{
+		name: "local",
+		runtime: &recordingLifecycleClient{
+			promoteWorkers: func(context.Context, *emptypb.Empty, ...grpc.CallOption) (*proto.PromoteWorkersResponse, error) {
+				calls++
+				return &proto.PromoteWorkersResponse{ProtocolVersion: proto.CurrentProtocolVersion}, nil
+			},
+		},
+	}
+	wrapped := &promotionCleanupWrapper{Provider: provider}
+	if err := wrapped.PromoteWorkers(context.Background()); err != nil {
+		t.Fatalf("PromoteWorkers: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("subprocess PromoteWorkers RPC calls = %d, want 1", calls)
+	}
+}
+
+type promotionCleanupWrapper struct {
+	coreworkflow.Provider
+}
+
+func (p *promotionCleanupWrapper) PromoteWorkers(ctx context.Context) error {
+	if promotable, ok := p.Provider.(interface {
+		PromoteWorkers(context.Context) error
+	}); ok {
+		return promotable.PromoteWorkers(ctx)
+	}
+	return errors.New("workflow provider does not support explicit worker promotion")
+}
+
+func TestRemoteWorkflowPromoteWorkersHonorsCancellation(t *testing.T) {
+	t.Parallel()
+
+	provider := &remoteWorkflow{
+		name: "local",
+		runtime: &recordingLifecycleClient{
+			promoteWorkers: func(ctx context.Context, _ *emptypb.Empty, _ ...grpc.CallOption) (*proto.PromoteWorkersResponse, error) {
+				<-ctx.Done()
+				return nil, ctx.Err()
+			},
+		},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := provider.PromoteWorkers(ctx); err == nil {
+		t.Fatal("expected cancellation error")
+	}
+}

--- a/sdk/go/client/runtime.go
+++ b/sdk/go/client/runtime.go
@@ -94,6 +94,14 @@ type StartRuntimeProviderResponse struct {
 	ProtocolVersion int32
 }
 
+// PromoteWorkersResponse is the native message type for gestalt.provider.v1.PromoteWorkersResponse.
+//
+// PromoteWorkersResponse confirms the protocol version the provider is serving
+// after explicit worker promotion completes.
+type PromoteWorkersResponse struct {
+	ProtocolVersion int32
+}
+
 // ProviderLifecycle is the generated client for gestalt.provider.v1.ProviderLifecycle.
 // Every transport error is converted to *GestaltError.
 //
@@ -163,4 +171,23 @@ func (c *ProviderLifecycle) StartProviderRaw(ctx context.Context) (*StartRuntime
 		return nil, toGestaltError(err)
 	}
 	return FromWireStartRuntimeProviderResponse(response), nil
+}
+
+// PromoteWorkers is the ergonomic form of [ProviderLifecycle.PromoteWorkersRaw].
+// The response collapses to its protocolVersion field.
+func (c *ProviderLifecycle) PromoteWorkers(ctx context.Context) (int32, error) {
+	response, err := c.client.PromoteWorkers(ctx, &emptypb.Empty{})
+	if err != nil {
+		return 0, toGestaltError(err)
+	}
+	return FromWirePromoteWorkersResponse(response).ProtocolVersion, nil
+}
+
+// PromoteWorkersRaw is the faithful form of [ProviderLifecycle.PromoteWorkers].
+func (c *ProviderLifecycle) PromoteWorkersRaw(ctx context.Context) (*PromoteWorkersResponse, error) {
+	response, err := c.client.PromoteWorkers(ctx, &emptypb.Empty{})
+	if err != nil {
+		return nil, toGestaltError(err)
+	}
+	return FromWirePromoteWorkersResponse(response), nil
 }

--- a/sdk/go/client/runtime_codec.go
+++ b/sdk/go/client/runtime_codec.go
@@ -125,3 +125,23 @@ func FromWireStartRuntimeProviderResponse(value *proto.StartRuntimeProviderRespo
 	}
 	return out
 }
+
+func ToWirePromoteWorkersResponse(value *PromoteWorkersResponse) *proto.PromoteWorkersResponse {
+	if value == nil {
+		return nil
+	}
+	out := &proto.PromoteWorkersResponse{
+		ProtocolVersion: value.ProtocolVersion,
+	}
+	return out
+}
+
+func FromWirePromoteWorkersResponse(value *proto.PromoteWorkersResponse) *PromoteWorkersResponse {
+	if value == nil {
+		return nil
+	}
+	out := &PromoteWorkersResponse{
+		ProtocolVersion: value.ProtocolVersion,
+	}
+	return out
+}

--- a/sdk/go/runtime_server.go
+++ b/sdk/go/runtime_server.go
@@ -93,9 +93,6 @@ func (s *runtimeServer) PromoteWorkers(ctx context.Context, _ *emptypb.Empty) (*
 		return nil, status.Error(codes.Unimplemented, "provider does not support explicit worker promotion")
 	}
 	if err := promoter.PromoteWorkers(ctx); err != nil {
-		if ctx.Err() != nil {
-			return nil, status.Errorf(codes.Canceled, "promote workers: %v", err)
-		}
 		return nil, status.Errorf(codes.Unknown, "promote workers: %v", err)
 	}
 	return &proto.PromoteWorkersResponse{ProtocolVersion: proto.CurrentProtocolVersion}, nil

--- a/sdk/go/runtime_server.go
+++ b/sdk/go/runtime_server.go
@@ -87,6 +87,20 @@ func (s *runtimeServer) StartProvider(ctx context.Context, _ *emptypb.Empty) (*p
 	return &proto.StartRuntimeProviderResponse{ProtocolVersion: proto.CurrentProtocolVersion}, nil
 }
 
+func (s *runtimeServer) PromoteWorkers(ctx context.Context, _ *emptypb.Empty) (*proto.PromoteWorkersResponse, error) {
+	promoter, ok := s.provider.(WorkerPromoter)
+	if !ok {
+		return nil, status.Error(codes.Unimplemented, "provider does not support explicit worker promotion")
+	}
+	if err := promoter.PromoteWorkers(ctx); err != nil {
+		if ctx.Err() != nil {
+			return nil, status.Errorf(codes.Canceled, "promote workers: %v", err)
+		}
+		return nil, status.Errorf(codes.Unknown, "promote workers: %v", err)
+	}
+	return &proto.PromoteWorkersResponse{ProtocolVersion: proto.CurrentProtocolVersion}, nil
+}
+
 func providerKindToProto(kind ProviderKind) proto.ProviderKind {
 	switch kind {
 	case ProviderKindApp:

--- a/sdk/go/types.go
+++ b/sdk/go/types.go
@@ -82,6 +82,12 @@ type Starter interface {
 	Start(ctx context.Context) error
 }
 
+// WorkerPromoter is implemented by workflow providers that can advance an
+// external worker deployment to the configured build during explicit promotion.
+type WorkerPromoter interface {
+	PromoteWorkers(ctx context.Context) error
+}
+
 // Closer is implemented by providers that need explicit shutdown handling.
 type Closer interface {
 	Close() error

--- a/sdk/go/workflow_provider_transport_test.go
+++ b/sdk/go/workflow_provider_transport_test.go
@@ -20,6 +20,8 @@ type fullWorkflowProvider struct {
 	definitionSubject   string
 	deliverEventSubject string
 	deliveredEvents     []string
+	promoteCalls        int
+	promoteErr          error
 }
 
 func (p *fullWorkflowProvider) Configure(_ context.Context, name string, _ map[string]any) error {
@@ -70,6 +72,11 @@ func (p *fullWorkflowProvider) DeliverEvent(ctx context.Context, req *gestalt.De
 		return &gestalt.WorkflowEvent{ID: "delivered-go", Type: req.Event.Type}, nil
 	}
 	return &gestalt.WorkflowEvent{ID: "delivered-go"}, nil
+}
+
+func (p *fullWorkflowProvider) PromoteWorkers(context.Context) error {
+	p.promoteCalls++
+	return p.promoteErr
 }
 
 func TestWorkflowProviderTypedTransportRoundTrip(t *testing.T) {
@@ -181,6 +188,44 @@ func TestWorkflowProviderTypedTransportRoundTrip(t *testing.T) {
 	}
 	if provider.deliverEventSubject != "user:transport" {
 		t.Fatalf("DeliverEvent subject = %q, want user:transport", provider.deliverEventSubject)
+	}
+
+	promoteResp, err := runtimeClient.PromoteWorkers(rpcCtx, &emptypb.Empty{}, grpc.WaitForReady(true))
+	if err != nil {
+		t.Fatalf("PromoteWorkers: %v", err)
+	}
+	if promoteResp.GetProtocolVersion() != proto.CurrentProtocolVersion {
+		t.Fatalf("PromoteWorkers protocol_version = %d, want %d", promoteResp.GetProtocolVersion(), proto.CurrentProtocolVersion)
+	}
+	if provider.promoteCalls != 1 {
+		t.Fatalf("promoteCalls = %d, want 1", provider.promoteCalls)
+	}
+}
+
+func TestWorkflowProviderPromoteWorkersReturnsUnimplementedWithoutWorkerPromoter(t *testing.T) {
+	socket := newSocketPath(t, "workflow-promote-unimplemented.sock")
+	t.Setenv(proto.EnvProviderSocket, socket)
+	t.Setenv(proto.EnvProviderName, "workflow-test")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	provider := &gestalt.UnimplementedWorkflowProvider{}
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- gestalt.ServeWorkflowProvider(ctx, provider)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		waitServeResult(t, errCh)
+	})
+
+	conn := newUnixConn(t, socket)
+	runtimeClient := proto.NewProviderLifecycleClient(conn)
+	rpcCtx, rpcCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer rpcCancel()
+
+	_, err := runtimeClient.PromoteWorkers(rpcCtx, &emptypb.Empty{}, grpc.WaitForReady(true))
+	if err == nil {
+		t.Fatal("expected PromoteWorkers to fail for provider without worker promotion support")
 	}
 }
 

--- a/sdk/proto/v1/runtime.proto
+++ b/sdk/proto/v1/runtime.proto
@@ -73,6 +73,14 @@ message StartRuntimeProviderResponse {
   int32 protocol_version = 1;
 }
 
+// PromoteWorkersResponse confirms the protocol version the provider is serving
+// after explicit worker promotion completes.
+message PromoteWorkersResponse {
+  option (unwrap) = "protocol_version";
+
+  int32 protocol_version = 1;
+}
+
 // ProviderLifecycle is the common lifecycle protocol shared by every provider
 // kind.
 service ProviderLifecycle {
@@ -84,4 +92,5 @@ service ProviderLifecycle {
   }
   rpc HealthCheck(google.protobuf.Empty) returns (HealthCheckResponse);
   rpc StartProvider(google.protobuf.Empty) returns (StartRuntimeProviderResponse);
+  rpc PromoteWorkers(google.protobuf.Empty) returns (PromoteWorkersResponse);
 }


### PR DESCRIPTION
## Summary
- Add `ProviderLifecycle.PromoteWorkers` RPC and `WorkerPromoter` SDK hook so subprocess workflow providers can advance Temporal worker deployments during explicit promotion.
- Forward promotion through `remoteWorkflow`, `workflowProviderWithCleanup`, and `workflowProviderWithRuntimeWorkers`; return HTTP 500 when no configured provider handles promotion instead of warning-and-200.
- Build on #3235 diagnostics with subprocess transport, wrapper, and fail-closed regression tests.

## Test plan
- [x] `go test ./internal/bootstrap/... -run 'Promote|WorkflowCleanup'`
- [x] `go test ./services/runtimehost/... -run Promote`
- [x] `go test ./services/workflows/... -run Promote`
- [x] `go test ./sdk/go -run 'WorkflowProvider.*Promote'`
- [x] `go build ./gestaltd/...`
- [ ] Rebuild candidate B with bumped `GESTALTD_PINNED_SHA` and replay controlled promotion with repair disabled


Made with [Cursor](https://cursor.com)