### PR TITLE
Plan 11: skip destructive cfg_* cleanup for isolated preparation

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -1641,8 +1641,11 @@ func BootstrapWithOptions(ctx context.Context, cfg *config.Config, factories *Fa
 		return merged
 	}
 
+	workflowConfigReconcileOpts := workflowConfigReconcileOptions{
+		allowDestructiveCleanup: !deferSharedStartupWrites,
+	}
 	reconcileWorkflowConfig := func(ctx context.Context, includeProvider workflowConfigProviderFilter) error {
-		return reconcileWorkflowConfigDefinitions(ctx, cfg, prepared.Deps.WorkflowRuntime, prepared.Deps.AppWorkflowDeclarations, includeProvider)
+		return reconcileWorkflowConfigDefinitions(ctx, cfg, prepared.Deps.WorkflowRuntime, prepared.Deps.AppWorkflowDeclarations, includeProvider, workflowConfigReconcileOpts)
 	}
 	var deferredWorkflowConfigReconcileTasks []workflowConfigReconcileTask
 	var startupWorkflowConfigReconcile func(context.Context) error

--- a/gestaltd/internal/bootstrap/workflow_app_definitions_test.go
+++ b/gestaltd/internal/bootstrap/workflow_app_definitions_test.go
@@ -205,6 +205,25 @@ func (p *principalCapturingProvider) DeleteDefinition(ctx context.Context, req *
 	return p.fakeWorkflowProvider.DeleteDefinition(ctx, req)
 }
 
