### PR TITLE
Plan 11: reject shared-state promotion HTTP writers when configured

### DIFF
--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -2020,6 +2020,11 @@ type ServerConfig struct {
 	// shared promotion explicitly. When unset, /activate keeps promoting shared
 	// state for backward compatibility.
 	PromoteSharedStateOnActivate *bool `yaml:"promoteSharedStateOnActivate,omitempty"`
+	// RejectSharedStatePromotion rejects POST /promote and POST /promote/registry
+	// before any registry or Temporal side effects. Use with
+	// promoteSharedStateOnActivate: false to fence all shared promotion writers
+	// while keeping local /activate preparation available.
+	RejectSharedStatePromotion *bool `yaml:"rejectSharedStatePromotion,omitempty"`
 	// AuthorizationStateApply gates whether server startup is allowed to
 	// overwrite active authorization provider state. When unset, the
 	// GESTALTD_AUTHORIZATION_STATE_APPLY environment variable is consulted;

--- a/gestaltd/internal/server/handlers_promote.go
+++ b/gestaltd/internal/server/handlers_promote.go
@@ -14,7 +14,18 @@ func (s *Server) mountPromoteRoute(r chi.Router) {
 	r.Post("/promote/registry", s.promoteRegistryHandler)
 }
 
+func (s *Server) rejectSharedStatePromotionIfDisabled(w http.ResponseWriter) bool {
+	if !s.rejectSharedStatePromotion {
+		return false
+	}
+	writeError(w, http.StatusForbidden, "shared state promotion is disabled for this revision")
+	return true
+}
+
 func (s *Server) promoteSharedStateHandler(w http.ResponseWriter, r *http.Request) {
+	if s.rejectSharedStatePromotionIfDisabled(w) {
+		return
+	}
 	req, errMsg := parseSharedActivationRequest(r.URL.Query())
 	if errMsg != "" {
 		writeError(w, http.StatusBadRequest, errMsg)
@@ -42,6 +53,9 @@ func (s *Server) promoteTemporalHandler(w http.ResponseWriter, r *http.Request) 
 }
 
 func (s *Server) promoteRegistryHandler(w http.ResponseWriter, r *http.Request) {
+	if s.rejectSharedStatePromotionIfDisabled(w) {
+		return
+	}
 	req, errMsg := parseSharedActivationRequest(r.URL.Query())
 	if errMsg != "" {
 		writeError(w, http.StatusBadRequest, errMsg)

--- a/gestaltd/internal/server/handlers_promote_test.go
+++ b/gestaltd/internal/server/handlers_promote_test.go
@@ -244,6 +244,63 @@ func TestPromoteRegistryUsesFleetTemporalPromotionEvidence(t *testing.T) {
 	}
 }
 
+func TestRejectSharedStatePromotionBlocksRegistryWriters(t *testing.T) {
+	t.Parallel()
+
+	var temporalPromoted bool
+	var services *coredata.Services
+	start := time.Date(2026, 9, 11, 12, 0, 0, 0, time.UTC)
+	srv := newTestServer(t, func(cfg *server.Config) {
+		cfg.SourceVersion = "source-new"
+		promoteOnActivate := false
+		rejectPromotion := true
+		cfg.PromoteSharedStateOnActivate = &promoteOnActivate
+		cfg.RejectSharedStatePromotion = &rejectPromotion
+		cfg.FinishSharedStartupPromotion = func(context.Context) error {
+			temporalPromoted = true
+			return nil
+		}
+		cfg.TemporalWorkersPromoted = func() bool { return temporalPromoted }
+		cfg.Now = func() time.Time { return start.Add(5 * time.Minute) }
+		services = cfg.Services
+		if _, err := services.GestaltdSourceVersionState.Activate(
+			context.Background(),
+			"source-old",
+			start,
+			false,
+			appregistry.DefaultRolloutEnrollmentWindow,
+			appregistry.DefaultRolloutTimeout,
+		); err != nil {
+			t.Fatalf("seed source version: %v", err)
+		}
+	})
+	testutil.CloseOnCleanup(t, srv)
+
+	for _, path := range []string{
+		"/promote?source_version=source-new&minimum_healthy_instances=5",
+		"/promote/registry?source_version=source-new&minimum_healthy_instances=5",
+	} {
+		resp, err := http.Post(srv.URL+path, "", nil)
+		if err != nil {
+			t.Fatalf("POST %s: %v", path, err)
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusForbidden {
+			t.Fatalf("%s status = %d, want %d", path, resp.StatusCode, http.StatusForbidden)
+		}
+	}
+	if temporalPromoted {
+		t.Fatal("temporal promotion ran while shared state promotion was rejected")
+	}
+	current, err := services.GestaltdSourceVersionState.CurrentForAdmission(context.Background())
+	if err != nil {
+		t.Fatalf("CurrentForAdmission: %v", err)
+	}
+	if current != "source-old" {
+		t.Fatalf("current source version = %q, want source-old", current)
+	}
+}
+
 func TestPromoteEndpointPromotesSharedState(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/server/handlers_startup_gate.go
+++ b/gestaltd/internal/server/handlers_startup_gate.go
@@ -7,6 +7,7 @@ import (
 type startupGateReport struct {
 	UIReadinessEnabled           bool   `json:"ui_readiness_enabled"`
 	PromoteSharedStateOnActivate bool   `json:"promote_shared_state_on_activate"`
+	RejectSharedStatePromotion   bool   `json:"reject_shared_state_promotion"`
 	ReleaseID                    string `json:"release_id"`
 	SourceVersion                string `json:"source_version"`
 	ReadyProbePath               string `json:"ready_probe_path"`
@@ -15,6 +16,7 @@ type startupGateReport struct {
 func (s *Server) startupGateReport(w http.ResponseWriter, _ *http.Request) {
 	report := startupGateReport{
 		PromoteSharedStateOnActivate: s.promoteSharedStateOnActivate,
+		RejectSharedStatePromotion:   s.rejectSharedStatePromotion,
 		SourceVersion:                s.sourceVersion,
 		ReadyProbePath:               "/ready",
 	}

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -153,6 +153,7 @@ func run(ctx context.Context, cfg *config.Config, result *bootstrap.Result, gest
 		ActivateAppProviders:         result.ActivateAppProviders,
 		WaitAppProvidersReady:        result.WaitAppProvidersReady,
 		PromoteSharedStateOnActivate: serverBoolPtr(!result.DeferSharedStartupWrites()),
+		RejectSharedStatePromotion:   cfg.Server.RejectSharedStatePromotion,
 		FinishSharedStartupPromotion: result.PromoteTemporalWorkers,
 		TemporalWorkersPromoted:      result.TemporalWorkersPromoted,
 		ServingReady:                 result.AppProvidersInitialized,

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -212,6 +212,7 @@ type Server struct {
 	activateAppProviders          func(context.Context)
 	waitAppProvidersReady         func(context.Context) error
 	promoteSharedStateOnActivate  bool
+	rejectSharedStatePromotion    bool
 	finishSharedStartupPromotion  func(context.Context) error
 	temporalWorkersPromoted       func() bool
 	servingReady                  <-chan struct{}
@@ -297,6 +298,7 @@ type Config struct {
 	ActivateAppProviders          func(context.Context)
 	WaitAppProvidersReady         func(context.Context) error
 	PromoteSharedStateOnActivate  *bool
+	RejectSharedStatePromotion    *bool
 	FinishSharedStartupPromotion  func(context.Context) error
 	TemporalWorkersPromoted       func() bool
 	ServingReady                  <-chan struct{}
@@ -320,6 +322,13 @@ func resolveServerPromoteSharedStateOnActivate(cfg Config) bool {
 		return *cfg.PromoteSharedStateOnActivate
 	}
 	return true
+}
+
+func resolveServerRejectSharedStatePromotion(cfg Config) bool {
+	if cfg.RejectSharedStatePromotion != nil {
+		return *cfg.RejectSharedStatePromotion
+	}
+	return false
 }
 
 func New(cfg Config) (*Server, error) {
@@ -578,6 +587,7 @@ func New(cfg Config) (*Server, error) {
 		activateAppProviders:          cfg.ActivateAppProviders,
 		waitAppProvidersReady:         cfg.WaitAppProvidersReady,
 		promoteSharedStateOnActivate:  resolveServerPromoteSharedStateOnActivate(cfg),
+		rejectSharedStatePromotion:    resolveServerRejectSharedStatePromotion(cfg),
 		finishSharedStartupPromotion:  cfg.FinishSharedStartupPromotion,
 		temporalWorkersPromoted:       cfg.TemporalWorkersPromoted,
 		servingReady:                  cfg.ServingReady,


### PR DESCRIPTION
## Summary
- Add `server.rejectSharedStatePromotion` to reject POST `/promote` and POST `/promote/registry` before registry or Temporal side effects.
- Expose the flag on the startup gate report for live containment verification.
- Keep isolated `/activate` preparation available when paired with `promoteSharedStateOnActivate: false`.

## Test plan
- [x] `go test ./internal/server -run 'TestRejectSharedStatePromotion|TestPromote'`
- [ ] Land toolshed overlay integration and bump `GESTALTD_PINNED_SHA` to this commit before VT redeploy


Made with [Cursor](https://cursor.com)