+func TestReconcileWorkflowConfigDefinitions_SkipsDestructiveCleanupWhenDisabled(t *testing.T) {
+	t.Parallel()
+
+	cfg, runtime, provider, decls := testWorkflowReconcileEnv(t)
+	if err := reconcileWorkflowConfigDefinitions(context.Background(), cfg, runtime, decls, nil, workflowConfigReconcileOptions{allowDestructiveCleanup: true}); err != nil {
+		t.Fatalf("initial reconcile: %v", err)
+	}
+	delete(cfg.Workflows.Definitions, "backup")
+	if err := reconcileWorkflowConfigDefinitions(context.Background(), cfg, runtime, decls, nil, workflowConfigReconcileOptions{allowDestructiveCleanup: false}); err != nil {
+		t.Fatalf("non-destructive reconcile: %v", err)
+	}
+	if len(provider.deletedDefinitions) != 0 {
+		t.Fatalf("deleted definitions = %#v, want none when destructive cleanup disabled", provider.deletedDefinitions)
+	}
+	if provider.definitions["cfg_backup"] == nil {
+		t.Fatal("cfg_backup was deleted while destructive cleanup was disabled")
+	}
+}
+
 func TestReconcileWorkflowConfigDefinitions_AttachesBootstrapPrincipal(t *testing.T) {
 	t.Parallel()
 
@@ -212,7 +231,7 @@ func TestReconcileWorkflowConfigDefinitions_AttachesBootstrapPrincipal(t *testin
 	provider := &principalCapturingProvider{fakeWorkflowProvider: inner}
 	runtime.providers["temporal"] = provider
 
-	if err := reconcileWorkflowConfigDefinitions(context.Background(), cfg, runtime, decls, nil); err != nil {
+	if err := reconcileWorkflowConfigDefinitions(context.Background(), cfg, runtime, decls, nil, workflowConfigReconcileOptions{allowDestructiveCleanup: true}); err != nil {
 		t.Fatalf("reconcile: %v", err)
 	}
 
@@ -230,7 +249,7 @@ func TestReconcileWorkflowConfigDefinitions_AttachesBootstrapPrincipal(t *testin
 	// to trigger cleanup. App-managed definitions are protected from cleanup
 	// when their app stops reporting, so removing an app decl does not delete.
 	delete(cfg.Workflows.Definitions, "backup")
-	if err := reconcileWorkflowConfigDefinitions(context.Background(), cfg, runtime, decls, nil); err != nil {
+	if err := reconcileWorkflowConfigDefinitions(context.Background(), cfg, runtime, decls, nil, workflowConfigReconcileOptions{allowDestructiveCleanup: true}); err != nil {
 		t.Fatalf("reconcile cleanup: %v", err)
 	}
 	if !provider.deleteOK || provider.deleteSubject != workflowConfigOwnerSubjectID() {
@@ -245,7 +264,7 @@ func TestReconcileAppWorkflowDefinitions(t *testing.T) {
 	decls.Set("notes", []*proto.WorkflowDefinitionSpec{
 		testAppWorkflowSpecProto("daily-summary", "service_account:sa1", "0 2 * * *"),
 	})
-	if err := reconcileWorkflowConfigDefinitions(context.Background(), cfg, runtime, decls, nil); err != nil {
+	if err := reconcileWorkflowConfigDefinitions(context.Background(), cfg, runtime, decls, nil, workflowConfigReconcileOptions{allowDestructiveCleanup: true}); err != nil {
 		t.Fatalf("reconcile apply: %v", err)
 	}
 	if len(provider.appliedDefinitions) != 2 {
@@ -268,7 +287,7 @@ func TestReconcileAppWorkflowDefinitions(t *testing.T) {
 	decls.Set("notes", []*proto.WorkflowDefinitionSpec{
 		testAppWorkflowSpecProto("daily-summary", "service_account:sa1", "0 3 * * *"),
 	})
-	if err := reconcileWorkflowConfigDefinitions(context.Background(), cfg, runtime, decls, nil); err != nil {
+	if err := reconcileWorkflowConfigDefinitions(context.Background(), cfg, runtime, decls, nil, workflowConfigReconcileOptions{allowDestructiveCleanup: true}); err != nil {
 		t.Fatalf("reconcile edit: %v", err)
 	}
 	if len(provider.appliedDefinitions) < 3 {
@@ -276,7 +295,7 @@ func TestReconcileAppWorkflowDefinitions(t *testing.T) {
 	}
 
 	decls.Set("notes", nil)
-	if err := reconcileWorkflowConfigDefinitions(context.Background(), cfg, runtime, decls, nil); err != nil {
+	if err := reconcileWorkflowConfigDefinitions(context.Background(), cfg, runtime, decls, nil, workflowConfigReconcileOptions{allowDestructiveCleanup: true}); err != nil {
 		t.Fatalf("reconcile remove: %v", err)
 	}
 	if len(provider.deletedDefinitions) != 1 || provider.deletedDefinitions[0].GetDefinitionId() != "app_notes_daily-summary" {
@@ -291,7 +310,7 @@ func TestReconcileAppWorkflowDefinitions(t *testing.T) {
 		"app_notes_old": {ID: "app_notes_old"},
 	}
 	decls = newAppWorkflowDeclarations()
-	if err := reconcileWorkflowConfigDefinitions(context.Background(), cfg, runtime, decls, nil); err != nil {
+	if err := reconcileWorkflowConfigDefinitions(context.Background(), cfg, runtime, decls, nil, workflowConfigReconcileOptions{allowDestructiveCleanup: true}); err != nil {
 		t.Fatalf("reconcile unreported app: %v", err)
 	}
 	if len(provider.deletedDefinitions) != 1 {
@@ -299,7 +318,7 @@ func TestReconcileAppWorkflowDefinitions(t *testing.T) {
 	}
 
 	delete(cfg.Apps, "notes")
-	if err := reconcileWorkflowConfigDefinitions(context.Background(), cfg, runtime, decls, nil); err != nil {
+	if err := reconcileWorkflowConfigDefinitions(context.Background(), cfg, runtime, decls, nil, workflowConfigReconcileOptions{allowDestructiveCleanup: true}); err != nil {
 		t.Fatalf("reconcile removed app: %v", err)
 	}
 	if len(provider.deletedDefinitions) != 2 || provider.deletedDefinitions[1].GetDefinitionId() != "app_notes_old" {
@@ -309,7 +328,7 @@ func TestReconcileAppWorkflowDefinitions(t *testing.T) {
 	decls.Set("notes", []*proto.WorkflowDefinitionSpec{
 		testAppWorkflowSpecProto("daily", "", "0 2 * * *"),
 	})
-	if err := reconcileWorkflowConfigDefinitions(context.Background(), cfg, runtime, decls, nil); err == nil {
+	if err := reconcileWorkflowConfigDefinitions(context.Background(), cfg, runtime, decls, nil, workflowConfigReconcileOptions{allowDestructiveCleanup: true}); err == nil {
 		t.Fatal("expected validation error for missing run_as")
 	}
 
@@ -329,7 +348,7 @@ func TestReconcileAppWorkflowDefinitions(t *testing.T) {
 			invalidDecls.Set("notes", []*proto.WorkflowDefinitionSpec{
 				testAppWorkflowSpecProto(tc.localID, "service_account:sa1", "0 2 * * *"),
 			})
-			err := reconcileWorkflowConfigDefinitions(context.Background(), cfg, runtime, invalidDecls, nil)
+			err := reconcileWorkflowConfigDefinitions(context.Background(), cfg, runtime, invalidDecls, nil, workflowConfigReconcileOptions{allowDestructiveCleanup: true})
 			if err == nil || !strings.Contains(err.Error(), tc.want) {
 				t.Fatalf("localID=%q err = %v, want substring %q", tc.localID, err, tc.want)
 			}
@@ -343,7 +362,7 @@ func TestReconcileAppWorkflowDefinitions(t *testing.T) {
 	decls.Set("a_b", []*proto.WorkflowDefinitionSpec{
 		testAppWorkflowSpecProto("c", "service_account:sa1", "0 2 * * *"),
 	})
-	if err := reconcileWorkflowConfigDefinitions(context.Background(), cfg, runtime, decls, nil); err == nil || !strings.Contains(err.Error(), "app_a_b_c") {
+	if err := reconcileWorkflowConfigDefinitions(context.Background(), cfg, runtime, decls, nil, workflowConfigReconcileOptions{allowDestructiveCleanup: true}); err == nil || !strings.Contains(err.Error(), "app_a_b_c") {
 		t.Fatalf("duplicate id error = %v", err)
 	}
 }

--- a/gestaltd/internal/bootstrap/workflow_config_definitions.go
+++ b/gestaltd/internal/bootstrap/workflow_config_definitions.go
@@ -31,12 +31,20 @@ type desiredWorkflowConfigDefinition struct {
 
 type workflowConfigProviderFilter func(providerName string) bool
 
-func reconcileWorkflowConfigDefinitions(ctx context.Context, cfg *config.Config, runtime *workflowRuntime, appDecls *appWorkflowDeclarations, includeProvider workflowConfigProviderFilter) error {
+type workflowConfigReconcileOptions struct {
+	// When false, apply desired config-managed definitions but skip deleting
+	// cfg_* definitions missing from the local desired set. Isolated preparation
+	// (promoteSharedStateOnActivate: false) uses this so overlapping revisions
+	// cannot prune another release's shared workflow catalog entries.
+	allowDestructiveCleanup bool
+}
+
+func reconcileWorkflowConfigDefinitions(ctx context.Context, cfg *config.Config, runtime *workflowRuntime, appDecls *appWorkflowDeclarations, includeProvider workflowConfigProviderFilter, opts workflowConfigReconcileOptions) error {
 	var reported map[string][]*proto.WorkflowDefinitionSpec
 	if appDecls != nil {
 		reported = appDecls.Snapshot()
 	}
-	return reconcileWorkflowConfigDefinitionsFromDeclarations(ctx, cfg, runtime, reported, includeProvider, "")
+	return reconcileWorkflowConfigDefinitionsFromDeclarations(ctx, cfg, runtime, reported, includeProvider, "", opts)
 }
 
 func reconcileAppWorkflowDefinitions(ctx context.Context, cfg *config.Config, runtime *workflowRuntime, appDecls *appWorkflowDeclarations, app string) error {
@@ -59,10 +67,11 @@ func reconcileAppWorkflowDefinitions(ctx context.Context, cfg *config.Config, ru
 		reported,
 		workflowConfigOnlyProvider(defaultProvider),
 		app,
+		workflowConfigReconcileOptions{allowDestructiveCleanup: true},
 	)
 }
 
-func reconcileWorkflowConfigDefinitionsFromDeclarations(ctx context.Context, cfg *config.Config, runtime *workflowRuntime, reported map[string][]*proto.WorkflowDefinitionSpec, includeProvider workflowConfigProviderFilter, app string) error {
+func reconcileWorkflowConfigDefinitionsFromDeclarations(ctx context.Context, cfg *config.Config, runtime *workflowRuntime, reported map[string][]*proto.WorkflowDefinitionSpec, includeProvider workflowConfigProviderFilter, app string, opts workflowConfigReconcileOptions) error {
 	if cfg == nil || runtime == nil {
 		return nil
 	}
@@ -131,8 +140,10 @@ func reconcileWorkflowConfigDefinitionsFromDeclarations(ctx context.Context, cfg
 		}
 	}
 
-	if err := cleanupRemovedWorkflowConfigDefinitions(ctx, cfg, runtime, reported, desired, includeProvider, app); err != nil {
-		return err
+	if opts.allowDestructiveCleanup {
+		if err := cleanupRemovedWorkflowConfigDefinitions(ctx, cfg, runtime, reported, desired, includeProvider, app); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/gestaltd/internal/bootstrap/workflow_config_isolated_cleanup_test.go
+++ b/gestaltd/internal/bootstrap/workflow_config_isolated_cleanup_test.go
@@ -1,0 +1,120 @@
+package bootstrap
+
+import (
+	"context"
+	"testing"
+
+	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+)
+
+func seedOverlayOnlyPlan11Definition(provider *fakeWorkflowProvider) {
+	provider.definitions = map[string]*coreworkflow.Definition{
+		"cfg_plan11_temporal_controlled_probe": {
+			ID:           "cfg_plan11_temporal_controlled_probe",
+			Generation:   1,
+			CreatedBy:    workflowConfigOwnerSubjectID(),
+			ProviderName: "temporal",
+		},
+	}
+}
+
+func TestIsolatedPreparationPreservesOverlayOnlyDefinition(t *testing.T) {
+	t.Parallel()
+
+	cfg, runtime, provider, decls := testWorkflowReconcileEnv(t)
+	seedOverlayOnlyPlan11Definition(provider)
+
+	// HTTP A / isolated-prep image: local desired set lacks overlay-only probe key.
+	if err := reconcileWorkflowConfigDefinitions(
+		context.Background(),
+		cfg,
+		runtime,
+		decls,
+		nil,
+		workflowConfigReconcileOptions{allowDestructiveCleanup: false},
+	); err != nil {
+		t.Fatalf("isolated reconcile: %v", err)
+	}
+	if len(provider.deletedDefinitions) != 0 {
+		t.Fatalf("deleted = %#v, want none under isolated preparation", provider.deletedDefinitions)
+	}
+	if provider.definitions["cfg_plan11_temporal_controlled_probe"] == nil {
+		t.Fatal("overlay-only cfg_plan11_temporal_controlled_probe was deleted")
+	}
+	if provider.definitions["cfg_backup"] == nil {
+		t.Fatal("expected local cfg_backup to be applied during isolated reconcile")
+	}
+}
+
+func TestOrdinaryModeRemovesAbsentConfigManagedDefinitions(t *testing.T) {
+	t.Parallel()
+
+	cfg, runtime, provider, decls := testWorkflowReconcileEnv(t)
+	seedOverlayOnlyPlan11Definition(provider)
+
+	if err := reconcileWorkflowConfigDefinitions(
+		context.Background(),
+		cfg,
+		runtime,
+		decls,
+		nil,
+		workflowConfigReconcileOptions{allowDestructiveCleanup: true},
+	); err != nil {
+		t.Fatalf("ordinary reconcile: %v", err)
+	}
+	if provider.definitions["cfg_plan11_temporal_controlled_probe"] != nil {
+		t.Fatal("overlay-only cfg_plan11_temporal_controlled_probe should be removed in ordinary mode")
+	}
+}
+
+func TestPromoteTemporalWorkersPreservesOverlayOnlyDefinitionWhenDeferred(t *testing.T) {
+	t.Parallel()
+
+	cfg, runtime, provider, decls := testWorkflowReconcileEnv(t)
+	seedOverlayOnlyPlan11Definition(provider)
+	promotable := &promotableTestWorkflowProvider{}
+
+	reconcileOpts := workflowConfigReconcileOptions{allowDestructiveCleanup: false}
+	result := &Result{
+		deferSharedStartupWrites: true,
+		ExtraWorkflows:           []coreworkflow.Provider{promotable},
+		startupWorkflowConfigReconcile: func(ctx context.Context) error {
+			return reconcileWorkflowConfigDefinitions(ctx, cfg, runtime, decls, nil, reconcileOpts)
+		},
+	}
+
+	if err := result.PromoteTemporalWorkers(context.Background()); err != nil {
+		t.Fatalf("PromoteTemporalWorkers: %v", err)
+	}
+	if promotable.promoteCalls != 1 {
+		t.Fatalf("promoteCalls = %d, want 1", promotable.promoteCalls)
+	}
+	if !result.TemporalWorkersPromoted() {
+		t.Fatal("expected deferred promotion bookkeeping to complete")
+	}
+	if len(provider.deletedDefinitions) != 0 {
+		t.Fatalf("deleted = %#v, want none after explicit promotion with deferred writes", provider.deletedDefinitions)
+	}
+	if provider.definitions["cfg_plan11_temporal_controlled_probe"] == nil {
+		t.Fatal("overlay-only cfg_plan11_temporal_controlled_probe was deleted during explicit promotion")
+	}
+}
+
+func TestBootstrapWiresNonDestructiveCleanupForIsolatedPreparation(t *testing.T) {
+	t.Parallel()
+
+	deferSharedStartupWrites := !resolvePromoteSharedStateOnActivate(&config.Config{
+		Server: config.ServerConfig{PromoteSharedStateOnActivate: boolPtr(false)},
+	})
+	opts := workflowConfigReconcileOptions{allowDestructiveCleanup: !deferSharedStartupWrites}
+	if opts.allowDestructiveCleanup {
+		t.Fatal("expected isolated preparation to disable destructive cfg_* cleanup")
+	}
+
+	deferSharedStartupWrites = !resolvePromoteSharedStateOnActivate(&config.Config{})
+	opts = workflowConfigReconcileOptions{allowDestructiveCleanup: !deferSharedStartupWrites}
+	if !opts.allowDestructiveCleanup {
+		t.Fatal("expected ordinary mode to keep destructive cfg_* cleanup enabled")
+	}
+}


### PR DESCRIPTION
## Summary

- When `promoteSharedStateOnActivate: false` (isolated preparation), bootstrap reconciliation applies desired `cfg_*` definitions but **skips** `cleanupRemovedWorkflowConfigDefinitions` so overlapping revisions cannot delete config-managed definitions absent from the local desired set.
- Explicit `POST /promote/temporal` uses the same non-destructive cleanup guard while still promoting Temporal workers.
- **Scope:** this is a cleanup guard for isolated-prep revisions only. It does **not** establish full shared reconciliation ownership across all overlapping revisions; ordinary revisions (`promoteSharedStateOnActivate: true`, default) retain existing destructive cleanup behavior.

## Tests

- `TestIsolatedPreparationPreservesOverlayOnlyDefinition` — overlay-only `cfg_*` survives isolated reconcile.
- `TestOrdinaryModeRemovesAbsentConfigManagedDefinitions` — ordinary mode still deletes absent `cfg_*`.
- `TestPromoteTemporalWorkersPreservesOverlayOnlyDefinitionWhenDeferred` — explicit promotion with deferred writes preserves foreign `cfg_*`.
- `TestBootstrapWiresNonDestructiveCleanupForIsolatedPreparation` — wiring from `promoteSharedStateOnActivate` to cleanup options.

## Test plan

- [x] `go test ./internal/bootstrap -run 'TestIsolatedPreparation|TestOrdinaryMode|TestPromoteTemporalWorkersPreserves|TestBootstrapWires|TestReconcileWorkflowConfigDefinitions'`
- [ ] CI green on gestaltd

## Deployment note

Existing runtimes already deployed **before** this pin will keep their current behavior until rebuilt with the new gestalt SHA. HTTP A and non-overlay revisions are not fixed in place by this change alone.


Made with [Cursor](https://cursor.com)